### PR TITLE
Add clear instruction about how to write PRs that'll close issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ The documentation in this repo is generated using [Hexo](https://hexo.io/).
 
 **Fork this repository**
 
-Using GitHub, create a copy (a fork) of this repository under your personal account.
+Using GitHub, [create a copy](https://guides.github.com/activities/forking/) (a fork) of this repository under your personal account.
 
 **Clone your forked repository**
 
@@ -91,7 +91,7 @@ Add an associated image with the example within the [`source/img/examples`](/sou
 
 ### Adding Plugins
 
-To add a plugin, submit a [pull request](#Pull-Requests) with the corresponding data added to the [`plugins.yml`](https://github.com/cypress-io/cypress-documentation/blob/develop/source/_data/plugins.yml) file. Your plugin should have a name, description, link to the plugins code, as well as any keywords.
+To add a plugin, submit a [pull request](#Pull-Requests) with the corresponding data added to the [`plugins.yml`](https://github.com/cypress-io/cypress-documentation/blob/develop/source/_data/plugins.yml) file. Your plugin should have a name, description, link to the plugin's code, as well as any keywords.
 
 ### Adding Pages
 
@@ -155,10 +155,10 @@ Danger 📛: because we are minifying client-side code using a [Hexo plugin](htt
 
 ### Pull Requests
 
-You should push your local changes to your forked GitHub repository and then open a pull request from your repo to the `cypress-io/cypress-documentation` repo.
+You should push your local changes to your forked GitHub repository and then open a pull request (PR) from your repo to the `cypress-io/cypress-documentation` repo.
 
-- The pull request should be from your repository to the `develop` branch in `cypress-io/cypress-documentation`
-- When opening a PR for a specific issue already open, please use the `address #[issue number]` or `closes #[issue number]` syntax in the pull request description.
+- The PR should be from your repository to the `develop` branch in `cypress-io/cypress-documentation`
+- When opening a PR for a specific issue already open, please use the `closes #[issue number]` syntax in the pull request description so that the issue will be [automatically closed](https://help.github.com/articles/closing-issues-using-keywords/) when the PR is merged.
 - Please check the "Allow edits from maintainers" checkbox when submitting your PR. This will make it easier for the maintainers to make minor adjustments, to help with tests or any other changes we may need.
 ![Allow edits from maintainers checkbox](https://user-images.githubusercontent.com/1271181/31393427-b3105d44-ada9-11e7-80f2-0dac51e3919e.png)
 


### PR DESCRIPTION
Despite having used GitHub for years I've never used GitHub's issue tracker... it's always been JIRA wherever I've worked. As such I didn't know about the feature whereby you can add text to your PR that'll [automatically close](https://help.github.com/articles/closing-issues-using-keywords/) the attendant issue(s) if the PR is merged.

Doh! :blush: Happily, Jennifer shared the knowledge about this feature so that I no longer have to darken her inbox with folderol about _"Can this issue be closed?"_

This PR does two things:

* makes this feature explicit in the contribution guide.
* trojans this PR to close some old tickets.

> _ima kno all teh kung fu!!1!_

* closes #565 :: _Update .type doc to include list of supported type elements_
* closes #468 :: _Link SelectorPlayground API docs to "Test Runner" section_
* closes #32 :: _Docs: Improve 'Debugging'_

![](https://media.giphy.com/media/ChkynEc2Y0f5e/giphy.gif)

![](https://media.giphy.com/media/3IEBYXFwrnUXu/giphy.gif)
