### PR TITLE
[#564] Tighten docs around force404 behaviour

### DIFF
--- a/source/api/commands/route.md
+++ b/source/api/commands/route.md
@@ -191,38 +191,14 @@ cy.route('POST', '**/comments', commentsResponse)
 
 Any request that matches the `method` and `url` of a route will be responded to based on the configuration of that route.
 
-If a request doesn't match any route, {% urlHash "it will automatically receive a 404" Notes %}. For example, given we have the following routes:
+{% note info %}
+If a request doesn't match any route then the behavior depends on the value of the `force404` option on the {% url `cy.server()` server %}:
 
-```javascript
-cy.server()
-cy.route('**/users', [
-  {id: 19, name: 'Laura'},
-  {id: 20, name: 'Jamie'}
-])
-cy.route('POST', '**/messages', {id: 123, message: 'Hi There!'})
-cy.get('form').submit()
-```
+* if `force404` is `false` (the default) then the request will {% url 'pass through to the server' network-requests#Don’t-Stub-Responses %}.
+* if `force404` is `true` then the response {% urlHash "will be a 404" Notes %}.
 
-```javascript
-// Application Code
-// when our form is submitted
-$('form').submit(() => {
-  // send an AJAX to: GET /users
-  $.get('https://localhost:7777/users' )
-
-  // send an AJAX to: POST /messages
-  $.post('https://localhost:7777/messages', {some: 'data'})
-
-  // send an AJAX to: GET /updates
-  $.get('https://localhost:7777/updates')
-})
-```
-
-**The above application code will issue 3 AJAX requests:**
-
-1. The `GET /users` will match our 1st route and respond with a `200` status code and the array of users.
-2. The `POST /messages` will match our 2nd route and respond with a `200` status code with the message object.
-3. The `GET /updates` did not match any routes and its response automatically sent back a `404` status code with an empty response body.
+You can {% url 'read more about this behavior here.' server#Options %}
+{% endnote %}
 
 ***Specify the method***
 
@@ -461,16 +437,10 @@ The following XHR's which were `xhr.open(...)` with these URLs would:
 
 ***Requests that don't match any routes***
 
-You can force routes that do not match a route to return `404`:
-
-Status | Body | Headers
---- | --- | ---
-`404` | "" | `null`
-
-If you'd like to enable this behavior you need to pass:
+You can force requests that do _not_ match a route to return a `404` status and an empty body by passing an option to the `cy.server()` like so:
 
 ```javascript
-cy.server({force404: true})
+cy.server({ force404: true })
 ```
 
 You can {% url 'read more about this here.' server#Options %}

--- a/source/api/commands/server.md
+++ b/source/api/commands/server.md
@@ -1,14 +1,12 @@
 ---
 title: server
-
 ---
 
-Start a server to begin routing responses to `cy.route()` and `cy.request()`.
+Start a server to begin routing responses to {% url `cy.route()` route %} and {% url `cy.request()` request %}.
 
 {% note info %}
 **Note:** `cy.server()` assumes you are already familiar with core concepts such as {% url 'network requests' network-requests %}.
 {% endnote %}
-
 
 # Syntax
 
@@ -53,7 +51,7 @@ Option | Default | Description
 Option | Default | Description
 --- | --- | ---
 `enable` | `true` | pass `false` to disable existing route stubs
-`force404` | `false` | forcibly send XHR's a 404 status when the XHR's do not match any existing
+`force404` | `false` | forcibly send XHR's a 404 status when the XHR's do not match any existing route
 `urlMatchingOptions` | `{ matchBase: true }` | The default options passed to `minimatch` when using glob strings to match URLs
 `whitelist` | function | Callback function that whitelists requests from ever being logged or stubbed. By default this matches against asset-like requests such as for `.js`, `.jsx`, `.html`, and `.css` files.
 
@@ -67,7 +65,7 @@ Option | Default | Description
 
 ***After starting a server:***
 
-- Any request that does not match a {% url `cy.route()` route %} will be sent a `404` status code.
+- Any request that does **NOT** match a {% url `cy.route()` route %} will {% url 'pass through to the server' network-requests#Don’t-Stub-Responses %}.
 - Any request that matches the `options.whitelist` function will **NOT** be logged or stubbed. In other words it is "whitelisted" and ignored.
 - You will see requests named as `(XHR Stub)` or `(XHR)` in the Command Log.
 
@@ -103,9 +101,9 @@ Adding delay can help simulate real world network latency. Normally stubbed resp
 cy.server({delay: 1500})
 ```
 
-***Prevent sending 404's to unmatched requests***
+***Send 404s on unmatched requests***
 
-If you'd like Cypress to automatically send requests that do *NOT* match routes the following:
+If you'd like Cypress to automatically send requests that do *NOT* match routes the following response:
 
 Status | Body | Headers
 --- | --- | ---


### PR DESCRIPTION
closes #564

> This change isn't as trivial as I thought originally 'cos there are a few places in the docs that have "incorrect" info. I'm scare quoting there because I'm now doubting my own understanding of the behaviour in light of the docs: I'm writing some (more) tests to prove the behaviour.

I verified the behaviour locally: routes that are _not_ matched will, by default, just pass through to the server.

<img width="783" alt="screen shot 2018-08-29 at 10 38 54" src="https://user-images.githubusercontent.com/1855109/44780209-54638180-ab79-11e8-82c7-c55fc7760c56.png">
