### PR TITLE
Add support for notes with Markdown in the header

### DIFF
--- a/lib/tags/note.js
+++ b/lib/tags/note.js
@@ -22,6 +22,12 @@ module.exports = function note (hexo, args, content) {
     bolt: 'bolt', // useful for tips / hints
   }
 
+  const toMarkdown = (text) =>
+    hexo.render.renderSync({ text, engine: 'markdown' })
+
+  const stripSurroundingParagraph = (text) =>
+    text.replace(/^<p>/, '').replace(/<\/p>$/, '')
+
   let header = ''
   const className = args.shift()
   const icon = iconLookup[className]
@@ -29,12 +35,12 @@ module.exports = function note (hexo, args, content) {
   if (args.length) {
     header += `<strong class="note-title foo">
       ${icon ? `<i class="fa fa-${icon}"></i>` : ''}
-      ${args.join(' ')}
+      ${stripSurroundingParagraph(toMarkdown(args.join(' ')))}
     </strong>`
   }
 
   return Promise.resolve(
-    hexo.render.renderSync({ text: content, engine: 'markdown' })
+    toMarkdown(content)
   ).then((markdown) => {
     return `<blockquote class="note ${className}">${header}${markdown}</blockquote>`
   })


### PR DESCRIPTION
`Minor`

Adds support for using Markdown in the header of a `{% note %}` tag.

## Before

<img width="756" alt="before" src="https://user-images.githubusercontent.com/1855109/44871156-f70b2580-ac89-11e8-8608-953febe8f7db.png">

## After

<img width="756" alt="after" src="https://user-images.githubusercontent.com/1855109/44871178-ff636080-ac89-11e8-981d-3a5031ee1845.png">
