### PR TITLE
Add the cypress-wait-until plugin

### DIFF
--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -183,6 +183,11 @@
       description: A collection of Cypress commands to extend and compliment the defaults
       link: https://github.com/Lakitna/cypress-commands
       keywords: [commands]
+      
+    - name: cypress-wait-until
+      description: Add the Cypress waiting power to virtually everything 🎉
+      link: https://github.com/NoriSte/cypress-wait-until
+      keywords: [commands, wait, wait-until, recursive-promise, check-async-value, check-value, open-source-saturday]
 
 - name: Authentication
   description: Also take a look at ["Logging in"](https://github.com/cypress-io/cypress-example-recipes#logging-in-recipes) recipes.


### PR DESCRIPTION
A lot of StackOverflow users had some difficulties in implementing a recursive promise with Cypress just to repeatedly check for something to happen (see two of the various questions about the topic: How can i wait for each element in a list to update to a certain text? And How do I wait until a cookie is set?). 
We wrote this plugin to file this kind of issues

<!--
Thanks for contributing!

Please explain what changes were made and also
reference any issues that were fixed with #[ISSUE]
-->

