### PR TITLE
fix(docs): Added missing render method in order to render the url helper

### DIFF
--- a/lib/tags/timeouts.js
+++ b/lib/tags/timeouts.js
@@ -4,6 +4,7 @@ const rawRender = require('../raw_render')
 const urls = {
   action: `{% url 'actionable state' interacting-with-elements %}`,
   exist: `{% url 'exist in the DOM' introduction-to-cypress#Default-Assertions %}`,
+  retry: `{% url 'retry' retry-ability %}`,
 }
 
 module.exports = function yields (hexo, args) {
@@ -103,9 +104,9 @@ module.exports = function yields (hexo, args) {
   }
 
   const timeouts = () => {
-    return `<ul>
-    <li><p>${cmd} will continue to {% url "retry" retry-ability %} its specified assertions until it times out.</p></li>
-    </ul>`
+    return render(`<ul>
+    <li><p>${cmd} will continue to ${urls.retry} its specified assertions until it times out.</p></li>
+    </ul>`)
   }
 
   switch (type) {


### PR DESCRIPTION
<!--
Thanks for contributing!

Please explain what changes were made
also reference any fixed issues with "close #[ISSUE]"
-->

### Translations updated

Changes made to documentation were also copied over to other languages (**copying English text is ok**).

- [ ] Japanese docs in [`/source/ja`](/source/ja).
- [ ] Chinese docs in [`/source/zh-cn`](/source/zh-cn).
- [x] Not applicable (this is not a change to an `en` doc content).

Closes #1867 