### PR TITLE
fixed duplicate issue referenced in changelog 1.4.2

### DIFF
--- a/source/_changelogs/1.4.2.md
+++ b/source/_changelogs/1.4.2.md
@@ -9,7 +9,7 @@
 - Fixed not being able to visit URLs that used `*localhost` such as `http://app.localhost:8080`. Fixes {% issue 451 %}.
 - Mochawesome now works correctly and outputs files in all versions. Fixes {% issue 551 %}.
 - Mochawesome will exit correctly with code `1` when a hook fails. {% issue 1063 %}.
-- Fixed some incorrect typings with TypeScript. Fixes {% issue 1219 %} and {% issue 1219 %}.
+- Fixed some incorrect typings with TypeScript. Fixes {% issue 1219 %} and {% issue 1186 %}.
 - Fixed bug with custom 3rd party mocha reporters relying on `test.titlePath` being a function. Fixes {% issue 1142 %}.
 - Fixed typo in `cypress.schema.json`. Fixes {% issue 1167 %}.
 - Fixed typo in CLI deps error about Docker. Fixes {% issue 1136 %}.


### PR DESCRIPTION
fixes duplicate issue references in one of the changelog files

<img width="959" alt="screen shot 2019-01-16 at 5 59 59 pm" src="https://user-images.githubusercontent.com/2212006/51284151-8f474400-19b8-11e9-801f-8c5ef12326c3.png">
