### PR TITLE
Improve GitHub integration "run group" link target

### DIFF
--- a/source/guides/dashboard/github-integration.md
+++ b/source/guides/dashboard/github-integration.md
@@ -79,7 +79,7 @@ If status checks are enabled within a project's GitHub integration settings, the
 
 The Cypress GitHub App reports commit status checks in two separate styles:
 
-- One check per {% url "run group" https://help.github.com/en/articles/about-status-checks %}.
+- One check per {% url "run group" https://docs.cypress.io/guides/guides/parallelization.html#Grouping-test-runs %}.
     {% imgTag /img/dashboard/github-integration/status-checks-per-group-failed.png "Status checks per group" "no-border" %}
 
 - Or one check per spec file.

--- a/source/guides/dashboard/github-integration.md
+++ b/source/guides/dashboard/github-integration.md
@@ -79,7 +79,7 @@ If status checks are enabled within a project's GitHub integration settings, the
 
 The Cypress GitHub App reports commit status checks in two separate styles:
 
-- One check per {% url "run group" https://docs.cypress.io/guides/guides/parallelization.html#Grouping-test-runs %}.
+- One check per {% url "run group" parallelization#Grouping-test-runs %}.
     {% imgTag /img/dashboard/github-integration/status-checks-per-group-failed.png "Status checks per group" "no-border" %}
 
 - Or one check per spec file.

--- a/source/ja/guides/dashboard/github-integration.md
+++ b/source/ja/guides/dashboard/github-integration.md
@@ -79,7 +79,7 @@ If status checks are enabled within a project's GitHub integration settings, the
 
 The Cypress GitHub App reports commit status checks in two separate styles:
 
-- One check per {% url "run group" https://help.github.com/en/articles/about-status-checks %}.
+- One check per {% url "run group" https://docs.cypress.io/guides/guides/parallelization.html#Grouping-test-runs %}.
     {% imgTag /img/dashboard/github-integration/status-checks-per-group-failed.png "Status checks per group" "no-border" %}
 
 - Or one check per spec file.

--- a/source/ja/guides/dashboard/github-integration.md
+++ b/source/ja/guides/dashboard/github-integration.md
@@ -79,7 +79,7 @@ If status checks are enabled within a project's GitHub integration settings, the
 
 The Cypress GitHub App reports commit status checks in two separate styles:
 
-- One check per {% url "run group" https://docs.cypress.io/guides/guides/parallelization.html#Grouping-test-runs %}.
+- One check per {% url "run group" parallelization#Grouping-test-runs %}.
     {% imgTag /img/dashboard/github-integration/status-checks-per-group-failed.png "Status checks per group" "no-border" %}
 
 - Or one check per spec file.

--- a/source/zh-cn/guides/dashboard/github-integration.md
+++ b/source/zh-cn/guides/dashboard/github-integration.md
@@ -79,7 +79,7 @@ If status checks are enabled within a project's GitHub integration settings, the
 
 The Cypress GitHub App reports commit status checks in two separate styles:
 
-- One check per {% url "run group" https://help.github.com/en/articles/about-status-checks %}.
+- One check per {% url "run group" https://docs.cypress.io/guides/guides/parallelization.html#Grouping-test-runs %}.
     {% imgTag /img/dashboard/github-integration/status-checks-per-group-failed.png "Status checks per group" "no-border" %}
 
 - Or one check per spec file.

--- a/source/zh-cn/guides/dashboard/github-integration.md
+++ b/source/zh-cn/guides/dashboard/github-integration.md
@@ -79,7 +79,7 @@ If status checks are enabled within a project's GitHub integration settings, the
 
 The Cypress GitHub App reports commit status checks in two separate styles:
 
-- One check per {% url "run group" https://docs.cypress.io/guides/guides/parallelization.html#Grouping-test-runs %}.
+- One check per {% url "run group" parallelization#Grouping-test-runs %}.
     {% imgTag /img/dashboard/github-integration/status-checks-per-group-failed.png "Status checks per group" "no-border" %}
 
 - Or one check per spec file.


### PR DESCRIPTION
<!--
Thanks for contributing!

Please explain what changes were made
also reference any fixed issues with "close #[ISSUE]"
-->

Wow, spotted the GitHub integration support from v3.4.1 changelog. Nice job!

It seems that the "Status checks" section in https://docs.cypress.io/guides/dashboard/github-integration.html#Status-checks links twice to https://help.github.com/en/articles/about-status-checks, even when it mentions "One check per run group". I suppose that `run group` link was supposed to be link to some other Cypress documentation page?

I'm not sure which page it was supposed to link to, but hey, I took a guess. Let me know what you'd like the link to be, or even do a direct update to this PR branch :relaxed:

### Translations updated

Changes made to documentation were also copied over to other languages (**copying English text is ok**).

- [x] Japanese docs in [`/source/ja`](/source/ja).
- [x] Chinese docs in [`/source/zh-cn`](/source/zh-cn).
- [ ] Not applicable (this is not a change to an `en` doc content).
