### PR TITLE
Update preprocessor descriptions to specify they watch files

### DIFF
--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -1,17 +1,17 @@
 - name: Preprocessors
   plugins:
     - name: Browserify
-      description: For bundling JavaScript via browserify. This is the default preprocessor that's built into Cypress.
+      description: Watches and bundles your spec files via browserify. This is the default preprocessor that's built into Cypress.
       link: https://github.com/cypress-io/cypress-browserify-preprocessor
       keywords: [browserify]
 
     - name: Webpack
-      description: For bundling JavaScript via webpack.
+      description: Watches and bundles your spec files via webpack.
       link: https://github.com/cypress-io/cypress-webpack-preprocessor
       keywords: [webpack]
 
     - name: Watch
-      description: Simple preprocessor that only watches files. Useful as an example reference.
+      description: Watches your spec files and serves them as-is. Useful as an example reference or if you don't need transpiling/bundling.
       link: https://github.com/cypress-io/cypress-watch-preprocessor
       keywords: [file-watcher]
 


### PR DESCRIPTION
Some users might be misled to believe they need the `watch` preprocessor for Cypress to watch their files. This makes it clearer that the `browserify` and `webpack` preprocessors watch your spec files as well as bundle them.