### PR TITLE
add links to CI repos, close #837

### DIFF
--- a/source/guides/guides/continuous-integration.md
+++ b/source/guides/guides/continuous-integration.md
@@ -35,16 +35,17 @@ For more examples please read the {% url 'Command Line' command-line#cypress-run
 Cypress should run on **all** CI providers. We currently have seen Cypress working on the following services:
 
 - {% url "Jenkins" https://jenkins.io/ %} (Linux)
-- {% url "TravisCI" https://travis-ci.org/ %}
-- {% url "CircleCI" https://circleci.com %}
-- {% url "CodeShip" https://codeship.com/ %} (Has open {% issue 328 "issue with cy.exec()" %})
-- {% url "GitLab" https://gitlab.com/ %}
-- {% url "BuildKite" https://buildkite.com %}
-- {% url "AppVeyor" https://appveyor.com %}
+- {% url "TravisCI" https://travis-ci.org/ %} see {% url "example repo" https://github.com/cypress-io/cypress-example-kitchensink %} and {% url ".travis.yml file" https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.travis.yml %}
+- {% url "CircleCI" https://circleci.com %} see {% url "example repo" https://github.com/cypress-io/cypress-example-kitchensink %} and {% url "circle.yml file" https://github.com/cypress-io/cypress-example-kitchensink/blob/master/circle.yml %}
+- {% url "CodeShip Basic" https://codeship.com/features/basic %} (has an open {% issue 328 "issue with cy.exec()" %})
+- {% url "CodeShip Pro" https://codeship.com/features/pro %} see {% url "example repo" https://github.com/cypress-io/cypress-example-docker-codeship %}
+- {% url "GitLab" https://gitlab.com/ %} see {% url "example repo" https://github.com/cypress-io/cypress-example-kitchensink %} and {% url ".gitlab-ci.yml file" https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.gitlab-ci.yml %}
+- {% url "BuildKite" https://buildkite.com %} see {% url "example repo" https://github.com/cypress-io/cypress-example-kitchensink %} and {% url ".buildkite/pipeline.yml file" https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.buildkite/pipeline.yml.yml %}
+- {% url "AppVeyor" https://appveyor.com %} see {% url "example repo" https://github.com/cypress-io/cypress-example-kitchensink %} and {% url "appveyor.yml file" https://github.com/cypress-io/cypress-example-kitchensink/blob/master/appveyor.yml.yml %}
 - {% url "Semaphore" https://semaphoreci.com/ %}
 - {% url "Concourse" https://concourse-ci.org/ %}
 - {% url "Solano" https://www.solanolabs.com/ %}
-- {% url "Docker" https://www.docker.com/ %}
+- {% url "Docker" https://www.docker.com/ %} see {% url "cypress-docker-images" https://github.com/cypress-io/cypress-docker-images %}
 
 # Setting Up CI
 


### PR DESCRIPTION
- close #837 

Adds links to example repo and direct CI config file, so it looks like this

<img width="782" alt="screen shot 2018-08-17 at 11 10 39 am" src="https://user-images.githubusercontent.com/2212006/44273764-5428c500-a20e-11e8-941b-5c286ac752f7.png">


