### PR TITLE
[#843] TOCs h2 is highlighted when in child h3

### DIFF
--- a/cypress/integration/guides_spec.coffee
+++ b/cypress/integration/guides_spec.coffee
@@ -83,9 +83,6 @@ describe "Guides", ->
             englishLink  = @english.sidebar.guides[@sidebarLinkNames[i]]
             expect(displayedLink.text().trim()).to.eq(englishLink)
 
-  ## This is running too slow to include for now
-  ## Issue #431 Needs to be fixed first
-  ## https://github.com/cypress-io/cypress/issues/431
   context "Table of Contents", ->
     before ->
       cy.visit(GUIDES_PATH)

--- a/themes/cypress/layout/page.swig
+++ b/themes/cypress/layout/page.swig
@@ -21,7 +21,7 @@
           <aside id="article-toc" role="navigation">
             <div id="article-toc-inner">
               <strong class="sidebar-title">{{ __('page.contents') }}</strong>
-              {{ toc(page.content, {list_number: false}) }}
+              {{ toc(page.content, {list_number: false, max_depth: 2}) }}
               <a href="#" id="article-toc-top"><i class="fa fa-long-arrow-up"></i> {{ __('page.back-to-top') }}</a>
             </div>
           </aside>

--- a/themes/cypress/source/css/_partial/toc.scss
+++ b/themes/cypress/source/css/_partial/toc.scss
@@ -79,10 +79,6 @@
   list-style: none;
 }
 
-.toc-item.toc-level-3 {
-  display: none;
-}
-
 .active>.toc-link {
   font-weight: 500;
   border-left: 4px solid $color-link;


### PR DESCRIPTION
Addresses #846

## Behaviour Before The Change

* we're in the `<h3>` section _We recommend users_
* the parent `<h2>` section is **not** highlighted in the sidebar

<img width="1284" alt="before" src="https://user-images.githubusercontent.com/1855109/44627234-086acf80-a922-11e8-9b12-92581ab3e1c3.png">

## Behaviour After The Change

* we're in the `<h3>` section _We recommend users_
* the parent `<h2>` section **is** highlighted in the sidebar

<img width="1286" alt="after" src="https://user-images.githubusercontent.com/1855109/44627232-01dc5800-a922-11e8-94ca-13439800503f.png">