### PR TITLE
Add instructions for running Cypress with Yarn

### DIFF
--- a/source/guides/getting-started/installing-cypress.md
+++ b/source/guides/getting-started/installing-cypress.md
@@ -104,6 +104,12 @@ $(npm bin)/cypress open
 npx cypress open
 ```
 
+**Or by using `yarn`**
+
+```shell
+yarn run cypress open
+```
+
 After a moment, the Cypress Test Runner will launch.
 
 ## Adding npm scripts


### PR DESCRIPTION
There were already instructions for installing Cypress with Yarn, this PR just adds instructions for running Cypress with it.

The result is similar (it runs `./node_modules/.bin/cypress open`).