### PR TITLE
Warning about cypress.env.json not being watched

### DIFF
--- a/source/guides/guides/environment-variables.md
+++ b/source/guides/guides/environment-variables.md
@@ -109,6 +109,10 @@ Cypress.env("host")       // "veronica.dev.local"
 Cypress.env("api_server") // "http://localhost:8888/api/v1/"
 ```
 
+{% note warning %}
+Creating or changing contents of this file while Cypress is open won't notice the change. You have to restart whole Test runner to be able to use variables set in this file.
+{% endnote %}
+
 ***Overview***
 
 {% note success Benefits %}


### PR DESCRIPTION
Unless I did something wrong on my side, but simply when I created the `cypress.env.json`, it wasn't read. Closing browser with test did not help. I had to exit whole Test runner and then it worked. Also changing values in existing file won't be noticed.