### PR TITLE
Clarify that non-XHRs won't be intercepted

### DIFF
--- a/lib/tags/partial.js
+++ b/lib/tags/partial.js
@@ -1,7 +1,14 @@
 const path = require('path')
+const fs = require('fs')
+const rawRender = require('../raw_render')
 
 module.exports = function partial (hexo, fileName) {
   const pathToFile = path.resolve('source', '_partial', `${fileName}.md`)
-
-  return hexo.render.renderSync({ path: pathToFile, engine: 'markdown' })
+  
+  return new Promise((resolve, reject) => {
+    fs.readFile(pathToFile, (err, data) => {
+      if (err) reject(err)
+      resolve(rawRender(hexo, data.toString(), { engine: 'markdown' }))
+    })
+  })
 }

--- a/source/_partial/network_stubbing_warning.md
+++ b/source/_partial/network_stubbing_warning.md
@@ -1,0 +1,3 @@
+{% note warning %}
+Please be aware that Cypress only currently supports intercepting XMLHttpRequests. Requests using the Fetch API and other types of network requests like page loads will not be intercepted. See {% issue 95 %} for more details and temporary workarounds.
+{% endnote %}

--- a/source/_partial/network_stubbing_warning.md
+++ b/source/_partial/network_stubbing_warning.md
@@ -1,3 +1,3 @@
 {% note warning %}
-Please be aware that Cypress only currently supports intercepting XMLHttpRequests. Requests using the Fetch API and other types of network requests like page loads will not be intercepted. See {% issue 95 %} for more details and temporary workarounds.
+Please be aware that Cypress only currently supports intercepting XMLHttpRequests. Requests using the Fetch API and other types of network requests like page loads and `<script>` tags will not be intercepted or visible in the Command Log. See {% issue 95 %} for more details and temporary workarounds.
 {% endnote %}

--- a/source/api/commands/route.md
+++ b/source/api/commands/route.md
@@ -8,9 +8,7 @@ Use `cy.route()` to manage the behavior of network requests.
 **Note:** `cy.route()` assumes you are already familiar with core concepts such as {% url 'network requests' network-requests %}
 {% endnote %}
 
-{% note warning %}
-Please be aware that Cypress does NOT currently support the Fetch API. See {% issue 95 %} for more details and temporary workarounds.
-{% endnote %}
+{% partial network_stubbing_warning %}
 
 # Syntax
 

--- a/source/api/commands/server.md
+++ b/source/api/commands/server.md
@@ -8,9 +8,7 @@ Start a server to begin routing responses to {% url `cy.route()` route %} and {%
 **Note:** `cy.server()` assumes you are already familiar with core concepts such as {% url 'network requests' network-requests %}.
 {% endnote %}
 
-{% note warning %}
-Please be aware that Cypress does NOT currently support the Fetch API. See {% issue 95 %} for more details and temporary workarounds.
-{% endnote %}
+{% partial network_stubbing_warning %}
 
 # Syntax
 

--- a/source/api/commands/wait.md
+++ b/source/api/commands/wait.md
@@ -63,9 +63,7 @@ Option | Default | Description
 
 {% yields sets_subject cy.wait 'yields an object containing the HTTP request and response properties of the XHR' %}
 
-{% note warning %}
-Please be aware that Cypress does NOT currently support the Fetch API. See {% issue 95 %} for more details and temporary workarounds.
-{% endnote %}
+{% partial network_stubbing_warning %}
 
 # Examples
 

--- a/source/guides/guides/network-requests.md
+++ b/source/guides/guides/network-requests.md
@@ -17,9 +17,7 @@ title: Network Requests
 
 Cypress makes it easy to test the entire lifecycle of Ajax / XHR requests within your application. Cypress provides you direct access to the XHR objects, enabling you to make assertions about its properties. Additionally you can even stub and mock a request's response.
 
-{% note warning %}
-Please be aware that Cypress does NOT currently support the Fetch API. See {% issue 95 %} for more details and temporary workarounds.
-{% endnote %}
+{% partial network_stubbing_warning %}
 
 ***Common testing scenarios:***
 


### PR DESCRIPTION
Closes #1391

Had to modify the `partial` tag so that it would support using the `note` tag inside of a partial, so that's why that's there