### PR TITLE
fix(style): add border-radius to code blocks

### DIFF
--- a/themes/cypress/source/css/_partial/highlight.scss
+++ b/themes/cypress/source/css/_partial/highlight.scss
@@ -145,6 +145,7 @@ a code {
   &[class*="language-"] {
     padding: 15px 0;
     margin: 25px 0;
+    border-radius: 6px;
 
     .token.punctuation {
       color: #ddd;


### PR DESCRIPTION
Code block corners were so sharp they were piercing my soul. IMO this looks better

before -> after
![out](https://user-images.githubusercontent.com/14625260/65731091-4476e380-e092-11e9-933a-ad28e464e5a4.png)
