### PR TITLE
update wait requirements to specify when it can be used as child / when as parent

### DIFF
--- a/lib/tags/requirements.js
+++ b/lib/tags/requirements.js
@@ -6,42 +6,16 @@ module.exports = function yields (hexo, args) {
   // {% requirements dom .click %}
   // {% requirements dom .children %}
 
-  const type = args[0]
   const cmd = `<code>${args[1]}()</code>`
 
   const focus = `${cmd} requires the element to be able to receive focus`
 
-  const parentCmd = `${cmd} requires being chained off of <code>cy</code>`
   const childCmd = `${cmd} requires being chained off a previous command`
   const childCmdDom = `${cmd} requires being chained off a command that yields DOM element(s)`
+  const dualCmd = `${cmd} can be chained off of <code>cy</code> or off another command`
+  const parentCmd = `${cmd} requires being chained off of <code>cy</code>`
 
-  const parentOrChild = () => {
-    return (args[1] === 'cy.get' || args[1] === 'cy.focused') ? parentCmd : childCmdDom
-  }
-
-  const none = () => {
-    return `<ul>
-      <li><p>${cmd} has no requirements or default assertions.</p></li>
-    </ul>`
-  }
-
-  const child = () => {
-    return `<ul>
-      <li><p>${childCmd}.</p></li>
-    </ul>`
-  }
-
-  const dom = () => {
-    return `<ul>
-      <li><p>${parentOrChild()}.</p></li>
-    </ul>`
-  }
-
-  const parent = () => {
-    return `<ul>
-      <li><p>${parentCmd}.</p></li>
-    </ul>`
-  }
+  const type = args[0]
 
   const blurability = () => {
     return `<ul>
@@ -51,10 +25,9 @@ module.exports = function yields (hexo, args) {
     </ul>`
   }
 
-  const focusability = () => {
+  const child = () => {
     return `<ul>
-      <li><p>${childCmdDom}.</p></li>
-      <li><p>${focus}.</p></li>
+      <li><p>${childCmd}.</p></li>
     </ul>`
   }
 
@@ -72,30 +45,15 @@ module.exports = function yields (hexo, args) {
     </ul>`
   }
 
-  const selectability = () => {
+  const dom = () => {
     return `<ul>
-      <li><p>${childCmdDom}.</p></li>
-      <li><p>${cmd} requires the element to be a <code>select</code>.</p></li>
-    </ul>`
-  }
-
-  const scrollability = () => {
-    return `<ul>
-      <li><p>${childCmdDom}.</p></li>
-      <li><p>${cmd} requires the element to be scrollable.</p></li>
-    </ul>`
-  }
-
-  const submitability = () => {
-    return `<ul>
-      <li><p>${childCmdDom}.</p></li>
-      <li><p>${cmd} requires the element to be a <code>form</code>.</p></li>
+      <li><p>${parentOrChild()}.</p></li>
     </ul>`
   }
 
   const dual = () => {
     return `<ul>
-      <li><p>${cmd} can be chained off of <code>cy</code> or off another command.</p></li>
+      <li><p>${cmd} ${dualCmd}</p></li>
     </ul>`
   }
 
@@ -111,13 +69,6 @@ module.exports = function yields (hexo, args) {
     </ul>`
   }
 
-  const spread = () => {
-    return `<ul>
-      <li><p>${childCmd}.</p></li>
-      <li><p>${cmd} requires being chained off of a command that yields an array-like structure.</p></li>
-    </ul>`
-  }
-
   const exec = () => {
     return `<ul>
       <li><p>${parentCmd}.</p></li>
@@ -126,25 +77,16 @@ module.exports = function yields (hexo, args) {
     </ul>`
   }
 
-  const task = () => {
+  const focusability = () => {
     return `<ul>
-      <li><p>${parentCmd}.</p></li>
-      <li><p>${cmd} requires the task to eventually end.</p></li>
+      <li><p>${childCmdDom}.</p></li>
+      <li><p>${focus}.</p></li>
     </ul>`
   }
 
-  const writeFile = () => {
+  const none = () => {
     return `<ul>
-      <li><p>${parentCmd}.</p></li>
-      <li><p>${cmd} requires the file be successfully written to disk. Anything preventing this such as OS permission issues will cause it to fail.</p></li>
-    </ul>`
-  }
-
-  const readFile = () => {
-    return `<ul>
-      <li><p>${parentCmd}.</p></li>
-      <li><p>${cmd} requires the file must exist.</p></li>
-      <li><p>${cmd} requires the file be successfully read from disk. Anything preventing this such as OS permission issues will cause it to fail.</p></li>
+      <li><p>${cmd} has no requirements or default assertions.</p></li>
     </ul>`
   }
 
@@ -157,10 +99,21 @@ module.exports = function yields (hexo, args) {
     </ul>`
   }
 
-  const tick = () => {
+  const parent = () => {
     return `<ul>
       <li><p>${parentCmd}.</p></li>
-      <li><p>${cmd} requires that <code>cy.clock()</code> be called before it.</p></li>
+    </ul>`
+  }
+
+  const parentOrChild = () => {
+    return (args[1] === 'cy.get' || args[1] === 'cy.focused') ? parentCmd : childCmdDom
+  }
+
+  const readFile = () => {
+    return `<ul>
+      <li><p>${parentCmd}.</p></li>
+      <li><p>${cmd} requires the file must exist.</p></li>
+      <li><p>${cmd} requires the file be successfully read from disk. Anything preventing this such as OS permission issues will cause it to fail.</p></li>
     </ul>`
   }
 
@@ -172,13 +125,71 @@ module.exports = function yields (hexo, args) {
     </ul>`
   }
 
+  const scrollability = () => {
+    return `<ul>
+      <li><p>${childCmdDom}.</p></li>
+      <li><p>${cmd} requires the element to be scrollable.</p></li>
+    </ul>`
+  }
+
+  const selectability = () => {
+    return `<ul>
+      <li><p>${childCmdDom}.</p></li>
+      <li><p>${cmd} requires the element to be a <code>select</code>.</p></li>
+    </ul>`
+  }
+
+  const spread = () => {
+    return `<ul>
+      <li><p>${childCmd}.</p></li>
+      <li><p>${cmd} requires being chained off of a command that yields an array-like structure.</p></li>
+    </ul>`
+  }
+
+  const submitability = () => {
+    return `<ul>
+      <li><p>${childCmdDom}.</p></li>
+      <li><p>${cmd} requires the element to be a <code>form</code>.</p></li>
+    </ul>`
+  }
+
+  const task = () => {
+    return `<ul>
+      <li><p>${parentCmd}.</p></li>
+      <li><p>${cmd} requires the task to eventually end.</p></li>
+    </ul>`
+  }
+
+  const tick = () => {
+    return `<ul>
+      <li><p>${parentCmd}.</p></li>
+      <li><p>${cmd} requires that <code>cy.clock()</code> be called before it.</p></li>
+    </ul>`
+  }
+
+  const wait = () => {
+    return `<ul>
+      <li><p>When passed a <code>time</code> argument ${dualCmd}.</p></li>
+      <li><p>When passed an <code>alias</code> argument ${parentCmd}.</p></li>
+    </ul>`
+  }
+
+  const writeFile = () => {
+    return `<ul>
+      <li><p>${parentCmd}.</p></li>
+      <li><p>${cmd} requires the file be successfully written to disk. Anything preventing this such as OS permission issues will cause it to fail.</p></li>
+    </ul>`
+  }
+
   switch (type) {
-    case 'none':
-      return none()
-    case 'parent':
-      return parent()
+    case 'blurability':
+      return blurability()
+    case 'checkability':
+      return checkability()
     case 'child':
       return child()
+    case 'clearability':
+      return clearability()
     case 'dom':
       return dom()
     case 'dual':
@@ -187,36 +198,36 @@ module.exports = function yields (hexo, args) {
       return dualExistence()
     case 'dual_existence_single_dom':
       return dualExistenceSingleDom()
-    case 'clearability':
-      return clearability()
-    case 'blurability':
-      return blurability()
-    case 'focusability':
-      return focusability()
-    case 'checkability':
-      return checkability()
-    case 'selectability':
-      return selectability()
-    case 'scrollability':
-      return scrollability()
-    case 'submitability':
-      return submitability()
-    case 'spread':
-      return spread()
     case 'exec':
       return exec()
-    case 'task':
-      return task()
-    case 'read_file':
-      return readFile()
-    case 'write_file':
-      return writeFile()
+    case 'focusability':
+      return focusability()
+    case 'none':
+      return none()
+    case 'parent':
+      return parent()
     case 'page':
       return page()
-    case 'tick':
-      return tick()
+    case 'read_file':
+      return readFile()
     case 'request':
       return request()
+    case 'scrollability':
+      return scrollability()
+    case 'selectability':
+      return selectability()
+    case 'spread':
+      return spread()
+    case 'submitability':
+      return submitability()
+    case 'task':
+      return task()
+    case 'tick':
+      return tick()
+    case 'wait':
+      return wait()
+    case 'write_file':
+      return writeFile()
     default:
       // error when an invalid usage option was provided
       throw new Error(`{% requirements %} tag helper was provided an invalid option: ${type}`)

--- a/source/api/commands/wait.md
+++ b/source/api/commands/wait.md
@@ -213,7 +213,7 @@ This gives you the best of both worlds - a fast error feedback loop when request
 
 ## Requirements {% helper_icon requirements %}
 
-{% requirements parent cy.wait %}
+{% requirements wait cy.wait %}
 
 ## Assertions {% helper_icon assertions %}
 

--- a/source/ja/api/commands/wait.md
+++ b/source/ja/api/commands/wait.md
@@ -213,7 +213,7 @@ This gives you the best of both worlds - a fast error feedback loop when request
 
 ## Requirements {% helper_icon requirements %}
 
-{% requirements parent cy.wait %}
+{% requirements wait cy.wait %}
 
 ## Assertions {% helper_icon assertions %}
 

--- a/source/zh-cn/api/commands/wait.md
+++ b/source/zh-cn/api/commands/wait.md
@@ -213,7 +213,7 @@ This gives you the best of both worlds - a fast error feedback loop when request
 
 ## Requirements {% helper_icon requirements %}
 
-{% requirements parent cy.wait %}
+{% requirements wait cy.wait %}
 
 ## Assertions {% helper_icon assertions %}
 


### PR DESCRIPTION
- close #1838 
- also alphabetize requirements methods