### PR TITLE
Improve docs continuous integration using Circleci

### DIFF
--- a/source/guides/guides/continuous-integration.md
+++ b/source/guides/guides/continuous-integration.md
@@ -79,7 +79,7 @@ dependencies:
     - npm install
 test:
   override:
-    - $(npm bin)/cypress run --record
+    - $(npm bin)/cypress run --record --key <record_key>
 ```
 
 ***Example `circle.yml` v2 config file***
@@ -97,7 +97,7 @@ jobs:
     steps:
       - checkout
       - run: npm install
-      - run: $(npm bin)/cypress run --record
+      - run: $(npm bin)/cypress run --record --key <record_key>
 ```
 
 Find the complete CircleCI v2 example with caching and artifact upload in [cypress-example-docker-circle](https://github.com/cypress-io/cypress-example-docker-circle) repo.


### PR DESCRIPTION
### What is new on this PR?
Since i get this issue in circleci
```

+
TEST
Spin up Environment00:01
Checkout code00:00
npm install02:17
$(npm bin)/cypress run --record00:09
Exit code: 1
#!/bin/bash -eo pipefail
$(npm bin)/cypress run --record
npm info it worked if it ends with ok
npm info using npm@3.10.10
npm info using node@v6.11.1
npm info ok 
It looks like this is your first time using Cypress: 1.4.2

[01:25:47]  Verifying Cypress can run /var/www/node_modules/cypress/dist/Cypress [started]
[01:25:49]  Verifying Cypress can run /var/www/node_modules/cypress/dist/Cypress [completed]

Opening Cypress...
You passed the --record flag but did not provide us your Record Key.

You can pass us your Record Key like this:

  cypress run --record --key <record_key>

You can also set the key as an environment variable with the name CYPRESS_RECORD_KEY.

https://on.cypress.io/how-do-i-record-runs
Exited with code 1
```

I think it's better to adding `--key <record_key>` in the docs 