### PR TITLE
'ALT' typo fix

### DIFF
--- a/source/api/commands/click.md
+++ b/source/api/commands/click.md
@@ -125,7 +125,7 @@ cy.get('button').click({ multiple: true })
 
 ## Click with key combinations
 
-The `.click()` command may also be fired with key modifiers in combination with the {% url "`.type()`" type %} command in order to simulate character sequences while clicking, such as `ATL + click`. In order to keep the modifier key active, `{release: false}` should be passed to the options of the {% url "`.type()`" type %} command.
+The `.click()` command may also be fired with key modifiers in combination with the {% url "`.type()`" type %} command in order to simulate character sequences while clicking, such as `ALT + click`. In order to keep the modifier key active, `{release: false}` should be passed to the options of the {% url "`.type()`" type %} command.
 
 The following modifiers can be combined with `.click()`.
 


### PR DESCRIPTION
Change 'ATL' to 'ALT' - typo fix

<!--
Thanks for contributing!

Please explain what changes were made
also reference any fixed issues with "close #[ISSUE]"
-->

### Translations updated

Changes made to documentation were also copied over to other languages (**copying English text is ok**).

- [ ] Japanese docs in [`/source/ja`](/source/ja).
- [ ] Chinese docs in [`/source/zh-cn`](/source/zh-cn).
- [ ] Not applicable (this is not a change to an `en` doc content).
