### PR TITLE
Add Shadow DOM recipes

### DIFF
--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -144,6 +144,11 @@
       link: https://github.com/NicholasBoll/cypress-pipe
       keywords: [commands]
 
+    - name: cypress-shadow-dom
+      description: Custom commands for shadow DOM support
+      link: https://github.com/abramenal/cypress-shadow-dom
+      keywords: [shadow, shadow-dom, polymer, lit-html, commands]
+
     - name: cypress-testing-library
       description: 🐅 Simple and complete custom Cypress commands and utilities that encourage good testing practices.
       link: https://github.com/kentcdodds/cypress-testing-library

--- a/source/examples/examples/recipes.md
+++ b/source/examples/examples/recipes.md
@@ -25,6 +25,7 @@ Recipe  | Description
 {% url 'Hover and Hidden Elements' https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/testing-dom__hover-hidden-elements %} | Test hidden elements requiring hover
 {% url 'Form Interactions' https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/testing-dom__form-interactions %} |  Test form elements like input type `range`
 {% url 'Drag and Drop' https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/testing-dom__drag-drop %} | Use `.trigger()` to test drag and drop
+{% url 'Shadow DOM' https://github.com/cypress-io/cypress-example-recipes/tree/master/testing-dom__shadow-dom %} | You need to use any of available custom commands
 
 ## Logging In 
 Recipe  | Description

--- a/source/ja/_data/plugins.yml
+++ b/source/ja/_data/plugins.yml
@@ -134,6 +134,11 @@
       link: https://github.com/meinaart/cypress-plugin-snapshots
       keywords: [snapshot]
 
+    - name: cypress-shadow-dom
+      description: Custom commands for shadow DOM support
+      link: https://github.com/abramenal/cypress-shadow-dom
+      keywords: [shadow, shadow-dom, polymer, lit-html, commands]
+
     - name: cypress-testing-library
       description: 🐅 Simple and complete custom Cypress commands and utilities that encourage good testing practices.
       link: https://github.com/kentcdodds/cypress-testing-library

--- a/source/ja/examples/examples/recipes.md
+++ b/source/ja/examples/examples/recipes.md
@@ -28,6 +28,7 @@ Recipe  | Description
 {% url 'Hover and Hidden Elements' https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/testing-dom__hover-hidden-elements %} | Test hidden elements requiring hover
 {% url 'Form Interactions' https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/testing-dom__form-interactions %} |  Test form elements like input type `range`
 {% url 'Drag and Drop' https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/testing-dom__drag-drop %} | Use `.trigger()` to test drag and drop
+{% url 'Shadow DOM' https://github.com/cypress-io/cypress-example-recipes/tree/master/testing-dom__shadow-dom %} | You need to use any of available custom commands
 
 ## Preprocessors
 Recipe  | Description

--- a/source/zh-cn/_data/plugins.yml
+++ b/source/zh-cn/_data/plugins.yml
@@ -144,6 +144,11 @@
       link: https://github.com/NicholasBoll/cypress-pipe
       keywords: [commands]
 
+    - name: cypress-shadow-dom
+      description: Custom commands for shadow DOM support
+      link: https://github.com/abramenal/cypress-shadow-dom
+      keywords: [shadow, shadow-dom, polymer, lit-html, commands]
+
     - name: cypress-testing-library
       description: 🐅 Simple and complete custom Cypress commands and utilities that encourage good testing practices.
       link: https://github.com/kentcdodds/cypress-testing-library

--- a/source/zh-cn/examples/examples/recipes.md
+++ b/source/zh-cn/examples/examples/recipes.md
@@ -25,6 +25,7 @@ Recipe  | Description
 {% url 'Hover and Hidden Elements' https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/testing-dom__hover-hidden-elements %} | Test hidden elements requiring hover
 {% url 'Form Interactions' https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/testing-dom__form-interactions %} |  Test form elements like input type `range`
 {% url 'Drag and Drop' https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/testing-dom__drag-drop %} | Use `.trigger()` to test drag and drop
+{% url 'Shadow DOM' https://github.com/cypress-io/cypress-example-recipes/tree/master/testing-dom__shadow-dom %} | You need to use any of available custom commands
 
 ## Logging In 
 Recipe  | Description


### PR DESCRIPTION
Currently there is no native implementation but some custom commands to help with that

### Translations updated

Changes made to documentation were also copied over to other languages (**copying English text is ok**).

- [x] Japanese docs in [`/source/ja`](/source/ja).
- [x] Chinese docs in [`/source/zh-cn`](/source/zh-cn).
- [ ] Not applicable (this is not a change to an `en` doc content).
