### PR TITLE
Document retryOnStatusCodeFailure, retryOnNetworkFailure

### DIFF
--- a/source/api/commands/request.md
+++ b/source/api/commands/request.md
@@ -109,6 +109,8 @@ Option | Default | Description
 `headers` | `null` | Additional headers to send; Accepts object literal
 `qs` | `null` | Query parameters to append to the `url` of the request
 `timeout` | {% url `responseTimeout` configuration#Timeouts %} | {% usage_options timeout cy.request %}
+`retryOnStatusCodeFailure` | `false` | Whether Cypress should automatically retry status code errors under the hood
+`retryOnNetworkFailure` | `true` | Whether Cypress should automatically retry transient network errors under the hood
 
 You can also set options for `cy.request`'s `baseUrl` and `responseTimeout` globally in {% url 'configuration' configuration %}.
 

--- a/source/api/commands/visit.md
+++ b/source/api/commands/visit.md
@@ -50,6 +50,8 @@ Option | Default | Description
 `onBeforeLoad` | `function` | Called before your page has loaded all of its resources.
 `onLoad` | `function` | Called once your page has fired its load event.
 `timeout` | {% url `pageLoadTimeout` configuration#Timeouts %} | {% usage_options timeout cy.visit %}
+`retryOnStatusCodeFailure` | `false` | Whether Cypress should automatically retry status code errors under the hood
+`retryOnNetworkFailure` | `true` | Whether Cypress should automatically retry transient network errors under the hood
 
 You can also set all `cy.visit()` commands' `pageLoadTimeout` and `baseUrl` globally in {% url 'configuration' configuration %}.
 


### PR DESCRIPTION
Closes #1648 

I wonder if we should document the nature of the request retries under the hood. Probably not, since it should be transparent to the user?