### PR TITLE
Change download link to use HTTPS

### DIFF
--- a/source/guides/getting-started/installing-cypress.md
+++ b/source/guides/getting-started/installing-cypress.md
@@ -68,7 +68,7 @@ yarn add cypress --dev
 
 ## {% fa fa-download %} Direct download
 
-If you're not using Node.js or `npm` in your project or you just want to try Cypress out quickly, you can always {% url "download Cypress directly from our CDN" http://download.cypress.io/desktop %}.
+If you're not using Node.js or `npm` in your project or you just want to try Cypress out quickly, you can always {% url "download Cypress directly from our CDN" https://download.cypress.io/desktop %}.
 
 The direct download will always grab the latest available version. Your platform will be detected automatically.
 


### PR DESCRIPTION
The download link was HTTP and the HSTS configuration for domain cypress.io doesn't include subdomains, so directing to http for download would allow a network attacker to redirect to an infected copy or other malware.

<!--
Thanks for contributing!

Please explain what changes were made and also
reference any issues that were fixed with #[ISSUE]
-->

