### PR TITLE
Display sections that were hidden because of missing quote

### DIFF
--- a/source/guides/core-concepts/dashboard-service.md
+++ b/source/guides/core-concepts/dashboard-service.md
@@ -218,7 +218,7 @@ Standard output includes details and summaries of your tests for each spec file 
 
 You will also see a summary at the bottom indicating the screenshots, or videos that were uploaded during the recording.
 
-{% img /img/dashboard/standard-output-of-recorded-test-run.png "standard output %}
+{% img /img/dashboard/standard-output-of-recorded-test-run.png "standard output" %}
 
 ***{% fa fa-picture-o fa-fw %} Screenshots***
 
@@ -228,7 +228,7 @@ All screenshots taken during the test run can be found in the **Screenshots** of
 
 The video recorded during the test run can be found under the **Video** of the spec. You can also download the video.
 
-{% url /img/dashboard/videos-of-recorded-test-run.png "Video of test runs" %}
+{% img /img/dashboard/videos-of-recorded-test-run.png "Video of test runs" %}
 
 ### {% fa fa-exclamation-triangle fa-fw %} Test Failures
 


### PR DESCRIPTION
A missing quote was causing a couple of sections to not be generated.

## Before

There's supposed to be a couple of sections here before the _Test Failures_ section... they're missing.

<img width="805" alt="before" src="https://user-images.githubusercontent.com/1855109/44908610-f6b76c80-ad13-11e8-975a-67197a0707ad.png">

## After

The sections are now present in the generated documentation.

<img width="855" alt="after" src="https://user-images.githubusercontent.com/1855109/44908619-ffa83e00-ad13-11e8-8286-b42476178f54.png">