### PR TITLE
Add clarity to first example of Without Stubbing

### DIFF
--- a/source/api/commands/route.md
+++ b/source/api/commands/route.md
@@ -75,7 +75,7 @@ You can also set options for all {% url `cy.wait()` wait %}'s `requestTimeout` a
 
 If you do not pass a `response` to a route, Cypress will pass the request through without stubbing it. We can still wait for the request to resolve later.
 
-***Wait on XHR request matching `url`***
+***Wait on XHR `GET` request matching `url`***
 
 ```javascript
 cy.server()


### PR DESCRIPTION
This example made me think that the Method was ignored when matching the URL.

cypress-io/cypress#1471