### PR TITLE
Installing Cypress  guide improvment

### DIFF
--- a/source/guides/getting-started/installing-cypress.md
+++ b/source/guides/getting-started/installing-cypress.md
@@ -39,11 +39,12 @@ This will install Cypress locally as a dev dependency for your project.
 {% img /img/guides/installing-cli.gif %}
 
 {% note info %}
-Notice that the Cypress `npm` package is a wrapper around the Cypress binary. The binary downloaded by the `npm` package is the same as the binary downloaded directly as explained below.
+Notice that the Cypress `npm` package is a wrapper around the Cypress binary. The version of the `npm` package determines the version of the binary downloaded.
 {% endnote %}
 
-{% note success %}
-{% fa fa-check-circle %} **Best Practice:** The recommended approach is to install Cypress with `npm` because :
+{% note success Best Practice %}
+
+The recommended approach is to install Cypress with `npm` because :
 
 - Cypress is versioned like any other dependency.
 - It simplifies running Cypress in {% url 'Continuous Integration' continuous-integration %}.
@@ -53,23 +54,11 @@ Notice that the Cypress `npm` package is a wrapper around the Cypress binary. Th
 
 If you're not using `node` or `npm` in your project or you just want to try Cypress out quickly, you can always {% url "download Cypress directly from our CDN" http://download.cypress.io/desktop %}.
 
-It will download the latest available version. Your platform will be detected automatically.
+The direct download will always grab the latest available version. Your platform will be detected automatically.
 
 Just manually unzip and double click. Cypress will run without needing to install any dependencies.
 
 {% img /img/guides/installing-global.gif %}
-
-## {% fa fa-cloud-download %} CDN Structure
-
-If you want to download a specific Cypress version for a given platform, you can get it from our CDN.
-
-The url pattern is `https://cdn.cypress.io/desktop/<version>/<platform>/cypress.zip` where :
-- `<version>` is the wanted Cypress version number.
-- `<plaform>` is the wanted platform string identifier which could be `osx64`, `win64` or `linux64`.
-
-Example : 
-
-`https://cdn.cypress.io/desktop/1.0.1/win64/cypress.zip` will download Cypress `1.0.1` for Windows plaftorm.
 
 ## {% fa fa-refresh %} Continuous Integration
 
@@ -133,6 +122,8 @@ You can {% url 'read more about the CLI here' command-line %}.
 
 # Advanced
 
+## Environment Variables
+
 Using an environment variable you can control how Cypress is installed.
 
 This is helpful if you want to:
@@ -165,6 +156,30 @@ To override what is installed, you simply set `CYPRESS_BINARY_VERSION` with the 
 
 In all cases, the fact that the binary was installed from a custom location *is not saved* in your `package.json` file. Every repeated installation would have to use the same environment variable to install the same binary.
 
-{% note warning %}
-If you have set an URL or a path to the `CYPRESS_BINARY_VERSION` environment variable, you will always get a warning message before tests execution. It is normal as the Cypress CLI cannot match the binary version with the `npm` package version. 
+{% note warning Note %}
+Setting the `CYPRESS_BINARY_VERSION` to a URL or local path will always display a warning message when opening. This is normal as the Cypress CLI cannot match the binary version with the `npm` package version.
 {% endnote %}
+
+## Hosting
+
+If you want to download a specific Cypress version for a given platform, you can get it from our CDN.
+
+You may want to do this if you want to host Cypress yourself and serve it from a local network.
+
+The download server url is `https://download.cypress.io`.
+
+ Method | Url | Description
+ ------ | --- | -----------
+`GET` | `/desktop                 `  | Download latest desktop app
+`GET` | `/desktop?platform=p      `  | downloads latest desktop app for specific platform
+`GET` | `/desktop.json            `  | returns desktop manifest.json
+`GET` | `/desktop/:version`          | downloads desktop app by version
+`GET` | `/desktop/:version?platform=p`    | downloads desktop app by OS which could be `darwin`, `win32` or `linux64`
+
+{% note info "Example:" %}
+`https://download.cypress.io/desktop/1.0.1?platform=win32`
+
+This will download Cypress `1.0.1` for Windows platform.
+{% endnote %}
+
+If you don't provide a platform, it will be detected automatically.

--- a/source/guides/getting-started/installing-cypress.md
+++ b/source/guides/getting-started/installing-cypress.md
@@ -34,20 +34,42 @@ cd /your/project/path
 npm install cypress --save-dev
 ```
 
-This will install Cypress locally as a dev dependency for your project. We recommend this approach because:
-
-- Cypress is versioned like any other dependency.
-- It simplifies running Cypress in {% url 'Continuous Integration' continuous-integration %}.
+This will install Cypress locally as a dev dependency for your project.
 
 {% img /img/guides/installing-cli.gif %}
 
+{% note info %}
+Notice that the Cypress `npm` package is a wrapper around the Cypress binary. The binary downloaded by the `npm` package is the same as the binary downloaded directly as explained below.
+{% endnote %}
+
+{% note success %}
+{% fa fa-check-circle %} **Best Practice:** The recommended approach is to install Cypress with `npm` because :
+
+- Cypress is versioned like any other dependency.
+- It simplifies running Cypress in {% url 'Continuous Integration' continuous-integration %}.
+{% endnote %}
+
 ## {% fa fa-download %} Direct Download
 
-If you're not using `node` or `npm` in your project or you just want to try Cypress out quickly, you can always {% url "download Cypress directly here" http://download.cypress.io/desktop %}.
+If you're not using `node` or `npm` in your project or you just want to try Cypress out quickly, you can always {% url "download Cypress directly from our CDN" http://download.cypress.io/desktop %}.
+
+It will download the latest available version. Your platform will be detected automatically.
 
 Just manually unzip and double click. Cypress will run without needing to install any dependencies.
 
 {% img /img/guides/installing-global.gif %}
+
+## {% fa fa-cloud-download %} CDN Structure
+
+If you want to download a specific Cypress version for a given platform, you can get it from our CDN.
+
+The url pattern is `https://cdn.cypress.io/desktop/<version>/<platform>/cypress.zip` where :
+- `<version>` is the wanted Cypress version number.
+- `<plaform>` is the wanted platform string identifier which could be `osx64`, `win64` or `linux64`.
+
+Example : 
+
+`https://cdn.cypress.io/desktop/1.0.1/win64/cypress.zip` will download Cypress `1.0.1` for Windows plaftorm.
 
 ## {% fa fa-refresh %} Continuous Integration
 
@@ -142,3 +164,7 @@ To override what is installed, you simply set `CYPRESS_BINARY_VERSION` with the 
     ```
 
 In all cases, the fact that the binary was installed from a custom location *is not saved* in your `package.json` file. Every repeated installation would have to use the same environment variable to install the same binary.
+
+{% note warning %}
+If you have set an URL or a path to the `CYPRESS_BINARY_VERSION` environment variable, you will always get a warning message before tests execution. It is normal as the Cypress CLI cannot match the binary version with the `npm` package version. 
+{% endnote %}


### PR DESCRIPTION
closes #200, closes #218 and closes cypress-io/cypress#866

* npm install section clarification

- what is the npm package
- best practice highlighted

* direct download section precisions

- what is exactly downloaded as the user didn't knew it exactly

* new CDN Structure section

- CDN url pattern
- it give to the user enough informations to download Cypress in the wanted
version for the wanted platform (could download a linux Cypress version from
a windows workstation)
- example

* Advanced section

- warning added about CLI output when running cypress
