### PR TITLE
Update should.md (fix docu about yields)

### DIFF
--- a/source/api/commands/should.md
+++ b/source/api/commands/should.md
@@ -71,10 +71,10 @@ However, some chainers change the subject. In the example below, the second `.sh
 
 ```javascript
 cy
-  .get('nav')                       // yields <nav>
-  .should('be.visible')             // yields <nav>
-  .and('have.css', 'font-family')   // yields 'sans-serif'
-  .and('match', /serif/)            // yields 'sans-serif'
+  .get('nav')                          // yields <nav>
+  .should('be.visible')                // yields <nav>
+  .should('have.css', 'font-family')   // yields 'sans-serif'
+  .and('match', /serif/)               // yields 'sans-serif'
 ```
 
 # Examples


### PR DESCRIPTION
First of all: I recently started using Cypress and it already feels like the best solution for tests I have ever tried. Great work!

I stumbled upon something in the documentation of `.should()`:
In the "yields" section about chainers changing the subject the text speaks about a second `.should()` whilst the code example only shows one `.should()` and two usages of `.and()`. Either the code example could be adapted (as in this PR) or alternatively the text could be changed mentioning the usage of `.and()` here.