### PR TITLE
Missing comma in login parent command example

### DIFF
--- a/source/api/cypress-api/custom-commands.md
+++ b/source/api/cypress-api/custom-commands.md
@@ -85,7 +85,7 @@ Cypress.Commands.add('login', function(userType, options = {}) {
     admin: {
       name: 'Jane Lane',
       admin: true,
-    }
+    },
     user: {
       name: 'Jim Bob',
       admin: false,


### PR DESCRIPTION
<!--
Thanks for contributing!

Please explain what changes were made and also
reference any issues that were fixed with #[ISSUE]
-->

Title says it all I think.