### PR TITLE
Adding documentation for addition of presets for following viewports:…

### DIFF
--- a/source/api/commands/viewport.md
+++ b/source/api/commands/viewport.md
@@ -47,11 +47,15 @@ A preset dimension to set the viewport. Preset supports the following options:
 | `macbook-11`  | 1366  | 768    |
 | `ipad-2`      | 768   | 1024    |
 | `ipad-mini`   | 768   | 1024    |
+| `iphone-xr`   | 414   | 896    |
+| `iphone-x`    | 375   | 812    |
 | `iphone-6+`   | 414   | 736    |
 | `iphone-6`    | 375   | 667    |
 | `iphone-5`    | 320   | 568    |
 | `iphone-4`    | 320   | 480    |
 | `iphone-3`    | 320   | 480    |
+| `samsung-s10` | 360   | 760    |
+| `samsung-note9` | 414 | 896    |
 
 **{% fa fa-angle-right %} orientation** ***(String)***
 


### PR DESCRIPTION
… 1) iPhone-XR, 2) iPhone-X, 3) Samsung-S10, 4) Samsung-Note9

Updated documentation for supporting preset for iPhone-XR, iPhone-X, Samsung-S10, Samsung-Note9 viewports. 
