### PR TITLE
fix typo/rewrite Sauce Labs section to be explicit/add Q to using-cypress faq

### DIFF
--- a/source/faq/questions/general-questions-faq.md
+++ b/source/faq/questions/general-questions-faq.md
@@ -37,7 +37,7 @@ Cypress essentially replaces Karma because it does all of this already and much 
 
 ***Capybara***
 
-The a `Ruby` specific tool that allows you to write integration tests for your web application is {% url "Capybara" http://teamcapybara.github.io/capybara/ %}. In the Rails world, this is the *go-to* tool for testing your application. It uses {% url "Sauce Labs" https://SauceLabs.com/ %} (or another headless driver) to interact with browsers. Its API consists of commands that query for DOM elements, perform user actions, navigate around, etc.
+The `Ruby` specific tool that allows you to write integration tests for your web application is {% url "Capybara" http://teamcapybara.github.io/capybara/ %}. In the Rails world, this is the *go-to* tool for testing your application. It uses {% url "Sauce Labs" https://SauceLabs.com/ %} (or another headless driver) to interact with browsers. Its API consists of commands that query for DOM elements, perform user actions, navigate around, etc.
 
 Cypress essentially replaces Capybara because it does all of these things and much more. The difference is that instead of testing your application in a GUI-less console, you'd see your application at all times. You'd never have to take a screenshot to debug because all commands instantly provide you the state of your application while they run. Upon any command failing, you'll get a human-readable error explaining why it failed. There's no "guessing" when debugging.
 
@@ -57,11 +57,13 @@ Using {% url "Sauce Labs" https://SauceLabs.com/ %} enables Selenium-based tests
 
 Sauce Labs also has a `manual testing` mode, where you can remotely control browsers in the cloud as if they were installed on your machine.
 
-Cypress's API is written to be completely compatible with Sauce Labs, even though our API is not Selenium based at all. We will be offering better integration with Sauce Labs in the future.
-
 Ultimately Sauce Labs and Cypress offer very different value propositions. Sauce Labs doesn't help you write your tests, it takes your existing tests and runs them across different browsers and aggregates the results for you.
 
 Cypress on the other hand **helps** you write your tests. You would use Cypress every day, building and testing your application, and then use Sauce Labs to ensure your application works on every browser.
+
+{% note info A note about Cypress and Sauce Labs %} 
+Cypress's API is written to be completely compatible with Sauce Labs, even though our API is not Selenium based at all. It is our goal to offer full integration with Sauce Labs in the future, however, complete integration is not yet available. 
+{% endnote %}
 
 ## {% fa fa-angle-right %} Do you support X language or X framework?
 

--- a/source/faq/questions/general-questions-faq.md
+++ b/source/faq/questions/general-questions-faq.md
@@ -62,7 +62,7 @@ Ultimately Sauce Labs and Cypress offer very different value propositions. Sauce
 Cypress on the other hand **helps** you write your tests. You would use Cypress every day, building and testing your application, and then use Sauce Labs to ensure your application works on every browser.
 
 {% note info A note about Cypress and Sauce Labs %} 
-Cypress's API is written to be completely compatible for integration with Sauce Labs. It is our goal to offer full integration with Sauce Labs in the future, however, complete integration is not yet available. 
+Cypress' API is written to be completely compatible for integration with Sauce Labs. It is our goal to offer full integration with Sauce Labs in the future, however, complete integration is not yet available. 
 {% endnote %}
 
 ## {% fa fa-angle-right %} Do you support X language or X framework?

--- a/source/faq/questions/general-questions-faq.md
+++ b/source/faq/questions/general-questions-faq.md
@@ -62,7 +62,7 @@ Ultimately Sauce Labs and Cypress offer very different value propositions. Sauce
 Cypress on the other hand **helps** you write your tests. You would use Cypress every day, building and testing your application, and then use Sauce Labs to ensure your application works on every browser.
 
 {% note info A note about Cypress and Sauce Labs %} 
-Cypress's API is written to be completely compatible with Sauce Labs, even though our API is not Selenium based at all. It is our goal to offer full integration with Sauce Labs in the future, however, complete integration is not yet available. 
+Cypress's API is written to be completely compatible for integration with Sauce Labs. It is our goal to offer full integration with Sauce Labs in the future, however, complete integration is not yet available. 
 {% endnote %}
 
 ## {% fa fa-angle-right %} Do you support X language or X framework?

--- a/source/faq/questions/using-cypress-faq.md
+++ b/source/faq/questions/using-cypress-faq.md
@@ -230,6 +230,10 @@ For those wanting to use page objects, we've highlighted the {% url 'best practi
 
 You can read more about parallelization {% issue 64 'here' %}.
 
+## {% fa fa-angle-right %} Is Cypress compatible with Sauce Labs and BrowserStack? 
+
+The answer is *not yet*. Cypress’s API was written to be completely compatible with Sauce Labs, you can read more about that {% url 'here' general-questions-faq %}. Connectivity with BrowserStack is something that has been discussed {% issue 310 'here' %}. 
+
 ## {% fa fa-angle-right %} Can I run a single test or group of tests?
 
 You can run a group of tests or a single test by placing an {% url `.only` writing-and-organizing-tests#Excluding-and-Including-Tests %} on a test suite or specific test.

--- a/source/faq/questions/using-cypress-faq.md
+++ b/source/faq/questions/using-cypress-faq.md
@@ -232,7 +232,7 @@ You can read more about parallelization {% issue 64 'here' %}.
 
 ## {% fa fa-angle-right %} Is Cypress compatible with Sauce Labs and BrowserStack? 
 
-The answer is *not yet*. Cypress’s API was written to be completely compatible with Sauce Labs, you can read more about that {% url 'here' general-questions-faq %}. Connectivity with BrowserStack is something that has been discussed {% issue 310 'here' %}. 
+It is our goal to offer full integration with Sauce Labs and BrowserStack in the future, however, complete integration is not yet available. Cypress’s API was written to be compatible with Webdriver specific tasks that Sauce Labs and BrowserStack use. 
 
 ## {% fa fa-angle-right %} Can I run a single test or group of tests?
 

--- a/source/faq/questions/using-cypress-faq.md
+++ b/source/faq/questions/using-cypress-faq.md
@@ -232,7 +232,7 @@ You can read more about parallelization {% issue 64 'here' %}.
 
 ## {% fa fa-angle-right %} Is Cypress compatible with Sauce Labs and BrowserStack? 
 
-It is our goal to offer full integration with Sauce Labs and BrowserStack in the future, however, complete integration is not yet available. Cypress’s API was written to be compatible with Webdriver specific tasks that Sauce Labs and BrowserStack use. 
+It is our goal to offer full integration with Sauce Labs and BrowserStack in the future, however, complete integration is not yet available. Cypress’ API was written to be compatible with WebDriver specific tasks that Sauce Labs and BrowserStack use. 
 
 ## {% fa fa-angle-right %} Can I run a single test or group of tests?
 

--- a/source/faq/questions/using-cypress-faq.md
+++ b/source/faq/questions/using-cypress-faq.md
@@ -232,7 +232,7 @@ You can read more about parallelization {% issue 64 'here' %}.
 
 ## {% fa fa-angle-right %} Is Cypress compatible with Sauce Labs and BrowserStack? 
 
-It is our goal to offer full integration with Sauce Labs and BrowserStack in the future, however, complete integration is not yet available. Cypress’ API was written to be compatible with WebDriver specific tasks that Sauce Labs and BrowserStack use. 
+Cypress’ API is compatible with WebDriver specific tasks that Sauce Labs and BrowserStack use to launch browsers. Because Cypress currently only supports Chrome* based browsers, we have not yet added integration for these services. When cross browsers are added, Cypress will add full integration with Sauce Labs and BrowserStack.
 
 ## {% fa fa-angle-right %} Can I run a single test or group of tests?
 


### PR DESCRIPTION
Remove article 'a' from Capybara section 
Move statements about Sauce Labs integration to the bottom, wrap in info box, and use explicit language that integration is not currently available.

This would address one half of issue #553, leaving adding a question to Using Cypress FAQ that would answer the question definitively and potentially link to this General Question and/or issue #310 

This request requires feedback. I will leave a comment on the issue requesting it. 

<!--
Thanks for contributing!

Please explain what changes were made and also
reference any issues that were fixed with #[ISSUE]
-->
