### PR TITLE
Make JSON Web tokens section match rest of page format

### DIFF
--- a/source/examples/examples/recipes.md
+++ b/source/examples/examples/recipes.md
@@ -14,7 +14,7 @@ Recipe | Category | Description
 {% urlHash 'HTML Web Forms' HTML-Web-Forms %} | Logging In | Log in with a basic HTML form
 {% urlHash 'XHR Web Forms' XHR-Web-Forms %} | Logging In | Log in using an XHR
 {% urlHash 'CSRF Tokens' CSRF-Tokens %} | Logging In | Log in with a required CSRF token
-{% url 'Json Web Tokens' https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/logging-in__jwt %} | Logging In | Log in using JWT
+{% urlHash 'Json Web Tokens' JSON Web Tokens %} | Logging In | Log in using JWT
 {% urlHash 'Tab Handling and Links' Tab-Handling-and-Links %} | Testing the DOM | Links that open in a new tab
 {% urlHash 'Hover and Hidden Elements' Hover-and-Hidden-Elements %} | Testing the DOM | Test hidden elements requiring hover
 {% urlHash 'Form Interactions' Form-Interactions %} | Testing the DOM | Test form elements like input type `range`
@@ -80,6 +80,13 @@ Recipe | Category | Description
 - Parse CSRF tokens out of response headers.
 - Expose CSRF via a route.
 - Disable CSRF when not in production.
+
+## [JSON Web Tokens](https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/logging-in__jwt) 
+
+- Test login UI form
+- Use cy.request() once to get user object and JWT
+- Before each test set the JWT and the user object in localStorage before visiting the page
+- The opened page instantly has the user logged in
 
 ## [Tab Handling and Links](https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/testing-dom__tab-handling-links)
 


### PR DESCRIPTION
clicking on the The "JSON web tokens" hash took a user to the github page instead of the hash fragment url. JSON web tokens did not have a description section on the page either. 

I fixed both of these issues to make JSON web tokens match the formatting of the rest of the page and copied the description info from the github page.

<!--
Thanks for contributing!

Please explain what changes were made
also reference any fixed issues with "close #[ISSUE]"
-->

### Translations updated

Changes made to documentation were also copied over to other languages (**copying English text is ok**).

- [ ] Japanese docs in [`/source/ja`](/source/ja).
- [ ] Chinese docs in [`/source/zh-cn`](/source/zh-cn).
- [ ] Not applicable (this is not a change to an `en` doc content).
