### PR TITLE
Add elm-batteries project template to plugins

### DIFF
--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -261,6 +261,11 @@
       link: https://github.com/matzeeable/wp-reactjs-starter
       keywords: [wp, wordpress]
 
+    - name: Elm Batteries Included
+      description: A project template to learn how Elm, Parcel, Cypress and Netlify work together.
+      link: https://github.com/cedricss/elm-batteries
+      keywords: [elm, parcel, netlify]
+
 - name: Component Testing
   description: ⚠️ Loading and mounting components from various frameworks is highly experimental and might change in the future.
   plugins:

--- a/source/ja/_data/plugins.yml
+++ b/source/ja/_data/plugins.yml
@@ -251,6 +251,11 @@
       link: https://github.com/matzeeable/wp-reactjs-starter
       keywords: [wp, wordpress]
 
+    - name: Elm Batteries Included
+      description: A project template to learn how Elm, Parcel, Cypress and Netlify work together.
+      link: https://github.com/cedricss/elm-batteries
+      keywords: [elm, parcel, netlify]
+
 - name: Component Testing
   description: ⚠️ Loading and mounting components from various frameworks is highly experimental and might change in the future.
   plugins:

--- a/source/zh-cn/_data/plugins.yml
+++ b/source/zh-cn/_data/plugins.yml
@@ -261,6 +261,11 @@
       link: https://github.com/matzeeable/wp-reactjs-starter
       keywords: [wp, wordpress]
 
+    - name: Elm Batteries Included
+      description: A project template to learn how Elm, Parcel, Cypress and Netlify work together.
+      link: https://github.com/cedricss/elm-batteries
+      keywords: [elm, parcel, netlify]
+
 - name: Component Testing
   description: ⚠️ Loading and mounting components from various frameworks is highly experimental and might change in the future.
   plugins:


### PR DESCRIPTION
Add [elm-batteries](https://github.com/cedricss/elm-batteries) to the plugins page (_Framework tooling_ section), an elm project template that includes Parcel, Netlify and Cypress.

Changes made to documentation were also copied over to other languages:

- [x] Japanese docs
- [x] Chinese docs