### PR TITLE
feat(plugins): add cypress-social-logins

### DIFF
--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -155,6 +155,11 @@
       description: NTLM authentication support for Cypress
       link: https://github.com/bjowes/cypress-ntlm-auth
       keywords: [authentication, ntlm]
+      
+    - name: cypress-social-logins
+      description: Cypress authentication flows using social network providers
+      link: https://github.com/lirantal/cypress-social-logins
+      keywords: [authentication, login, social profiles, github, google]
 
 - name: Framework Tooling
   plugins:


### PR DESCRIPTION
Adds a new authentication plugin type to the list of Plugins: [cypress-social-plugins](https://github.com/lirantal/cypress-social-logins)