### PR TITLE
add Linux 64 bit in system requirements

### DIFF
--- a/source/guides/getting-started/installing-cypress.md
+++ b/source/guides/getting-started/installing-cypress.md
@@ -17,7 +17,7 @@ title: Installing Cypress
 Cypress is a desktop application that is installed on your computer. The desktop application supports these operating systems:
 
 - **Mac OS** 10.9+ (Mavericks+), only 64bit binaries are provided for macOS.
-- **Linux** Ubuntu 12.04+, Fedora 21, Debian 8
+- **Linux** Ubuntu 12.04+, Fedora 21, Debian 8, 64-bit binaries
 - **Windows** 7+, only 32bit binaries are provided for Windows.
 
 # Installing


### PR DESCRIPTION
Add 'Linux 64 bit binaries', in system requirements, so it clarify things.

fix #786   

