### PR TITLE
Add the cypress-protobuf plugin

### DIFF
--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -275,3 +275,10 @@
       description: A simple tool which integrates Cypress with Slack to report failing tests.
       link: https://github.com/bdimitrovski/cypress-healthcheck
       keywords: [reporter, slack, healthcheck]
+
+- name: Fixture encoding
+  plugins:
+    - name: cypress-protobuf
+      description: Encode a fixture with Protocol Buffers.
+      link: https://github.com/NoriSte/cypress-protobuf
+      keywords: [encoding, protobuf]

--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -41,6 +41,11 @@
       description: Several color themes for Cypress test runner
       link: https://github.com/bahmutov/cypress-dark
       keywords: [theme]
+      
+    - name: cypress-protobuf
+      description: Encode a fixture with Protocol Buffers.
+      link: https://github.com/NoriSte/cypress-protobuf
+      keywords: [encoding, protobuf]
 
     - name: Docker
       description: Docker images providing all the dependencies to run Cypress in CI including browsers.
@@ -275,10 +280,3 @@
       description: A simple tool which integrates Cypress with Slack to report failing tests.
       link: https://github.com/bdimitrovski/cypress-healthcheck
       keywords: [reporter, slack, healthcheck]
-
-- name: Fixture encoding
-  plugins:
-    - name: cypress-protobuf
-      description: Encode a fixture with Protocol Buffers.
-      link: https://github.com/NoriSte/cypress-protobuf
-      keywords: [encoding, protobuf]


### PR DESCRIPTION
I created a Cypress plugin that allows encoding the fixtures with [Protobuf](https://developers.google.com/protocol-buffers/) before sending them to the web app. It allows to easily manage the fixtures in case your of Protobuf-based client-server communication.