### PR TITLE
Fixed the order of arguments for .map in example

### DIFF
--- a/source/guides/core-concepts/introduction-to-cypress.md
+++ b/source/guides/core-concepts/introduction-to-cypress.md
@@ -831,7 +831,7 @@ cy
   .should(($p) => {
     // massage our subject from a DOM element
     // into an array of texts from all of the p's
-    let texts = $p.map((i, el) => {
+    let texts = $p.map((el, i) => {
       return Cypress.$(el).text()
     })
 


### PR DESCRIPTION
**This pull request fixes the order of arguments for .map in code example**

Details:
https://docs.cypress.io/guides/core-concepts/introduction-to-cypress.html#Explicit-Subjects - jQuery map accept callback function with arguments `( Object elementOfArray, Integer indexInArray )` (http://api.jquery.com/jQuery.map/).

So, it should be
`$p.map((el, i) => {`
instead of
`$p.map((i, el) => {`