### PR TITLE
Add instructions to collect git related info using environment variables

### DIFF
--- a/source/guides/guides/continuous-integration.md
+++ b/source/guides/guides/continuous-integration.md
@@ -301,6 +301,21 @@ Typically you'd set this inside of your CI provider.
 
 ![Travis key environment variable](/img/guides/cypress-record-key-as-env-var-travis.png)
 
+
+## Git Information 
+Cypress uses {% url 'commit-info' https://github.com/cypress-io/commit-info %} package to extract git information (e.g. branch, commit message, author)
+
+It assumes there is `.git` folder and uses Git commands to get each property, like `git show -s --pretty=%B` to get commit message, see {% url 'src/git-api.js' https://github.com/cypress-io/commit-info/blob/master/src/git-api.js %}.
+
+Under some environment setup (e.g. `docker`/`docker-compose`) if `.git` directory is not available/mounted, you can pass all git related information under custom environment variables.
+
+- branch: `COMMIT_INFO_BRANCH`
+- message: `COMMIT_INFO_MESSAGE`
+- email: `COMMIT_INFO_EMAIL`
+- author: `COMMIT_INFO_AUTHOR`
+- sha: `COMMIT_INFO_SHA`
+- remote: `COMMIT_INFO_REMOTE`
+
 ## Custom Environment Variables
 
 You can also set custom environment variables for use in your tests. These enable your code to reference dynamic values.

--- a/source/guides/guides/continuous-integration.md
+++ b/source/guides/guides/continuous-integration.md
@@ -260,7 +260,22 @@ Once multiple machines are available within your CI environment, you can pass th
 
 You can set various environment variables to modify how Cypress runs.
 
-## Record Key
+## Configuration Values
+
+You can set any configuration value as an environment variable. This overrides values in your `cypress.json`.
+
+### Typical use cases would be modifying things like:
+
+- `CYPRESS_BASE_URL`
+- `CYPRESS_VIDEO_COMPRESSION`
+- `CYPRESS_REPORTER`
+- `CYPRESS_INSTALL_BINARY`
+
+{% note info %}
+Refer to the {% url 'configuration' configuration#Environment-Variables %} for more examples.
+{% endnote %}
+
+### Record Key
 
 If you are {% url 'recording your runs' continuous-integration#Recording-tests-in-CI %} on a public project, you'll want to protect your Record Key. {% url 'Learn why.' dashboard-service#Identification %}
 
@@ -285,21 +300,6 @@ Typically you'd set this inside of your CI provider.
 ### TravisCI Environment Variable
 
 ![Travis key environment variable](/img/guides/cypress-record-key-as-env-var-travis.png)
-
-## Other Configuration Values
-
-You can set any configuration value as an environment variable. This overrides values in your `cypress.json`.
-
-### Typical use cases would be modifying things like:
-
-- `CYPRESS_BASE_URL`
-- `CYPRESS_VIDEO_COMPRESSION`
-- `CYPRESS_REPORTER`
-- `CYPRESS_INSTALL_BINARY`
-
-{% note info %}
-Refer to the {% url 'configuration' configuration#Environment-Variables %} for more examples.
-{% endnote %}
 
 ## Custom Environment Variables
 

--- a/source/guides/guides/continuous-integration.md
+++ b/source/guides/guides/continuous-integration.md
@@ -303,11 +303,11 @@ Typically you'd set this inside of your CI provider.
 
 
 ## Git Information 
-Cypress uses {% url 'commit-info' https://github.com/cypress-io/commit-info %} package to extract git information (e.g. branch, commit message, author)
+Cypress uses the {% url 'commit-info' https://github.com/cypress-io/commit-info %} package to extract git information to associate with the run (e.g. branch, commit message, author).
 
-It assumes there is `.git` folder and uses Git commands to get each property, like `git show -s --pretty=%B` to get commit message, see {% url 'src/git-api.js' https://github.com/cypress-io/commit-info/blob/master/src/git-api.js %}.
+It assumes there is a `.git` folder and uses Git commands to get each property, like `git show -s --pretty=%B` to get commit message, see {% url 'src/git-api.js' https://github.com/cypress-io/commit-info/blob/master/src/git-api.js %}.
 
-Under some environment setup (e.g. `docker`/`docker-compose`) if `.git` directory is not available/mounted, you can pass all git related information under custom environment variables.
+Under some environment setups (e.g. `docker`/`docker-compose`) if the `.git` directory is not available or mounted, you can pass all git related information under custom environment variables.
 
 - branch: `COMMIT_INFO_BRANCH`
 - message: `COMMIT_INFO_MESSAGE`


### PR DESCRIPTION
This PR tackles few modifications to the [Continuous-Integration](https://docs.cypress.io/guides/guides/continuous-integration.html) documentation

- Update environment variables in 
   - Renamed `Other Configuration Values` to `Configuration Values`
   - Placed `Record Key` under `Configuration Values` (does that make sense?)
- Add section for git info in continuous-integration.md, which closes #1176 

