### PR TITLE
Add 'Chromium' and 'Canary' to browser launch api doc to imply they're also supported

### DIFF
--- a/source/api/plugins/browser-launch-api.md
+++ b/source/api/plugins/browser-launch-api.md
@@ -20,7 +20,7 @@ This event will yield you the `browser` as an object, and `args` which are the d
 
 Here are options for the currently supported browsers:
 
-* {% url 'Chrome' "https://peter.sh/experiments/chromium-command-line-switches/" %}
+* {% url 'Chrome, Chromium, or Canary' "https://peter.sh/experiments/chromium-command-line-switches/" %}
 * {% url 'Electron' "https://github.com/electron/electron/blob/master/docs/api/browser-window.md#new-browserwindowoptions" %}
 
 ```js


### PR DESCRIPTION
- close #1576 