### PR TITLE
fix broken link

### DIFF
--- a/source/guides/guides/continuous-integration.md
+++ b/source/guides/guides/continuous-integration.md
@@ -34,7 +34,7 @@ Cypress should run on **all** CI providers. We currently have seen Cypress worki
 - {% url "BuildKite" https://buildkite.com %}
 - {% url "AppVeyor" https://appveyor.com %}
 - {% url "Semaphore" https://semaphoreci.com/ %}
-- {% url "Concourse" https://concourse.ci/ %}
+- {% url 'Concourse' https://concourse.ci/ %}
 - {% url "Solano" https://www.solanolabs.com/ %}
 - {% url "Docker" https://www.docker.com/ %}
 


### PR DESCRIPTION
Fix broken link, maybe?
Strangely enough, my local was broken too, though the formatting was correct. Commenting out and uncommenting out the hexo link updated it on my local. 
I wasn't able to commit a change without altering a line of code, so I used  `'`single quotes`'` to make my commit, but I can't be sure it will fix this broken link since it was _always_ properly formatted. 

<!--
closes #713 


-->

