### PR TITLE
WIP: Use cypress fiddle

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -2,5 +2,6 @@
   "baseUrl": "http://localhost:2222",
   "projectId": "ma3dkn",
   "viewportWidth": 1500,
+  "viewportHeight": 1000,
   "blacklistHosts": ["trackcmp.net", "js.hs-analytics.net", "js.hs-scripts.com"]
 }

--- a/cypress/fiddles/and.js
+++ b/cypress/fiddles/and.js
@@ -17,5 +17,34 @@ module.exports = {
           .and('eq', 'bar')                                // Assert 'foo' property is 'bar'
       `,
     },
+    Examples: {
+      chain: {
+        html: stripIndent`
+          <button class="active">Active button</button>
+        `,
+        test: stripIndent`
+          cy.get('button').should('have.class', 'active').and('not.be.disabled')
+        `,
+      },
+      value: {
+        only: true,
+        html: stripIndent`
+          <!-- App Code -->
+          <ul>
+            <li>
+              <a href="users/123/edit">Edit User</a>
+            </li>
+          </ul>
+        `,
+        test: stripIndent`
+          cy
+            .get('a')
+            .should('contain', 'Edit User') // yields <a>
+            .and('have.attr', 'href')       // yields string value of href
+            .and('match', /users/)          // yields string value of href
+            .and('not.include', '#')        // yields string value of href
+        `,
+      },
+    },
   },
 }

--- a/cypress/fiddles/and.js
+++ b/cypress/fiddles/and.js
@@ -1,20 +1,21 @@
 
-import { source } from 'common-tags'
+const { stripIndent } = require('common-tags')
 
-export default {
-  '.and': [{
-    name: 'Usage',
-    html: source`
-      <!-- there are no errors -->
-      <div class="err"></div>
-      <button>Login</button>
-    `,
-    test: source`
-      cy.get('.err').should('be.empty').and('be.hidden') // Assert '.err' is empty & hidden
-      cy.contains('Login').and('be.visible')             // Assert el is visible
-      cy.wrap({ foo: 'bar' })
-        .should('have.property', 'foo')                  // Assert 'foo' property exists
-        .and('eq', 'bar')                                // Assert 'foo' property is 'bar'
-    `,
-  }],
+module.exports = {
+  'and': {
+    Usage: {
+      html: stripIndent`
+        <!-- there are no errors -->
+        <div class="err"></div>
+        <button>Login</button>
+      `,
+      test: stripIndent`
+        cy.get('.err').should('be.empty').and('be.hidden') // Assert '.err' is empty & hidden
+        cy.contains('Login').and('be.visible')             // Assert el is visible
+        cy.wrap({ foo: 'bar' })
+          .should('have.property', 'foo')                  // Assert 'foo' property exists
+          .and('eq', 'bar')                                // Assert 'foo' property is 'bar'
+      `,
+    },
+  },
 }

--- a/cypress/fiddles/and.js
+++ b/cypress/fiddles/and.js
@@ -1,0 +1,20 @@
+
+import { source } from 'common-tags'
+
+export default {
+  '.and': [{
+    name: 'Usage',
+    html: source`
+      <!-- there are no errors -->
+      <div class="err"></div>
+      <button>Login</button>
+    `,
+    test: source`
+      cy.get('.err').should('be.empty').and('be.hidden') // Assert '.err' is empty & hidden
+      cy.contains('Login').and('be.visible')             // Assert el is visible
+      cy.wrap({ foo: 'bar' })
+        .should('have.property', 'foo')                  // Assert 'foo' property exists
+        .and('eq', 'bar')                                // Assert 'foo' property is 'bar'
+    `,
+  }],
+}

--- a/cypress/fiddles/and.js
+++ b/cypress/fiddles/and.js
@@ -26,8 +26,32 @@ module.exports = {
           cy.get('button').should('have.class', 'active').and('not.be.disabled')
         `,
       },
+      yields1: {
+        html: stripIndent`
+          <nav class="open">...</nav>
+        `,
+        test: stripIndent`
+          cy
+            .get('nav')                       // yields <nav>
+            .should('be.visible')             // yields <nav>
+            .and('have.class', 'open')        // yields <nav>
+        `,
+      },
+      yields2: {
+        html: stripIndent`
+          <div style="font-family: sans-serif">
+            <nav class="open">...</nav>
+          </div>
+        `,
+        test: stripIndent`
+          cy
+            .get('nav')                       // yields <nav>
+            .should('be.visible')             // yields <nav>
+            .and('have.css', 'font-family')   // yields 'sans-serif'
+            .and('match', /serif/)            // yields 'sans-serif'
+        `,
+      },
       value: {
-        only: true,
         html: stripIndent`
           <!-- App Code -->
           <ul>
@@ -39,10 +63,57 @@ module.exports = {
         test: stripIndent`
           cy
             .get('a')
-            .should('contain', 'Edit User') // yields <a>
+            .should('contain', 'Edit User') // yields the anchor element
             .and('have.attr', 'href')       // yields string value of href
             .and('match', /users/)          // yields string value of href
             .and('not.include', '#')        // yields string value of href
+        `,
+      },
+      'method and value': {
+        html: stripIndent`
+          <div id="header">
+            <a class="active" href="/users">Users</a>
+          </div>
+        `,
+        test: stripIndent`
+          cy
+            .get('#header a')
+            .should('have.class', 'active')
+            .and('have.attr', 'href', '/users')
+        `,
+      },
+      'multiple p': {
+        html: stripIndent`
+          <div>
+            <p class="text-primary">Hello World</p>
+            <p class="text-danger">You have an error</p>
+            <p class="text-default">Try again later</p>
+          </div>
+        `,
+        test: stripIndent`
+          cy
+            .get('p')
+            .should('not.be.empty')
+            .and(($p) => {
+              // should have found 3 elements
+              expect($p).to.have.length(3)
+
+              // make sure the first contains some text content
+              expect($p.first()).to.contain('Hello World')
+
+              // use jquery's map to grab all of their classes
+              // jquery's map returns a new jquery object
+              const classes = $p.map((i, el) => {
+                return Cypress.$(el).attr('class')
+              })
+
+              // call classes.get() to make this a plain array
+              expect(classes.get()).to.deep.eq([
+                'text-primary',
+                'text-danger',
+                'text-default'
+              ])
+            })
         `,
       },
     },

--- a/cypress/integration/fiddles_spec.js
+++ b/cypress/integration/fiddles_spec.js
@@ -1,0 +1,4 @@
+import { testExamples } from '@cypress/fiddle'
+import and from '../fiddles/and'
+
+testExamples(and)

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -1,5 +1,6 @@
 /// <reference types="cypress" />
 import './defaults'
+import '@cypress/fiddle'
 
 const resizeObserverLoopErrRe = /^ResizeObserver loop limit exceeded/
 

--- a/lib/tags/fiddle.js
+++ b/lib/tags/fiddle.js
@@ -1,16 +1,20 @@
 const path = require('path')
 const { stripIndent } = require('common-tags')
 const _ = require('lodash')
+const requireWithoutCaching = require('require-and-forget')
 
 module.exports = function fiddle (hexo, args) {
   const fiddleFileName = args[0]
   const pathToFiddle = args[1]
+  const testPropertyName = args[2] || 'test'
 
   const fiddlePath = path.join(__dirname, '..', '..', 'cypress', 'fiddles', fiddleFileName)
   let loadedFiddles
 
   try {
-    loadedFiddles = require(fiddlePath)
+    // to enable editing test files and showing changed pages
+    // do not cache loaded JavaScript in the require cache
+    loadedFiddles = requireWithoutCaching(fiddlePath)
   } catch (e) {
     /* eslint-disable no-console */
     console.error('Was trying to load fiddle "%s" from file "%s"', pathToFiddle, fiddleFileName)
@@ -33,6 +37,13 @@ module.exports = function fiddle (hexo, args) {
   }
 
   // the code block will be later processed using hexo-prism-plugin to have syntax highlighting
-  const escapedCode = _.escape(foundTest.test)
-  return `<pre><code class="javascript">${escapedCode}</code></pre>`
+  if (!foundTest[testPropertyName]) {
+    throw new Error(stripIndent`
+      Cannot find property ${testPropertyName} in test object ${foundTest}
+    `)
+  }
+  const escapedCode = _.escape(foundTest[testPropertyName])
+  // we could pass custom language names through the tag parameter
+  const language = testPropertyName === 'html' ? 'html' : 'javascript'
+  return `<pre><code class="${language}">${escapedCode}</code></pre>`
 }

--- a/lib/tags/fiddle.js
+++ b/lib/tags/fiddle.js
@@ -1,0 +1,24 @@
+const rawRender = require('../raw_render')
+const path = require('path')
+const { stripContent } = require('@common-tags')
+
+module.exports = function fiddle (hexo, args) {
+  const fiddleFileName = args[0]
+  const type = args[1]
+
+  const render = (str) => {
+    return rawRender.call(this, hexo, str)
+  }
+
+  const fiddlePath = path.join(__dirname, '..', '..', 'cypress', 'fiddles', fiddleFileName)
+
+  console.log('loading fiddle "%s"', fiddlePath)
+
+  const loadedFiddles = require(fiddlePath)
+
+  console.log('loaded fiddles')
+
+  return render(stripContent`
+    JavaScript fiddle
+  `)
+}

--- a/lib/tags/fiddle.js
+++ b/lib/tags/fiddle.js
@@ -1,29 +1,28 @@
-const rawRender = require('../raw_render')
 const path = require('path')
 const { stripIndent } = require('common-tags')
 const _ = require('lodash')
-const Promise = require('bluebird')
 
 module.exports = function fiddle (hexo, args) {
-  /* eslint-disable */
   const fiddleFileName = args[0]
   const pathToFiddle = args[1]
 
-  const render = (str) => {
-    return rawRender.call(this, hexo, str, { engine: 'markdown' })
-    // return rawRender.call(this, hexo, str)
+  const fiddlePath = path.join(__dirname, '..', '..', 'cypress', 'fiddles', fiddleFileName)
+  let loadedFiddles
+
+  try {
+    loadedFiddles = require(fiddlePath)
+  } catch (e) {
+    /* eslint-disable no-console */
+    console.error('Was trying to load fiddle "%s" from file "%s"', pathToFiddle, fiddleFileName)
+    console.error('by requiring file "%s"', fiddlePath)
+    console.error('but got error', e)
+    throw e
   }
 
-  const fiddlePath = path.join(__dirname, '..', '..', 'cypress', 'fiddles', fiddleFileName)
-
-  // console.log('loading fiddle "%s"', fiddlePath)
-
-  const loadedFiddles = require(fiddlePath)
-
-  // console.log('loaded fiddles', loadedFiddles)
   const foundTest = _.get(loadedFiddles, pathToFiddle)
 
   if (!foundTest) {
+    /* eslint-disable */
     console.error('All fiddles from file', fiddlePath)
     console.error(loadedFiddles)
 
@@ -33,19 +32,7 @@ module.exports = function fiddle (hexo, args) {
     `)
   }
 
-  console.log('rendering test')
-  console.log(foundTest.test)
-
-  const md = `\`\`\`javascript\n${foundTest.test}\n\`\`\`\n`
-
-  // TODO get the render method to use "hexo-prism-plugin"
-  // right now for some reason the render does not apply same code blocks
-  return Promise.resolve(hexo.render.renderSync({ text: md, engine: 'markdown' }))
-  .then((md) => {
-    console.log('markdown')
-    console.log(md)
-  })
-
-  // return render('```javascript\n' + foundTest.test + '\n```\n')
-  // return `<pre class="language-javascript"><code class="language-javascript">${foundTest.test}</code></pre>`
+  // the code block will be later processed using hexo-prism-plugin to have syntax highlighting
+  const escapedCode = _.escape(foundTest.test)
+  return `<pre><code class="javascript">${escapedCode}</code></pre>`
 }

--- a/lib/tags/fiddle.js
+++ b/lib/tags/fiddle.js
@@ -1,24 +1,51 @@
 const rawRender = require('../raw_render')
 const path = require('path')
-const { stripContent } = require('@common-tags')
+const { stripIndent } = require('common-tags')
+const _ = require('lodash')
+const Promise = require('bluebird')
 
 module.exports = function fiddle (hexo, args) {
+  /* eslint-disable */
   const fiddleFileName = args[0]
-  const type = args[1]
+  const pathToFiddle = args[1]
 
   const render = (str) => {
-    return rawRender.call(this, hexo, str)
+    return rawRender.call(this, hexo, str, { engine: 'markdown' })
+    // return rawRender.call(this, hexo, str)
   }
 
   const fiddlePath = path.join(__dirname, '..', '..', 'cypress', 'fiddles', fiddleFileName)
 
-  console.log('loading fiddle "%s"', fiddlePath)
+  // console.log('loading fiddle "%s"', fiddlePath)
 
   const loadedFiddles = require(fiddlePath)
 
-  console.log('loaded fiddles')
+  // console.log('loaded fiddles', loadedFiddles)
+  const foundTest = _.get(loadedFiddles, pathToFiddle)
 
-  return render(stripContent`
-    JavaScript fiddle
-  `)
+  if (!foundTest) {
+    console.error('All fiddles from file', fiddlePath)
+    console.error(loadedFiddles)
+
+    throw new Error(stripIndent`
+      Cannot find fiddle "${pathToFiddle}" in file "${fiddleFileName}"
+      file path "${fiddlePath}"
+    `)
+  }
+
+  console.log('rendering test')
+  console.log(foundTest.test)
+
+  const md = `\`\`\`javascript\n${foundTest.test}\n\`\`\`\n`
+
+  // TODO get the render method to use "hexo-prism-plugin"
+  // right now for some reason the render does not apply same code blocks
+  return Promise.resolve(hexo.render.renderSync({ text: md, engine: 'markdown' }))
+  .then((md) => {
+    console.log('markdown')
+    console.log(md)
+  })
+
+  // return render('```javascript\n' + foundTest.test + '\n```\n')
+  // return `<pre class="language-javascript"><code class="language-javascript">${foundTest.test}</code></pre>`
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16670,6 +16670,26 @@
         "tough-cookie": "^2.3.3"
       }
     },
+    "require-and-forget": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/require-and-forget/-/require-and-forget-1.0.0.tgz",
+      "integrity": "sha512-TKYkwAiLL5riH/ut1L4w30iqEHgvc3RLPMphT6OC06lisP6vMbYA632h3sk3LMw99LxsL7S+F1n2q+XXgd65jg==",
+      "dev": true,
+      "requires": {
+        "debug": "3.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.0.1.tgz",
+          "integrity": "sha512-6nVc6S36qbt/mutyt+UGMnawAMrPDZUPQjRZI3FS9tCtDRhvxJbK79unYBLPi+z5SLXQ3ftoVBFCblQtNSls8w==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -554,6 +554,15 @@
         }
       }
     },
+    "@cypress/fiddle": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@cypress/fiddle/-/fiddle-1.1.1.tgz",
+      "integrity": "sha512-Us6v19Mqe8shKru/O7NwJQmuoOABE0kD11A1+B2i38XC7NYaXUy8vq6ouCiYU0sI1EZ+L0t4aXPsv7p5vwSvcA==",
+      "dev": true,
+      "requires": {
+        "safe-marked": "1.0.1"
+      }
+    },
     "@cypress/listr-verbose-renderer": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@cypress/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz",
@@ -1939,6 +1948,12 @@
       "version": "20.0.1",
       "resolved": "https://registry.npmjs.org/@types/jest-diff/-/jest-diff-20.0.1.tgz",
       "integrity": "sha512-yALhelO3i0hqZwhjtcr6dYyaLoCHbAMshwtj6cGxTvHZAKXHsYGdff6E8EPw3xLKY0ELUTQ69Q1rQiJENnccMA==",
+      "dev": true
+    },
+    "@types/marked": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-0.6.5.tgz",
+      "integrity": "sha512-6kBKf64aVfx93UJrcyEZ+OBM5nGv4RLsI6sR1Ar34bpgvGVRoyTgpxn4ZmtxOM5aDTAaaznYuYUH8bUX3Nk3YA==",
       "dev": true
     },
     "@types/minimatch": {
@@ -5471,6 +5486,12 @@
       "requires": {
         "domelementtype": "1"
       }
+    },
+    "dompurify": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-1.0.11.tgz",
+      "integrity": "sha512-XywCTXZtc/qCX3iprD1pIklRVk/uhl8BKpkTxr+ZyMVUzSUg7wkQXRBp/euJ5J5moa1QvfpvaPQVP71z1O59dQ==",
+      "dev": true
     },
     "domutils": {
       "version": "1.5.1",
@@ -16908,6 +16929,103 @@
       "integrity": "sha512-gH8eh2nZudPQO6TytOvbxnuhYBOvDBBLW52tz5q6X58lJcd/tkmqFR+5Z9adS8aJtURSXWThWy/xJtJwixErvg==",
       "optional": true
     },
+    "safe-marked": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/safe-marked/-/safe-marked-1.0.1.tgz",
+      "integrity": "sha512-L59XgpX8eP6yKwyyq6JCeTkI6TKQzSOXN9YXh5DcWzEBM4/btKXnRT6bFG88JQA4loZsYv0UyJdm7u6FcLQ84Q==",
+      "dev": true,
+      "requires": {
+        "@types/marked": "^0.6.5",
+        "dompurify": "^1.0.11",
+        "jsdom": "^15.1.1",
+        "marked": "^0.7.0"
+      },
+      "dependencies": {
+        "ip-regex": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
+          "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
+          "dev": true
+        },
+        "jsdom": {
+          "version": "15.1.1",
+          "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-15.1.1.tgz",
+          "integrity": "sha512-cQZRBB33arrDAeCrAEWn1U3SvrvC8XysBua9Oqg1yWrsY/gYcusloJC3RZJXuY5eehSCmws8f2YeliCqGSkrtQ==",
+          "dev": true,
+          "requires": {
+            "abab": "^2.0.0",
+            "acorn": "^6.1.1",
+            "acorn-globals": "^4.3.2",
+            "array-equal": "^1.0.0",
+            "cssom": "^0.3.6",
+            "cssstyle": "^1.2.2",
+            "data-urls": "^1.1.0",
+            "domexception": "^1.0.1",
+            "escodegen": "^1.11.1",
+            "html-encoding-sniffer": "^1.0.2",
+            "nwsapi": "^2.1.4",
+            "parse5": "5.1.0",
+            "pn": "^1.1.0",
+            "request": "^2.88.0",
+            "request-promise-native": "^1.0.7",
+            "saxes": "^3.1.9",
+            "symbol-tree": "^3.2.2",
+            "tough-cookie": "^3.0.1",
+            "w3c-hr-time": "^1.0.1",
+            "w3c-xmlserializer": "^1.1.2",
+            "webidl-conversions": "^4.0.2",
+            "whatwg-encoding": "^1.0.5",
+            "whatwg-mimetype": "^2.3.0",
+            "whatwg-url": "^7.0.0",
+            "ws": "^7.0.0",
+            "xml-name-validator": "^3.0.0"
+          }
+        },
+        "marked": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
+          "integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==",
+          "dev": true
+        },
+        "parse5": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
+          "integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==",
+          "dev": true
+        },
+        "tough-cookie": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
+          "integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
+          "dev": true,
+          "requires": {
+            "ip-regex": "^2.1.0",
+            "psl": "^1.1.28",
+            "punycode": "^2.1.1"
+          }
+        },
+        "whatwg-url": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.0.0.tgz",
+          "integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
+          "dev": true,
+          "requires": {
+            "lodash.sortby": "^4.7.0",
+            "tr46": "^1.0.1",
+            "webidl-conversions": "^4.0.2"
+          }
+        },
+        "ws": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.1.2.tgz",
+          "integrity": "sha512-gftXq3XI81cJCgkUiAVixA0raD9IVmXqsylCrjRygw4+UOOGzPoxnQ6r/CnVL9i+mDncJo94tSkyrtuuQVBmrg==",
+          "dev": true,
+          "requires": {
+            "async-limiter": "^1.0.0"
+          }
+        }
+      }
+    },
     "safe-regex": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
@@ -17042,6 +17160,15 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
+    "saxes": {
+      "version": "3.1.11",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-3.1.11.tgz",
+      "integrity": "sha512-Ydydq3zC+WYDJK1+gRxRapLIED9PWeSuuS41wqyoRmzvhhh9nc+QQrVMKJYzJFULazeGhzSV0QleN2wD3boh2g==",
+      "dev": true,
+      "requires": {
+        "xmlchars": "^2.1.1"
+      }
     },
     "scrollingelement": {
       "version": "1.5.2",
@@ -17844,11 +17971,11 @@
           "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
           "dev": true,
           "requires": {
-            "nice-try": "1.0.5",
-            "path-key": "2.0.1",
-            "semver": "5.7.0",
-            "shebang-command": "1.2.0",
-            "which": "1.3.1"
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
           }
         },
         "execa": {
@@ -17857,13 +17984,13 @@
           "integrity": "sha512-k5AR22vCt1DcfeiRixW46U5tMLtBg44ssdJM9PiXw3D8Bn5qyxFCSnKY/eR22y+ctFDGPqafpaXg2G4Emyua4A==",
           "dev": true,
           "requires": {
-            "cross-spawn": "6.0.5",
-            "get-stream": "4.1.0",
-            "is-stream": "1.1.0",
-            "npm-run-path": "2.0.2",
-            "p-finally": "1.0.0",
-            "signal-exit": "3.0.2",
-            "strip-eof": "1.0.0"
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^4.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
           }
         },
         "get-stream": {
@@ -17872,7 +17999,7 @@
           "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
           "dev": true,
           "requires": {
-            "pump": "3.0.0"
+            "pump": "^3.0.0"
           }
         },
         "pump": {
@@ -17881,8 +18008,8 @@
           "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
           "dev": true,
           "requires": {
-            "end-of-stream": "1.4.1",
-            "once": "1.4.0"
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
           }
         }
       }
@@ -18273,9 +18400,9 @@
           "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "astral-regex": "1.0.0",
-            "is-fullwidth-code-point": "2.0.0"
+            "ansi-styles": "^3.2.0",
+            "astral-regex": "^1.0.0",
+            "is-fullwidth-code-point": "^2.0.0"
           }
         },
         "string-width": {
@@ -18284,9 +18411,9 @@
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
-            "emoji-regex": "7.0.3",
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "5.2.0"
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
           }
         }
       }
@@ -19888,6 +20015,17 @@
         "browser-process-hrtime": "^0.1.2"
       }
     },
+    "w3c-xmlserializer": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-1.1.2.tgz",
+      "integrity": "sha512-p10l/ayESzrBMYWRID6xbuCKh2Fp77+sA0doRuGn4tTIMrrZVeqfpKjXHY+oDh3K4nLdPgNwMTVP6Vp4pvqbNg==",
+      "dev": true,
+      "requires": {
+        "domexception": "^1.0.1",
+        "webidl-conversions": "^4.0.2",
+        "xml-name-validator": "^3.0.0"
+      }
+    },
     "wait-on": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-3.3.0.tgz",
@@ -20217,6 +20355,12 @@
       "version": "9.0.7",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
       "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+    },
+    "xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "prompt-confirm": "2.0.4",
     "ramda": "0.26.1",
     "request-promise": "4.2.4",
+    "require-and-forget": "1.0.0",
     "sinon": "7.4.1",
     "sinon-chai": "3.3.0",
     "start-server-and-test": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
   "devDependencies": {
     "@cypress/deploy-bits": "1.7.1",
     "@cypress/env-or-json-file": "2.0.0",
+    "@cypress/fiddle": "1.1.1",
     "@cypress/questions-remain": "1.0.1",
     "@keyv/redis": "github:bahmutov/keyv-redis#b64f44cd1d1e87893d989b1469068af8292299d5",
     "@types/fluent-ffmpeg": "2.1.10",

--- a/scripts/tags.js
+++ b/scripts/tags.js
@@ -20,6 +20,7 @@ const imgTag = require('../lib/tags/image')
 const changelog = require('../lib/tags/changelog')
 const history = require('../lib/tags/history')
 const aliases = require('../lib/tags/aliases')
+const fiddle = require('../lib/tags/fiddle')
 
 const tags = {
   // aliases
@@ -68,6 +69,8 @@ const tags = {
 
   // yields
   yields: yields,
+
+  fiddle,
 }
 
 // tags which require ending

--- a/source/api/commands/and.md
+++ b/source/api/commands/and.md
@@ -77,9 +77,15 @@ cy
 
 ### Chain assertions on the same subject
 
+Instead of
+
 ```javascript
 cy.get('button').should('have.class', 'active').and('not.be.disabled')
 ```
+
+Just load test code from
+
+{% fiddle "and" "and.Examples.chain" %}
 
 ## Value
 
@@ -102,6 +108,9 @@ cy
   .and('match', /users/)          // yields string value of href
   .and('not.include', '#')        // yields string value of href
 ```
+
+{% fiddle "and" "and.Examples.value" "html" %}
+{% fiddle "and" "and.Examples.value" %}
 
 ## Method and Value
 

--- a/source/api/commands/and.md
+++ b/source/api/commands/and.md
@@ -27,16 +27,6 @@ An alias of {% url `.should()` should %}
 
 {% fiddle "and" "and.Usage" %}
 
-Hard-coded
-
-```javascript
-cy.get('.err').should('be.empty').and('be.hidden') // Assert '.err' is empty & hidden
-cy.contains('Login').and('be.visible')             // Assert el is visible
-cy.wrap({ foo: 'bar' })
-  .should('have.property', 'foo')                  // Assert 'foo' property exists
-  .and('eq', 'bar')                                // Assert 'foo' property is 'bar'
-```
-
 **{% fa fa-exclamation-triangle red %} Incorrect Usage**
 
 ```javascript

--- a/source/api/commands/and.md
+++ b/source/api/commands/and.md
@@ -55,21 +55,11 @@ Pass a function that can have any number of explicit assertions within it. Whate
 
 {% yields assertion_indeterminate .and %}
 
-```javascript
-cy
-  .get('nav')                       // yields <nav>
-  .should('be.visible')             // yields <nav>
-  .and('have.class', 'open')        // yields <nav>
-```
+{% fiddle "and" "and.Examples.yields1" %}
+
 However, some chainers change the subject. In the example below, `.and()` yields the string `sans-serif` because the chainer `have.css, 'font-family'` changes the subject.
 
-```javascript
-cy
-  .get('nav')                       // yields <nav>
-  .should('be.visible')             // yields <nav>
-  .and('have.css', 'font-family')   // yields 'sans-serif'
-  .and('match', /serif/)            // yields 'sans-serif'
-```
+{% fiddle "and" "and.Examples.yields2" %}
 
 # Examples
 
@@ -91,24 +81,6 @@ Just load test code from
 
 ### Chain assertions when yield changes
 
-```html
-<!-- App Code -->
-<ul>
-  <li>
-    <a href="users/123/edit">Edit User</a>
-  </li>
-</ul>
-```
-
-```javascript
-cy
-  .get('a')
-  .should('contain', 'Edit User') // yields <a>
-  .and('have.attr', 'href')       // yields string value of href
-  .and('match', /users/)          // yields string value of href
-  .and('not.include', '#')        // yields string value of href
-```
-
 {% fiddle "and" "and.Examples.value" "html" %}
 {% fiddle "and" "and.Examples.value" %}
 
@@ -116,12 +88,7 @@ cy
 
 ### Assert the href is equal to '/users'
 
-```javascript
-cy
-  .get('#header a')
-  .should('have.class', 'active')
-  .and('have.attr', 'href', '/users')
-```
+{% fiddle "and" "and.Examples.method and value" %}
 
 ## Function
 
@@ -133,39 +100,8 @@ Just be sure *not* to include any code that has side effects in your callback fu
 
 The callback function will be retried over and over again until no assertions within it throw.
 
-```html
-<div>
-  <p class="text-primary">Hello World</p>
-  <p class="text-danger">You have an error</p>
-  <p class="text-default">Try again later</p>
-</div>
-```
-
-```javascript
-cy
-  .get('p')
-  .should('not.be.empty')
-  .and(($p) => {
-    // should have found 3 elements
-    expect($p).to.have.length(3)
-
-    // make sure the first contains some text content
-    expect($p.first()).to.contain('Hello World')
-
-    // use jquery's map to grab all of their classes
-    // jquery's map returns a new jquery object
-    const classes = $p.map((i, el) => {
-      return Cypress.$(el).attr('class')
-    })
-
-    // call classes.get() to make this a plain array
-    expect(classes.get()).to.deep.eq([
-      'text-primary',
-      'text-danger',
-      'text-default'
-    ])
-  })
-```
+{% fiddle "and" "and.Examples.multiple p" "html" %}
+{% fiddle "and" "and.Examples.multiple p" %}
 
 {% note info %}
 Using a callback function {% urlHash 'will not change the subject' Subjects %}

--- a/source/api/commands/and.md
+++ b/source/api/commands/and.md
@@ -25,6 +25,10 @@ An alias of {% url `.should()` should %}
 
 **{% fa fa-check-circle green %} Correct Usage**
 
+{% fiddle "and" "and.Usage" %}
+
+Hard-coded
+
 ```javascript
 cy.get('.err').should('be.empty').and('be.hidden') // Assert '.err' is empty & hidden
 cy.contains('Login').and('be.visible')             // Assert el is visible


### PR DESCRIPTION
- brings https://github.com/cypress-io/cypress-fiddle that can insert test definitions from specs into Hexo pages via custom tag.

Example Hexo page to include both HTML markup and test code

<img width="401" alt="Screen Shot 2019-09-09 at 3 27 24 PM" src="https://user-images.githubusercontent.com/2212006/64567752-f1c5c980-d326-11e9-93a4-2bf9c26e009e.png">


Using fiddles that are actually run as Cypress tests should help us avoid giving users incorrect test samples. Also it will make writing example faster because we can simply write a test and then include its name / description / html / code in the Hexo page.