### PR TITLE
Added long-press event example to trigger.md

### DIFF
--- a/source/api/commands/trigger.md
+++ b/source/api/commands/trigger.md
@@ -22,6 +22,10 @@ Trigger an event on a DOM element.
 
 ```javascript
 cy.get('a').trigger('mousedown') // Trigger mousedown event on link
+
+cy.get(`selector`).trigger('mousedown')  // Longpress event, trigger mousedown
+cy.wait(1000) // Longpress event, wait 1000 ms (1 second)
+cy.get(`selector`).trigger('mouseleave') // Longpress event, trigger mouseleave
 ```
 
 **{% fa fa-exclamation-triangle red %} Incorrect Usage**


### PR DESCRIPTION
<!--
Thanks for contributing!

Please explain what changes were made and also
reference any issues that were fixed with #[ISSUE]
-->
Issue #501. Documented long-press event by adding an example to cypress-documentation/source/api/commands/_trigger.md.