### PR TITLE
Fix wrong comment regarding new Date() in docs

### DIFF
--- a/source/api/commands/clock.md
+++ b/source/api/commands/clock.md
@@ -148,7 +148,7 @@ $('#date').text(new Date().toJSON())
 ```
 
 ```javascript
-const now = new Date(2017, 3, 14).getTime() // March 14, 2017 timestamp
+const now = new Date(2017, 3, 14).getTime() // April 14, 2017 timestamp
 
 cy.clock(now)
 cy.visit('/index.html')


### PR DESCRIPTION
Month numbers are 0-indexed in JS Dates, which means that `new Date(2017, 3, 14)` creates a date in **April** and not March.
