### PR TITLE
Update screenshots-and-videos.md

### DIFF
--- a/source/guides/guides/screenshots-and-videos.md
+++ b/source/guides/guides/screenshots-and-videos.md
@@ -3,13 +3,14 @@ title: Screenshots and Videos
 ---
 
 {% note info %}
+
 # {% fa fa-graduation-cap %} What you'll learn
 
 - How Cypress captures screenshots of test failures automatically
 - How to manually capture your own screenshot
 - How Cypress can record a video of the entire run
 - Some options of what to do with screenshot and video artifacts
-{% endnote %}
+  {% endnote %}
 
 # Screenshots
 
@@ -34,6 +35,8 @@ This behavior can be turned off by setting {% url `video` configuration#Videos %
 Videos are stored in the {% url `videosFolder` configuration#Videos %} which is set to `cypress/videos` by default.
 
 After `cypress run` completes, Cypress will automatically compress the video in order to save on file size. By default it compresses to a `32 CRF` but this is configurable with the {% url `videoCompression` configuration#Videos %} property.
+
+By default, videos are processed + compressed after every run, successful or not. To change this behavior to only process videos in the case that tests fail, set the {% url `videoUploadOnPasses` configuration#Videos %} configuration option to `false`.
 
 By default, Cypress clears any existing videos before a `cypress run`. If do not want to clear your videos folder before a run, you can set {% url `trashAssetsBeforeRuns` configuration#Videos %} to `false`.
 

--- a/source/guides/guides/screenshots-and-videos.md
+++ b/source/guides/guides/screenshots-and-videos.md
@@ -3,14 +3,13 @@ title: Screenshots and Videos
 ---
 
 {% note info %}
-
 # {% fa fa-graduation-cap %} What you'll learn
 
 - How Cypress captures screenshots of test failures automatically
 - How to manually capture your own screenshot
 - How Cypress can record a video of the entire run
 - Some options of what to do with screenshot and video artifacts
-  {% endnote %}
+{% endnote %}
 
 # Screenshots
 

--- a/source/guides/guides/screenshots-and-videos.md
+++ b/source/guides/guides/screenshots-and-videos.md
@@ -35,7 +35,7 @@ Videos are stored in the {% url `videosFolder` configuration#Videos %} which is 
 
 After `cypress run` completes, Cypress will automatically compress the video in order to save on file size. By default it compresses to a `32 CRF` but this is configurable with the {% url `videoCompression` configuration#Videos %} property.
 
-By default, videos are processed + compressed after every run, successful or not. To change this behavior to only process videos in the case that tests fail, set the {% url `videoUploadOnPasses` configuration#Videos %} configuration option to `false`.
+By default, videos are processed and compressed after every spec file runs, successful or not. To change this behavior to only process videos in the case that tests fail, set the {% url `videoUploadOnPasses` configuration#Videos %} configuration option to `false`.
 
 By default, Cypress clears any existing videos before a `cypress run`. If do not want to clear your videos folder before a run, you can set {% url `trashAssetsBeforeRuns` configuration#Videos %} to `false`.
 


### PR DESCRIPTION
Add a note about how the `videoUploadOnPasses` option can be used to avoid processing and uploading videos in the case that all tests pass.

Partially addresses https://github.com/cypress-io/cypress/issues/2217, https://github.com/cypress-io/cypress/issues/2522