### PR TITLE
Add back tests for Table of Contents link checks

### DIFF
--- a/cypress/integration/api_spec.coffee
+++ b/cypress/integration/api_spec.coffee
@@ -95,18 +95,14 @@ describe "API", ->
             englishLink  = @english.sidebar.api[@sidebarLinkNames[i]]
             expect(displayedLink.text().trim()).to.eq(englishLink)
 
-
-  ## This is running too slow to include for now
-  ## Issue #431 Needs to be fixed first
-  ## https://github.com/cypress-io/cypress/issues/431
-  context.skip "Table of Contents", ->
+  context "Table of Contents", ->
     beforeEach ->
       cy.visit(API_PATH + ".html")
 
     it "displays toc", ->
       cy.get('.sidebar-link').each (linkElement) ->
+        cy.log(linkElement[0].innerText)
         cy.request(linkElement[0].href).its('body').then (body) ->
-
           $body = Cypress.$(body)
 
           $h1s = $body.find('.article h1').not('.article-title')

--- a/cypress/integration/guides_spec.coffee
+++ b/cypress/integration/guides_spec.coffee
@@ -86,14 +86,14 @@ describe "Guides", ->
   ## This is running too slow to include for now
   ## Issue #431 Needs to be fixed first
   ## https://github.com/cypress-io/cypress/issues/431
-  context.skip "Table of Contents", ->
+  context "Table of Contents", ->
     before ->
       cy.visit(GUIDES_PATH)
 
     it "displays toc", ->
       cy.get('.sidebar-link').each (linkElement) ->
+        cy.log(linkElement[0].innerText)
         cy.request(linkElement[0].href).its('body').then (body) ->
-
           $body = Cypress.$(body)
 
           $h1s = $body.find('.article h1').not('.article-title')


### PR DESCRIPTION
- The initial performance issues for these tests has been resolved in
Cypress - https://github.com/cypress-io/cypress/issues/431
- creating PR to ensure headless run is :thumbsup: too