### PR TITLE
[#663] Generate links even when validation fails

### DIFF
--- a/lib/tags/url.js
+++ b/lib/tags/url.js
@@ -91,6 +91,15 @@ function url (hexo, args) {
 
       return util.htmlTag('a', attrs, markdown)
     })
+    .catch((err) => {
+      /* eslint-disable no-console */
+      console.error(`Failed to validate "${props.url}".`, err)
+      /* eslint-enable no-console */
+
+      // generate the hyperlink anyway 'cos the link is likely fine and
+      // there's some transient issue (HTTP 500) b0rking the validation.
+      return util.htmlTag('a', attrs, markdown)
+    })
   })
 
 }

--- a/source/faq/questions/using-cypress-faq.md
+++ b/source/faq/questions/using-cypress-faq.md
@@ -147,7 +147,10 @@ When you load your application using `cy.visit()`, Cypress will wait for the `lo
 
 **_In CI, how do I make sure my server has started?_**
 
-There are a couple really great modules that we recommend using for this, {% url '`wait-on`' https://www.npmjs.com/package/wait-on %} and {% url '`start-server-and-test`' https://github.com/bahmutov/start-server-and-test %}.
+We recommend these great modules for this use case:
+
+* {% url '`wait-on`' https://www.npmjs.com/package/wait-on %}
+* {% url '`start-server-and-test`' https://github.com/bahmutov/start-server-and-test %}
 
 **_How can I wait for my requests to be complete?_**
 


### PR DESCRIPTION
Closes #663 

Right, so this is a _pragmatic_ tactical fix for an issue that's manifest on the Cypress documentation site right now: "blank" hyperlinks leading to malformed sentences.

## Examples

* https://docs.cypress.io/guides/getting-started/installing-cypress.html#Continuous-Integration

Notice how the link to the `npx` module on NPM is missing from the generated text.

<img width="780" alt="npx-missing" src="https://user-images.githubusercontent.com/1855109/44918011-dac2c380-ad31-11e8-8954-4750bb780561.png">

* https://docs.cypress.io/faq/questions/using-cypress-faq.html#How-do-I-wait-for-my-application-to-load

The following example is the one originally reported by Valerie in #663 

Notice how the link to the `wait-on` module on NPM is missing from the generated text.

<img width="750" alt="wait-on-missing" src="https://user-images.githubusercontent.com/1855109/44918178-41e07800-ad32-11e8-944c-fe343bc87385.png">

## After The Fix

With the change from this PR in place the above docs are generated correctly.

<img width="462" alt="screen shot 2018-08-31 at 15 40 11" src="https://user-images.githubusercontent.com/1855109/44918980-38f0a600-ad34-11e8-87aa-6aa27f369e85.png">
<img width="776" alt="screen shot 2018-08-31 at 15 40 24" src="https://user-images.githubusercontent.com/1855109/44918988-3c842d00-ad34-11e8-9576-c5da4083115b.png">


## Root Cause

This was spotted in #663 and attributed to errant punctuation: however, the root cause is actually that the site generation process can (and does) result in "blank" content being generated during the validation of external links.

If the validation of the URL results in an error -- HTTP `500`, `404`, etc. -- then... nothing is generated which manifests as "blank" hyperlinks leading to malformed sentences.

## Tactical Fix

This PR contains a tactical fix: generate the hyperlink even in the face of an error. (The error continues to be logged to the error stream.)

This addresses the issue that's currently live on the published Cypress.io site: namely, "blank" hyperlinks leading to malformed sentences. The current approach to _external_ link validation has issues -- #197 #353 -- which'll only be addressed properly in #197.

> I do plan to address those issues with a strategic fix after I've done the much more interesting work of contributing some architecture diagrams for #872 

In the interim this tactical fix addresses a real issue on the website. Totes open to this being bounced back but I hope that my explanation communicates _why_ I've submitted this PR.

🤗 