### PR TITLE
[#923] Fix mutton and nut substitution in notes

### DIFF
--- a/lib/tags/note.js
+++ b/lib/tags/note.js
@@ -40,7 +40,11 @@ module.exports = function note (hexo, args, content) {
   }
 
   return Promise.resolve(
+    // these replacements are a temporary fix: see the comments on
+    // https://github.com/cypress-io/cypress-documentation/pull/935
     toMarkdown(content)
+    .replace('–', '--')
+    .replace('—', '---')
   ).then((markdown) => {
     return `<blockquote class="note ${className}">${header}${markdown}</blockquote>`
   })


### PR DESCRIPTION
Right, I was sufficiently bugged by this to investigate it.

It looks to be a bug in the Markdown library that Hexo uses. ([`marked`](https://marked.js.org/#/README.md))

Even though the SmartyPants "spec" says that content inside a `<code>` block is not to be SmartyPants-ed, I have tested a small file against the library directly and it _does_ SmartyPants-ify content in such blocks:

Input
```md
--report <code>--report</code>
```
Output
```html
<p>–report <code>–report</code></p>
```

Code that is fenced in backticks doesn't exhibit the same behaviour:

Input (some Markdown)
```md
--report `--report`
```
Output
```html
<p>–report <code>--report</code></p>
```

Right, onto the Cypress code. We have content with nested tags:

```md
{% note info %}
`--report` {% url `--report` foo.html %}
{% endnote %}
```

What happens is that the `url` tag is processed _first_ and it spits out HTML into the surrounding block:

```md
{% note info %}
`--report` <a href="foo.html"><code>--report</code></a>
{% endnote %}
```

The entire content of the `note` block is then rendered into Markdown... and as we saw with my wee example at the start of this comment the `--` inside the `<code>` block _is_ SmartyPants-ed, resulting in:

```html
<code>--report</code> <a href="foo.html"><code>–report</code></a>
```

I'll have a shuftie at sorting the issue at source in the underlying `marked` library.

In the interim, I submit a PR that addresses the issue _tactically_.

<img width="697" alt="sweet" src="https://user-images.githubusercontent.com/1855109/45385872-d20f9e80-b609-11e8-9ff6-a62f63776ebd.png">

> I feel kinda ill submitting this: it is my sincere hope that you'll be so outraged by how _bleurgh_ it is that you'll submit a PR that fixes it in another brilliant way.

![](https://media.giphy.com/media/PJeKg31621Wgw/giphy.gif)