### PR TITLE
add jQuery UI Sortable WIP

### DIFF
--- a/source/api/commands/trigger.md
+++ b/source/api/commands/trigger.md
@@ -95,6 +95,8 @@ cy.get('.target').trigger('mouseleave')
 {% url 'Check out our example recipe triggering mouse and drag events to test dragging and dropping' recipes#Drag-and-Drop %}
 {% endnote %}
 
+#### jQuery UI Sortable ??
+
 ## Change Event
 
 ### Interact with a range input (slider)

--- a/source/api/commands/trigger.md
+++ b/source/api/commands/trigger.md
@@ -88,14 +88,22 @@ cy.get('.target').trigger('mousedown')
 cy.wait(1000)
 cy.get('.target').trigger('mouseleave')
 ```
+### jQuery UI Sortable 
+
+To simulate drag and drop using jQuery UI sortable requires `pageX` and `pageY` properties along with `which:1`.     
+
+```javascript
+cy.get('[data-cy=draggable]')
+  .trigger('mousedown', { which: 1, pageX: 600, pageY: 100 })
+  .trigger('mousemove', { which: 1, pageX: 600, pageY: 600 })
+  .trigger('mouseup')
+```
 
 ### Drag and Drop
 
 {% note info %}
 {% url 'Check out our example recipe triggering mouse and drag events to test dragging and dropping' recipes#Drag-and-Drop %}
 {% endnote %}
-
-#### jQuery UI Sortable ??
 
 ## Change Event
 


### PR DESCRIPTION
Looking for best place to land jQuery UI sortable example

The only place I can see in the `.tirgger` docs to add this is under the existing Drag and Drop header, however, we link to a recipe and I'm worried about uniformity in the doc. 
Would it be out of place to throw in an example here or would it be okay? 

<!--
Thanks for contributing!

closes #518
-->
