### PR TITLE
fix typo in example url. two slash should be one

### DIFF
--- a/source/api/commands/url.md
+++ b/source/api/commands/url.md
@@ -94,7 +94,7 @@ Instead of hardcoding the URL you can use the `baseUrl` of the {% url 'Cypress c
 Given the remote URL, `http://localhost:8000/index.html`, these assertions are the same.
 
 ```javascript
-cy.url().should('eq', 'http://localhost:8000//index.html')
+cy.url().should('eq', 'http://localhost:8000/index.html')
 cy.url().should('eq', Cypress.config().baseUrl + '/index.html') // tests won't fail in case the port changes
 ```
 


### PR DESCRIPTION

example url is http://localhost:8000/index.html but code snipped used http://localhost:8000//index.html