### PR TITLE
Update Error Handling documentation

### DIFF
--- a/source/guides/core-concepts/conditional-testing.md
+++ b/source/guides/core-concepts/conditional-testing.md
@@ -387,6 +387,7 @@ However, this is really the same question as asking to do conditional testing ju
 
 For instance you may want to do this:
 
+**The following code is not valid, you cannot add error handling to Cypress commands. The code is just for demonstration purposes.**
 ```js
 cy.get('button').contains('hello')
   .catch((err) => {
@@ -406,6 +407,7 @@ Enabling this would mean that for every single command, it would recover from er
 
 Let's reimagine our "Welcome Wizard" example from before.
 
+**The following code is not valid, you cannot add error handling to Cypress commands. The code is just for demonstration purposes.**
 ```js
 // great error recovery code
 function keepCalmAndCarryOn () {


### PR DESCRIPTION
This doesn't remove `.catch()` from the code examples in the Error Handling section, but it does make it clear the code is not valid and is for demonstration purposes only.

closes #789 