### PR TITLE
Fix broken link in best practice page

### DIFF
--- a/source/guides/references/_best-practices.md
+++ b/source/guides/references/_best-practices.md
@@ -1,7 +1,0 @@
-title: Best Practices
-
----
-
-# What You'll Learn
-
-- abc

--- a/source/guides/references/best-practices.md
+++ b/source/guides/references/best-practices.md
@@ -546,7 +546,7 @@ cy.get("table tr").should("have.length", 2)
 
 We do NOT recommend trying to start your backend web server from within Cypress.
 
-{% url "`cy.exec()`" exec %} and {% url "`cy.task()`" task %} can only run commands which eventually exit.
+Any command run by {% url "`cy.exec()`" exec %} or {% url "`cy.task()`" task %} has to exit eventually.
 
 Trying to start a web server from {% url "`cy.exec()`" exec %} or {% url "`cy.task()`" task %} causes all kinds of problems because:
 

--- a/source/guides/references/best-practices.md
+++ b/source/guides/references/best-practices.md
@@ -546,7 +546,7 @@ cy.get("table tr").should("have.length", 2)
 
 We do NOT recommend trying to start your backend web server from within Cypress.
 
-Any command run by {% url "`cy.exec()`" exec %} or {% url "`cy.task()`" task %} has to exit eventually.
+Any command run by {% url "`cy.exec()`" exec %} or {% url "`cy.task()`" task %} has to exit eventually. Otherwise, Cypress will not continue running any other commands.
 
 Trying to start a web server from {% url "`cy.exec()`" exec %} or {% url "`cy.task()`" task %} causes all kinds of problems because:
 

--- a/source/guides/references/best-practices.md
+++ b/source/guides/references/best-practices.md
@@ -548,7 +548,7 @@ We do NOT recommend trying to start your backend web server from within Cypress.
 
 {% url "`cy.exec()`" exec %} and {% url "`cy.task()`" task %} can only run commands which eventually exit.
 
-Trying to start a web server from {% url "`cy.exec()`" exec %} or `cy.task()` causes all kinds of problems because:
+Trying to start a web server from {% url "`cy.exec()`" exec %} or {% url "`cy.task()`" task %} causes all kinds of problems because:
 
 - You have to background the process
 - You lose access to it via terminal


### PR DESCRIPTION
I'm not sure why but starting a line with `{% .. %}` makes the header in its below section (`## Setting a global baseUrl`) become a normal text.

![screen shot 2018-10-07 at 11 06 27 pm](https://user-images.githubusercontent.com/7040242/46583750-a4d9d300-ca85-11e8-9eaf-c58e8ce23892.png)

I fixed it by rephrasing the sentence so that it start with some other word. (65ba94a)

**This PR also:**
- Remove unused example page, the actual page already exist 45586a8
- Add a missing link for command reference 9066777
- Add more explanation for why command in `cy.exec` or `cy.task` has to exit e6a09d2

Before | After
--- | ---
![screen shot 2018-10-07 at 11 00 17 pm](https://user-images.githubusercontent.com/7040242/46583720-3eed4b80-ca85-11e8-813c-64803ae04b3f.png) | ![screen shot 2018-10-07 at 10 59 48 pm](https://user-images.githubusercontent.com/7040242/46583721-41e83c00-ca85-11e8-8a50-06e56635ae24.png)
