### PR TITLE
[Typo] Fix syntax error in Usage example for Custom Commands page

### DIFF
--- a/source/api/cypress-api/custom-commands.md
+++ b/source/api/cypress-api/custom-commands.md
@@ -176,7 +176,7 @@ Cypress.Commands.add('console', {
 ***Usage***
 
 ```javascript
-cy.get('button').console('info').then($button) => {
+cy.get('button').console('info').then(($button) => {
   // subject is still $button
 })
 ```


### PR DESCRIPTION
I noticed a syntax error on the Custom Commands page, the Custom console command section, the current block states:

```javascript
cy.get('button').console('info').then($button) => {
  // subject is still $button
})
```

It should read:
```javascript
cy.get('button').console('info').then(($button) => {
  // subject is still $button
})
```