### PR TITLE
Please don't use implicit variable declarations!

### DIFF
--- a/source/guides/getting-started/testing-your-app.md
+++ b/source/guides/getting-started/testing-your-app.md
@@ -270,7 +270,7 @@ describe('The Login Page', function(){
 
   it('sets auth cookie when logging in via form submission', function(){
     // destructuring assignment of the this.currentUser object
-    { username, password } = this.currentUser
+    const { username, password } = this.currentUser
 
     cy.visit('/login')
 
@@ -351,7 +351,7 @@ describe('The Dashboard Page', function(){
 
   it('logs in programmatically without using the UI', function(){
     // destructuring assignment of the this.currentUser object
-    { username, password } = this.currentUser
+    const { username, password } = this.currentUser
 
     // programmatically log us in without needing the UI
     cy.request('POST', '/login', {


### PR DESCRIPTION
This should be an error when running JavaScript in ES5 "strict mode," because implicit variables in JavaScript become globals. It's a small thing, but having the declaration (const/let/var, whichever -- although I've used `const` out of preference), will hopefully reduce confusion for beginners (who should expect all variables to be declared!) and make the code more idiomatic.