### PR TITLE
Fixed link to "wait" docs from "configuration" docs

### DIFF
--- a/cypress/v0.0/documentation/3-Guides/0-Configuration.md
+++ b/cypress/v0.0/documentation/3-Guides/0-Configuration.md
@@ -55,7 +55,7 @@ Option | Default | Description
 `defaultCommandTimeout` | `4000` | Time, in milliseconds, to wait until most DOM based commands are considered timed out
 `execTimeout` | `60000` | Time, in milliseconds, to wait for a system command to finish executing during [`cy.exec`](https://on.cypress.io/api/exec) command
 `pageLoadTimeout` | `60000` | Time, in milliseconds, to wait until [`cy.visit`](https://on.cypress.io/api/visit), [`cy.go`](https://on.cypress.io/api/go), [`cy.reload`](https://on.cypress.io/api/reload), or a page load times out
-`requestTimeout` | `5000` | Time, in milliseconds, to wait for an XHR request during [`cy.wait`](wait) command
+`requestTimeout` | `5000` | Time, in milliseconds, to wait for an XHR request during [`cy.wait`](https://on.cypress.io/api/wait) command
 `responseTimeout` | `30000` | Time, in milliseconds, to wait until a response for [`cy.request`](https://on.cypress.io/api/request), [`cy.wait`](https://on.cypress.io/api/wait), [`cy.fixture`](https://on.cypress.io/api/fixture), [`cy.getCookie`](https://on.cypress.io/api/getcookie), [`cy.getCookies`](https://on.cypress.io/api/getcookies), [`cy.setCookie`](https://on.cypress.io/api/setcookie), [`cy.clearCookie`](https://on.cypress.io/api/clearcookie) and [`cy.clearCookies`](https://on.cypress.io/api/clearcookies), and [`cy.screenshot`](https://on.cypress.io/api/screenshot) commands
 
 ***


### PR DESCRIPTION
Not sure if we want to link to the `on` subdomain because it redirects to `docs` but at least the link now works.