### PR TITLE
Fix incorrect iphone-6 widthin comment

### DIFF
--- a/source/api/commands/viewport.md
+++ b/source/api/commands/viewport.md
@@ -24,7 +24,7 @@ cy.viewport(preset, orientation, options)
 
 ```javascript
 cy.viewport(550, 750)    // Set viewport to 550px x 750px
-cy.viewport('iphone-6')  // Set viewport to 357px x 667px
+cy.viewport('iphone-6')  // Set viewport to 375px x 667px
 ```
 
 ## Arguments


### PR DESCRIPTION
In the comment describing the iphone-6 width, there was a typo. This change fixes it. 

Should be 375px not 357px. 

375px is correct according to actual Cypress behavior and as widely [reported](http://viewportsizes.com/?filter=iphone) as the iPhone 6 viewport size.

<!--
Thanks for contributing!

Please explain what changes were made and also
reference any issues that were fixed with #[ISSUE]
-->

