### PR TITLE
Added cypress-commands to the list of plugins

### DIFF
--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -174,6 +174,11 @@
       link: https://github.com/Bkucera/cypress-plugin-tab
       keywords: [commands]
 
+    - name: cypress-commands
+      description: A collection of Cypress commands to extend and compliment the defaults
+      link: https://github.com/Lakitna/cypress-commands
+      keywords: [commands]
+
 - name: Authentication
   description: Also take a look at ["Logging in"](https://github.com/cypress-io/cypress-example-recipes#logging-in-recipes) recipes.
   plugins:


### PR DESCRIPTION
Added `cypress-commands` to the list of plugins as requested by @jennifer-shehane in https://github.com/cypress-io/cypress/issues/3109