### PR TITLE
Remove `length` expectation from documentation

### DIFF
--- a/source/guides/core-concepts/introduction-to-cypress.md
+++ b/source/guides/core-concepts/introduction-to-cypress.md
@@ -820,9 +820,6 @@ cy
     // and .get() converts this to a simple array
     texts = texts.get()
 
-    // array should have length of 3
-    expect(texts).to.have.length(3)
-
     // with this specific content
     expect(texts).to.deep.eq([
       'Some text from first p',


### PR DESCRIPTION
<!--
Thanks for contributing!

Please explain what changes were made and also
reference any issues that were fixed with #[ISSUE]
-->

I think that it's a bit redundant to test the length of the array because the next expectation checks the contents of the whole array - which implicitly checks that there are three elements in the array.