### PR TITLE
Adding HTML form validation to FAQ, closes #1824

### DIFF
--- a/source/faq/questions/using-cypress-faq.md
+++ b/source/faq/questions/using-cypress-faq.md
@@ -203,6 +203,23 @@ describe('The Document Metadata', () => {
 })
 ```
 
+## {% fa fa-angle-right %} Can I check that a form's HTML form validation is shown when an input is invalid?
+
+You certainly can.
+
+```javascript
+it('check validation message on invalid input', () => {
+  cy.get('input:invalid').should('have.length', 0)
+  cy.get('[type="email"]').type('not_an_email')
+  cy.get('[type="submit"]').click()
+  cy.get('input:invalid').should('have.length', 1)
+  cy.get('[type="email"]').then(($input) => {
+    expect($input[0].validationMessage).to.eq('I expect an email!')
+  })
+})
+```
+
+
 ## {% fa fa-angle-right %} Can I throttle network speeds using Cypress?
 
 You can throttle your network connection by accessing your Developer Tools Network panel. Additionally, you can add your own custom presets by selecting **Custom > Add** from the Network Conditions drawer.


### PR DESCRIPTION
Adding example of how to check for HTML form validation to FAQ ( closes #1824 )

### Translations updated

Changes made to documentation were also copied over to other languages (**copying English text is ok**).

- [ ] Japanese docs in [`/source/ja`](/source/ja).
- [ ] Chinese docs in [`/source/zh-cn`](/source/zh-cn).
- [ ] Not applicable (this is not a change to an `en` doc content).
