### PR TITLE
Update Installing-Cypress.md - intall local

### DIFF
--- a/source/guides/getting-started/installing-cypress.md
+++ b/source/guides/getting-started/installing-cypress.md
@@ -34,7 +34,8 @@ cd /your/project/path
 npm install cypress --save-dev
 ```
 
-This will install Cypress locally as a dev dependency for your project.
+This will install Cypress locally as a dev dependency for your project. 
+Note: Make sure that you have a node_modules folder in your project path first, otherwise cypress will install globally.
 
 {% img /img/guides/installing-cli.gif %}
 


### PR DESCRIPTION
You have to mkdir node_modules before you run the npm cypress install --save-dev if you are using a non-node based project. I ran into this issue as a noob to npm.

<!--
Thanks for contributing!

Please explain what changes were made and also
reference any issues that were fixed with #[ISSUE]
-->
