### PR TITLE
Fix 2.0.0 release date year

### DIFF
--- a/source/guides/references/changelog.md
+++ b/source/guides/references/changelog.md
@@ -5,7 +5,7 @@ comments: false
 
 ## 2.0.0
 
-*Released 2/15/2017*
+*Released 2/15/2018*
 
 **Breaking Changes:**
 


### PR DESCRIPTION
This seems to be a pattern, considering https://github.com/cypress-io/cypress-documentation/pull/411/commits/2515ede39198fcfd59e179ab3ea9b0d1aec906de 😂