### PR TITLE
Fix typos around 'it is'

### DIFF
--- a/source/api/commands/focus.md
+++ b/source/api/commands/focus.md
@@ -69,7 +69,7 @@ cy.get('textarea').focus().type('Nice Product!').blur()
 
 `.focus()` is just a helpful command which is a simple shortcut. Normally there's no way for a user to simply "focus" an element without causing another action or side effect. Typically the user would have to click or tab to this element.
 
-Oftentimes its much simpler and conveys what you're trying to test by just using `.focus()` directly.
+Oftentimes it's much simpler and conveys what you're trying to test by just using `.focus()` directly.
 
 If you want the other guarantees of waiting for an element to become actionable, you should use a different command like {% url `.click()` click %}.
 

--- a/source/api/cypress-api/custom-commands.md
+++ b/source/api/cypress-api/custom-commands.md
@@ -292,7 +292,7 @@ Require subject be of type: `element`.
 Cypress.Commands.add('click', {
   prevSubject: 'element'
 }, (subject, options) => {
-  // receives the previous subject and its
+  // receives the previous subject and it's
   // guaranteed to be an element
 })
 ```
@@ -321,7 +321,7 @@ Require subject be one of the following types: `element`, `document` or `window`
 Cypress.Commands.add('trigger', {
   prevSubject: ['element', 'document', 'window']
 }, (subject, eventName, options) => {
-  // receives the previous subject and its
+  // receives the previous subject and it's
   // guaranteed to be an element, document, or window
 })
 ```
@@ -356,7 +356,7 @@ Cypress.Commands.add('contains', {
   // since it's optional.
   //
   // if it's present
-  // then its window, document, or element.
+  // then it's window, document, or element.
   // - when window or document we'll query the entire DOM.
   // - when element we'll query only inside of its children.
   if (subject) {
@@ -413,7 +413,7 @@ The answer is usually **yes**. Here's an example:
 // There's no reason to create something like a cy.search() custom
 // command because this behavior is only applicable to a single spec file
 //
-// Just us a regular ol' javascript function folks!
+// Just use a regular ol' javascript function folks!
 const search = (term, options = {}) => {
   // example massaging to defaults
   _.defaults(options, {

--- a/source/guides/core-concepts/conditional-testing.md
+++ b/source/guides/core-concepts/conditional-testing.md
@@ -77,7 +77,7 @@ it('does something different based on the class of the button', function () {
 
   cy.get('button').then(($btn) => {
     if ($btn.hasClass('active')) {
-      // do something if its active
+      // do something if it's active
     } else {
       // do something else
     }

--- a/source/guides/core-concepts/variables-and-aliases.md
+++ b/source/guides/core-concepts/variables-and-aliases.md
@@ -148,7 +148,7 @@ cy.get('#num').then(($span) => {
     // now capture it again
     const num2 = parseFloat($span.text())
 
-    // make sure its what we expected
+    // make sure it's what we expected
     expect(num2).to.eq(num1 + 1)
   })
 })


### PR DESCRIPTION
With apologies for this slow drip of typos 😳

> We're doing a lot of Cypress at the mo' and I'm reading the docs top to bottom.