### PR TITLE
use node 8.15.1 base image

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -14,7 +14,7 @@ defaults: &defaults
   docker:
     # the Docker image with Cypress dependencies
     # https://github.com/cypress-io/cypress-docker-images
-    - image: cypress/base:8
+    - image: cypress/base:8.15.1
       environment:
         <<: *env_defaults
 


### PR DESCRIPTION
brings the new `cypress/base:8.15.1` Docker image