### PR TITLE
include links to slides for many presentations

### DIFF
--- a/source/_data/talks.yml
+++ b/source/_data/talks.yml
@@ -15,6 +15,7 @@ large:
     date: Dec 6, 2018
     author: Gleb Bahmutov
     youtubeId: uowaTHQDcKc
+    slides: https://slides.com/bahmutov/end-vue-end-testing
 
   - title: Next Generation Web Application End to End Testing
     url: https://youtu.be/CkGQ0fFH3yE
@@ -23,6 +24,7 @@ large:
     date: Nov 4, 2018
     author: Amir Rustamzadeh
     youtubeId: CkGQ0fFH3yE
+    slides: https://speakerdeck.com/amir/next-generation-web-application-end-to-end-testing-with-cypress
 
   - title: End-to-end testing is hard - but it doesn't have to be
     url: https://www.youtube.com/watch?v=swpz0H0u13k
@@ -31,6 +33,7 @@ large:
     sourceUrl: https://reactiveconf.com/
     date: Oct 29, 2018
     author: Gleb Bahmutov
+    slides: https://slides.com/bahmutov/reactive-conf
 
   - title: "TDD in Vue with Cypress"
     url: https://www.vuemastery.com/conferences/connect-tech-2018/Test-Driven-Development-in-Vue-with-Cypress/
@@ -55,6 +58,7 @@ large:
     sourceUrl: http://www.reactboston.com/
     date: Sep 29, 2018
     author: Hillary Bauer & Mark Faga
+    slides: https://github.com/mjfaga/react-boston-2018-lunar-launch
 
   - title: "Everything I know about writing quality software"
     url: https://www.youtube.com/watch?v=1PMxLTfh6lo
@@ -62,6 +66,7 @@ large:
     date: Jul 30, 2018
     author: Gleb Bahmutov
     youtubeId: 1PMxLTfh6lo
+    slides: https://slides.com/bahmutov/quality-software
 
   - title: "Hassle free E2E tests with Cypress"
     url: https://www.youtube.com/watch?v=jijOIqtBGYg
@@ -83,6 +88,7 @@ large:
     date: Jun 21, 2018
     author: Steve Schwarz
     youtubeId: LFUm9qV_Gjo
+    slides: https://docs.google.com/presentation/d/1wMR3n8WJAw7VeibSkosdXA2VRjtKNpDD4wRqOPKQElQ/edit#slide=id.p
 
   - title: "Automated Testing for the Modern Web"
     url: https://www.recallact.com/presentation/automated-testing-modern-web
@@ -91,6 +97,7 @@ large:
     date: Jun 21, 2018
     author: Jennifer Shehane
     img: /img/examples/automated-testing-for-the-modern.png
+    slides: https://speakerdeck.com/jennifershehane/automated-testing-for-the-modern-web
 
   - title: "Cypress"
     url: https://www.youtube.com/watch?v=GhyE3Y5oS_0
@@ -105,6 +112,7 @@ large:
     date: May 18, 2018
     author: Gleb Bahmutov
     youtubeId: p38bIMC-YOU
+    slides: https://slides.com/bahmutov/e2e-in-the-future
 
   - title: "Accélerez vos tests end to end avec Cypress"
     url: https://www.youtube.com/watch?v=UpBfQ6mdb8U&amp=&feature=youtu.be


### PR DESCRIPTION
- closes #1195

to include slide link in the talk video, use property `slides: <url>` in the talks.yml like 

```
  - title: Testing Vue with Cypress
    url: https://www.youtube.com/watch?v=uowaTHQDcKc
    sourceName: VueNYC meetup
    sourceUrl: https://www.meetup.com/vueJsNYC/events/254789852/
    date: Dec 6, 2018
    author: Gleb Bahmutov
    youtubeId: uowaTHQDcKc
    slides: https://slides.com/bahmutov/end-vue-end-testing
```