### PR TITLE
Clarify that cy.visit headers are only for initial request

### DIFF
--- a/source/api/commands/visit.md
+++ b/source/api/commands/visit.md
@@ -43,7 +43,7 @@ Option | Default | Description
 `url` | `null` | The URL to visit. Behaves the same as the `url` argument.
 `method` | `GET` | The HTTP method to use in the visit. Can be `GET` or `POST`.
 `body` | `null` | An optional body to send along with a `POST` request. If it is a string, it will be passed along unmodified. If it is an object, it will be URL encoded to a string and sent with a `Content-Type: application/x-www-urlencoded` header.
-`headers` | `{}` | An object that maps HTTP header names to values to be sent along with the request.
+`headers` | `{}` | An object that maps HTTP header names to values to be sent along with the request. *Note:* `headers` will only be sent for the initial `cy.visit()` request, not for any subsequent requests.
 `log` | `true` | {% usage_options log %}
 `auth` | `null` | Adds Basic Authorization headers
 `failOnStatusCode` | `true` | Whether to fail on response codes other than `2xx` and `3xx`


### PR DESCRIPTION
Fixes #1697