### PR TITLE
add html example to .not assertion

### DIFF
--- a/source/api/commands/not.md
+++ b/source/api/commands/not.md
@@ -60,8 +60,18 @@ Option | Default | Description
 
 ***Yield the elements that do not have class `active`.***
 
+```html
+<ul>
+  <li>Home</li>
+  <li class='active'>About</li>
+  <li>Services</li>
+  <li>Pricing</li>
+  <li>Contact</li>
+</ul>
+```
+
 ```javascript
-cy.get('.left-nav>li').not('.active').should('not.have.class', 'active') // true
+cy.get('ul>li').not('.active').should('have.length', 4) // true
 ```
 
 # Rules


### PR DESCRIPTION
Used same html mark up from `filter` doc. Changed assertion to length instead of class, but how do you feel about that? I think it works. I wanted to use `should` and `and` but it felt too lengthy. 
<!--
closes #677 
-->
