### PR TITLE
Update installing-cypress with new download URLs

### DIFF
--- a/source/guides/getting-started/installing-cypress.md
+++ b/source/guides/getting-started/installing-cypress.md
@@ -247,7 +247,7 @@ The download server url is `https://download.cypress.io`.
 We currently have the following downloads available:
 
 * Windows 64-bit (`?platform=win32&arch=x64`)
-* Windows 32-bit (`?platform=win32&arch=ia32`, available since Cypress 3.3.0)
+* Windows 32-bit (`?platform=win32&arch=ia32`, available since {% url "Cypress 3.3.0" changelog#3-3-0 %})
 * Linux 64-bit (`?platform=linux`)
 * macOS 64-bit (`?platform=darwin`)
 

--- a/source/guides/getting-started/installing-cypress.md
+++ b/source/guides/getting-started/installing-cypress.md
@@ -238,26 +238,33 @@ CYPRESS_RUN_BINARY=~/Downloads/Cypress/Cypress.exe cypress run
 We recommend **not exporting** the `CYPRESS_RUN_BINARY` environment variable, since it will affect every cypress module installed on your file system.
 {% endnote %}
 
-## Hosting
+## Download URLs
 
-If you want to download a specific Cypress version for a given platform (Operating System), you can get it from our CDN. You may also want to host Cypress yourself and serve it from a local network.
+If you want to download a specific Cypress version for a given platform (Operating System), you can get it from our CDN.
 
 The download server url is `https://download.cypress.io`.
 
-See {% url "https://download.cypress.io/desktop.json" https://download.cypress.io/desktop.json %} for all available platforms.
+We currently have the following downloads available:
+
+* Windows 64-bit (`?platform=win32&arch=x64`)
+* Windows 32-bit (`?platform=win32&arch=ia32`, available since Cypress 3.3.0)
+* Linux 64-bit (`?platform=linux`)
+* macOS 64-bit (`?platform=darwin`)
+
+Here are the available download URLs:
 
  Method | Url                            | Description
  ------ | ------------------------------ | -------------------------------------------------------------------------
  `GET`  | `/desktop                 `    | Download Cypress at latest version (platform auto-detected)
  `GET`  | `/desktop.json            `    | Returns JSON containing latest available CDN destinations
- `GET`  | `/desktop?platform=p      `    | Download Cypress for a specific platform
+ `GET`  | `/desktop?platform=p&arch=a  ` | Download Cypress for a specific platform and/or architecture
  `GET`  | `/desktop/:version`            | Download Cypress with a specified version
- `GET`  | `/desktop/:version?platform=p` | Download Cypress with a specified version and platform
+ `GET`  | `/desktop/:version?platform=p&arch=a` | Download Cypress with a specified version and platform and/or architecture
 
-**Example of downloading Cypress `3.0.0` for Windows platform:**
+**Example of downloading Cypress `3.0.0` for Windows 64-bit:**
 
 ```
-https://download.cypress.io/desktop/3.0.0?platform=win
+https://download.cypress.io/desktop/3.0.0?platform=win32&arch=x64
 ```
 
 ## Mirroring


### PR DESCRIPTION
This documents how to download the new 32-bit builds, as well as updates the section to document only the platforms and arches which should be used going forward.

Fixes #1568 
