### PR TITLE
Fix comma typo and extra spaces in the introduction

### DIFF
--- a/source/zh-cn/guides/core-concepts/introduction-to-cypress.md
+++ b/source/zh-cn/guides/core-concepts/introduction-to-cypress.md
@@ -678,7 +678,7 @@ You don't need to write {% url "`.should('exist')`" should %} after a DOM based 
 {% endnote %}
 
 {% note danger "Negative DOM assertions" %}
-If you chain any `.should()` command, the default `.should('exist')` is not asserted. This does not matter for most *positive* assertions, such as `.should('have.class')`, because those imply existence in the first place, but if you chain *negative* assertions ,such as `.should('not.have.class')`, they will pass even if the DOM element doesn't exist:
+If you chain any `.should()` command, the default `.should('exist')` is not asserted. This does not matter for most *positive* assertions, such as `.should('have.class')`, because those imply existence in the first place, but if you chain *negative* assertions, such as `.should('not.have.class')`, they will pass even if the DOM element doesn't exist:
 
 ```
 cy.get('.does-not-exist').should('not.be.visible')         // passes
@@ -689,8 +689,8 @@ This also applies to custom assertions such as when passing a callback:
 
 ```
 // passes, provided the callback itself passes
-cy.get('.does-not-exist').should(($element) => {   
-  expect($element.find('input')).to.not.exist 
+cy.get('.does-not-exist').should(($element) => {
+  expect($element.find('input')).to.not.exist
 })
 ```
 


### PR DESCRIPTION
Fix comma typo in the `introduction-to-cypress.md`

Here's a screenshot of what I was reading:

![Screen Shot 2019-07-05 at 12 34 25 PM](https://user-images.githubusercontent.com/10498035/60742271-8bd15600-9f21-11e9-8dc2-0679bc81ec73.png)

### Translations updated
Changes made to documentation were also copied over to other languages (**copying English text is ok**).

- [ ] Japanese docs in [`/source/ja`](/source/ja).
- [ ] Chinese docs in [`/source/zh-cn`](/source/zh-cn).
- [ ] Not applicable (this is not a change to an `en` doc content).
