### PR TITLE
Correct API documentation for clock command

### DIFF
--- a/source/api/commands/clock.md
+++ b/source/api/commands/clock.md
@@ -34,7 +34,7 @@ cy.clock()
 
 ## Arguments
 
-**{% fa fa-angle-right %} now** ***(Date)***
+**{% fa fa-angle-right %} now** ***(number)***
 
 A timestamp specifying where the clock should start.
 


### PR DESCRIPTION
The current documentation claims that the `now` parameter should be a `Date`, but the examples (and [the test suite](https://github.com/cypress-io/cypress/blob/b2e7148dbef87289336bdbaf39020d22a5544d1f/packages/driver/test/cypress/integration/commands/clock_spec.coffee#L30)) show that it actually expects the UNIX timestamp as a `number`. When we tried to use a `Date` object, we always ended up at the start of the UNIX epoch.

<!--
Thanks for contributing!

Please explain what changes were made and also
reference any issues that were fixed with #[ISSUE]
-->

