### PR TITLE
Update continuous-integration.md

### DIFF
--- a/source/guides/guides/continuous-integration.md
+++ b/source/guides/guides/continuous-integration.md
@@ -348,7 +348,7 @@ See our {% url 'examples' docker %} for additional information on our maintained
 If you are not using one of the above CI providers then make sure your system has these dependencies installed.
 
 ```shell
-apt-get install xvfb libgtk2.0-0 libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2
+apt-get install xvfb libgtk-3-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2
 ```
 
 ## Caching


### PR DESCRIPTION
Update dependencies (electron now depends on gtk3 instead of gtk2)

### Translations updated

Changes made to documentation were also copied over to other languages (**copying English text is ok**).

- [ ] Japanese docs in [`/source/ja`](/source/ja).
- [ ] Chinese docs in [`/source/zh-cn`](/source/zh-cn).
- [x] Not applicable (this is not a change to an `en` doc content).
