### PR TITLE
Add anchors to plugin types 1257

### DIFF
--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -1,6 +1,7 @@
 'use strict'
 
 /* global hexo */
+const debug = require('debug')('docs')
 
 const helpers = require('../lib/helpers')
 
@@ -190,3 +191,22 @@ hexo.extend.helper.register('lang_name', function (lang) {
 hexo.extend.helper.register('order_by_name', function (posts) {
   return _.sortBy(posts, (post) => post.name.toLowerCase(), 'name')
 })
+
+/**
+ * Helper that creates safe url id from section title.
+ * @example
+ ```
+  {% for pluginType in site.data.plugins %}
+    <h2 id="{{ id(pluginType.name) }}">{{ pluginType.name }}</h2>
+  {% endfor %}
+ ```
+ */
+const id = (title) => {
+  const id = _.kebabCase(_.deburr(title))
+
+  debug('from title "%s" got id "%s"', title, id)
+
+  return id
+}
+
+hexo.extend.helper.register('id', id)

--- a/themes/cypress/layout/plugins.swig
+++ b/themes/cypress/layout/plugins.swig
@@ -8,7 +8,7 @@
       <div class="article-content" itemprop="articleBody">
         {{ (page.content) }}
         {% for pluginType in site.data.plugins %}
-          <h2>{{ pluginType.name }}</h2>
+          <h2 id="{{ id(pluginType.name) }}"><a href="#{{ id(pluginType.name) }}">{{ pluginType.name }}</a></h2>
           <ul class="plugins-list">
             {% for plugin in order_by_name(pluginType.plugins) %}
               <li>


### PR DESCRIPTION
so we can refer to specific types of plugins and send a link. Might look better with a little bit of styling

<img width="565" alt="screen shot 2018-12-26 at 4 17 35 pm" src="https://user-images.githubusercontent.com/2212006/50457526-26752a80-092a-11e9-81d0-e51b51b9b990.png">

- closes #1257 