### PR TITLE
remove datetime references from docs

### DIFF
--- a/source/api/commands/type.md
+++ b/source/api/commands/type.md
@@ -277,7 +277,6 @@ cy.get('input[type=text]').type('Test all the things', { force: true })
   * `week`
   * `month`
   * `time`
-  * `datetime`
   * `datetime-local`
   * `search`
   * `url`

--- a/source/ja/api/commands/type.md
+++ b/source/ja/api/commands/type.md
@@ -277,7 +277,6 @@ cy.get('input[type=text]').type('Test all the things', { force: true })
   * `week`
   * `month`
   * `time`
-  * `datetime`
   * `datetime-local`
   * `search`
   * `url`

--- a/source/zh-cn/api/commands/type.md
+++ b/source/zh-cn/api/commands/type.md
@@ -277,7 +277,6 @@ cy.get('input[type=text]').type('Test all the things', { force: true })
   * `week`
   * `month`
   * `time`
-  * `datetime`
   * `datetime-local`
   * `search`
   * `url`


### PR DESCRIPTION
<!--
Thanks for contributing!

Please explain what changes were made
also reference any fixed issues with "close #[ISSUE]"
-->
As `datetime` input type got deprecated removed it from docs

close #1850

### Translations updated
Changes made to documentation were also copied over to other languages (**copying English text is ok**).

- [x] Japanese docs in [`/source/ja`](/source/ja).
- [x] Chinese docs in [`/source/zh-cn`](/source/zh-cn).
- [ ] Not applicable (this is not a change to an `en` doc content).
