### PR TITLE
Develop

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,8 @@ open a pull request from your repo to the `cypress-io/cypress-documentation` rep
 
 - The pull request should be from your repository to the `develop` branch in `cypress-io/cypress-documentation`
 - When opening a PR for a specific issue already open, please use the `address #[issue number]` or `closes #[issue number]` syntax in the pull request description.
+- Please check the "Allow edits from maintainers" checkbox when submitting your PR. This will make it easier for the maintainers to make minor adjustments, to help with tests or any other changes we may need.
+![Allow edits from maintainers checkbox](https://user-images.githubusercontent.com/1271181/31393427-b3105d44-ada9-11e7-80f2-0dac51e3919e.png)
 
 ### Contributor License Agreement
 

--- a/source/guides/getting-started/installing-cypress.md
+++ b/source/guides/getting-started/installing-cypress.md
@@ -34,16 +34,27 @@ cd /your/project/path
 npm install cypress --save-dev
 ```
 
-This will install Cypress locally as a dev dependency for your project. We recommend this approach because:
-
-- Cypress is versioned like any other dependency.
-- It simplifies running Cypress in {% url 'Continuous Integration' continuous-integration %}.
+This will install Cypress locally as a dev dependency for your project.
 
 {% img /img/guides/installing-cli.gif %}
 
+{% note info %}
+Notice that the Cypress `npm` package is a wrapper around the Cypress binary. The version of the `npm` package determines the version of the binary downloaded.
+{% endnote %}
+
+{% note success Best Practice %}
+
+The recommended approach is to install Cypress with `npm` because :
+
+- Cypress is versioned like any other dependency.
+- It simplifies running Cypress in {% url 'Continuous Integration' continuous-integration %}.
+{% endnote %}
+
 ## {% fa fa-download %} Direct Download
 
-If you're not using `node` or `npm` in your project or you just want to try Cypress out quickly, you can always {% url "download Cypress directly here" http://download.cypress.io/desktop %}.
+If you're not using `node` or `npm` in your project or you just want to try Cypress out quickly, you can always {% url "download Cypress directly from our CDN" http://download.cypress.io/desktop %}.
+
+The direct download will always grab the latest available version. Your platform will be detected automatically.
 
 Just manually unzip and double click. Cypress will run without needing to install any dependencies.
 
@@ -111,6 +122,8 @@ You can {% url 'read more about the CLI here' command-line %}.
 
 # Advanced
 
+## Environment Variables
+
 Using an environment variable you can control how Cypress is installed.
 
 This is helpful if you want to:
@@ -142,3 +155,31 @@ To override what is installed, you simply set `CYPRESS_BINARY_VERSION` with the 
     ```
 
 In all cases, the fact that the binary was installed from a custom location *is not saved* in your `package.json` file. Every repeated installation would have to use the same environment variable to install the same binary.
+
+{% note warning Note %}
+Setting the `CYPRESS_BINARY_VERSION` to a URL or local path will always display a warning message when opening. This is normal as the Cypress CLI cannot match the binary version with the `npm` package version.
+{% endnote %}
+
+## Hosting
+
+If you want to download a specific Cypress version for a given platform, you can get it from our CDN.
+
+You may want to do this if you want to host Cypress yourself and serve it from a local network.
+
+The download server url is `https://download.cypress.io`.
+
+ Method | Url | Description
+ ------ | --- | -----------
+`GET` | `/desktop                 `  | Download latest desktop app
+`GET` | `/desktop?platform=p      `  | downloads latest desktop app for specific platform
+`GET` | `/desktop.json            `  | returns desktop manifest.json
+`GET` | `/desktop/:version`          | downloads desktop app by version
+`GET` | `/desktop/:version?platform=p`    | downloads desktop app by OS which could be `darwin`, `win32` or `linux64`
+
+{% note info "Example:" %}
+`https://download.cypress.io/desktop/1.0.1?platform=win32`
+
+This will download Cypress `1.0.1` for Windows platform.
+{% endnote %}
+
+If you don't provide a platform, it will be detected automatically.

--- a/source/guides/getting-started/writing-your-first-test.md
+++ b/source/guides/getting-started/writing-your-first-test.md
@@ -356,7 +356,7 @@ There is also a new menu panel. Some commands (like action commands) will take m
 
 The **before** snapshot is taken prior to the click event firing. The **after** snapshot is taken immediately after the click event. Although this click event caused our browser to load a new page, it's not an instantaneous transition. Depending on how fast your page loaded, you may see still see the same page, or a blank screen as the page is unloading and in transition.
 
-When a command causes an immediate visual change in our application, Cycling between before and after will update our snapshot. We can see this in action by clicking the `TYPE` command in the Command Log. Now, clicking **before** will show us the input in a default state, showing the placeholder text. Click **after** will show us what the input looks like when the `TYPE` command has completed.
+When a command causes an immediate visual change in our application, cycling between before and after will update our snapshot. We can see this in action by clicking the `TYPE` command in the Command Log. Now, clicking **before** will show us the input in a default state, showing the placeholder text. Click **after** will show us what the input looks like when the `TYPE` command has completed.
 
 ## Page Events
 


### PR DESCRIPTION
* Installing Cypress  guide improvment

closes #200, closes #218 and closes cypress-io/cypress#866

* npm install section clarification

- what is the npm package
- best practice highlighted

* direct download section precisions

- what is exactly downloaded as the user didn't knew it exactly

* new CDN Structure section

- CDN url pattern
- it give to the user enough informations to download Cypress in the wanted
version for the wanted platform (could download a linux Cypress version from
a windows workstation)
- example

* Advanced section

- warning added about CLI output when running cypress

* updates to new advanced instructions

- Some wording changes
- Moved CDN section into section called ‘Hosting’ within the Advanced
install instructions.
- Added the download table (we only want to expose our
download.cypress.io endpoint, not the cdn directly)
- update platforms to correct os names.

- Fix capitalization of Cycling