### PR TITLE
Update command-line.md with notes about --group

### DIFF
--- a/source/guides/guides/command-line.md
+++ b/source/guides/guides/command-line.md
@@ -124,7 +124,7 @@ Typically, this is defined as an environment variable within your CI provider, d
 cypress run --ci-build-id BUILD_NUMBER
 ```
 
-Read our {% url "parallelization" parallelization %} documentation to learn more.
+Only valid when providing a `--group` or `--parallel` flag. Read our {% url "parallelization" parallelization %} documentation to learn more.
 
 ### `cypress run --config <config>`
 
@@ -171,6 +171,8 @@ cypress run --group admin-tests --spec 'cypress/integration/admin/**/*
 ```shell
 cypress run --group user-tests --spec 'cypress/integration/user/**/*
 ```
+
+Specifying the `--ci-build-id` may also be necessary.
 
 {% url "Read more about grouping." parallelization#Grouping-test-runs %}
 


### PR DESCRIPTION
While trying to get tests running, the documentation wasn't clear on what was needed, so wanted to make the document hint that there are interdependencies on the flags.

I was supplying just `--group` and got this:

```
We encountered an unexpected error talking to our servers.
There is likely something wrong with the request.
The --group flag you passed was: Windows/Electron
The server's response was:
StatusCodeError: 422
{
"code": "INDETERMINATE_CI_BUILD_ID",
"message": "CI Build ID could not be generated and was not specified."
}
```

I then figured out that I needed to supply a `--ci-build-id` flag.  However the free Cypress.io plan doesn't allow for grouping, so I removed `--group` leaving only `--ci-build-id` and got this:

```
You passed the --ci-build-id flag but did not provide either a --group or --parallel flag.
The --ci-build-id flag you passed was: 2019.4.7.3
The --ci-build-id flag is used to either group or parallelize multiple runs together.
```

This pull request adds to the documentation that these can't be used independently, and especially in the `--group` case, that more might be needed.
