### PR TITLE
Add window.prompt stubbing example to api section

### DIFF
--- a/source/api/commands/stub.md
+++ b/source/api/commands/stub.md
@@ -97,6 +97,21 @@ App.stop()
 expect(removeStub).to.be.called
 ```
 
+***Replace built-in window methods like prompt***
+```javascript
+// assume App.start uses prompt to set the value of an element with class "name"
+cy.visit('http://localhost:3000', {
+    onBeforeLoad(win) {
+        cy.stub(win, 'prompt').returns('my custom message');
+    }
+});
+
+App.start();
+
+cy.window().its('prompt').should('be.called');
+cy.get('.name').should('have.value', 'my custom message');
+```
+
 ***Using cy.stub***
 
 {% note info %}

--- a/source/api/commands/stub.md
+++ b/source/api/commands/stub.md
@@ -102,14 +102,14 @@ expect(removeStub).to.be.called
 // assume App.start uses prompt to set the value of an element with class "name"
 cy.visit('http://localhost:3000', {
     onBeforeLoad(win) {
-        cy.stub(win, 'prompt').returns('my custom message');
+        cy.stub(win, 'prompt').returns('my custom message')
     }
-});
+})
 
-App.start();
+App.start()
 
-cy.window().its('prompt').should('be.called');
-cy.get('.name').should('have.value', 'my custom message');
+cy.window().its('prompt').should('be.called')
+cy.get('.name').should('have.value', 'my custom message')
 ```
 
 ***Using cy.stub***


### PR DESCRIPTION
This addresses #193. I followed the pattern of the "Stubbing window.fetch" example recipe to make the change before the app runs.

Also, thank you folks for being friendly to new contributors. The "first-timers-only" label of this issue is what made the difference for me between starting 24 pull requests or not.