### PR TITLE
Update command link

### DIFF
--- a/source/guides/core-concepts/introduction-to-cypress.md
+++ b/source/guides/core-concepts/introduction-to-cypress.md
@@ -656,7 +656,7 @@ Many commands have a default, built-in assertion, or rather have requirements th
 
 - {% url `cy.visit()` visit %} expects the page to send `text/html` content with a `200` status code.
 - {% url `cy.request()` request %} expects the remote server to exist and provide a response.
-- {% url `cy.contains()` get %} expects the element with content to eventually exist in the DOM.
+- {% url `cy.contains()` contains %} expects the element with content to eventually exist in the DOM.
 - {% url `cy.get()` get %} expects the element to eventually exist in the DOM.
 - {% url `.find()` find %} also expects the element to eventually exist in the DOM.
 - {% url `.type()` type %} expects the element to eventually be in a *typeable* state.


### PR DESCRIPTION
Just a quick link update, `contains` method heads to `get` in the **Default-Assertions** https://docs.cypress.io/guides/core-concepts/introduction-to-cypress.html#Default-Assertions
