### PR TITLE
[#123] Add another example of using the selector in cy.contains()

### DIFF
--- a/source/api/commands/contains.md
+++ b/source/api/commands/contains.md
@@ -1,6 +1,5 @@
 ---
 title: contains
-
 ---
 
 Get the DOM element containing the text. DOM elements can contain *more* than the desired text and still match. Additionally, Cypress {% urlHash 'prefers some DOM elements' Notes %} over the deepest element found.
@@ -31,8 +30,8 @@ cy.contains('Hello')              // Yield first el in document containing 'Hell
 **{% fa fa-exclamation-triangle red %} Incorrect Usage**
 
 ```javascript
-cy.title().contains('My App')        // Errors, 'title' does not yield DOM element
-cy.getCookies().contains('_key')     // Errors, 'getCookies' does not yield DOM element
+cy.title().contains('My App')     // Errors, 'title' does not yield DOM element
+cy.getCookies().contains('_key')  // Errors, 'getCookies' does not yield DOM element
 ```
 
 ## Arguments
@@ -106,7 +105,7 @@ cy.get('form').contains('submit the form!').click()
 
 ***Find the first element containing a number***
 
-Even though the `<span>` is the deepest element that contains a "4", Cypress automatically yields `<button>` elements over spans.
+Even though the `<span>` is the deepest element that contains a "4", Cypress automatically yields `<button>` elements over spans because of its {% urlHash 'preferred element order' Preferences %}.
 
 ```html
 <button class="btn btn-primary" type="button">
@@ -142,9 +141,9 @@ cy.contains(/^b\w+/)
 
 Technically the `<html>`, `<body>`, `<ul>`, and first `<li>` in the example below all contain "apples".
 
-Normally Cypress would return the first `<li>` since that is the *deepest* element that contains: "apples"
+Normally Cypress would return the first `<li>` since that is the *deepest* element that contains "apples".
 
-To override the element that is yielded, we can pass 'ul' as the selector.
+To override the element that is yielded we can pass 'ul' as the selector.
 
 ```html
 <html>
@@ -162,6 +161,28 @@ To override the element that is yielded, we can pass 'ul' as the selector.
 // yields <ul>...</ul>
 cy.contains('ul', 'apples')
 ```
+
+***Keeping the form as the subject***
+
+Here's an example that uses the selector to ensure that the `<form>` remains the {% url subject introduction-to-cypress#Subject-Management %} for future chaining.
+
+```html
+<form>
+  <div>
+    <label>name</label>
+    <input name="name" />
+  </div>
+  <button type="submit">Proceed</button>
+</form>
+```
+
+```javascript
+cy.get('form')                  // yields <form>...</form>
+  .contains('form', 'Proceed')  // yields <form>...</form>
+  .submit()                     // yields <form>...</form>
+```
+
+Without the explicit selector the subject would change to be the `<button>`. Using the explicit selector ensures that chained commands will have the `<form>` as the subject.
 
 # Notes
 
@@ -240,12 +261,14 @@ cy.get('#main').contains('Jane Lane')
 
 ***Element preference order***
 
-`.contains()` will always prefer elements higher in the tree when they are:
+`.contains()` defaults to preferring elements higher in the tree when they are:
 
 - `input[type='submit']`
 - `button`
 - `a`
 - `label`
+
+Cypress will ignore this element preference order if you pass a selector argument to `.contains()`.
 
 ***Favor of `<button>` over other deeper elements***
 

--- a/source/api/commands/submit.md
+++ b/source/api/commands/submit.md
@@ -1,12 +1,11 @@
 ---
 title: submit
-
 ---
 
 Submit a form.
 
 {% note warning %}
-This element must be an `<form>`.
+The {% url subject introduction-to-cypress#Subject-Management %} must be a `<form>`.
 {% endnote %}
 
 # Syntax


### PR DESCRIPTION
Addresses #123

Kinda... the docs in that area already seemed pretty clear and complete to me. I've added another example of using the selector.

I _could_ add yet more examples but I dunno that that'd improve the existing docs... it'd just make 'em longer. Open to a steer here 😄

<img width="727" alt="another-example" src="https://user-images.githubusercontent.com/1855109/44654380-61516b00-a9e9-11e8-8f5a-c7bb914d49c3.png">
