### PR TITLE
docs: update guides/command-line.md

### DIFF
--- a/source/guides/guides/command-line.md
+++ b/source/guides/guides/command-line.md
@@ -25,6 +25,8 @@ You'll need to prefix each command with:
 - `$(npm bin)/cypress`
 - ...or...
 - `./node_modules/.bin/cypress`
+- ...or... (requires npm@5.2.0 or greater
+- 'npx cypress`
 
 Or just add cypress commands to the `scripts` field in your `package.json` file.
 {% endnote %}


### PR DESCRIPTION
Adds another command for usage with `npx`, a better practice than the former `./node_modules/.bin/some-executable`