### PR TITLE
add should(cb) examples for #1267

### DIFF
--- a/source/api/commands/should.md
+++ b/source/api/commands/should.md
@@ -127,11 +127,11 @@ cy.get('#header a').should('have.attr', 'href', '/users')
 
 ## Function
 
-### Verify length, content, and classes from multiple `<p>`
-
 Passing a function to `.should()` enables you to make multiple assertions on the yielded subject. This also gives you the opportunity to *massage* what you'd like to assert on.
 
 Just be sure *not* to include any code that has side effects in your callback function. The callback function will be retried over and over again until no assertions within it throw.
+
+### Verify length, content, and classes from multiple `<p>`
 
 ```html
 <div>
@@ -163,6 +163,31 @@ cy
       'text-danger',
       'text-default'
     ])
+  })
+```
+
+### Asserting class name that starts with `heading-` is present
+
+```html
+<div class="scope-classes">
+  <div class="main-abc123 heading-xyz987">Scoped classes</div>
+</div>
+```
+
+```js
+cy.get('.scope-classes')
+  .find('div')
+  // .should(cb) callback function will be retried
+  .should(($div) => {
+    expect($div).to.have.length(1)
+    const className = $div[0].className
+
+    expect(className).to.match(/heading-/)
+  })
+  // .then(cb) callback is not retried,
+  // it either passes or fails
+  .then(($div) => {
+    expect($div).to.have.text('Scoped classes')
   })
 ```
 

--- a/source/guides/references/assertions.md
+++ b/source/guides/references/assertions.md
@@ -240,3 +240,21 @@ cy.get('#loading').should('not.exist')
 // retry until our radio is checked
 cy.get(':radio').should('be.checked')
 ```
+
+# Should callback
+
+If built-in assertions are not enough, you can easily write your own assertion function and pass it as a callback to `.should()` method. Cypress will automatically retry the callback function until it passes or the command times out. See {% url `should(cb)` should#Function %} documentation.
+
+```html
+<div class="main-abc123 heading-xyz987">Scoped classes</div>
+```
+```javascript
+cy.get('div')
+  .should(($div) => {
+    expect($div).to.have.length(1)
+    const className = $div[0].className
+
+    // className will be a string like "main-abc123 heading-xyz987"
+    expect(className).to.match(/heading-/)
+  })
+```


### PR DESCRIPTION
- closes #1267 
- [ ] clarify the `Assert explicitly within .should() - Any errors raised by failed assertions will immediately bubble up and cause the test to fail.` text because it is confusing, isn't the `should(cb)` retried until it times out or passes, but not immediately fail?
- [ ] add `cypress-pipe` example where `cy.pipe(cb1).should(cb2)` is used