### PR TITLE
Added documentation for disableSpecialCharSequences option for cy.type

### DIFF
--- a/source/api/commands/type.md
+++ b/source/api/commands/type.md
@@ -71,7 +71,7 @@ Option | Default | Description
 `delay` | `10` | Delay after each keypress
 `force` | `false` | {% usage_options force type %}
 `release` | `true` | Keep a modifier activated between commands
-`disableSpecialCharSequences` | `false` | Determines whether strings such as `{backspace}` are typed literally or are treated as commands to type special characters
+`disableSpecialCharSequences` | `false` | Disable typing special characters for strings surrounded by `{}`, such as `{esc}`, and type the literal characters instead
 `timeout` | {% url `defaultCommandTimeout` configuration#Timeouts %} | {% usage_options timeout .type %}
 
 ## Yields {% helper_icon yields %}

--- a/source/api/commands/type.md
+++ b/source/api/commands/type.md
@@ -71,6 +71,7 @@ Option | Default | Description
 `delay` | `10` | Delay after each keypress
 `force` | `false` | {% usage_options force type %}
 `release` | `true` | Keep a modifier activated between commands
+`disableSpecialCharSequences` | `false` | Determines whether strings such as `{backspace}` are typed literally or are treated as commands to type special characters
 `timeout` | {% url `defaultCommandTimeout` configuration#Timeouts %} | {% usage_options timeout .type %}
 
 ## Yields {% helper_icon yields %}

--- a/source/ja/api/commands/type.md
+++ b/source/ja/api/commands/type.md
@@ -71,7 +71,7 @@ Option | Default | Description
 `delay` | `10` | Delay after each keypress
 `force` | `false` | {% usage_options force type %}
 `release` | `true` | Keep a modifier activated between commands
-`disableSpecialCharSequences` | `false` | Determines whether strings such as `{backspace}` are typed literally or are treated as commands to type special characters
+`disableSpecialCharSequences` | `false` | Disable typing special characters for strings surrounded by `{}`, such as `{esc}`, and type the literal characters instead
 `timeout` | {% url `defaultCommandTimeout` configuration#Timeouts %} | {% usage_options timeout .type %}
 
 ## Yields {% helper_icon yields %}

--- a/source/ja/api/commands/type.md
+++ b/source/ja/api/commands/type.md
@@ -71,6 +71,7 @@ Option | Default | Description
 `delay` | `10` | Delay after each keypress
 `force` | `false` | {% usage_options force type %}
 `release` | `true` | Keep a modifier activated between commands
+`disableSpecialCharSequences` | `false` | Determines whether strings such as `{backspace}` are typed literally or are treated as commands to type special characters
 `timeout` | {% url `defaultCommandTimeout` configuration#Timeouts %} | {% usage_options timeout .type %}
 
 ## Yields {% helper_icon yields %}

--- a/source/zh-cn/api/commands/type.md
+++ b/source/zh-cn/api/commands/type.md
@@ -71,7 +71,7 @@ Option | Default | Description
 `delay` | `10` | Delay after each keypress
 `force` | `false` | {% usage_options force type %}
 `release` | `true` | Keep a modifier activated between commands
-`disableSpecialCharSequences` | `false` | Determines whether strings such as `{backspace}` are typed literally or are treated as commands to type special characters
+`disableSpecialCharSequences` | `false` | Disable typing special characters for strings surrounded by `{}`, such as `{esc}`, and type the literal characters instead
 `timeout` | {% url `defaultCommandTimeout` configuration#Timeouts %} | {% usage_options timeout .type %}
 
 ## Yields {% helper_icon yields %}

--- a/source/zh-cn/api/commands/type.md
+++ b/source/zh-cn/api/commands/type.md
@@ -71,6 +71,7 @@ Option | Default | Description
 `delay` | `10` | Delay after each keypress
 `force` | `false` | {% usage_options force type %}
 `release` | `true` | Keep a modifier activated between commands
+`disableSpecialCharSequences` | `false` | Determines whether strings such as `{backspace}` are typed literally or are treated as commands to type special characters
 `timeout` | {% url `defaultCommandTimeout` configuration#Timeouts %} | {% usage_options timeout .type %}
 
 ## Yields {% helper_icon yields %}


### PR DESCRIPTION
Added documentation of disableSpecialCharSequences option for cy.type from https://github.com/cypress-io/cypress/pull/4744

### Translations updated

Changes made to documentation were also copied over to other languages (**copying English text is ok**).

- [x] Japanese docs in [`/source/ja`](/source/ja).
- [x] Chinese docs in [`/source/zh-cn`](/source/zh-cn).
- [ ] Not applicable (this is not a change to an `en` doc content).
