### PR TITLE
[#291] Make the 404 page somewhat more helpful

### DIFF
--- a/source/404.md
+++ b/source/404.md
@@ -13,4 +13,4 @@ Well darn&hellip; we can't find the page you're looking for. One of these links 
 * {% fa fa-angle-right %} {% url 'Tutorials' tutorials %}
 * {% fa fa-angle-right %} {% url 'The Cypress Dashboard' https://www.cypress.io/dashboard/ %}
 
-> {% fa fa-hand-point-right %} Try **searching** using the box in the header {% fa fa-search %}
+> {% fa fa-hand-point-right %} Try using our sweet custom search in the header above {% fa fa-search %}

--- a/source/404.md
+++ b/source/404.md
@@ -5,3 +5,12 @@ containerClass: not-found
 ---
 
 # 404 Page not Found
+
+Well darn&hellip; we can't find the page you're looking for. One of these links might help.
+
+* {% fa fa-angle-right %} {% url 'Introduction to Cypress' introduction-to-cypress %}
+* {% fa fa-angle-right %} {% url 'The API docs' api %}
+* {% fa fa-angle-right %} {% url 'Tutorials' tutorials %}
+* {% fa fa-angle-right %} {% url 'The Cypress Dashboard' https://www.cypress.io/dashboard/ %}
+
+> Also, {% url Gleb https://glebbahmutov.com/ %} is a legend. Just sayin'.

--- a/source/404.md
+++ b/source/404.md
@@ -13,4 +13,4 @@ Well darn&hellip; we can't find the page you're looking for. One of these links 
 * {% fa fa-angle-right %} {% url 'Tutorials' tutorials %}
 * {% fa fa-angle-right %} {% url 'The Cypress Dashboard' https://www.cypress.io/dashboard/ %}
 
-> Also, {% url Gleb https://glebbahmutov.com/ %} is a legend. Just sayin'.
+> {% fa fa-hand-point-right %} Try **searching** using the box in the header {% fa fa-search %}

--- a/themes/cypress/source/css/_partial/base.scss
+++ b/themes/cypress/source/css/_partial/base.scss
@@ -160,7 +160,7 @@ button, select, input, input[type="submit"]::-moz-focus-inner, input[type="butto
   ul {
     list-style: none;
     padding: 0;
-    margin: 50px 0 50px 0;
+    margin: 50px 0 20px 0;
     display: inline-block;
     text-align: left;
 
@@ -179,9 +179,13 @@ button, select, input, input[type="submit"]::-moz-focus-inner, input[type="butto
   }
 
   blockquote {
-    margin: 15px 0 100px 0;
+    margin: 10px 0 100px 0;
     padding: 15px;
     font-style: italic;
+
+    strong {
+      font-weight: bold;
+    }
   }
 }
 

--- a/themes/cypress/source/css/_partial/base.scss
+++ b/themes/cypress/source/css/_partial/base.scss
@@ -145,11 +145,44 @@ button, select, input, input[type="submit"]::-moz-focus-inner, input[type="butto
   height: 100%;
 }
 
-.not-found h1 {
+.not-found {
   text-align: center;
-  font-size: 50px;
-  line-height: 100px;
-  margin: 100px 0;
+
+  h1 {
+    font-family: 'Fira Sans';
+    font-size: 50px;
+    font-weight: bold;
+    line-height: 100px;
+    margin: 50px 0 50px 0;
+    text-transform: capitalize;
+  }
+
+  ul {
+    list-style: none;
+    padding: 0;
+    margin: 50px 0 50px 0;
+    display: inline-block;
+    text-align: left;
+
+    li {
+      margin-bottom: 20px;
+      &>i.fa {
+        margin-right: 5px;
+      }
+    }
+  }
+
+  a {
+    color: #3B94D9;
+    text-decoration: none;
+    border-bottom: 1px dotted #bde1fd;
+  }
+
+  blockquote {
+    margin: 15px 0 100px 0;
+    padding: 15px;
+    font-style: italic;
+  }
 }
 
 i.fa {

--- a/themes/cypress/source/css/_partial/media_queries.scss
+++ b/themes/cypress/source/css/_partial/media_queries.scss
@@ -307,3 +307,22 @@
     width: 100%;
   }
 }
+
+@media screen and(max-width: 375px) {
+  .not-found {
+  
+    h1 {
+      font-size: 30px;
+      line-height: 50px;
+    }
+
+    p {
+      margin-left: 20px;
+      margin-right: 20px;
+    }
+
+    ul {
+      margin-bottom: 20px;
+    }
+  }
+}

--- a/themes/cypress/source/css/_partial/media_queries.scss
+++ b/themes/cypress/source/css/_partial/media_queries.scss
@@ -322,7 +322,7 @@
     }
 
     ul {
-      margin-bottom: 20px;
+      margin: 30px 20px 0 20px;
     }
   }
 }


### PR DESCRIPTION
Closes #291 

I just followed @bahmutov 's instruction by adding some helpful links to the `404` page.

I also styled the `404` page for both desktop and smaller devices.

## Before

<img width="988" alt="before" src="https://user-images.githubusercontent.com/1855109/44998887-0ef7e780-afb1-11e8-94f0-ee7dc5d3668e.png">

## After :: Desktop

<img width="892" alt="regular" src="https://user-images.githubusercontent.com/1855109/44998894-1b7c4000-afb1-11e8-9b31-1953d00eb3f1.png">

## After :: iPhone

<img width="402" alt="iphone" src="https://user-images.githubusercontent.com/1855109/44998900-28992f00-afb1-11e8-96e6-b0b419f3aab9.png">

