### PR TITLE
Fix mistake

### DIFF
--- a/source/api/commands/first.md
+++ b/source/api/commands/first.md
@@ -74,7 +74,7 @@ cy.get('li').first()
 
 ## Assertions {% helper_icon assertions %}
 
-{% assertions existence .find %}
+{% assertions existence .first %}
 
 ## Timeouts {% helper_icon timeout %}
 


### PR DESCRIPTION
I think that the explanations should be about `first` rather than about `find`.

