### PR TITLE
Closes #718 - cy.fixture typo

### DIFF
--- a/source/api/commands/get.md
+++ b/source/api/commands/get.md
@@ -123,7 +123,7 @@ it('disables on click', function () {
 
 ```javascript
 beforeEach(function () {
-  cy.fixtures('users.json').as('users')
+  cy.fixture('users.json').as('users')
 })
 
 it('disables on click', function () {


### PR DESCRIPTION
Replaced `cy.fixtures` with `cy.fixture` (as it should be)
