### PR TITLE
Append config title to page title or subtitle - replace cypress.io w/ cypress

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,7 @@
 ## Source: https://github.com/hexojs/hexo/
 
 # Site
-title: Cypress.io Documentation
+title: Cypress Documentation
 subtitle: Testing, the way it should be.
 description: Cypress is a test engine that runs unit and integration tests in your browser. It makes it easy to write and debug web application tests.
 author: Cypress.io

--- a/themes/cypress/layout/partial/head.swig
+++ b/themes/cypress/layout/partial/head.swig
@@ -3,7 +3,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <title>{% if page.title %}{{ page.title }}{% else %}{{ config.title }} | {{ config.subtitle }}{% endif %}</title>
+  <title>{% if page.title %}{{ page.title }} | {{ config.title }}{% else %}{{ config.subtitle }} | {{ config.title }}{% endif %}</title>
 
   <!-- Canonical links -->
   <link rel="canonical" href="{{ url }}">


### PR DESCRIPTION
- Convention states we reference ‘cypress.io’ as ‘cypress’ when
participant is already aware of cypress product
- Add Cypress to title for help with bookmarks, etc.
- close #610