### PR TITLE
update to include Windows debugging

### DIFF
--- a/source/guides/guides/command-line.md
+++ b/source/guides/guides/command-line.md
@@ -325,12 +325,17 @@ Cypress is built using the {% url 'debug' https://github.com/visionmedia/debug %
 
 **To see all Cypress modules debug output**
 
+### On macOS or Linux
 ```shell
 DEBUG=cypress:* cypress open
 ```
 
 ```shell
 DEBUG=cypress:* cypress run
+```
+### On Windows
+```
+set DEBUG=cypress:*
 ```
 
 Cypress is a rather large and complex project involving a dozen or more submodules, and the default output is overwhelming.

--- a/source/guides/guides/command-line.md
+++ b/source/guides/guides/command-line.md
@@ -336,6 +336,12 @@ DEBUG=cypress:* cypress run
 ### On Windows
 ```
 set DEBUG=cypress:*
+cypress open
+```
+
+```
+set DEBUG=cypress:*
+cypress run
 ```
 
 Cypress is a rather large and complex project involving a dozen or more submodules, and the default output is overwhelming.


### PR DESCRIPTION
To enable Windows debugging, you have to set the environment variable differently. Improved documentation for Cypress (and instead of relying on looking at visionmedia/debug) will be helpful.
