### PR TITLE
Fixing and adjusting syntax in a few code examples

### DIFF
--- a/source/api/commands/route.md
+++ b/source/api/commands/route.md
@@ -381,12 +381,12 @@ cy.route(() => {
 ```javascript
 cy.route(() => {
   // a silly example of async return
-  return new Cypress.Promise((resolve) =>{
+  return new Cypress.Promise((resolve) => {
     // resolve this promise after 1 second
     setTimeout(() => {
       resolve({
-        method: 'PUT'
-        url: '**/posts/**'
+        method: 'PUT',
+        url: '**/posts/**',
         response: '@postFixture'
       })
     }, 1000)

--- a/source/api/commands/should.md
+++ b/source/api/commands/should.md
@@ -112,7 +112,7 @@ cy.get('input').should('not.have.value', 'Jane')
 ***The current subject is yielded***
 
 ```javascript
-cy.get('button').should('have.id', 'new-user').then(($button) =>{
+cy.get('button').should('have.id', 'new-user').then(($button) => {
   // $button is yielded
 })
 ```
@@ -145,7 +145,7 @@ Just be sure *not* to include any code that has side effects in your callback fu
 ```javascript
 cy
   .get('p')
-  .should(($p) =>{
+  .should(($p) => {
     // should have found 3 elements
     expect($p).to.have.length(3)
 
@@ -237,7 +237,7 @@ Whatever is returned in the function is ignored. Cypress always forces the comma
 
 ```javascript
 cy
-  .get('button').should(($button) =>{
+  .get('button').should(($button) => {
     expect({foo: 'bar'}).to.deep.eq({foo: 'bar'})
     return {foo: 'bar'} // return is ignored, .should() yields <button>
   })

--- a/source/api/commands/then.md
+++ b/source/api/commands/then.md
@@ -73,7 +73,7 @@ cy.get('button').then(($btn) => {
 cy.wrap(null).then(() => {
     return {id: 123}
   })
-  .then((obj) =>{
+  .then((obj) => {
     // subject is now the obj {id: 123}
     expect(obj.id).to.eq(123) // true
   })
@@ -87,7 +87,7 @@ cy.get('form').then(($form) => {
     // undefined is returned here, but $form will be
     // yielded to allow for continued chaining
   })
-  .find('input').then(($input) =>{
+  .find('input').then(($input) => {
     // we have our $input element here since
     // our form element was yielded and we called
     // .find('input') on it

--- a/source/api/cypress-api/custom-commands.md
+++ b/source/api/cypress-api/custom-commands.md
@@ -484,7 +484,7 @@ it('paginates many search results', function () {
         }
       })
     })
-    .get('#pagination').should($pagination) => {
+    .get('#pagination').should(($pagination) => {
       // should offer to goto next page
       expect($pagination).to.contain('Next')
 


### PR DESCRIPTION
Noticed some inconsistency in a few of the code examples and a few syntax issues.

- Updated `=>{` to `=> {`
- Updated broken example in custom-commands example.
- Missing commas in route example