### PR TITLE
Update 'setting up projects to record' to be more clear with the new 1.0 workflow

### DIFF
--- a/source/dashboard/overview/projects-dashboard.md
+++ b/source/dashboard/overview/projects-dashboard.md
@@ -7,13 +7,13 @@ With Cypress, you have the ability to record the tests for each project you work
 
 You typically want to record when running tests in {% url 'Continuous Integration' continuous-integration %}, but you can also record your tests when running locally.
 
+# Setup
+
 {% note info %}
 To set up your project to record, you must use the Test Runner.
 
 Make sure you {% url "install" installing-cypress %} and {% url "open" installing-cypress#Opening-Cypress %} it first!
 {% endnote %}
-
-# Setup
 
 ***To set up a project to record:***
 
@@ -100,7 +100,7 @@ If your Record Key is accidentally exposed, you should remove it and generate a 
 
 - **Private** means that only {% url 'users' organizations-dashboard#Inviting-Users %} you invite to your {% url 'organization' organizations-dashboard %} can see its recorded runs. Even if someone knows your `projectId`, they will not have access to your runs unless you have invited them.
 
-# Transfer Ownership
+# Transfer ownership
 
 You can transfer projects that you own to another organization you are a part of or to another user in the organization. Projects can only be transferred from our {% url 'Dashboard' https://on.cypress.io/dashboard %}.
 

--- a/source/dashboard/overview/projects-dashboard.md
+++ b/source/dashboard/overview/projects-dashboard.md
@@ -3,19 +3,17 @@ title: Projects
 comments: false
 ---
 
-A Cypress project represents the directory of files and folders that make up your tests. This is often the same repository as your code, but can also be a subfolder or a separate repository altogether.
+With Cypress, you have the ability to record the tests for each project you work in.
 
-{% note info  %}
-Projects added in our Test Runner are strictly local to your computer. They are not tracked in any way by Cypress servers and do not communicate with us until they are {% urlHash "set up to be recorded" Set-up-a-project-to-record %}.
+You typically want to record when running tests in {% url 'Continuous Integration' continuous-integration %}, but you can also record your tests when running locally.
+
+{% note info %}
+To set up your project to record, you must use the Test Runner.
+
+Make sure you {% url "install" installing-cypress %} and {% url "open" installing-cypress#Opening-Cypress %} it first!
 {% endnote %}
 
-# Set up a project to record
-
-In Cypress, you have the ability to record your running tests. You would typically want to record when running tests in {% url 'Continuous Integration' continuous-integration %} or when running headlessly (when you can't see the Test Runner).
-
-Cypress records all failing tests, logs, screenshots, and videos and make these available in our {% url 'Dashboard' https://on.cypress.io/dashboard %}.
-
-Projects can *only* be set up to record through our Test Runner. You will need to {% url "install" installing-cypress %} and {% url "open" installing-cypress#Opening-Cypress %} our Test Runner first.
+# Setup
 
 ***To set up a project to record:***
 
@@ -31,7 +29,7 @@ Projects can *only* be set up to record through our Test Runner. You will need t
   - **A private project** restricts its access to *{% url "only users you invite" organizations-dashboard#Inviting-Users %}*.
 7. Click "Setup Project".
 8. Now you should see a view explaining how to record your first run.
-9. After {% urlHash "setting up your project" Set-up-a-project-to-record %}, Cypress inserted a unique {% urlHash "projectId" Project-ID %} into your `cypress.json`. You will want to check your `cypress.json` into source control.
+9. After setting up your project, Cypress inserted a unique {% urlHash "projectId" Project-ID %} into your `cypress.json`. You will want to check your `cypress.json` into source control.
 10. Within {% url 'Continuous Integration' continuous-integration %}, or from your local computer's terminal, pass the displayed {% urlHash "Record Key" Record-Key %} while running the {% url '`cypress run`' command-line#cypress-run %} command.
   - Provide record key directly:
     ```shell
@@ -96,13 +94,13 @@ Think of your record key as the key that enables you to *write and create* runs.
 If your Record Key is accidentally exposed, you should remove it and generate a new one from our {% url 'Dashboard' https://on.cypress.io/dashboard %}.
 {% endnote %}
 
-# Public vs Private Projects
+# Public vs Private
 
 - **Public** means that anyone can see the recorded test runs for it. It is similar to how public projects on Github, Travis CI, or CircleCI are handled. Anyone who knows your `projectId` will be able to see the recorded runs for public projects.
 
 - **Private** means that only {% url 'users' organizations-dashboard#Inviting-Users %} you invite to your {% url 'organization' organizations-dashboard %} can see its recorded runs. Even if someone knows your `projectId`, they will not have access to your runs unless you have invited them.
 
-# Transfer ownership of project
+# Transfer Ownership
 
 You can transfer projects that you own to another organization you are a part of or to another user in the organization. Projects can only be transferred from our {% url 'Dashboard' https://on.cypress.io/dashboard %}.
 

--- a/source/dashboard/overview/projects-dashboard.md
+++ b/source/dashboard/overview/projects-dashboard.md
@@ -5,81 +5,54 @@ comments: false
 
 A Cypress project represents the directory of files and folders that make up your tests. This is often the same repository as your code, but can also be a subfolder or a separate repository altogether.
 
-# Add a New Project
-
-Projects can *only* be added to Cypress through our Desktop Application.
-
-1. Drag your project into the Desktop App or click 'select manually'.
-
-{% img no-border /img/guides/add-your-first-project-in-guid.png "Adding an empty folder to Cypress Desktop" %}
-
 {% note info  %}
-Projects added in our Desktop Application are strictly local to your computer. They are not tracked in any way by Cypress servers and do not communicate with us until they are {% urlHash "set up to be recorded" Set-up-a-Project-to-Record %}.
+Projects added in our Test Runner are strictly local to your computer. They are not tracked in any way by Cypress servers and do not communicate with us until they are {% urlHash "set up to be recorded" Set-up-a-project-to-record %}.
 {% endnote %}
 
-# Set up a Project to Record
+# Set up a project to record
 
-During a run we record all failing tests, logs, screenshots, and videos and make these available in our {% url 'Dashboard' https://on.cypress.io/dashboard %}.
+In Cypress, you have the ability to record your running tests. You would typically want to record when running tests in {% url 'Continuous Integration' continuous-integration %} or when running headlessly (when you can't see the Test Runner).
+
+Cypress records all failing tests, logs, screenshots, and videos and make these available in our {% url 'Dashboard' https://on.cypress.io/dashboard %}.
+
+Projects can *only* be set up to record through our Test Runner. You will need to {% url "install" installing-cypress %} and {% url "open" installing-cypress#Opening-Cypress %} our Test Runner first.
 
 ***To set up a project to record:***
 
-**1. Click on the "Runs" tab of your project, then click "Setup Project to Record".**
+![Setup Project Screen](/img/dashboard/setup-to-record.gif)
 
-![Setup Project Screen](/img/dashboard/setup-project-to-record-in-desktop-gui.png)
+1. Click on the "Runs" tab of your project within the Test Runner.
+2. You will need to log in to record your tests, so you may need to log in with GitHub here.
+3. Click "Setup Project to Record".
+4. Fill in the name of your project (this is only for display purposes and can be changed later).
+5. Choose who owns the project. You can personally own it or select an organization you've created. Organizations work just like they do in Github. They enable you to separate your personal and work projects. {% url 'Read more about organizations' organizations-dashboard %}.
+6. Choose whether this project is Public or Private.
+  - **A public project** can have its recordings and runs seen by *anyone*. Typically these are open source projects.
+  - **A private project** restricts its access to *{% url "only users you invite" organizations-dashboard#Inviting-Users %}*.
+7. Click "Setup Project".
+8. Now you should see a view explaining how to record your first run.
+9. After {% urlHash "setting up your project" Set-up-a-project-to-record %}, Cypress inserted a unique {% urlHash "projectId" Project-ID %} into your `cypress.json`. You will want to check your `cypress.json` into source control.
+10. Within {% url 'Continuous Integration' continuous-integration %}, or from your local computer's terminal, pass the displayed {% urlHash "Record Key" Record-Key %} while running the {% url '`cypress run`' command-line#cypress-run %} command.
+  - Provide record key directly:
+    ```shell
+    cypress run --record --key abc-key-123
+    ```
 
-**2. Fill in the name of your project (this is only for display purposes and can be changed later).**
+  - Or set record key as environment variable
+    ```shell
+    export CYPRESS_RECORD_KEY=abc-key-123
+    ```
+    ```shell
+    cypress run --record
+  ```
 
-![Project Name in Setup Project](/img/dashboard/fill-in-project-name-to-setup-project-to-record.png)
-
-**3. Choose who owns the project. You can personally own it or select an organization you've created.**
-
-Organizations work just like they do in Github. They enable you to separate your personal and work projects. {% url 'Read more about organizations' organizations-dashboard %}.
-
-![Chosen Organization to Own](/img/dashboard/select-organization-who-should-own-project.png)
-
-**4. Choose whether this project is Public or Private.**
-
-- **A public project** can have its recordings and runs seen by *anyone*. Typically these are open source projects.
-
-- **A private project** restricts its access to *only users you invite* to see your Organization or your own projects.
-
-![Privacy of Project](/img/dashboard/choose-privacy-of-recorded-project.png)
-
-**5. Click "Setup Project".**
-
-![Setup Project](/img/dashboard/after-setting-up-project-to-record-screen.png)
-
-🎉 Your tests runs are now ready to record! Typically you would record your runs when running in {% url 'Continuous Integration' continuous-integration %} but you can also record your runs from your local computer.
-
-## Record Test Runs
-
-After setting up your project, Cypress inserted a unique {% urlHash "projectId" Project-ID %} into your `cypress.json`. You'll want to check your `cypress.json` into source control.
-
-In order to record your test runs, you'll also need to provide a {% urlHash "Record Key" Record-Key %}. The record key along with your `projectId` are used by Cypress to uniquely identify your project.
-
-***Provide record key in {% url '`cypress run`' command-line#cypress-run %}:***
-
-```shell
-cypress run --record --key abc-key-123
-```
-
-***Or set record key as environment variable***
-
-```shell
-export CYPRESS_RECORD_KEY=abc-key-123
-```
-
-```shell
-cypress run --record
-```
-
-Now as soon as tests finish running, you'll see them in the {% url 'Dashboard' https://on.cypress.io/dashboard %} and in the Runs tab of the Desktop Application.
-
-![Runs List](/img/dashboard/runs-list-in-desktop-gui.png)
+🎉 Your tests are now recording! As soon as tests finish running, you will see them in the {% url 'Dashboard' https://on.cypress.io/dashboard %} and in the Runs tab of the Test Runner.
 
 ![Dashboard Screenshot](/img/dashboard/dashboard-runs-list.png)
 
-## Project ID
+![Runs List](/img/dashboard/runs-list-in-desktop-gui.png)
+
+# Project ID
 
 Once you set up your project to record, we generate a unique `projectId` for your project and automatically insert it into your `cypress.json` file.
 
@@ -91,9 +64,9 @@ Once you set up your project to record, we generate a unique `projectId` for you
 }
 ```
 
-This is helps us uniquely identify your project. If you manually alter this, **Cypress will no longer be able to identify your project or find the recorded builds for it**. We recommend that you check your `cypress.json` including the `projectId` into source control.
+This helps us uniquely identify your project. If you manually alter this, **Cypress will no longer be able to identify your project or find the recorded builds for it**. We recommend that you check your `cypress.json` including the `projectId` into source control.
 
-## Record Key {% fa fa-key %}
+# Record Key {% fa fa-key %}
 
 Once you're set up to record test runs, we automatically generate a *Record Key* for the project.
 
@@ -107,7 +80,7 @@ You can create multiple Record Keys for a project, or delete existing ones from 
 
 ![Record Key in Configuration Tab](/img/dashboard/record-key-shown-in-desktop-gui-configuration.png)
 
-## Authentication
+# Authentication
 
 Cypress uses your `projectId` and *Record Key* together to uniquely identify projects.
 
@@ -125,18 +98,18 @@ If your Record Key is accidentally exposed, you should remove it and generate a 
 
 # Public vs Private Projects
 
-- **Public** means that anyone can see the recorded test runs for it. It's similar to how public projects on Github, Travis, or Circle are handled. Anyone who knows your `projectId` will be able to see the recorded runs for public projects.
+- **Public** means that anyone can see the recorded test runs for it. It is similar to how public projects on Github, Travis CI, or CircleCI are handled. Anyone who knows your `projectId` will be able to see the recorded runs for public projects.
 
-- **Private** means that only {% url 'users' organizations-dashboard#Inviting-Users %} you explicitly invite to your {% url 'organization' organizations-dashboard %} can see its recorded runs. Even if someone knows your `projectId`, they will not have access to your runs unless you have invited them.
+- **Private** means that only {% url 'users' organizations-dashboard#Inviting-Users %} you invite to your {% url 'organization' organizations-dashboard %} can see its recorded runs. Even if someone knows your `projectId`, they will not have access to your runs unless you have invited them.
 
-# Transfer Ownership of Project
+# Transfer ownership of project
 
 You can transfer projects that you own to another organization you are a part of or to another user in the organization. Projects can only be transferred from our {% url 'Dashboard' https://on.cypress.io/dashboard %}.
 
 ![Transfer Project dialog](/img/dashboard/transfer-ownership-of-project-dialog.png)
 
-# Delete a Project
+# Delete a project
 
-You can delete projects you own. This will also delete all of their recorded runs. Deleting projects can only be done from our {% url 'Dashboard' https://on.cypress.io/dashboard %}.
+You can delete projects you own. This will also delete all of their recorded test runs. Deleting projects can only be done from our {% url 'Dashboard' https://on.cypress.io/dashboard %}.
 
 ![Delete project dialog](/img/dashboard/remove-project-dialog.png)

--- a/source/dashboard/overview/runs-dashboard.md
+++ b/source/dashboard/overview/runs-dashboard.md
@@ -7,7 +7,7 @@ Recorded runs are the results and artifacts captured from your test runs.
 
 ***To record your tests:***
 
-1. First {% url 'set up the project to record' projects-dashboard#Set-up-a-Project-to-Record %}.
+1. First {% url 'set up the project to record' projects-dashboard#Set-up-a-project-to-record %}.
 2. Then {% url 'record your runs' runs-dashboard %}.
 
 # What is recorded during a test run?

--- a/source/dashboard/overview/runs-dashboard.md
+++ b/source/dashboard/overview/runs-dashboard.md
@@ -3,14 +3,13 @@ title: Recorded Runs
 comments: false
 ---
 
-Recorded runs are the results and artifacts captured from your test runs.
+Recorded runs capture the results from your test runs.
 
-***To record your tests:***
+{% note info %}
+If you haven't set up your project to record {% url "read here" projects-dashboard#Set-up-a-project-to-record %}.
+{% endnote %}
 
-1. First {% url 'set up the project to record' projects-dashboard#Set-up-a-project-to-record %}.
-2. Then {% url 'record your runs' runs-dashboard %}.
-
-# What is recorded during a test run?
+# What is recorded?
 
 We capture the following:
 

--- a/source/faq/questions/dashboard-faq.md
+++ b/source/faq/questions/dashboard-faq.md
@@ -15,7 +15,7 @@ You can read more {% url 'here' features-dashboard %}.
 
 ## {% fa fa-angle-right %} How do I record my tests?
 
-1. First {% url 'set up the project to record' projects-dashboard#Set-up-a-Project-to-Record %}.
+1. First {% url 'set up the project to record' projects-dashboard#Set-up-a-project-to-record %}.
 2. Then {% url 'record your runs' runs-dashboard %}.
 
 After recording your tests, you will see them in the {% url 'Dashboard' https://on.cypress.io/dashboard %} and in the "Runs" tab of the Desktop Application.

--- a/source/guides/guides/command-line.md
+++ b/source/guides/guides/command-line.md
@@ -135,7 +135,7 @@ cypress run --project ./some/nested/folder
 
 ***Run and record video of tests***
 
-Record video of tests running after {% url 'setting up your project to record' projects-dashboard#Set-up-a-Project-to-Record %}. After setting up your project you will be given a **Record Key**.
+Record video of tests running after {% url 'setting up your project to record' projects-dashboard#Set-up-a-project-to-record %}. After setting up your project you will be given a **Record Key**.
 
 ```shell
 cypress run --record --key <record_key>
@@ -155,7 +155,7 @@ Now you can omit the `--key` flag.
 cypress run --record
 ```
 
-You can {% url 'read more about recording runs here' projects-dashboard#Set-up-a-Project-to-Record %}.
+You can {% url 'read more about recording runs here' projects-dashboard#Set-up-a-project-to-record %}.
 
 ## `cypress open`
 

--- a/source/guides/guides/continuous-integration.md
+++ b/source/guides/guides/continuous-integration.md
@@ -31,7 +31,7 @@ Cypress should run on **all** CI providers. We currently have seen Cypress worki
 - {% url "TravisCI" https://travis-ci.org/ %}
 - {% url "CircleCI" https://circleci.com %}
 - {% url "CodeShip" https://codeship.com/ %}
-- {% url "GitLab" https://gitlab.com %}
+- {% url "GitLab" https://gitlab.com/ %}
 - {% url "BuildKite" https://buildkite.com %}
 - {% url "AppVeyor" https://appveyor.com %}
 - {% url "Docker" https://www.docker.com/ %}
@@ -99,7 +99,7 @@ Cypress can record your tests running and make them available in our {% url 'Das
 
 ***To record tests running:***
 
-1. {% url 'Set up your project to record' projects-dashboard#Set-up-a-Project-to-Record %}
+1. {% url 'Set up your project to record' projects-dashboard#Set-up-a-project-to-record %}
 2. {% url 'Pass the `--record` flag to `cypress run`' command-line#cypress-run %}
 
 You can {% url 'read more about the Dashboard here' features-dashboard %}.

--- a/source/guides/references/configuration.md
+++ b/source/guides/references/configuration.md
@@ -3,7 +3,7 @@ title: Configuration
 comments: false
 ---
 
-When a project is added to Cypress, a `cypress.json` file is created in the project. This file is used to store the `projectId` ({% url 'after configuring your tests to record' projects-dashboard#Set-up-a-Project-to-Record %}) and any configuration values you supply.
+When a project is added to Cypress, a `cypress.json` file is created in the project. This file is used to store the `projectId` ({% url 'after configuring your tests to record' projects-dashboard#Set-up-a-project-to-record %}) and any configuration values you supply.
 
 ```json
 {


### PR DESCRIPTION
- add gif of entire setup
- clean up steps to set up
- merge recording and ‘setting up to record’ into one workflow
- titleize headings
- replace ‘Desktop GUI’ wording with ‘Test Runner’