### PR TITLE
Add html examples to accompany command usage for .parent / .parents

### DIFF
--- a/source/api/commands/parent.md
+++ b/source/api/commands/parent.md
@@ -4,6 +4,8 @@ title: parent
 
 Get the parent DOM element of a set of DOM elements.
 
+Please note that `.parent()` only travels a single level up the DOM tree as opposed to the {% url ".parents()" parents %} command.
+
 {% note info %}
 The querying behavior of this command matches exactly how {% url `.parent()` http://api.jquery.com/parent %} works in jQuery.
 {% endnote %}
@@ -57,16 +59,44 @@ Option | Default | Description
 
 ### Get the parent of the active `li`
 
+```html
+<ul class='main-nav'>
+  <li>Overview</li>
+  <li>Getting started
+    <ul class='sub-nav'>
+      <li>Install</li>
+      <li class='active'>Build</li>
+      <li>Test</li>
+    </ul>
+  </li>
+</ul>
+```
+
 ```javascript
+// yields .sub-nav
 cy.get('li.active').parent()
 ```
 
 ## Selector
 
-### Get the parent with class `nav` of the active `li`
+### Get the parent with class `sub-nav` of all `li` elements
+
+```html
+<ul class='main-nav'>
+  <li>Overview</li>
+  <li>Getting started
+    <ul class='sub-nav'>
+      <li>Install</li>
+      <li class='active'>Build</li>
+      <li>Test</li>
+    </ul>
+  </li>
+</ul>
+```
 
 ```javascript
-cy.get('li.active').parent('.nav')
+// yields .sub-nav
+cy.get('li').parent('.sub-nav')
 ```
 
 # Rules

--- a/source/api/commands/parents.md
+++ b/source/api/commands/parents.md
@@ -4,6 +4,9 @@ title: parents
 
 Get the parent DOM elements of a set of DOM elements.
 
+Please note that `.parents()` travels multiple levels up the DOM tree as opposed to the {% url ".parent
+()" parent %} command which travels a single level up the DOM tree.
+
 {% note info %}
 The querying behavior of this command matches exactly how {% url `.parents()` http://api.jquery.com/parents %} works in jQuery.
 {% endnote %}
@@ -57,16 +60,31 @@ Option | Default | Description
 
 ### Get the parents of the active li
 
+```html
+<ul class='main-nav'>
+  <li>Overview</li>
+  <li>Getting started
+    <ul class='sub-nav'>
+      <li>Install</li>
+      <li class='active'>Build</li>
+      <li>Test</li>
+    </ul>
+  </li>
+</ul>
+```
+
 ```javascript
+// yields [.sub-nav, li, .main-nav]
 cy.get('li.active').parents()
 ```
 
 ## Selector
 
-### Get the parents with class `nav` of the active li
+### Get the parents with class `main-nav` of the active li
 
 ```javascript
-cy.get('li.active').parents('.nav')
+// yields [.main-nav]
+cy.get('li.active').parents('.main-nav')
 ```
 
 # Rules

--- a/source/ja/api/commands/parent.md
+++ b/source/ja/api/commands/parent.md
@@ -4,6 +4,8 @@ title: parent
 
 Get the parent DOM element of a set of DOM elements.
 
+Please note that `.parent()` only travels a single level up the DOM tree as opposed to the {% url ".parents()" parents %} command.
+
 {% note info %}
 The querying behavior of this command matches exactly how {% url `.parent()` http://api.jquery.com/parent %} works in jQuery.
 {% endnote %}
@@ -57,16 +59,44 @@ Option | Default | Description
 
 ### Get the parent of the active `li`
 
+```html
+<ul class='main-nav'>
+  <li>Overview</li>
+  <li>Getting started
+    <ul class='sub-nav'>
+      <li>Install</li>
+      <li class='active'>Build</li>
+      <li>Test</li>
+    </ul>
+  </li>
+</ul>
+```
+
 ```javascript
+// yields .sub-nav
 cy.get('li.active').parent()
 ```
 
 ## Selector
 
-### Get the parent with class `nav` of the active `li`
+### Get the parent with class `sub-nav` of all `li` elements
+
+```html
+<ul class='main-nav'>
+  <li>Overview</li>
+  <li>Getting started
+    <ul class='sub-nav'>
+      <li>Install</li>
+      <li class='active'>Build</li>
+      <li>Test</li>
+    </ul>
+  </li>
+</ul>
+```
 
 ```javascript
-cy.get('li.active').parent('.nav')
+// yields .sub-nav
+cy.get('li').parent('.sub-nav')
 ```
 
 # Rules

--- a/source/ja/api/commands/parents.md
+++ b/source/ja/api/commands/parents.md
@@ -4,6 +4,9 @@ title: parents
 
 Get the parent DOM elements of a set of DOM elements.
 
+Please note that `.parents()` travels multiple levels up the DOM tree as opposed to the {% url ".parent
+()" parent %} command which travels a single level up the DOM tree.
+
 {% note info %}
 The querying behavior of this command matches exactly how {% url `.parents()` http://api.jquery.com/parents %} works in jQuery.
 {% endnote %}
@@ -57,16 +60,31 @@ Option | Default | Description
 
 ### Get the parents of the active li
 
+```html
+<ul class='main-nav'>
+  <li>Overview</li>
+  <li>Getting started
+    <ul class='sub-nav'>
+      <li>Install</li>
+      <li class='active'>Build</li>
+      <li>Test</li>
+    </ul>
+  </li>
+</ul>
+```
+
 ```javascript
+// yields [.sub-nav, li, .main-nav]
 cy.get('li.active').parents()
 ```
 
 ## Selector
 
-### Get the parents with class `nav` of the active li
+### Get the parents with class `main-nav` of the active li
 
 ```javascript
-cy.get('li.active').parents('.nav')
+// yields [.main-nav]
+cy.get('li.active').parents('.main-nav')
 ```
 
 # Rules

--- a/source/zh-cn/api/commands/parent.md
+++ b/source/zh-cn/api/commands/parent.md
@@ -4,6 +4,8 @@ title: parent
 
 Get the parent DOM element of a set of DOM elements.
 
+Please note that `.parent()` only travels a single level up the DOM tree as opposed to the {% url ".parents()" parents %} command.
+
 {% note info %}
 The querying behavior of this command matches exactly how {% url `.parent()` http://api.jquery.com/parent %} works in jQuery.
 {% endnote %}
@@ -57,16 +59,44 @@ Option | Default | Description
 
 ### Get the parent of the active `li`
 
+```html
+<ul class='main-nav'>
+  <li>Overview</li>
+  <li>Getting started
+    <ul class='sub-nav'>
+      <li>Install</li>
+      <li class='active'>Build</li>
+      <li>Test</li>
+    </ul>
+  </li>
+</ul>
+```
+
 ```javascript
+// yields .sub-nav
 cy.get('li.active').parent()
 ```
 
 ## Selector
 
-### Get the parent with class `nav` of the active `li`
+### Get the parent with class `sub-nav` of all `li` elements
+
+```html
+<ul class='main-nav'>
+  <li>Overview</li>
+  <li>Getting started
+    <ul class='sub-nav'>
+      <li>Install</li>
+      <li class='active'>Build</li>
+      <li>Test</li>
+    </ul>
+  </li>
+</ul>
+```
 
 ```javascript
-cy.get('li.active').parent('.nav')
+// yields .sub-nav
+cy.get('li').parent('.sub-nav')
 ```
 
 # Rules

--- a/source/zh-cn/api/commands/parents.md
+++ b/source/zh-cn/api/commands/parents.md
@@ -4,6 +4,9 @@ title: parents
 
 Get the parent DOM elements of a set of DOM elements.
 
+Please note that `.parents()` travels multiple levels up the DOM tree as opposed to the {% url ".parent
+()" parent %} command which travels a single level up the DOM tree.
+
 {% note info %}
 The querying behavior of this command matches exactly how {% url `.parents()` http://api.jquery.com/parents %} works in jQuery.
 {% endnote %}
@@ -57,16 +60,31 @@ Option | Default | Description
 
 ### Get the parents of the active li
 
+```html
+<ul class='main-nav'>
+  <li>Overview</li>
+  <li>Getting started
+    <ul class='sub-nav'>
+      <li>Install</li>
+      <li class='active'>Build</li>
+      <li>Test</li>
+    </ul>
+  </li>
+</ul>
+```
+
 ```javascript
+// yields [.sub-nav, li, .main-nav]
 cy.get('li.active').parents()
 ```
 
 ## Selector
 
-### Get the parents with class `nav` of the active li
+### Get the parents with class `main-nav` of the active li
 
 ```javascript
-cy.get('li.active').parents('.nav')
+// yields [.main-nav]
+cy.get('li.active').parents('.main-nav')
 ```
 
 # Rules


### PR DESCRIPTION
- Also make a note as to the difference between parent and parents at
top of doc.
- Addresses https://github.com/cypress-io/cypress/issues/4658