### PR TITLE
Search background in safari

### DIFF
--- a/themes/cypress/source/css/_partial/search.scss
+++ b/themes/cypress/source/css/_partial/search.scss
@@ -30,8 +30,6 @@
   color: $white;
   outline: none;
   border: 0;
-  -webkit-appearance: textfield;
-  background-color: $color-background !important;
 }
 
 .searchbox {

--- a/themes/cypress/source/css/_partial/search.scss
+++ b/themes/cypress/source/css/_partial/search.scss
@@ -30,6 +30,8 @@
   color: $white;
   outline: none;
   border: 0;
+  -webkit-appearance: textfield;
+  background-color: $color-background !important;
 }
 
 .searchbox {


### PR DESCRIPTION
**Issue**
In Safari, the search input field is white.  Since the text color of the search field is also white, the user cannot see the search string being entered.

**Fix**
To overcome default webkit search field styling, change the appearance property to be a textfield and then applied the same background color as the header.
