### PR TITLE
Fixture API doc to reflect cypress PR 924

### DIFF
--- a/source/api/commands/fixture.md
+++ b/source/api/commands/fixture.md
@@ -187,9 +187,9 @@ cy.route('GET', '/users/**', 'fx:users')      // this also works
 
 ## Validation
 
-***Validation and Formatting***
+***Automated File Validation***
 
-Cypress automatically validates and formats your fixtures. If your `.json`, `.js`, or `.coffee` files contain syntax errors, they will be shown in the Command Log.
+Cypress automatically validates your fixtures. If your `.json`, `.js`, or `.coffee` files contain syntax errors, they will be shown in the Command Log.
 
 ## Encoding
 


### PR DESCRIPTION
Fixture API doc to reflect https://github.com/cypress-io/cypress/pull/924 behavior change (stop formatting and saving fixtures)

Should be merged only after PR review.
