### PR TITLE
Update dead link in trade-off reference

### DIFF
--- a/source/guides/references/trade-offs.md
+++ b/source/guides/references/trade-offs.md
@@ -30,7 +30,7 @@ Many of these issues are currently being worked on or are on our {% url "Roadmap
 - {% issue 433#issuecomment-280465552 "Testing file downloads is application specific." %}
 - {% issue 685 "Iframe support is somewhat limited, but does work." %}
 - {% issue 310 "There is no cross browser support other than Chrome and Electron." %}
-- {% issue 95#issuecomment-281273126 "You cannot use `cy.route()` on `window.fetch` but there is a workaround." %}, also a {% url "recipe here." https://github.com/cypress-io/cypress-example-recipes/blob/master/examples/stubbing-spying__window-fetch/cypress/integration/spy-stub-clock-spec.js %}
+- {% issue 95#issuecomment-281273126 "You cannot use `cy.route()` on `window.fetch` but there is a workaround." %} See the implementation in {% url "this recipe." https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/stubbing-spying__window-fetch/cypress/integration %}
 
 # Permanent trade-offs
 


### PR DESCRIPTION
This generally references the [window.fetch recipe](https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/stubbing-spying__window-fetch/cypress/integration) but I could see wanting to reference a specific file. 