### PR TITLE
Fix small typo

### DIFF
--- a/source/api/commands/eq.md
+++ b/source/api/commands/eq.md
@@ -76,7 +76,7 @@ Option | Default | Description
 ```javascript
 cy.get('li').eq(1).should('contain', 'siamese') // true
 ```
-***Make an assertion on the 2nd row of a table***
+***Make an assertion on the 3rd row of a table***
 
 ```html
 <table>


### PR DESCRIPTION
#744 

Document example referenced Index 2 of a list which is the 3rd element, not the 2nd element.