### PR TITLE
clarify effect of should command on implicit DOM assertions

### DIFF
--- a/source/api/commands/should.md
+++ b/source/api/commands/should.md
@@ -290,6 +290,10 @@ cy.get('button').click()
 
 # Notes
 
+## Effect on default DOM assertions
+
+When you chain `.should()` on a DOM-based command, the default `.should('exist')` assertion is skipped. This may result in an unexpected behavior such as negative assertions passing even when the element doesn't exist in the DOM. See {% url 'Default Assertions' introduction-to-cypress#Default-Assertions %} for more.
+
 ## Subjects
 
 ### How do I know which assertions change the subject and which keep it the same?

--- a/source/guides/core-concepts/introduction-to-cypress.md
+++ b/source/guides/core-concepts/introduction-to-cypress.md
@@ -674,7 +674,27 @@ Even more - action commands will automatically wait for their element to reach a
 {% note success Core Concept %}
 All DOM based commands automatically wait for their elements to exist in the DOM.
 
-You **never** need to write {% url "`.should('exist')`" should %} after a DOM based command.
+You don't need to write {% url "`.should('exist')`" should %} after a DOM based command, unless you chain extra `.should()` assertions -- see below.
+{% endnote %}
+
+{% note danger Negative DOM assertions %}
+If you chain any `.should()` command, the default `.should('exist')` is not asserted. This does not matter for most *positive* assertions (such as `.should('have.class')`) because those imply existence in the first place, but if you chain *negative* assertions (such as `.should('not.have.class')`) they will pass even if the DOM element doesn't exist:
+
+```js
+cy.get('.does-not-exist').should('not.be.visible'); // passes
+cy.get('.does-not-exist').should('not.have.descendants') // passes
+```
+
+This also applies to custom assertions such as when passing a callback:
+
+```js
+// passes, provided the callback itself passes
+cy.get('.does-not-exist').should( $element => {
+  expect($element.find('input')).to.not.exist;
+});
+```
+
+There's an {% url 'open discussion' https://github.com/cypress-io/cypress/issues/205 %} about this behavior.
 {% endnote %}
 
 These rules are pretty intuitive, and most commands give you flexibility to override or bypass the default ways they can fail, typically by passing a `{force: true}` option.

--- a/source/guides/core-concepts/introduction-to-cypress.md
+++ b/source/guides/core-concepts/introduction-to-cypress.md
@@ -674,14 +674,14 @@ Even more - action commands will automatically wait for their element to reach a
 {% note success Core Concept %}
 All DOM based commands automatically wait for their elements to exist in the DOM.
 
-You don't need to write {% url "`.should('exist')`" should %} after a DOM based command, unless you chain extra `.should()` assertions -- see below.
+You don't need to write {% url "`.should('exist')`" should %} after a DOM based command, unless you chain extra `.should()` assertions.
 {% endnote %}
 
 {% note danger Negative DOM assertions %}
 If you chain any `.should()` command, the default `.should('exist')` is not asserted. This does not matter for most *positive* assertions (such as `.should('have.class')`) because those imply existence in the first place, but if you chain *negative* assertions (such as `.should('not.have.class')`) they will pass even if the DOM element doesn't exist:
 
 ```js
-cy.get('.does-not-exist').should('not.be.visible'); // passes
+cy.get('.does-not-exist').should('not.be.visible')       // passes
 cy.get('.does-not-exist').should('not.have.descendants') // passes
 ```
 
@@ -689,15 +689,15 @@ This also applies to custom assertions such as when passing a callback:
 
 ```js
 // passes, provided the callback itself passes
-cy.get('.does-not-exist').should( $element => {
-  expect($element.find('input')).to.not.exist;
-});
+cy.get('.does-not-exist').should(($element) => {
+  expect($element.find('input')).to.not.exist
+})
 ```
 
 There's an {% url 'open discussion' https://github.com/cypress-io/cypress/issues/205 %} about this behavior.
 {% endnote %}
 
-These rules are pretty intuitive, and most commands give you flexibility to override or bypass the default ways they can fail, typically by passing a `{force: true}` option.
+These rules are pretty intuitive, and most commands give you the flexibility to override or bypass the default ways they can fail, typically by passing a `{force: true}` option.
 
 ### Example #1: Existence and Actionability
 


### PR DESCRIPTION
Addresses https://github.com/cypress-io/cypress/issues/205.

I'm unsure of styleguide, technical correctness etc. (see below). Changes welcome.

# notes

- I've changed the strong wording of `You **never** need to write` → `You don't need to write`, because it's not strictly true.
- I'm not sure the statement:
  
  > When you chain `.should()` on a DOM-based command, the default `.should('exist')` assertion is skipped
  
  is *technically* correct (I've only skimmed [`asserting.coffee`](https://github.com/cypress-io/cypress/blob/develop/packages/driver/src/cy/commands/asserting.coffee) and [`assertions.coffee`](https://github.com/cypress-io/cypress/blob/develop/packages/driver/src/cy/assertions.coffee) and haven't quite figured it out), but it seems *practically* correct.

- I haven't yet managed to run docs locally thus I have no real idea how the changes look rendered.
- As for commit message, I'm not sure if I'm supposed to reference issues from other repos.