### PR TITLE
add instructions how to run the binary by itself, close #1781

### DIFF
--- a/source/guides/guides/debugging.md
+++ b/source/guides/guides/debugging.md
@@ -319,9 +319,12 @@ If you'd like to contribute directly to the Cypress code, we'd love to have your
 
 ## Run the Cypress app by itself
 
-Cypress comes with an npm CLI module that parses the arguments, starts the Xvfb server (if necessary), and then opens the Test Runner application built on top of {% url "Electron" https://electronjs.org/ %}. To see the raw output from the Test Runner application itself, you can launch it without the npm CLI module.
+Cypress comes with an npm CLI module that parses the arguments, starts the Xvfb server (if necessary), and then opens the Test Runner application built on top of {% url "Electron" https://electronjs.org/ %}. Some common situations on why you would want to do this are:
 
-First, find where the binary is installed using the {% url "`cypress cache path`" command-line#cypress-cache-path %} command.
+- debug Cypress not starting or hanging
+- debug problems related to the way CLI arguments are parsed by the npm CLI module
+
+Here is how you can launch Cypress application directly without the npm CLI module. First, find where the binary is installed using the {% url "`cypress cache path`" command-line#cypress-cache-path %} command.
 
 For example, on a Linux machine:
 
@@ -388,7 +391,13 @@ cypress:server:cypress about to exit with code 0 +4ms
 
 ## Edit the installed Cypress code
 
-The installed Test Runner comes with the fully transpiled, unobfuscated JavaScript source code that you can hack on. First, print where the binary is installed using the {% url "`cypress cache path`" command-line#cypress-cache-path %} command.
+The installed Test Runner comes with the fully transpiled, unobfuscated JavaScript source code that you can hack on. You might want to directly modify the installed Test Runner code to:
+
+- investigate a hard to recreate bug that happens on your machine
+- change the run-time behavior of Cypress before opening a pull request
+- have fun 🎉
+
+First, print where the binary is installed using the {% url "`cypress cache path`" command-line#cypress-cache-path %} command.
 
 For example, on a Mac:
 

--- a/source/guides/guides/debugging.md
+++ b/source/guides/guides/debugging.md
@@ -301,9 +301,78 @@ cy.now('task', 123)
 The `cy.now()` command is an internal command and may change in the future.
 {% endnote %}
 
+## Run the Cypress application by itself
+
+Cypress comes with npm CLI module that parses the arguments, starts Xvfb server if necessary, and then opens the Test Runner application built on top of {% url "Electron.js" https://electronjs.org/ %}. To see the raw output from the Test Runner application itself, you can launch it without the npm CLI module.
+
+First, find where the binary is installed using the {% url "`cypress cache path`" command-line#cypress-cache-path %} command.
+
+For example, on Linux machine:
+
+```shell
+npx cypress cache path
+/root/.cache/Cypress
+```
+
+Second, try a smoke test that verifies that the application has all its required dependencies present on the host machine:
+
+```shell
+/root/.cache/Cypress/3.3.1/Cypress/Cypress --smoke-test --ping=101
+101
+```
+
+If there is a missing dependency, the application should print an error message. You can see the Electron own verbose log messages by setting an {% url "environment variable ELECTRON_ENABLE_LOGGING" https://electronjs.org/docs/api/environment-variables %}:
+
+```shell
+ELECTRON_ENABLE_LOGGING=true DISPLAY=10.130.4.201:0 /root/.cache/Cypress/3.3.1/Cypress/Cypress --smoke-test --ping=101
+[809:0617/151243.281369:ERROR:bus.cc(395)] Failed to connect to the bus: Failed to connect to socket /var/run/dbus/system_bus_socket: No such file or directory
+101
+```
+
+If the smoke test fails to execute, check if a shared library is missing (a common problem on Linux machines without all Cypress dependencies present)
+
+```shell
+ldd /home/person/.cache/Cypress/3.3.1/Cypress/Cypress
+	linux-vdso.so.1 (0x00007ffe9eda0000)
+	libnode.so => /home/person/.cache/Cypress/3.3.1/Cypress/libnode.so (0x00007fecb43c8000)
+	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007fecb41ab000)
+	libgtk-3.so.0 => not found
+	libgdk-3.so.0 => not found
+  ...
+```
+
+**Tip:** use {% url "Cypress Docker image" docker %} or install dependencies by copying them from one of our official Docker images.
+
+**Note:** verbose Electron logging might show warnings that still allow Cypress to work normally. For example, Cypress GUI opens normally despite the scary output below:
+
+```shell
+ELECTRON_ENABLE_LOGGING=true DISPLAY=10.130.4.201:0 /root/.cache/Cypress/3.3.1/Cypress/Cypress
+[475:0617/150421.326986:ERROR:bus.cc(395)] Failed to connect to the bus: Failed to connect to socket /var/run/dbus/system_bus_socket: No such file or directory
+[475:0617/150425.061526:ERROR:bus.cc(395)] Failed to connect to the bus: Could not parse server address: Unknown address type (examples of valid types are "tcp" and on UNIX "unix")
+[475:0617/150425.079819:ERROR:bus.cc(395)] Failed to connect to the bus: Could not parse server address: Unknown address type (examples of valid types are "tcp" and on UNIX "unix")
+[475:0617/150425.371013:INFO:CONSOLE(73292)] "%cDownload the React DevTools for a better development experience: https://fb.me/react-devtools
+You might need to use a local HTTP server (instead of file://): https://fb.me/react-devtools-faq", source: file:///root/.cache/Cypress/3.3.1/Cypress/resources/app/packages/desktop-gui/dist/app.js (73292)
+```
+
+You can also see verbose Cypress logs when running the Test Runner binary
+
+```shell
+DEBUG=cypress* DISPLAY=10.130.4.201:0 /root/.cache/Cypress/3.3.1/Cypress/Cypress --smoke-test --ping=101
+cypress:ts Running without ts-node hook in environment "production" +0ms
+cypress:server:cypress starting cypress with argv [ '/root/.cache/Cypress/3.3.1/Cypress/Cypress', '--smoke-test', '--ping=101' ] +0ms
+cypress:server:args argv array: [ '/root/.cache/Cypress/3.3.1/Cypress/Cypress', '--smoke-test', '--ping=101' ] +0ms
+cypress:server:args argv parsed: { _: [ '/root/.cache/Cypress/3.3.1/Cypress/Cypress' ], smokeTest: true, ping: 101, cwd: '/root/.cache/Cypress/3.3.1/Cypress/resources/app/packages/server' } +7ms
+cypress:server:args options { _: [ '/root/.cache/Cypress/3.3.1/Cypress/Cypress' ], smokeTest: true, ping: 101, cwd: '/root/.cache/Cypress/3.3.1/Cypress/resources/app/packages/server', config: {} } +2ms
+cypress:server:args argv options: { _: [ '/root/.cache/Cypress/3.3.1/Cypress/Cypress' ], smokeTest: true, ping: 101, cwd: '/root/.cache/Cypress/3.3.1/Cypress/resources/app/packages/server', config: {}, pong: 101 } +1ms
+cypress:server:appdata path: /root/.config/Cypress/cy/production +0ms
+cypress:server:cypress starting in mode smokeTest +356ms
+101
+cypress:server:cypress about to exit with code 0 +4ms
+```
+
 ## Hack the installed Cypress code
 
-The installed Test Runner comes with the fully transpiled, unobfuscated JavaScript source code that you can hack on. First, print where the binary is installed using the {% url "`cypress cache path`" command-line#cypress-cache-path %} command. 
+The installed Test Runner comes with the fully transpiled, unobfuscated JavaScript source code that you can hack on. First, print where the binary is installed using the {% url "`cypress cache path`" command-line#cypress-cache-path %} command.
 
 For example, on a Mac:
 

--- a/source/guides/guides/debugging.md
+++ b/source/guides/guides/debugging.md
@@ -301,13 +301,29 @@ cy.now('task', 123)
 The `cy.now()` command is an internal command and may change in the future.
 {% endnote %}
 
-## Run the Cypress application by itself
+## Additional information
 
-Cypress comes with npm CLI module that parses the arguments, starts Xvfb server if necessary, and then opens the Test Runner application built on top of {% url "Electron.js" https://electronjs.org/ %}. To see the raw output from the Test Runner application itself, you can launch it without the npm CLI module.
+### Write command log to the terminal
+
+You can include the plugin [cypress-failed-log](https://github.com/bahmutov/cypress-failed-log) in your tests. This plugin writes the list of Cypress commands to the terminal as well as a JSON file if a test fails.
+
+{% imgTag /img/api/debug/failed-log.png "cypress-failed-log terminal output" %}
+
+# Hacking on Cypress
+
+If you want to dive into Cypress and edit the code yourself, you can do that. The Cypress code is open source and licensed under an {% url "MIT license" https://github.com/cypress-io/cypress/blob/develop/LICENSE %}. There are a few tips on getting started that we've outlined below.
+
+## Contribute
+
+If you'd like to contribute directly to the Cypress code, we'd love to have your help! Please check out our {% url "contributing guide" https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md %} to learn about the many ways you can contribute.
+
+## Run the Cypress app by itself
+
+Cypress comes with an npm CLI module that parses the arguments, starts the Xvfb server (if necessary), and then opens the Test Runner application built on top of {% url "Electron" https://electronjs.org/ %}. To see the raw output from the Test Runner application itself, you can launch it without the npm CLI module.
 
 First, find where the binary is installed using the {% url "`cypress cache path`" command-line#cypress-cache-path %} command.
 
-For example, on Linux machine:
+For example, on a Linux machine:
 
 ```shell
 npx cypress cache path
@@ -321,7 +337,7 @@ Second, try a smoke test that verifies that the application has all its required
 101
 ```
 
-If there is a missing dependency, the application should print an error message. You can see the Electron own verbose log messages by setting an {% url "environment variable ELECTRON_ENABLE_LOGGING" https://electronjs.org/docs/api/environment-variables %}:
+If there is a missing dependency, the application should print an error message. You can see the Electron verbose log messages by setting an {% url "environment variable ELECTRON_ENABLE_LOGGING" https://electronjs.org/docs/api/environment-variables %}:
 
 ```shell
 ELECTRON_ENABLE_LOGGING=true DISPLAY=10.130.4.201:0 /root/.cache/Cypress/3.3.1/Cypress/Cypress --smoke-test --ping=101
@@ -329,7 +345,7 @@ ELECTRON_ENABLE_LOGGING=true DISPLAY=10.130.4.201:0 /root/.cache/Cypress/3.3.1/C
 101
 ```
 
-If the smoke test fails to execute, check if a shared library is missing (a common problem on Linux machines without all Cypress dependencies present)
+If the smoke test fails to execute, check if a shared library is missing (a common problem on Linux machines without all of the Cypress dependencies present).
 
 ```shell
 ldd /home/person/.cache/Cypress/3.3.1/Cypress/Cypress
@@ -343,7 +359,7 @@ ldd /home/person/.cache/Cypress/3.3.1/Cypress/Cypress
 
 **Tip:** use {% url "Cypress Docker image" docker %} or install dependencies by copying them from one of our official Docker images.
 
-**Note:** verbose Electron logging might show warnings that still allow Cypress to work normally. For example, Cypress GUI opens normally despite the scary output below:
+**Note:** verbose Electron logging might show warnings that still allow Cypress to work normally. For example, the Cypress Test Runner opens normally despite the scary output below:
 
 ```shell
 ELECTRON_ENABLE_LOGGING=true DISPLAY=10.130.4.201:0 /root/.cache/Cypress/3.3.1/Cypress/Cypress
@@ -370,7 +386,7 @@ cypress:server:cypress starting in mode smokeTest +356ms
 cypress:server:cypress about to exit with code 0 +4ms
 ```
 
-## Hack the installed Cypress code
+## Edit the installed Cypress code
 
 The installed Test Runner comes with the fully transpiled, unobfuscated JavaScript source code that you can hack on. First, print where the binary is installed using the {% url "`cypress cache path`" command-line#cypress-cache-path %} command.
 
@@ -397,11 +413,3 @@ When finished, if necessary, remove the edited Test Runner version and reinstall
 rm -rf /Users/jane/Library/Caches/Cypress/3.3.1
 npm install cypress@3.3.1
 ```
-
-## Additional information
-
-### Write command log to the terminal
-
-You can include the plugin [cypress-failed-log](https://github.com/bahmutov/cypress-failed-log) in your tests. This plugin writes the list of Cypress commands to the terminal as well as a JSON file if a test fails.
-
-{% imgTag /img/api/debug/failed-log.png "cypress-failed-log terminal output" %}

--- a/source/ja/guides/guides/debugging.md
+++ b/source/ja/guides/guides/debugging.md
@@ -301,9 +301,103 @@ cy.now('task', 123)
 The `cy.now()` command is an internal command and may change in the future.
 {% endnote %}
 
-## Hack the installed Cypress code
+## Additional information
 
-The installed Test Runner comes with the fully transpiled, unobfuscated JavaScript source code that you can hack on. First, print where the binary is installed using the {% url "`cypress cache path`" command-line#cypress-cache-path %} command. 
+### Write command log to the terminal
+
+You can include the plugin [cypress-failed-log](https://github.com/bahmutov/cypress-failed-log) in your tests. This plugin writes the list of Cypress commands to the terminal as well as a JSON file if a test fails.
+
+{% imgTag /img/api/debug/failed-log.png "cypress-failed-log terminal output" %}
+
+# Hacking on Cypress
+
+If you want to dive into Cypress and edit the code yourself, you can do that. The Cypress code is open source and licensed under an {% url "MIT license" https://github.com/cypress-io/cypress/blob/develop/LICENSE %}. There are a few tips on getting started that we've outlined below.
+
+## Contribute
+
+If you'd like to contribute directly to the Cypress code, we'd love to have your help! Please check out our {% url "contributing guide" https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md %} to learn about the many ways you can contribute.
+
+## Run the Cypress app by itself
+
+Cypress comes with an npm CLI module that parses the arguments, starts the Xvfb server (if necessary), and then opens the Test Runner application built on top of {% url "Electron" https://electronjs.org/ %}. Some common situations on why you would want to do this are:
+
+- debug Cypress not starting or hanging
+- debug problems related to the way CLI arguments are parsed by the npm CLI module
+
+Here is how you can launch Cypress application directly without the npm CLI module. First, find where the binary is installed using the {% url "`cypress cache path`" command-line#cypress-cache-path %} command.
+
+For example, on a Linux machine:
+
+```shell
+npx cypress cache path
+/root/.cache/Cypress
+```
+
+Second, try a smoke test that verifies that the application has all its required dependencies present on the host machine:
+
+```shell
+/root/.cache/Cypress/3.3.1/Cypress/Cypress --smoke-test --ping=101
+101
+```
+
+If there is a missing dependency, the application should print an error message. You can see the Electron verbose log messages by setting an {% url "environment variable ELECTRON_ENABLE_LOGGING" https://electronjs.org/docs/api/environment-variables %}:
+
+```shell
+ELECTRON_ENABLE_LOGGING=true DISPLAY=10.130.4.201:0 /root/.cache/Cypress/3.3.1/Cypress/Cypress --smoke-test --ping=101
+[809:0617/151243.281369:ERROR:bus.cc(395)] Failed to connect to the bus: Failed to connect to socket /var/run/dbus/system_bus_socket: No such file or directory
+101
+```
+
+If the smoke test fails to execute, check if a shared library is missing (a common problem on Linux machines without all of the Cypress dependencies present).
+
+```shell
+ldd /home/person/.cache/Cypress/3.3.1/Cypress/Cypress
+	linux-vdso.so.1 (0x00007ffe9eda0000)
+	libnode.so => /home/person/.cache/Cypress/3.3.1/Cypress/libnode.so (0x00007fecb43c8000)
+	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007fecb41ab000)
+	libgtk-3.so.0 => not found
+	libgdk-3.so.0 => not found
+  ...
+```
+
+**Tip:** use {% url "Cypress Docker image" docker %} or install dependencies by copying them from one of our official Docker images.
+
+**Note:** verbose Electron logging might show warnings that still allow Cypress to work normally. For example, the Cypress Test Runner opens normally despite the scary output below:
+
+```shell
+ELECTRON_ENABLE_LOGGING=true DISPLAY=10.130.4.201:0 /root/.cache/Cypress/3.3.1/Cypress/Cypress
+[475:0617/150421.326986:ERROR:bus.cc(395)] Failed to connect to the bus: Failed to connect to socket /var/run/dbus/system_bus_socket: No such file or directory
+[475:0617/150425.061526:ERROR:bus.cc(395)] Failed to connect to the bus: Could not parse server address: Unknown address type (examples of valid types are "tcp" and on UNIX "unix")
+[475:0617/150425.079819:ERROR:bus.cc(395)] Failed to connect to the bus: Could not parse server address: Unknown address type (examples of valid types are "tcp" and on UNIX "unix")
+[475:0617/150425.371013:INFO:CONSOLE(73292)] "%cDownload the React DevTools for a better development experience: https://fb.me/react-devtools
+You might need to use a local HTTP server (instead of file://): https://fb.me/react-devtools-faq", source: file:///root/.cache/Cypress/3.3.1/Cypress/resources/app/packages/desktop-gui/dist/app.js (73292)
+```
+
+You can also see verbose Cypress logs when running the Test Runner binary
+
+```shell
+DEBUG=cypress* DISPLAY=10.130.4.201:0 /root/.cache/Cypress/3.3.1/Cypress/Cypress --smoke-test --ping=101
+cypress:ts Running without ts-node hook in environment "production" +0ms
+cypress:server:cypress starting cypress with argv [ '/root/.cache/Cypress/3.3.1/Cypress/Cypress', '--smoke-test', '--ping=101' ] +0ms
+cypress:server:args argv array: [ '/root/.cache/Cypress/3.3.1/Cypress/Cypress', '--smoke-test', '--ping=101' ] +0ms
+cypress:server:args argv parsed: { _: [ '/root/.cache/Cypress/3.3.1/Cypress/Cypress' ], smokeTest: true, ping: 101, cwd: '/root/.cache/Cypress/3.3.1/Cypress/resources/app/packages/server' } +7ms
+cypress:server:args options { _: [ '/root/.cache/Cypress/3.3.1/Cypress/Cypress' ], smokeTest: true, ping: 101, cwd: '/root/.cache/Cypress/3.3.1/Cypress/resources/app/packages/server', config: {} } +2ms
+cypress:server:args argv options: { _: [ '/root/.cache/Cypress/3.3.1/Cypress/Cypress' ], smokeTest: true, ping: 101, cwd: '/root/.cache/Cypress/3.3.1/Cypress/resources/app/packages/server', config: {}, pong: 101 } +1ms
+cypress:server:appdata path: /root/.config/Cypress/cy/production +0ms
+cypress:server:cypress starting in mode smokeTest +356ms
+101
+cypress:server:cypress about to exit with code 0 +4ms
+```
+
+## Edit the installed Cypress code
+
+The installed Test Runner comes with the fully transpiled, unobfuscated JavaScript source code that you can hack on. You might want to directly modify the installed Test Runner code to:
+
+- investigate a hard to recreate bug that happens on your machine
+- change the run-time behavior of Cypress before opening a pull request
+- have fun 🎉
+
+First, print where the binary is installed using the {% url "`cypress cache path`" command-line#cypress-cache-path %} command.
 
 For example, on a Mac:
 
@@ -328,11 +422,3 @@ When finished, if necessary, remove the edited Test Runner version and reinstall
 rm -rf /Users/jane/Library/Caches/Cypress/3.3.1
 npm install cypress@3.3.1
 ```
-
-## Additional information
-
-### Write command log to the terminal
-
-You can include the plugin [cypress-failed-log](https://github.com/bahmutov/cypress-failed-log) in your tests. This plugin writes the list of Cypress commands to the terminal as well as a JSON file if a test fails.
-
-{% imgTag /img/api/debug/failed-log.png "cypress-failed-log terminal output" %}

--- a/source/zh-cn/guides/guides/debugging.md
+++ b/source/zh-cn/guides/guides/debugging.md
@@ -3,7 +3,7 @@ title: 调试
 ---
 
 {% note info %}
-# {% fa fa-graduation-cap %} 你将会学习到什么
+# {% fa fa-graduation-cap %} What you'll learn
 
 - How Cypress runs in the same event loop with your code, keeping debugging simple and understandable
 - How Cypress embraces the standard Developer Tools
@@ -301,9 +301,103 @@ cy.now('task', 123)
 The `cy.now()` command is an internal command and may change in the future.
 {% endnote %}
 
-## Hack the installed Cypress code
+## Additional information
 
-The installed Test Runner comes with the fully transpiled, unobfuscated JavaScript source code that you can hack on. First, print where the binary is installed using the {% url "`cypress cache path`" command-line#cypress-cache-path %} command. 
+### Write command log to the terminal
+
+You can include the plugin [cypress-failed-log](https://github.com/bahmutov/cypress-failed-log) in your tests. This plugin writes the list of Cypress commands to the terminal as well as a JSON file if a test fails.
+
+{% imgTag /img/api/debug/failed-log.png "cypress-failed-log terminal output" %}
+
+# Hacking on Cypress
+
+If you want to dive into Cypress and edit the code yourself, you can do that. The Cypress code is open source and licensed under an {% url "MIT license" https://github.com/cypress-io/cypress/blob/develop/LICENSE %}. There are a few tips on getting started that we've outlined below.
+
+## Contribute
+
+If you'd like to contribute directly to the Cypress code, we'd love to have your help! Please check out our {% url "contributing guide" https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md %} to learn about the many ways you can contribute.
+
+## Run the Cypress app by itself
+
+Cypress comes with an npm CLI module that parses the arguments, starts the Xvfb server (if necessary), and then opens the Test Runner application built on top of {% url "Electron" https://electronjs.org/ %}. Some common situations on why you would want to do this are:
+
+- debug Cypress not starting or hanging
+- debug problems related to the way CLI arguments are parsed by the npm CLI module
+
+Here is how you can launch Cypress application directly without the npm CLI module. First, find where the binary is installed using the {% url "`cypress cache path`" command-line#cypress-cache-path %} command.
+
+For example, on a Linux machine:
+
+```shell
+npx cypress cache path
+/root/.cache/Cypress
+```
+
+Second, try a smoke test that verifies that the application has all its required dependencies present on the host machine:
+
+```shell
+/root/.cache/Cypress/3.3.1/Cypress/Cypress --smoke-test --ping=101
+101
+```
+
+If there is a missing dependency, the application should print an error message. You can see the Electron verbose log messages by setting an {% url "environment variable ELECTRON_ENABLE_LOGGING" https://electronjs.org/docs/api/environment-variables %}:
+
+```shell
+ELECTRON_ENABLE_LOGGING=true DISPLAY=10.130.4.201:0 /root/.cache/Cypress/3.3.1/Cypress/Cypress --smoke-test --ping=101
+[809:0617/151243.281369:ERROR:bus.cc(395)] Failed to connect to the bus: Failed to connect to socket /var/run/dbus/system_bus_socket: No such file or directory
+101
+```
+
+If the smoke test fails to execute, check if a shared library is missing (a common problem on Linux machines without all of the Cypress dependencies present).
+
+```shell
+ldd /home/person/.cache/Cypress/3.3.1/Cypress/Cypress
+	linux-vdso.so.1 (0x00007ffe9eda0000)
+	libnode.so => /home/person/.cache/Cypress/3.3.1/Cypress/libnode.so (0x00007fecb43c8000)
+	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007fecb41ab000)
+	libgtk-3.so.0 => not found
+	libgdk-3.so.0 => not found
+  ...
+```
+
+**Tip:** use {% url "Cypress Docker image" docker %} or install dependencies by copying them from one of our official Docker images.
+
+**Note:** verbose Electron logging might show warnings that still allow Cypress to work normally. For example, the Cypress Test Runner opens normally despite the scary output below:
+
+```shell
+ELECTRON_ENABLE_LOGGING=true DISPLAY=10.130.4.201:0 /root/.cache/Cypress/3.3.1/Cypress/Cypress
+[475:0617/150421.326986:ERROR:bus.cc(395)] Failed to connect to the bus: Failed to connect to socket /var/run/dbus/system_bus_socket: No such file or directory
+[475:0617/150425.061526:ERROR:bus.cc(395)] Failed to connect to the bus: Could not parse server address: Unknown address type (examples of valid types are "tcp" and on UNIX "unix")
+[475:0617/150425.079819:ERROR:bus.cc(395)] Failed to connect to the bus: Could not parse server address: Unknown address type (examples of valid types are "tcp" and on UNIX "unix")
+[475:0617/150425.371013:INFO:CONSOLE(73292)] "%cDownload the React DevTools for a better development experience: https://fb.me/react-devtools
+You might need to use a local HTTP server (instead of file://): https://fb.me/react-devtools-faq", source: file:///root/.cache/Cypress/3.3.1/Cypress/resources/app/packages/desktop-gui/dist/app.js (73292)
+```
+
+You can also see verbose Cypress logs when running the Test Runner binary
+
+```shell
+DEBUG=cypress* DISPLAY=10.130.4.201:0 /root/.cache/Cypress/3.3.1/Cypress/Cypress --smoke-test --ping=101
+cypress:ts Running without ts-node hook in environment "production" +0ms
+cypress:server:cypress starting cypress with argv [ '/root/.cache/Cypress/3.3.1/Cypress/Cypress', '--smoke-test', '--ping=101' ] +0ms
+cypress:server:args argv array: [ '/root/.cache/Cypress/3.3.1/Cypress/Cypress', '--smoke-test', '--ping=101' ] +0ms
+cypress:server:args argv parsed: { _: [ '/root/.cache/Cypress/3.3.1/Cypress/Cypress' ], smokeTest: true, ping: 101, cwd: '/root/.cache/Cypress/3.3.1/Cypress/resources/app/packages/server' } +7ms
+cypress:server:args options { _: [ '/root/.cache/Cypress/3.3.1/Cypress/Cypress' ], smokeTest: true, ping: 101, cwd: '/root/.cache/Cypress/3.3.1/Cypress/resources/app/packages/server', config: {} } +2ms
+cypress:server:args argv options: { _: [ '/root/.cache/Cypress/3.3.1/Cypress/Cypress' ], smokeTest: true, ping: 101, cwd: '/root/.cache/Cypress/3.3.1/Cypress/resources/app/packages/server', config: {}, pong: 101 } +1ms
+cypress:server:appdata path: /root/.config/Cypress/cy/production +0ms
+cypress:server:cypress starting in mode smokeTest +356ms
+101
+cypress:server:cypress about to exit with code 0 +4ms
+```
+
+## Edit the installed Cypress code
+
+The installed Test Runner comes with the fully transpiled, unobfuscated JavaScript source code that you can hack on. You might want to directly modify the installed Test Runner code to:
+
+- investigate a hard to recreate bug that happens on your machine
+- change the run-time behavior of Cypress before opening a pull request
+- have fun 🎉
+
+First, print where the binary is installed using the {% url "`cypress cache path`" command-line#cypress-cache-path %} command.
 
 For example, on a Mac:
 
@@ -329,10 +423,3 @@ rm -rf /Users/jane/Library/Caches/Cypress/3.3.1
 npm install cypress@3.3.1
 ```
 
-## Additional information
-
-### Write command log to the terminal
-
-You can include the plugin [cypress-failed-log](https://github.com/bahmutov/cypress-failed-log) in your tests. This plugin writes the list of Cypress commands to the terminal as well as a JSON file if a test fails.
-
-{% imgTag /img/api/debug/failed-log.png "cypress-failed-log terminal output" %}


### PR DESCRIPTION
- closes #1781 

Changes made to documentation were also copied over to other languages (**copying English text is ok**).

- [x] only English docs
- [x] Japanese docs in [`/source/ja`](/source/ja).
- [x] Chinese docs in [`/source/zh-cn`](/source/zh-cn).
- [ ] Not applicable (this is not a change to an `en` doc content).
