### PR TITLE
Reference recommendation not to use after(Each)

### DIFF
--- a/source/guides/core-concepts/writing-and-organizing-tests.md
+++ b/source/guides/core-concepts/writing-and-organizing-tests.md
@@ -174,7 +174,7 @@ describe('Hooks', function() {
 - All `after()` hooks run (once)
 
 {% note danger %}
-{% fa fa-warning %} Before writing `after()` or `afterEach()` hooks, please see our [thoughts on the anti-pattern of cleaning up state with `after()` or `afterEach()`](https://docs.cypress.io/guides/references/best-practices.html#Using-after-or-afterEach-hooks).
+{% fa fa-warning %} Before writing `after()` or `afterEach()` hooks, please see our {% url "thoughts on the anti-pattern of cleaning up state with `after()` or `afterEach()`" https://on.cypress.io/best-practices#Using-after-or-afterEach-hooks %}.
 {% endnote %}
 
 ## Excluding and Including Tests

--- a/source/guides/core-concepts/writing-and-organizing-tests.md
+++ b/source/guides/core-concepts/writing-and-organizing-tests.md
@@ -173,6 +173,10 @@ describe('Hooks', function() {
 - Any `afterEach()` hooks run
 - All `after()` hooks run (once)
 
+{% note danger %}
+{% fa fa-warning %} Before writing `after()` or `afterEach()` hooks, please see our [thoughts on the anti-pattern of cleaning up state with `after()` or `afterEach()`](https://docs.cypress.io/guides/references/best-practices.html#Using-after-or-afterEach-hooks).
+{% endnote %}
+
 ## Excluding and Including Tests
 
 To run a specified suite or test, simply append `.only()` to the function. All nested suites will also be executed.

--- a/source/guides/core-concepts/writing-and-organizing-tests.md
+++ b/source/guides/core-concepts/writing-and-organizing-tests.md
@@ -174,7 +174,7 @@ describe('Hooks', function() {
 - All `after()` hooks run (once)
 
 {% note danger %}
-{% fa fa-warning %} Before writing `after()` or `afterEach()` hooks, please see our {% url "thoughts on the anti-pattern of cleaning up state with `after()` or `afterEach()`" https://on.cypress.io/best-practices#Using-after-or-afterEach-hooks %}.
+{% fa fa-warning %} Before writing `after()` or `afterEach()` hooks, please see our {% url "thoughts on the anti-pattern of cleaning up state with `after()` or `afterEach()`" best-practices#Using-after-or-afterEach-hooks %}.
 {% endnote %}
 
 ## Excluding and Including Tests


### PR DESCRIPTION
Link to the recommendation not to use the anti-pattern of cleaning up state with after()/afterEach()
