### PR TITLE
redirect old known-issues to 404

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -40,9 +40,10 @@ alias:
   index.html: guides/overview/why-cypress.html
 
   guides/index.html: guides/overview/why-cypress.html
-  guides.html/: guides/overview/why-cypress.html
+  guides.html: guides/overview/why-cypress.html
   guides/references/type/: api/commands/type.html
-  guides/integrating-cypress/features.html/: guides/guides/continuous-integration.html
+  guides/references/known-issues.html: 404.html
+  guides/integrating-cypress/features.html: guides/guides/continuous-integration.html
   guides/network-requests-xhr/: guides/guides/network-requests.html
   guides/issuing-commands/: guides/core-concepts/introduction-to-cypress.html#Subject-Management
   guides/installing-and-running/: guides/getting-started/installing-cypress.html


### PR DESCRIPTION
Adds alias to redirect `guides/references/known-issues.html` to `404.html`
This page is a remnant of older docs and no longer needed. 

close #2114 