### PR TITLE
Add Angular CI example to recipes

### DIFF
--- a/source/examples/examples/recipes.md
+++ b/source/examples/examples/recipes.md
@@ -8,15 +8,14 @@ Recipes show you how to test common scenarios in Cypress.
 {% fa fa-github %} {% url https://github.com/cypress-io/cypress-example-recipes %}
 
 ## Fundamentals 
-
 Recipe  | Description
 --- | --- 
 {% url 'Node Modules' https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/fundamentals__node-modules %} | Import your own Node modules
-{% url "Environment variables" https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/server-communication__env-variables %} | Passing environment variables to tests
-{% url "Dynamic tests" https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/fundamentals__dynamic-tests %} | Create tests dynamically from data
-{% url "Fixtures" https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/fundamentals__fixtures %} | Loading single or multiple fixtures
-{% url "Adding Chai Assertions" https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/extending-cypress__chai-assertions %} | Add new or custom chai assertions
-{% url "Cypress module API" https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/fundamentals__module-api %} | Run Cypress via its module API
+{% url 'Environment variables' https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/server-communication__env-variables %} | Passing environment variables to tests
+{% url 'Dynamic tests' https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/fundamentals__dynamic-tests %} | Create tests dynamically from data
+{% url 'Fixtures' https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/fundamentals__fixtures %} | Loading single or multiple fixtures
+{% url 'Adding Chai Assertions' https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/extending-cypress__chai-assertions %} | Add new or custom chai assertions
+{% url 'Cypress module API' https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/fundamentals__module-api %} | Run Cypress via its module API
 
 ## Testing the DOM
 Recipe  | Description
@@ -37,7 +36,7 @@ Recipe  | Description
 {% url 'Json Web Tokens' https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/logging-in__jwt %} | Log in using JWT
 {% url 'Using application code' https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/logging-in__using-app-code %} | Log in by calling the application code
 
-Also see {% url "Authentication plugins" plugins#authentication and watch {% url "Organizing Tests, Logging In, Controlling State" https://www.youtube.com/watch?v=5XQOK0v_YRE %}
+Also see {% url 'Authentication plugins' plugins#authentication and watch {% url 'Organizing Tests, Logging In, Controlling State' https://www.youtube.com/watch?v=5XQOK0v_YRE %}
 
 ## Preprocessors
 Recipe  | Description
@@ -47,20 +46,20 @@ Recipe  | Description
 {% url 'TypeScript with webpack' https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/preprocessors__typescript-webpack %} | Add TypeScript support with webpack
 
 ## Blogs
-
-Demo recipes from the blog posts at {% url "Cypress blog" https://www.cypress.io/blog %}.
+Demo recipes from the blog posts at {% url 'Cypress blog' https://www.cypress.io/blog %}.
 
 Recipe  | Description
 --- | --- 
 {% url 'Application Actions' https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/blogs__application-actions %} | Application actions are a replacement for Page Objects
 {% url 'Direct Control of AngularJS' https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/blogs__direct-control-angular %} | Bypass the DOM and control AngularJS
 {% url 'E2E API Testing' https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/blogs__e2e-api-testing %} | Run your API Tests with a GUI
-{% url "E2E Snapshots" https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/blogs__e2e-snapshots %} | End-to-End Snapshot Testing
-{% url "Element Coverage" https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/blogs__element-coverage %} | Track elements covered by tests
+{% url 'E2E Snapshots' https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/blogs__e2e-snapshots %} | End-to-End Snapshot Testing
+{% url 'Element Coverage' https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/blogs__element-coverage %} | Track elements covered by tests
 {% url 'Codepen.io Testing' https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/blogs__codepen-demo %} | Test a HyperApp Codepen demo
 {% url 'Testing Redux Store' https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/blogs__testing-redux-store %} | Test an application that uses central Redux data store
 {% url 'Vue + Vuex + REST Testing' https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/blogs__vue-vuex-rest %} | Test an application that uses central Vuex data store
-{% url "A11y Testing" https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/blogs__a11y %} | Accessability testing with {% url "cypress-axe" https://github.com/avanslaars/cypress-axe %}
+{% url 'A11y Testing' https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/blogs__a11y %} | Accessibility testing with {% url 'cypress-axe' https://github.com/avanslaars/cypress-axe %}
+{% url 'Automate Angular Testing' https://www.cypress.io/blog/2019/08/02/guest-post-angular-adding-cypress-ui-tests-to-your-devops-pipeline %} | Automate Angular Testing
 
 ## Stubbing and spying
 Recipe  | Description
@@ -84,10 +83,9 @@ Recipe  | Description
 {% url 'Seeding your Database in Node' https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/server-communication__seeding-database-in-node %} | Seed your database with test data
 
 ## Community Recipes
-
 Recipe | Description
 --- | ---
-{% url "Visual Regression Testing" https://github.com/mjhea0/cypress-visual-regression %} | Adding visual regression testing to Cypress
-{% url "Code coverage" https://github.com/paulfalgout/cypress-coverage-example %} | Cypress with Coverage reports
-{% url "Cucumber" https://github.com/TheBrainFamily/cypress-cucumber-example %} | Example usage of Cypress with Cucumber
-{% url "Jest" https://github.com/TheBrainFamily/jest-runner-cypress-example %} | Example for the jest-runner-cypress
+{% url 'Visual Regression Testing' https://github.com/mjhea0/cypress-visual-regression %} | Adding visual regression testing to Cypress
+{% url 'Code coverage' https://github.com/paulfalgout/cypress-coverage-example %} | Cypress with Coverage reports
+{% url 'Cucumber' https://github.com/TheBrainFamily/cypress-cucumber-example %} | Example usage of Cypress with Cucumber
+{% url 'Jest' https://github.com/TheBrainFamily/jest-runner-cypress-example %} | Example for the jest-runner-cypress


### PR DESCRIPTION
Add new entry to the blog table in `recipes.md` for automating Angular project using CI. Linking to our blog entry at [https://www.cypress.io/blog/2019/08/02/guest-post-angular-adding-cypress-ui-tests-to-your-devops-pipeline](https://www.cypress.io/blog/2019/08/02/guest-post-angular-adding-cypress-ui-tests-to-your-devops-pipeline)

close #2113 