### PR TITLE
Speed up url validation via Redis cache

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -66,7 +66,8 @@ jobs:
       - run: npm run deps
       - run: npm run lint
       - run: npm run stop-only
-      - run: npm test
+      # unset REDIS_URL to make sure we are not using cached url check result
+      - run: REDIS_URL= npm test
       - run: npm run build
 
       ## save entire folder + Cypress binary as the workspace for other jobs to continue

--- a/index.js
+++ b/index.js
@@ -5,6 +5,14 @@ process.on('unhandledRejection', function (reason, p) {
   process.exit(-1)
 })
 
+process.on('beforeExit', (exitCode) => {
+  console.log('beforExit exitCode:', exitCode)
+})
+
+process.on('exit', (code) => {
+  console.log('exitting with code', code)
+})
+
 const Hexo = require('hexo')
 const chalk = require('chalk')
 const minimist = require('minimist')
@@ -83,6 +91,13 @@ function initHexo () {
   return hexo.init()
   .then(() => {
     return hexo.call(cmd, args)
+  })
+  .then(() => {
+    console.log('all done with command', cmd)
+  }, (e) => {
+    console.error('error in command', cmd)
+    console.error(e)
+    throw e
   })
 
 }

--- a/lib/tags/url.js
+++ b/lib/tags/url.js
@@ -93,7 +93,8 @@ function url (hexo, args) {
     })
     .catch((err) => {
       /* eslint-disable no-console */
-      console.error(`Failed to validate "${props.url}".`, err)
+      console.error(`⚠️ Failed to validate "${props.url}".`)
+      console.error(err.message)
       /* eslint-enable no-console */
 
       // generate the hyperlink anyway 'cos the link is likely fine and

--- a/lib/url_generator.js
+++ b/lib/url_generator.js
@@ -30,7 +30,10 @@ debug('caching HREF checks for %s', pluralize('hour', CACHE_HOURS, true))
 const startsWithHttpRe = /^http/
 const everythingAfterHashRe = /(#.+)/
 
-const args = minimist(process.argv.slice(2))
+const args = minimist(process.argv.slice(2), {
+  boolean: 'validate',
+})
+debug('should validate external links? %j', args.validate)
 
 // converts seconds to milliseconds
 const seconds = (n) => 1000 * n

--- a/lib/url_generator.js
+++ b/lib/url_generator.js
@@ -13,7 +13,7 @@ const minimist = require('minimist')
 const Keyv = require('keyv')
 const pluralize = require('pluralize')
 
-const CACHE_HOURS = 1
+const CACHE_HOURS = 12
 
 const keyv = new Keyv(process.env.REDIS_URL)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "bluebird": {
           "version": "3.5.1",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+          "integrity": "sha1-2VUfnemPH82h5oPRfukaBgLuLrk=",
           "dev": true
         },
         "cross-spawn": {
@@ -138,7 +138,7 @@
         "bluebird": {
           "version": "3.5.1",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+          "integrity": "sha1-2VUfnemPH82h5oPRfukaBgLuLrk=",
           "dev": true
         },
         "chalk": {
@@ -390,7 +390,7 @@
     "@sinonjs/commons": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.0.2.tgz",
-      "integrity": "sha512-WR3dlgqJP4QNrLC4iXN/5/2WaLQQ0VijOOkmflqFGVJ6wLEpbSjo7c0ZeGIdtY8Crk7xBBp87sM6+Mkerz7alw==",
+      "integrity": "sha1-PgrHN3gWJ7iEQlf63D2AOZfQUm4=",
       "dev": true,
       "requires": {
         "type-detect": "4.0.8"
@@ -408,7 +408,7 @@
     "@sinonjs/samsam": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.0.0.tgz",
-      "integrity": "sha512-D7VxhADdZbDJ0HjUTMnSQ5xIGb4H2yWpg8k9Sf1T08zfFiQYlaxM8LZydpR4FQ2E6LZJX8IlabNZ5io4vdChwg==",
+      "integrity": "sha1-kWN0KsNcEtNgLeznQxdkOzXbaoA=",
       "dev": true
     },
     "@types/blob-util": {
@@ -568,7 +568,7 @@
     "acorn-jsx": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-4.1.1.tgz",
-      "integrity": "sha512-JY+iV6r+cO21KtntVvFkD+iqjtdpRUpGqKWgfkCdZq1R+kbreEl8EcdcJR4SmiIgsIQT33s6QzheQ9a275Q8xw==",
+      "integrity": "sha1-6OQeSOov4MiWdAYQq2pP/YrdIl4=",
       "dev": true,
       "requires": {
         "acorn": "^5.0.3"
@@ -1801,7 +1801,7 @@
     "bluebird": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.2.tgz",
-      "integrity": "sha512-dhHTWMI7kMx5whMQntl7Vr9C6BvV10lFXDAasnqnrMYhXVCzzk6IO9Fo2L75jXHT07WrOngL1WDXOp+yYS91Yg=="
+      "integrity": "sha1-G+CQjgVKdRdUVJwnBInBUF1KsVo="
     },
     "bmp-js": {
       "version": "0.0.3",
@@ -2275,7 +2275,7 @@
     "circular-json": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+      "integrity": "sha1-gVyZ6oT2gJUp0vRXkb34JxE1LWY=",
       "dev": true
     },
     "class-utils": {
@@ -3805,7 +3805,7 @@
     "doctrine": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "integrity": "sha1-XNAfwQFiG0LEzX9dGmYkNxbT850=",
       "dev": true,
       "requires": {
         "esutils": "^2.0.2"
@@ -4112,7 +4112,7 @@
     "eslint": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.5.0.tgz",
-      "integrity": "sha512-m+az4vYehIJgl1Z0gb25KnFXeqQRdNreYsei1jdvkd9bB+UNQD3fsuiC2AWSQ56P+/t++kFSINZXFbfai+krOw==",
+      "integrity": "sha1-hVf8zqtRQagZfan/2ZBPifZEJcY=",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -4158,7 +4158,7 @@
         "@babel/code-frame": {
           "version": "7.0.0",
           "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
-          "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+          "integrity": "sha1-BuKrGb21NThVWaq7W6WXKUgoAPg=",
           "dev": true,
           "requires": {
             "@babel/highlight": "^7.0.0"
@@ -4167,7 +4167,7 @@
         "@babel/highlight": {
           "version": "7.0.0",
           "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
-          "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+          "integrity": "sha1-9xDDjI1Fjm3ZogGvtjf8t4HOmeQ=",
           "dev": true,
           "requires": {
             "chalk": "^2.0.0",
@@ -4178,7 +4178,7 @@
         "ajv": {
           "version": "6.5.3",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.3.tgz",
-          "integrity": "sha512-LqZ9wY+fx3UMiiPd741yB2pj3hhil+hQc8taf4o2QGRFpWgZ2V5C8HA165DY9sS3fJwsk7uT7ZlFEyC3Ig3lLg==",
+          "integrity": "sha1-caVp0Yns9PTzISJP7LFm8HHdkPk=",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^2.0.1",
@@ -4190,13 +4190,13 @@
         "chardet": {
           "version": "0.7.0",
           "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-          "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+          "integrity": "sha1-kAlISfCTfy7twkJdDSip5fDLrZ4=",
           "dev": true
         },
         "cross-spawn": {
           "version": "6.0.5",
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "integrity": "sha1-Sl7Hxk364iw6FBJNus3uhG2Ay8Q=",
           "dev": true,
           "requires": {
             "nice-try": "^1.0.4",
@@ -4209,7 +4209,7 @@
         "external-editor": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
-          "integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
+          "integrity": "sha1-WGbbKal4Jtvkvzr9JAcOrZ6kOic=",
           "dev": true,
           "requires": {
             "chardet": "^0.7.0",
@@ -4235,7 +4235,7 @@
         "iconv-lite": {
           "version": "0.4.24",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+          "integrity": "sha1-ICK0sl+93CHS9SSXSkdKr+czkIs=",
           "dev": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3"
@@ -4244,13 +4244,13 @@
         "ignore": {
           "version": "4.0.6",
           "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-          "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+          "integrity": "sha1-dQ49tYYgh7RzfrrIIH/9HvJ7Jfw=",
           "dev": true
         },
         "inquirer": {
           "version": "6.2.0",
           "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.0.tgz",
-          "integrity": "sha512-QIEQG4YyQ2UYZGDC4srMZ7BjHOmNk1lR2JQj5UknBapklm6WHA+VVH7N+sUdX3A7NeCfGF8o4X1S3Ao7nAcIeg==",
+          "integrity": "sha1-Ua3Nd29mE2ncHolIWcJWCiJKvdg=",
           "dev": true,
           "requires": {
             "ansi-escapes": "^3.0.0",
@@ -4277,13 +4277,13 @@
         "js-tokens": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+          "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk=",
           "dev": true
         },
         "json-schema-traverse": {
           "version": "0.4.1",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+          "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA=",
           "dev": true
         },
         "minimist": {
@@ -4319,13 +4319,13 @@
         "semver": {
           "version": "5.5.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
-          "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==",
+          "integrity": "sha1-ff3YgUvbfKvHvg+x1zTPtmyUBHc=",
           "dev": true
         },
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
@@ -4343,7 +4343,7 @@
     "eslint-scope": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",
-      "integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
+      "integrity": "sha1-UL8wcekzi83EMzF5Sgy1M/ATYXI=",
       "dev": true,
       "requires": {
         "esrecurse": "^4.1.0",
@@ -4353,7 +4353,7 @@
     "eslint-utils": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
-      "integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
+      "integrity": "sha1-moUbqJ7nxGA0b5fPiTnHKYgn5RI=",
       "dev": true
     },
     "eslint-visitor-keys": {
@@ -4365,7 +4365,7 @@
     "espree": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-4.0.0.tgz",
-      "integrity": "sha512-kapdTCt1bjmspxStVKX6huolXVV5ZfyZguY1lcfhVVZstce3bqxH9mcLzNn3/mlgW6wQ732+0fuG9v7h0ZQoKg==",
+      "integrity": "sha1-JTmY8goPgttdhmOFeZ2RKoOjZjQ=",
       "dev": true,
       "requires": {
         "acorn": "^5.6.0",
@@ -4380,7 +4380,7 @@
     "esquery": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
-      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+      "integrity": "sha1-QGxRZYsfWZGl+bYrHcJbAOPlxwg=",
       "dev": true,
       "requires": {
         "estraverse": "^4.0.0"
@@ -6372,7 +6372,7 @@
     "ggit": {
       "version": "2.4.5",
       "resolved": "https://registry.npmjs.org/ggit/-/ggit-2.4.5.tgz",
-      "integrity": "sha512-Uz5g5kcp79OG1b3E0kECKplYjePOpoqw9TWYTrH/aoJiQ0bUQxRMTGbkF+Z4oG9lOAYTtEaCWqGDVM55TlpykA==",
+      "integrity": "sha1-w3/tZeEi2s6iPM0z1Qd3FRLMD58=",
       "dev": true,
       "requires": {
         "always-error": "1.0.0",
@@ -6401,13 +6401,13 @@
         "bluebird": {
           "version": "3.5.1",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+          "integrity": "sha1-2VUfnemPH82h5oPRfukaBgLuLrk=",
           "dev": true
         },
         "commander": {
           "version": "2.17.1",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
-          "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
+          "integrity": "sha1-vXerfebelCBc6sxy8XFtKfIKd78=",
           "dev": true
         },
         "find-up": {
@@ -6422,7 +6422,7 @@
         "glob": {
           "version": "7.1.3",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "integrity": "sha1-OWCDLT8VdBCDQtr9OmezMsCWnfE=",
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -6446,7 +6446,7 @@
         "moment-timezone": {
           "version": "0.5.21",
           "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.21.tgz",
-          "integrity": "sha512-j96bAh4otsgj3lKydm3K7kdtA3iKf2m6MY2iSYCzCm5a1zmHo1g+aK3068dDEeocLZQIS9kU8bsdQHLqEvgW0A==",
+          "integrity": "sha1-PLokfYRJIXTb9x3iqYSPoTIHuEU=",
           "dev": true,
           "requires": {
             "moment": ">= 2.9.0"
@@ -6496,7 +6496,7 @@
         "semver": {
           "version": "5.5.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
-          "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==",
+          "integrity": "sha1-ff3YgUvbfKvHvg+x1zTPtmyUBHc=",
           "dev": true
         }
       }
@@ -6523,7 +6523,7 @@
     "git-last": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/git-last/-/git-last-1.2.2.tgz",
-      "integrity": "sha512-Kuc1eekwONU/PFbO4DI0n/LuC0Mk4w1JuhLAUgpa0LaEcwxVoH0u0Gmo820Ou2AQqI90G1k0qcFZiccUyEI+Dw==",
+      "integrity": "sha1-2dP3990AoEybFoaz2Z9OAIuMrHg=",
       "dev": true,
       "requires": {
         "check-more-types": "2.24.0",
@@ -6541,7 +6541,7 @@
         "commander": {
           "version": "2.17.1",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
-          "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
+          "integrity": "sha1-vXerfebelCBc6sxy8XFtKfIKd78=",
           "dev": true
         },
         "find-up": {
@@ -6909,7 +6909,7 @@
     "globals": {
       "version": "11.7.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
-      "integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg==",
+      "integrity": "sha1-pYP6pDBVsayncZFL9oJY4vwSVnM=",
       "dev": true
     },
     "globby": {
@@ -8963,7 +8963,7 @@
     "is-path-in-cwd": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
-      "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
+      "integrity": "sha1-WsSLNF72dTOb1sekipEhELJBz1I=",
       "dev": true,
       "requires": {
         "is-path-inside": "^1.0.0"
@@ -9051,7 +9051,7 @@
     "is-resolvable": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
-      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+      "integrity": "sha1-+xj4fOH+uSUWnJpAfBkxijIG7Yg=",
       "dev": true
     },
     "is-retry-allowed": {
@@ -10245,7 +10245,7 @@
     "just-extend": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-3.0.0.tgz",
-      "integrity": "sha512-Fu3T6pKBuxjWT/p4DkqGHFRsysc8OauWr4ZRTY9dIx07Y9O0RkoR5jcv28aeD1vuAwhm3nLkDurwLXoALp4DpQ==",
+      "integrity": "sha1-zuAEAx6qv2QG2gOnuE5P6deO8og=",
       "dev": true
     },
     "kew": {
@@ -11558,7 +11558,7 @@
     "nise": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/nise/-/nise-1.4.4.tgz",
-      "integrity": "sha512-pxE0c9PzgrUTyhfv5p+5eMIdfU2bLEsq8VQEuE0kxM4zP7SujSar7rk9wpI2F7RyyCEvLyj5O7Is3RER5F36Fg==",
+      "integrity": "sha1-uNndNTNMmeUUt15G/MOONYyuzdA=",
       "dev": true,
       "requires": {
         "@sinonjs/formatio": "^2.0.0",
@@ -14465,7 +14465,7 @@
     "regexpp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.0.tgz",
-      "integrity": "sha512-g2FAVtR8Uh8GO1Nv5wpxW7VFVwHcCEr4wyA8/MHiRkO8uHoR5ntAA8Uq3P1vvMTX/BeQiRVSpDGLd+Wn5HNOTA==",
+      "integrity": "sha1-sqdTSoXKGwM7z1zp/45W1OB1U2U=",
       "dev": true
     },
     "relateurl": {
@@ -14865,7 +14865,7 @@
     "samsam": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
-      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
+      "integrity": "sha1-jR2TUOJWItow3j5EumkrUiGrfFA=",
       "dev": true
     },
     "sane": {
@@ -15464,7 +15464,7 @@
     "sinon": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-6.2.0.tgz",
-      "integrity": "sha512-gLFZz5UYvOhYzQ+DBzw/OCkmWaLAHlAyQiE2wxUOmAGVdasP9Yw93E+OwZ0UuhW3ReMu1FKniuNsL6VukvC77w==",
+      "integrity": "sha1-7JWvOoiutFHwJ18UIT5unwZoeeI=",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.0.2",
@@ -15481,7 +15481,7 @@
         "supports-color": {
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
@@ -15901,7 +15901,7 @@
     "start-server-and-test": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/start-server-and-test/-/start-server-and-test-1.7.1.tgz",
-      "integrity": "sha512-obfOkRyeCDghjiAUjmsY+bIIKFDf5h/Hvj6waTx7z7yaD07F0ujwHKlyGHOcyPGjikR/VDAwEtLypsjJLd4s7Q==",
+      "integrity": "sha1-k1m9FeA5oMGSlwIGjboh25WAhdg=",
       "dev": true,
       "requires": {
         "bluebird": "3.5.2",
@@ -15922,7 +15922,7 @@
         "core-js": {
           "version": "2.5.7",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-          "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
+          "integrity": "sha1-+XJgj/DOrWi4QaFqky0LGDeRgU4=",
           "dev": true
         },
         "cross-spawn": {
@@ -15962,7 +15962,7 @@
         "wait-on": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-2.1.0.tgz",
-          "integrity": "sha512-hDwJ674+7dfiiK/cxtYCwPxlnjXDjto/pCz1PF02sXUhqCqCWsgvxZln0699PReWqXXgkxqkF6DDo5Rj9sjNvw==",
+          "integrity": "sha1-PErOH1cmbKW+f6JeDBWAO4icpGo=",
           "dev": true,
           "requires": {
             "core-js": "^2.4.1",
@@ -17133,7 +17133,7 @@
         "hoek": {
           "version": "4.2.1",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-          "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
+          "integrity": "sha1-ljRQKqEsRF3Vp8VzS1cruHOKrLs=",
           "dev": true
         }
       }
@@ -17212,7 +17212,7 @@
     "tslib": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+      "integrity": "sha1-1+TdeSRdhUKMTX5IIqeZF5VMooY=",
       "dev": true
     },
     "tunnel-agent": {
@@ -17463,7 +17463,7 @@
     "uri-js": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "integrity": "sha1-lMVA4f93KVbiKZUHwBCupsiDjrA=",
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
@@ -17472,7 +17472,7 @@
         "punycode": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+          "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew=",
           "dev": true
         }
       }
@@ -17730,7 +17730,7 @@
     "wait-on": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-2.1.2.tgz",
-      "integrity": "sha512-Jm6pzZkbswtcRUXohxY1Ek5MrL16AwHj83drgW2FTQuglHuhZhVMyBLPIYG0rL1wvr5rdC1uzRuU/7Bc+B9Pwg==",
+      "integrity": "sha1-qXamqsErwjqby5dO3EqY9Uq+0jY=",
       "dev": true,
       "requires": {
         "core-js": "^2.4.1",
@@ -17743,7 +17743,7 @@
         "core-js": {
           "version": "2.5.7",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-          "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
+          "integrity": "sha1-+XJgj/DOrWi4QaFqky0LGDeRgU4=",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "deploy": "echo Deploying built docs",
     "deps": "deps-ok && dependency-check . --no-default-entries --entry cy_scripts/deploy.js",
     "lint": "echo 'Linting scripts...' && eslint --fix *.js cy_scripts/*.js scripts/*.js && echo 'Lint successful'",
-    "postbuild": "gulp post:build && git-last -m -f public/build.json",
+    "postbuild": "ls -la && gulp post:build && git-last -m -f public/build.json",
     "postdeploy": "npm run deploy-prebuilt",
     "prebuild": "npm run clean && npm run deps && gulp pre:build",
     "predeploy": "NODE_ENV=production npm run build",


### PR DESCRIPTION
 - close #911 

🛑blocked for now - when `REDIS_URL=...` is set, the `npm run build` finishes early without actually generating `public` documentation! See failed CI builds https://circleci.com/gh/cypress-io/cypress-documentation/6318

Even locally I can see bad process exit (but without non-zero exit code)

```
$ REDIS_URL=redis://... DEBUG=docs node --stack-size=8192 ./index.js generate
disabling filter cleanup for environment development
in environment development site url is https://docs.cypress.io
NODE_ENV is: development
  docs using external Redis server to store HREF checks +0ms
  docs caching HREF checks for 12 hours +2ms
INFO  Start processing
~/git/cypress-documentation on clean-url-validate
$ echo $?
0
```

Once this is resolved, this can really speed up documentation generation.