### PR TITLE
Include searchable keywords 'nth', 'row'

### DIFF
--- a/source/api/commands/eq.md
+++ b/source/api/commands/eq.md
@@ -76,26 +76,6 @@ Option | Default | Description
 ```javascript
 cy.get('li').eq(1).should('contain', 'siamese') // true
 ```
-
-## Index Form End
-
-***Find the 2nd from the last element within the elements***
-
-```html
-<ul>
-  <li>tabby</li>
-  <li>siamese</li>
-  <li>persian</li>
-  <li>sphynx</li>
-  <li>burmese</li>
-</ul>
-```
-
-```javascript
-cy.get('li').eq(-2).should('contain', 'sphynx') // true
-```
-## Table Data
-
 ***Make an assertion on the 2nd row of a table***
 
 ```html
@@ -118,8 +98,26 @@ cy.get('li').eq(-2).should('contain', 'sphynx') // true
 </table>
 ```
 
-```js
+```javascript
 cy.get('tr').eq(2).should('contain', 'Canada')  //true
+```
+
+## Index Form End
+
+***Find the 2nd from the last element within the elements***
+
+```html
+<ul>
+  <li>tabby</li>
+  <li>siamese</li>
+  <li>persian</li>
+  <li>sphynx</li>
+  <li>burmese</li>
+</ul>
+```
+
+```javascript
+cy.get('li').eq(-2).should('contain', 'sphynx') // true
 ```
 
 # Rules

--- a/source/api/commands/eq.md
+++ b/source/api/commands/eq.md
@@ -6,7 +6,7 @@ comments: false
 Get A DOM element at a specific index in an array of elements.
 
 {% note info %}
-The querying behavior of this command matches exactly how {% url `.eq()` http://api.jquery.com/eq %} works in jQuery.
+The querying behavior of this command matches exactly how {% url `.eq()` http://api.jquery.com/eq %} works in jQuery. Its behavior is also similar to that of the CSS pseudo-class {% url `:nth-child()` https://api.jquery.com/nth-child-selector/ %} selector. 
 {% endnote %}
 
 # Syntax
@@ -93,6 +93,33 @@ cy.get('li').eq(1).should('contain', 'siamese') // true
 
 ```javascript
 cy.get('li').eq(-2).should('contain', 'sphynx') // true
+```
+## Table Data
+
+***Make an assertion on the 2nd row of a table***
+
+```html
+<table>
+  <tr>
+    <th>Breed</th>
+    <th>Origin</th>
+  </tr>
+  <tr>
+    <td>Siamese</td>
+    <td>Thailand</td>
+  </tr>
+  <tr>
+    <td>Sphynx</td>
+    <td>Canada</td>
+  </tr>
+  <tr>
+    <td>Persian</td>
+    <td>Iran</td>
+</table>
+```
+
+```js
+cy.get('tr').eq(2).should('contain', 'Canada')  //true
 ```
 
 # Rules

--- a/source/api/commands/eq.md
+++ b/source/api/commands/eq.md
@@ -102,7 +102,7 @@ cy.get('li').eq(1).should('contain', 'siamese') // true
 cy.get('tr').eq(2).should('contain', 'Canada')  //true
 ```
 
-## Index Form End
+## Index From End
 
 ***Find the 2nd from the last element within the elements***
 


### PR DESCRIPTION
Add searchable keywords nth and row to .eq doc

<!--
This is just a first draft. 
I feel like the nth child stuff belongs in the info box up top
But—
I'm not feeling super confident about the language or location of the row example. 
Should it go here? Should it be titled something else? 
Should the descriptor be something else? Does this even satisfy issue 522?
i.e. 
* "Find text from the 2nd row of a table"
* "Make an assertion on the 2nd row of a table"
* "Assert the 2nd row of a table contains my text" 
closes #522 
-->
