### PR TITLE
Remove wording that command.js is loaded automatically

### DIFF
--- a/source/api/cypress-api/custom-commands.md
+++ b/source/api/cypress-api/custom-commands.md
@@ -6,7 +6,7 @@ comments: false
 Cypress comes with its own API for creating custom commands and overwriting existing commands. The built in Cypress commands use the very same API that's defined below.
 
 {% note info  %}
-A great place to define or overwrite commands is in your `cypress/support/commands.js` file, since it is loaded before any test files are evaluated.
+A great place to define or overwrite commands is in your `cypress/support/commands.js` file.  An easy way to import commands.js for your tests is to un-comment the line that is provided for this purpose in index.js.
 {% endnote %}
 
 # Syntax

--- a/source/api/cypress-api/custom-commands.md
+++ b/source/api/cypress-api/custom-commands.md
@@ -6,7 +6,7 @@ comments: false
 Cypress comes with its own API for creating custom commands and overwriting existing commands. The built in Cypress commands use the very same API that's defined below.
 
 {% note info  %}
-A great place to define or overwrite commands is in your `cypress/support/commands.js` file.  An easy way to import commands.js for your tests is to un-comment the line that is provided for this purpose in index.js.
+A great place to define or overwrite commands is in your `cypress/support/commands.js` file, since it is loaded before any test files are evaluated via an import statement in cypress/support/index.js.
 {% endnote %}
 
 # Syntax


### PR DESCRIPTION
Include statement to un-comment line in index.js in order to import command.js.
Reference:  https://stackoverflow.com/questions/47695535/cypress-custom-command-is-not-recognized-when-invoked/47707642#47707642
