### PR TITLE
dont return from a custom command

### DIFF
--- a/source/api/cypress-api/custom-commands.md
+++ b/source/api/cypress-api/custom-commands.md
@@ -164,11 +164,7 @@ Cypress.Commands.add('console', {
   // log the subject to the console
   console[method]('The subject is', subject)
 
-  // whatever we return becomes the new subject
-  //
-  // we don't want to change the subject so
-  // we return whatever was passed in
-  return subject
+  // we do not return anything: https://docs.cypress.io/guides/references/error-messages.html#Cypress-detected-that-you-invoked-one-or-more-cy-commands-in-a-custom-command-but-returned-a-different-value
 })
 ```
 


### PR DESCRIPTION
see comment

### Translations updated

Changes made to documentation were also copied over to other languages (**copying English text is ok**).

- [ ] Japanese docs in [`/source/ja`](/source/ja).
- [ ] Chinese docs in [`/source/zh-cn`](/source/zh-cn).
- [ ] Not applicable (this is not a change to an `en` doc content).
