### PR TITLE
Switch order of args for imgTag (alt text <=> src)

### DIFF
--- a/source/guides/core-concepts/test-runner.md
+++ b/source/guides/core-concepts/test-runner.md
@@ -13,7 +13,7 @@ title: The Test Runner
 
 Cypress runs tests in a unique interactive runner that allows you to see commands as they execute while also viewing the application under test.
 
-{% imgTag /img/guides/gui-diagram.png no-border "Cypress Test Runner" %}
+{% imgTag /img/guides/gui-diagram.png "Cypress Test Runner" "no-border" %}
 
 # Command Log
 

--- a/source/guides/core-concepts/test-runner.md
+++ b/source/guides/core-concepts/test-runner.md
@@ -13,7 +13,7 @@ title: The Test Runner
 
 Cypress runs tests in a unique interactive runner that allows you to see commands as they execute while also viewing the application under test.
 
-{% imgTag no-border /img/guides/gui-diagram.png "Cypress Test Runner" %}
+{% imgTag /img/guides/gui-diagram.png no-border "Cypress Test Runner" %}
 
 # Command Log
 

--- a/source/ja/guides/core-concepts/test-runner.md
+++ b/source/ja/guides/core-concepts/test-runner.md
@@ -13,7 +13,7 @@ title: The Test Runner
 
 Cypress runs tests in a unique interactive runner that allows you to see commands as they execute while also viewing the application under test.
 
-{% imgTag no-border /img/guides/gui-diagram.png "Cypress Test Runner" %}
+{% imgTag /img/guides/gui-diagram.png "Cypress Test Runner" "no-border" %}
 
 # Command Log
 

--- a/source/zh-cn/guides/core-concepts/test-runner.md
+++ b/source/zh-cn/guides/core-concepts/test-runner.md
@@ -13,7 +13,7 @@ title: The Test Runner
 
 Cypress runs tests in a unique interactive runner that allows you to see commands as they execute while also viewing the application under test.
 
-{% imgTag no-border /img/guides/gui-diagram.png "Cypress Test Runner" %}
+{% imgTag /img/guides/gui-diagram.png "Cypress Test Runner" "no-border" %}
 
 # Command Log
 


### PR DESCRIPTION
Order of args was causing the src to be the alt text, and vice versa