### PR TITLE
Documented cy.clearLocalStorage and cy.clearCookies only clearing domain

### DIFF
--- a/source/api/commands/clearcookies.md
+++ b/source/api/commands/clearcookies.md
@@ -3,7 +3,7 @@ title: clearCookies
 
 ---
 
-Clear all browser cookies.
+Clear all browser cookies for current domain and subdomain.
 
 {% note warning %}
 Cypress automatically clears all cookies *before* each test to prevent state from being shared across tests. You shouldn't need to use this command unless you're using it to clear a specific cookie inside a single test.

--- a/source/api/commands/clearlocalstorage.md
+++ b/source/api/commands/clearlocalstorage.md
@@ -3,7 +3,7 @@ title: clearLocalStorage
 
 ---
 
-Clear data in local storage.
+Clear data in local storage for current domain and subdomain.
 
 {% note warning %}
 Cypress automatically runs this command *before* each test to prevent state from being shared across tests. You shouldn't need to use this command unless you're using it to clear localStorage inside a single test.


### PR DESCRIPTION
Clarified that LocalStorage and ClearCookies only clear work on the current domain and subdomains. closes #1034 
