### PR TITLE
Update continuous-integration.md

### DIFF
--- a/source/guides/guides/continuous-integration.md
+++ b/source/guides/guides/continuous-integration.md
@@ -83,7 +83,7 @@ Here are a few CI example repositories using our Docker images
 If you are not using one of the above CI providers then make sure your system has these dependencies installed.
 
 ```shell
-apt-get install xvfb libgtk2.0-0 libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2
+apt-get install xvfb libgtk2.0-0 libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 x264
 ```
 
 # Recording Tests in CI


### PR DESCRIPTION
We were missing x264 from our testing environment and that caused Cypress to hang at processing the video

<!--
Thanks for contributing!

Please explain what changes were made and also
reference any issues that were fixed with #[ISSUE]
-->
