### PR TITLE
Issue [#743] search input box misleading

### DIFF
--- a/themes/cypress/source/css/_partial/media_queries.scss
+++ b/themes/cypress/source/css/_partial/media_queries.scss
@@ -212,8 +212,6 @@
     position: relative;
     top: -6px;
     left: -120px;
-    max-width: 320px;
-    min-width: 320px;
   }
 
   #content-inner {
@@ -299,6 +297,11 @@
   .media {
     width: 100%;
     padding-right: 0;
+  }
+  
+  .algolia-autocomplete .ds-dropdown-menu {
+    max-width: 320px;
+    min-width: 320px;
   }
 }
 

--- a/themes/cypress/source/css/_partial/search.scss
+++ b/themes/cypress/source/css/_partial/search.scss
@@ -12,6 +12,9 @@
   &.on {
     display: inline-block;
   }
+  .algolia-autocomplete {
+    width: calc(100% - 30px);
+  }
 }
 
 #search-input-icon {
@@ -24,6 +27,7 @@
 }
 
 #search-input {
+  width: 100%;
   background: none;
   font-size: inherit;
   font-family: $font-sans;


### PR DESCRIPTION
closes #743

The clickable search box has been expended to fill it's wrapper by giving it explicit width (minus the width of the search icon).

The autocomplete drop-down has been made to keep the original width in screen width from 1001 - 620px since the original size can't go outside the window before the 620px breakpoint this looks better.
(The autocomplete drop-down is to far from the text without this in some screen widths because it is right aligned)

