### PR TITLE
add examples for binding to Cypress events

### DIFF
--- a/source/api/events/catalog-of-events.md
+++ b/source/api/events/catalog-of-events.md
@@ -11,14 +11,10 @@ Here are some examples you can do with these events:
 
 - Listen for `uncaught exceptions` and prevent Cypress from failing the test
 - Listen for `alert` or `confirm` calls and change the `confirm` behavior
-- Listen for `before:window:load` events and modify the `window` before any of your app code runs between page transitions
+- Listen for `window:before:load` events and modify the `window` before any of your app code runs between page transitions
 - Listen for `command:retry` events to understand why Cypress is internally retrying for debugging purposes
 
-{% note info WIP %}
-This page is currently a work in progress and is not fully documented.
-{% endnote %}
-
-# Events
+# Event Types
 
 ## App Events
 
@@ -169,7 +165,258 @@ The `cy` object is bound to each individual test. Events bound to `cy` will **au
 
 # Examples
 
-WIP.
+## Uncaught Exceptions
+
+***To turn off all uncaught exception handling***
+
+```javascript
+// likely want to do this in a support file
+// so its applied to all spec files
+// cypress/support/index.js
+
+Cypress.on('uncaught:exception', (err, runnable) => {
+  // returning false here prevents Cypress from
+  // failing the test
+  return false
+})
+
+```
+
+***To catch a single uncaught exception***
+
+```javascript
+it('is doing something very important', function(done) {
+  // this event will automatically be unbound when this
+  // test ends because its attached to 'cy'
+  cy.on('uncaught:exception', (err, runnable) => {
+    expect(err.message).to.include('something about the error')
+
+    // using mocha's async done callback to finish
+    // this test so we prove that an uncaught exception
+    // was thrown
+    done()
+
+    // return false to prevent the error from
+    // failing this test
+    return false
+  })
+
+  // assume this causes an error
+  cy.get('button').click()
+})
+
+```
+
+## Catching Test Failures
+
+***Debug the moment a test fails***
+
+```javascript
+// if you want to debug when any test fails
+// bind to Cypress, and you likely want to
+// put this in a support file, or at the top
+// of an individual spec file
+Cypress.on('fail', (err, runnable) => {
+  debugger
+
+  // we now have access to the err instance
+  // and the mocha runnable this failed on
+})
+
+it('calls the "fail" callback when this test fails', function () {
+  // when this cy.get() fails the callback is invoked
+  // with the error
+  cy.get('element-that-does-not-exist')
+})
+```
+
+## Page Navigation
+
+***Test that your application was redirected***
+
+```javascript
+// app code
+$('button').on('click', (e) => {
+  // change the page programmatically
+  window.location.href = '/some/new/link'
+})
+
+// test code
+it('redirects to another page on click', function (done) {
+  // this event will automatically be unbound when this
+  // test ends because its attached to 'cy'
+  cy.on('window:before:unload', (e) => {
+    // no return value on the event
+    expect(e.returnValue).to.be.undefined
+  })
+
+  cy.on('window:unload', (e) => {
+    // using mocha's async done callback to finish
+    // this test so we are guaranteed the application
+    // was unloaded while navigating to the new page
+    done()
+  })
+
+  // click the button causing the page redirect
+  cy.get('button').click()
+})
+```
+
+## Window Before Load
+
+***Modify your Application before it loads after page transitions***
+
+```javascript
+it('can modify the window prior to page load on all pages', function () {
+  // this does the same thing as the onBeforeLoad callback for
+  // cy.visit()
+
+  // create the stub here
+  const stub = cy.stub()
+
+  // prevent google analytics from loading
+  // and replace it with a stub before every
+  // single page load including all new page
+  // navigations
+  cy.on('window:before:load', (win) => {
+    Object.defineProperty(win, 'ga', {
+      configurable: false,
+      writeable: false,
+      get: () => stub // always return the stub
+    })
+  })
+
+
+  cy
+    // window:before:load will be called here
+    .visit('/first/page')
+
+    .then((win) => {
+      // and here
+      win.location.href = '/second/page'
+    })
+
+    // and here
+    .get('a').click()
+
+})
+```
+
+## Window Confirm
+
+***Control whether you accept or reject confirmations***
+
+This enables you to test how your application reacts to accepted confirmations and rejected confirmations.
+
+```javascript
+// app code
+$('button').on('click', (e) => {
+  const one = confirm('first confirm')
+
+  if (one) {
+    const two = confirm('second confirm')
+
+    if (!two) {
+      const three = confirm('third confirm')
+
+      confirm('third confirm was ' + three)
+    }
+  }
+})
+
+// test code
+it('can control application confirms', function (done) {
+  const count = 0
+
+  // make sure you bind to this **before** the
+  // confirm method is called in your application
+  //
+  // this event will automatically be unbound when this
+  // test ends because its attached to 'cy'
+  cy.on('window:confirm', (str) => {
+    count += 1
+
+    switch(count) {
+      case 1:
+        expect(str).to.eq('first confirm')
+        // returning nothing here automatically
+        // accepts the confirmation
+      case 2:
+        expect(str).to.eq('second confirm')
+
+        // reject the confirmation
+        return false
+
+      case 3:
+        expect(str).to.eq('third confirm')
+
+        // don't have to return true but it works
+        // as well
+        return true
+
+      case 4:
+        expect(str).to.eq('third confirm was true')
+
+        // using mocha's async done callback to finish
+        // this test so we are guaranteed everything
+        // got to this point okay without throwing an error
+        done()
+    }
+  })
+
+  // click the button causing the confirm to fire
+  cy.get('button').click()
+})
+
+it('could also use a stub instead of imperative code', function () {
+  const stub = cy.stub()
+
+  // not necessary but showing for clarity
+  stub.onFirstCall().returns(undefined)
+  stub.onSecondCall().returns(false)
+  stub.onThirdCall().returns(true)
+
+  cy.on('window:confirm', stub)
+
+  cy
+    .get('button').click()
+    .then(() => {
+      expect(stub.getCall(0)).to.be.calledWith('first confirm')
+      expect(stub.getCall(1)).to.be.calledWith('second confirm')
+      expect(stub.getCall(2)).to.be.calledWith('third confirm')
+      expect(stub.getCall(3)).to.be.calledWith('third confirm was true')
+    })
+})
+```
+
+## Window Alert
+
+**Assert on the alert text**
+
+Cypress automatically accepts alerts but you can still assert on the text content.
+
+```javascript
+// app code
+$('button').on('click', (e) => {
+  alert('hi')
+  alert('there')
+  alert('friend')
+})
+
+it('can assert on the alert text content', function () {
+  const stub = cy.stub()
+
+  cy.on('window:alert', stub)
+
+  cy
+    .get('button').click()
+    .then(() => {
+      expect(stub.getCall(0)).to.be.calledWith('hi')
+      expect(stub.getCall(1)).to.be.calledWith('there')
+      expect(stub.getCall(2)).to.be.calledWith('friend')
+    })
+})
+```
 
 # Notes
 

--- a/source/faq/questions/dashboard-faq.md
+++ b/source/faq/questions/dashboard-faq.md
@@ -26,9 +26,7 @@ Everything is free while we are in Beta.
 
 In the future, we will charge per month for private projects.
 
-Public projects will be free but will likely have a monthly usage cap on them.
-
-We will offer similar pricing models of other Developer Tools you are familiar with using.
+Please see our {% url 'Pricing Page' https://www.cypress.io/pricing %} for more details.
 
 ## {% fa fa-angle-right %} What is the difference between public and private projects?
 

--- a/source/faq/questions/general-questions-faq.md
+++ b/source/faq/questions/general-questions-faq.md
@@ -51,7 +51,7 @@ Cypress on the other hand **helps** you write your tests. You would use Cypress 
 
 ## {% fa fa-angle-right %} Is Cypress free?
 
-Cypress desktop app and CLI are free to use. The Cypress Dashboard is a premium feature for non-open source projects and offers recording videos, screenshots and logs in a web interface.
+The Cypress Test Runner is free and open source (MIT). The Cypress Dashboard is a premium feature for non-open source projects and offers recording videos, screenshots and logs in a web interface.
 
 ## {% fa fa-angle-right %} What operating systems do you support?
 

--- a/source/faq/questions/using-cypress-faq.md
+++ b/source/faq/questions/using-cypress-faq.md
@@ -93,6 +93,39 @@ cy.get('input').invoke('val').then((val1) => {
 })
 ```
 
+## {% fa fa-angle-right %} How do I get the native DOM reference of an element found using Cypress?
+
+Cypress wraps elements in jQuery so you'd just get the native element from there within a {% url "`.then()`" then %} command.
+
+```javascript
+cy.get('button').then(($el) => {
+  $el.get(0)
+})
+```
+
+## {% fa fa-angle-right %} Can I prevent Cypress from failing my test when my application throws an uncaught exception error?
+
+Yes.
+
+By default Cypress will automatically fail tests whenever an uncaught exception bubbles up out of your app.
+
+Cypress exposes an event for this (amongst many others) that you can listen for to either:
+
+- Debug the error instance itself
+- Prevent Cypress from failing the test
+
+This is documented in detail on the {% url "Catalog Of Events" catalog-of-events %} page.
+
+## {% fa fa-angle-right %} Can I use the Page Object pattern?
+
+Yes.
+
+The page object pattern isn't actually anything "special". If you're coming from Selenium you may be accustomed to creating instances of classes, but this is completely unnecessary and irrelevant.
+
+The "Page Object Pattern" should really be renamed to: "Using functions and creating custom commands".
+
+If you're looking to abstract behavior or roll up a series of actions you can create reusable {% url 'Custom Commands with our API' custom-commands %}. You can also just use regular ol' JavaScript functions without any of the ceremony typical with "Page Objects".
+
 ## {% fa fa-angle-right %} How can I parallelize my runs?
 
 You can read more about parallelization {% issue 64 'here' %}.
@@ -140,16 +173,6 @@ You can create multiple Record Keys for a project, or delete existing ones from 
 You can also find your Record Key inside of the *Settings* tab in our Desktop Application.
 
 ![Settings Tab of Desktop](/img/dashboard/record-key-shown-in-desktop-gui-configuration.png)
-
-## {% fa fa-angle-right %} How do I get the native DOM reference of an element found using Cypress?
-
-Cypress wraps elements in jQuery so you'd just get the native element from there within a {% url "`.then()`" then %} command.
-
-```javascript
-cy.get('button').then(($el) => {
-  $el.get(0)
-})
-```
 
 ## {% fa fa-angle-right %} How do I wait for multiple XHR requests to the same url?
 
@@ -210,7 +233,10 @@ cy.get('button', { timeout: 10000 }) // wait up to 10 seconds for this 'button' 
 
 cy.get('.element').click({ timeout: 10000 }).should('not.have.class', 'animating')
 // wait up to 10 seconds for the .element to not have 'animating' class
+
 ```
+
+However, most of the time you don't even have to worry about animations. Why not?  Cypress will {% url "automatically wait" interacting-with-elements %} for elements to stop animating prior to interacting with them via action commands like `.click()` or `.type()`.
 
 ## {% fa fa-angle-right %} Can I test anchor links that open in a new tab?
 
@@ -234,16 +260,6 @@ Cypress doesn't have direct access to node or your file system. We recommend uti
 ## {% fa fa-angle-right %} Is there a way to give a proper SSL certificate to your proxy so the page doesn't show up as "not secure"?
 
 No, Cypress modifies network traffic in real time and therefore must sit between your server and the browser. There is no other way for us to achieve that.
-
-## {% fa fa-angle-right %} Can I use the Page Object pattern?
-
-Yes.
-
-The page object pattern isn't actually anything "special". If you're coming from Selenium you may be accustomed to creating instances of classes, but this is completely unnecessary and irrelevant.
-
-The "Page Object Pattern" should really be renamed to: "Using functions and creating custom commands".
-
-If you're looking to abstract behavior or roll up a series of actions you can create reusable {% url 'Custom Commands with our API' custom-commands %}. You can also just use regular ol' JavaScript functions without any of the ceremony typical with "Page Objects".
 
 ## {% fa fa-angle-right %} Is there any way to detect if my app is running under Cypress?
 
@@ -299,7 +315,7 @@ There are a few ways.
 
 - The easiest way is probably to check our {% url "changelog" changelog %}.
 - You can also check the latest version {% url "here" https://download.cypress.io/desktop.json %}.
-- Once we're open source (soon!), we'll have it tagged in the {% url "repo" https://github.com/cypress-io/cypress %}.
+- It's also always in our {% url "repo" https://github.com/cypress-io/cypress %}.
 
 ## {% fa fa-angle-right %} Is there an ESLint plugin for Cypress or a list of globals?
 

--- a/source/guides/references/changelog.md
+++ b/source/guides/references/changelog.md
@@ -18,6 +18,11 @@ comments: false
 - You can now use environment variables that have a `=` character as values. Fixes {% issue 620 %}. Contributed by {% user HugoGiraudel %}.
 - There is now a new `videoUploadOnPasses` configuration option in `cypress.json`. Turning this off will only compress and upload videos on failures. This only affects projects which are setup to record to the Dashboard. Fixes {% issue 460 %}. Contributed by {% user carlos-granados %}.
 
+**Documentation Changes:**
+
+- {% url 'Added examples for "Catalog of Events"' catalog-of-events %}
+- {% url 'Added / Updated FAQ for "Using Cypress"' using-cypress-faq %}
+
 ## 1.0.1
 
 *Released 10/10/2017*


### PR DESCRIPTION
- uncaught exceptions
- test failures
- page navigation
- window before load
- window confirm
- window alert