### PR TITLE
Typo in Date Object

### DIFF
--- a/source/api/commands/clock.md
+++ b/source/api/commands/clock.md
@@ -148,7 +148,7 @@ $('#date').text(new Date().toJSON())
 ```
 
 ```javascript
-const now = new Date(2017, 2, 14).getTime() // March 14, 2017 timestamp
+const now = new Date(2017, 3, 14).getTime() // March 14, 2017 timestamp
 
 cy.clock(now)
 cy.visit('/index.html')


### PR DESCRIPTION
Just a small typo in the cy.clock() documentation. Comment read march when the code was for February. I changed it to match.