### PR TITLE
Update Travis example re: Travis env. update

### DIFF
--- a/source/guides/guides/continuous-integration.md
+++ b/source/guides/guides/continuous-integration.md
@@ -162,12 +162,11 @@ CI Provider | Example Project | Example Config
 language: node_js
 node_js:
   - 10
-services:
-- xvfb
 addons:
   apt:
     packages:
-    - libgconf-2-4
+      # Ubuntu 16+ does not install this dependency by default, so we need to install it ourselves
+      - libgconf-2-4
 cache:
   # Caches $HOME/.npm when npm ci is default script command
   # Caches node_modules in all other cases

--- a/source/guides/guides/continuous-integration.md
+++ b/source/guides/guides/continuous-integration.md
@@ -162,6 +162,12 @@ CI Provider | Example Project | Example Config
 language: node_js
 node_js:
   - 10
+services:
+- xvfb
+addons:
+  apt:
+    packages:
+    - libgconf-2-4
 cache:
   # Caches $HOME/.npm when npm ci is default script command
   # Caches node_modules in all other cases


### PR DESCRIPTION
In response to this issue in the primary repo - https://github.com/cypress-io/cypress/issues/4069

Travis build environment(s) have been updated from running Ubuntu 14 to Ubuntu 16 which requires `libgconf-2-4` (Electron dependency which might be removed in future) to be installed manually.

Also xvfb must be installed/started manually as well it seems -- though unsure if Cypress itself does this when ran headlessly so this could be moot.

<!--
Thanks for contributing!

Please explain what changes were made and also
reference any issues that were fixed with #[ISSUE]
-->

