### PR TITLE
Consider adding chrome to the travis-ci example

### DIFF
--- a/source/guides/guides/continuous-integration.md
+++ b/source/guides/guides/continuous-integration.md
@@ -61,9 +61,13 @@ As of Cypress version 3.0, Cypress downloads its binary to the global system cac
 ### Example `.travis.yml` config file
 
 ```yaml
+dist: trusty
+sudo: required
 language: node_js
 node_js:
   - 10
+addons:
+  chrome: stable  
 cache:
   directories:
     - ~/.npm


### PR DESCRIPTION
By default travis comes with Chromium v61 which has some [significant performance issues](https://github.com/cypress-io/cypress/issues/1905#issuecomment-410953582) with Cypress v3.  Users may also not expect that the tests are running in Chromium or understand that chrome is an option.

Introducing this would add extra opinion to the example that isn't necessarily needed, but I think not mentioning this in some fashion will lead to headaches that could be avoided.
https://docs.travis-ci.com/user/chrome#selecting-a-chrome-version

<!--
Thanks for contributing!

Please explain what changes were made and also
reference any issues that were fixed with #[ISSUE]
-->

