### PR TITLE
Point to correct example project

### DIFF
--- a/source/api/commands/route.md
+++ b/source/api/commands/route.md
@@ -326,7 +326,7 @@ cy.route({
 ***Setup route to error on POST to login***
 
 {% note info %}
-{% url "Check out our example recipe using `cy.route()` to simulate a `503` on `POST` to login" recipes#HTML-Web-Forms %}
+{% url "Check out our example recipe using `cy.route()` to simulate a `503` on `POST` to login" recipes#XHR-Web-Forms %}
 {% endnote %}
 
 ***Change `headers`***


### PR DESCRIPTION
The previously linked example [HTML Web Forms](https://github.com/cypress-io/cypress-example-recipes/blob/master/examples/logging-in__html-web-forms/cypress/integration/logging-in-html-web-form-spec.js) doesn't contain usage of `cy.route`.

Fixed it to point to [XHR-Web-Forms](https://github.com/cypress-io/cypress-example-recipes/blob/master/examples/logging-in__xhr-web-forms/cypress/integration/logging-in-xhr-web-form-spec.js), which has the mentioned POST using route example.

<!--
Thanks for contributing!

Please explain what changes were made and also
reference any issues that were fixed with #[ISSUE]
-->

