### PR TITLE
Removed condescending language from docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -197,7 +197,7 @@ You should push your local changes to your forked GitHub repository and then ope
 
 We use a [`cla-assistant.io`](https://cla-assistant.io/) web hook to make sure every contributor assigns the rights of their contribution to Cypress.io. If you want to read the CLA agreement, its text is in this [gist](https://gist.github.com/bahmutov/cf22bc6c6b55219d0f9a76d04981f7ae).
 
-After making a [pull request](#pull-requests), the CLA assistant will add a review comment. Just click on the link and accept the CLA. That's it!
+After making a [pull request](#pull-requests), the CLA assistant will add a review comment. Click on the link and accept the CLA. That's it!
 
 ## Deployment
 

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -39,7 +39,7 @@ To debug deployment actions, run with `DEBUG=deploy ...` environment variable.
 
 On CI, the deployment and scraping configuration are passed via environment
 variables `support__aws_credentials_json` and `support__circle_credentials_json`,
-which are just JSON files as strings.
+which are JSON files as strings.
 
 ```shell
 cat support/.circle-credentials.json | pbcopy

--- a/cy_scripts/should-deploy.js
+++ b/cy_scripts/should-deploy.js
@@ -47,7 +47,7 @@ function isRightBranch (env) {
   la(is.unemptyString(env), 'expected environment name', env)
 
   // allow multiple branches to deploy to staging environment,
-  // just add to the keys in this object
+  // add to the keys in this object
   // "my-fix-branch": "staging"
   const branchToEnv = {
     develop: 'staging',

--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -67,7 +67,7 @@ hexo.extend.helper.register('doc_sidebar', function (className) {
   let expandAll = false
 
   // IF the sidebar's categories aren't that many,
-  // just expand them all, since it's more of a hassle to expand one by one
+  // expand them all, since it's more of a hassle to expand one by one
   if (_.keys(sidebar).length <= 6) {
     expandAll = true
   }

--- a/source/_data/blogs.yml
+++ b/source/_data/blogs.yml
@@ -1,4 +1,4 @@
-# small links with just title and url
+# small links with title and url
 small:
   - title: "Cypress Technology Blog"
     sourceUrl: https://www.cypress.io/blog

--- a/source/api/commands/and.md
+++ b/source/api/commands/and.md
@@ -126,7 +126,7 @@ cy
 
 Passing a function to `.and()` enables you to assert on the yielded subject. This gives you the opportunity to *massage* what you'd like to assert.
 
-Just be sure *not* to include any code that has side effects in your callback function.
+Be sure *not* to include any code that has side effects in your callback function.
 
 The callback function will be retried over and over again until no assertions within it throw.
 

--- a/source/api/commands/blur.md
+++ b/source/api/commands/blur.md
@@ -75,9 +75,9 @@ cy.get('input:first').blur({ force: true })
 
 `.blur()` is not implemented like other action commands, and does not follow the same rules of {% url 'waiting for actionability' interacting-with-elements %}.
 
-`.blur()` is just a helpful command which is a simple shortcut. Normally there's no way for a user to "blur" an element. Typically the user would have to perform **another** action like clicking or tabbing to a different element. Needing to perform a separate action like this is very indirect.
+`.blur()` is a helpful command used as a shortcut. Normally there's no way for a user to "blur" an element. Typically the user would have to perform **another** action like clicking or tabbing to a different element. Needing to perform a separate action like this is very indirect.
 
-Therefore it's oftentimes much easier and simpler to test the blur behavior directly with `.blur()`.
+Therefore it's often much more efficient to test the blur behavior directly with `.blur()`.
 
 ## Timeouts
 

--- a/source/api/commands/clear.md
+++ b/source/api/commands/clear.md
@@ -69,7 +69,7 @@ cy.get('textarea').clear().type('Hello, World')
 
 ## Documentation
 
-`.clear()` is just an alias for {% url `.type({selectall}{backspace})` type %}.
+`.clear()` is an alias for {% url `.type({selectall}{backspace})` type %}.
 
 Please read the {% url `.type()` type %} documentation for more details.
 

--- a/source/api/commands/clock.md
+++ b/source/api/commands/clock.md
@@ -164,7 +164,7 @@ This example below will only override `setTimeout` and `clearTimeout` and leave 
 cy.clock(null, ['setTimeout', 'clearTimeout'])
 ```
 
-Note that you must specify `Date` in order to override the current datetime. The example below just affects the current datetime without affecting scheduled timers.
+Note that you must specify `Date` in order to override the current datetime. The example below affects the current datetime without affecting scheduled timers.
 
 ```javascript
 cy.clock(Date.UTC(2018, 10, 30), ['Date'])

--- a/source/api/commands/focus.md
+++ b/source/api/commands/focus.md
@@ -66,9 +66,9 @@ cy.get('textarea').focus().type('Nice Product!').blur()
 
 `.focus()` is not implemented like other action commands, and does not follow the same rules of {% url 'waiting for actionability' interacting-with-elements %}.
 
-`.focus()` is just a helpful command which is a simple shortcut. Normally there's no way for a user to "focus" an element without causing another action or side effect. Typically the user would have to click or tab to this element.
+`.focus()` is a helpful command used as a shortcut. Normally there's no way for a user to "focus" an element without causing another action or side effect. Typically the user would have to click or tab to this element.
 
-Oftentimes it's much simpler and conveys what you're trying to test by just using `.focus()` directly.
+Oftentimes using `.focus()` directly is more concise and conveys what you're trying to test.
 
 If you want the other guarantees of waiting for an element to become actionable, you should use a different command like {% url `.click()` click %}.
 

--- a/source/api/commands/location.md
+++ b/source/api/commands/location.md
@@ -109,7 +109,7 @@ cy.location('pathname').should('eq', '/login')
 
 ### No need to use `window.location`
 
-Cypress automatically normalizes the `cy.location()` command and strips out extraneous values and properties found in `window.location`. Also, the object literal yielded by `cy.location()` is just a basic object literal, not the special `window.location` object.
+Cypress automatically normalizes the `cy.location()` command and strips out extraneous values and properties found in `window.location`. Also, the object literal yielded by `cy.location()` is a basic object literal, not the special `window.location` object.
 
 When changing properties on the real `window.location` object, it forces the browser to navigate away. In Cypress, the object yielded is a plain object, so changing its properties will have no effect on navigation.
 

--- a/source/api/commands/request.md
+++ b/source/api/commands/request.md
@@ -201,7 +201,7 @@ cy.request({
 
 Oftentimes, once you have a proper e2e test around logging in, there's no reason to continue to `cy.visit()` the login and wait for the entire page to load all associated resources before running any other commands. Doing so can slow down our entire test suite.
 
-Using `cy.request()`, we can bypass all of this because it automatically gets and sets cookies just as if the requests had come from the browser.
+Using `cy.request()`, we can bypass all of this because it automatically gets and sets cookies as if the requests had come from the browser.
 
 ```javascript
 cy.request({
@@ -214,7 +214,7 @@ cy.request({
   }
 })
 
-// just to prove we have a session
+// to prove we have a session
 cy.getCookie('cypress-session-cookie').should('exist')
 ```
 
@@ -233,7 +233,7 @@ This is useful when you're polling a server for a response that may take awhile 
 All we're really doing here is creating a recursive function. Nothing more complicated than that.
 
 ```js
-// just a regular ol' function folks
+// a regular ol' function folks
 function req () {
   cy
     .request(...)

--- a/source/api/commands/request.md
+++ b/source/api/commands/request.md
@@ -136,7 +136,7 @@ beforeEach(function () {
 })
 ```
 
-### Issue a simple HTTP request
+### Issue an HTTP request
 
 Sometimes it's quicker to test the contents of a page rather than {% url `cy.visit()` visit %} and wait for the entire page and all of its resources to load.
 

--- a/source/api/commands/should.md
+++ b/source/api/commands/should.md
@@ -138,7 +138,7 @@ cy.get('#input-receives-focus').should('have.focus') // equivalent to should('be
 
 Passing a function to `.should()` enables you to make multiple assertions on the yielded subject. This also gives you the opportunity to *massage* what you'd like to assert on.
 
-Just be sure *not* to include any code that has side effects in your callback function. The callback function will be retried over and over again until no assertions within it throw.
+Be sure *not* to include any code that has side effects in your callback function. The callback function will be retried over and over again until no assertions within it throw.
 
 ### Verify length, content, and classes from multiple `<p>`
 
@@ -316,7 +316,7 @@ cy.get('.company-details')
 
 ### Chaining multiple assertions
 
-Cypress makes it easy to chain assertions together.
+Cypress makes it easier to chain assertions together.
 
 In this example we use {% url `.and()` and %} which is identical to `.should()`.
 

--- a/source/api/commands/submit.md
+++ b/source/api/commands/submit.md
@@ -70,9 +70,9 @@ cy.get('#contact').submit()
 
 `.submit()` is not implemented like other action commands, and does not follow the same rules of {% url 'waiting for actionability' interacting-with-elements %}.
 
-`.submit()` is just a helpful command which is a simple shortcut. Normally a user has to perform a different "action" to submit a form. It could be clicking a submit `<button>`, or pressing `enter` on a keyboard.
+`.submit()` is a helpful command used as a shortcut. Normally a user has to perform a different "action" to submit a form. It could be clicking a submit `<button>`, or pressing `enter` on a keyboard.
 
-Oftentimes it's much simpler and conveys what you're trying to test by just using `.submit()` directly.
+Oftentimes using `.submit()` directly is more concise and conveys what you're trying to test.
 
 If you want the other guarantees of waiting for an element to become actionable, you should use a different command like {% url `.click()` click %} or {% url `.type()` type %}.
 

--- a/source/api/commands/task.md
+++ b/source/api/commands/task.md
@@ -230,7 +230,7 @@ on('task', myTask)
 See {% issue 2284 '#2284' %} for implementation.
 
 {% note warning Duplicate task keys %}
-If multiple task objects use the same key, the later registration will overwrite that particular key, just like merging multiple objects with duplicate keys will overwrite the first one.
+If multiple task objects use the same key, the later registration will overwrite that particular key, similar to how merging multiple objects with duplicate keys will overwrite the first one.
 {% endnote %}
 
 # Rules

--- a/source/api/commands/type.md
+++ b/source/api/commands/type.md
@@ -432,7 +432,7 @@ Additionally Cypress handles these 4 other situations as defined in the spec:
 3. Submits a form, but does not fire synthetic `click` event, if there is 1 `input` and no `submit` button
 4. Submits form and fires a synthetic `click` event to the `submit` when it exists.
 
-Of course if the form's `submit` event is `preventedDefault` the form will not actually be submitted.
+If the form's `submit` event is `preventedDefault` the form will not actually be submitted.
 
 # Rules
 

--- a/source/api/commands/visit.md
+++ b/source/api/commands/visit.md
@@ -186,7 +186,7 @@ cy.visit('127.0.0.1:3000') // Visits http://127.0.0.1:3000
 
 Cypress will automatically attempt to serve your files if you don't provide a host. The path should be relative to your project's root folder (where `cypress.json` is located).
 
-Having Cypress serve your files is useful in simple projects and example apps, but isn't recommended for real apps.  It is always better to run your own server and provide the url to Cypress.
+Having Cypress serve your files is useful in smaller projects and example apps, but isn't recommended for production apps.  It is always better to run your own server and provide the url to Cypress.
 
 ```javascript
 cy.visit('app/index.html')

--- a/source/api/cypress-api/config.md
+++ b/source/api/cypress-api/config.md
@@ -62,7 +62,7 @@ Cypress.config() // => {defaultCommandTimeout: 10000, pageLoadTimeout: 30000, ..
 
 ## Name
 
-### Return just a single configuration option value
+### Return a single configuration option value
 
 ```json
 {

--- a/source/api/cypress-api/cookies.md
+++ b/source/api/cypress-api/cookies.md
@@ -71,7 +71,7 @@ Cypress.Cookies.debug(false) // now debugging is turned off
 
 ### Preserve cookies through multiple tests
 
-Cypress gives you a simple interface to automatically preserve cookies for multiple tests. Cypress automatically clears all cookies before each new test starts by default.
+Cypress gives you an interface to automatically preserve cookies for multiple tests. Cypress automatically clears all cookies before each new test starts by default.
 
 By clearing cookies before each test you are guaranteed to always start from a clean slate. Starting from a clean state prevents coupling your tests to one another and prevents situations where mutating something in your application in one test affects another one downstream.
 
@@ -99,7 +99,7 @@ describe('Dashboard', function () {
     // will not be cleared before the NEXT test starts.
     //
     // the name of your cookies will likely be different
-    // this is just a simple example
+    // this is an example
     Cypress.Cookies.preserveOnce('session_id', 'remember_token')
   })
 

--- a/source/api/cypress-api/custom-commands.md
+++ b/source/api/cypress-api/custom-commands.md
@@ -235,7 +235,7 @@ cy.get('#dialog').dismiss() // with subject
 
 ## Overwrite Existing Commands
 
-You can also modify the behavior of existing Cypress commands. This is useful to always set some defaults to avoid creating another command that ends up just using the original.
+You can also modify the behavior of existing Cypress commands. This is useful to always set some defaults to avoid creating another command that ends up using the original.
 
 ### Overwrite `visit` command
 
@@ -262,7 +262,7 @@ Cypress.Commands.overwrite('visit', (originalFn, url, options) => {
 {% note info %}
 We see many of our users creating their own `visitApp` command. We commonly see that all you're doing is swapping out base urls for `development` vs `production` environments.
 
-This is usually unnecessary because Cypress is already configured to swap out baseUrl's that both `cy.visit()` and `cy.request()` use. Just set the `baseUrl` config property in `cypress.json` and override it with environment variable `CYPRESS_BASE_URL`.
+This is usually unnecessary because Cypress is already configured to swap out baseUrl's that both `cy.visit()` and `cy.request()` use. Set the `baseUrl` config property in `cypress.json` and override it with environment variable `CYPRESS_BASE_URL`.
 
 For more complex use cases feel free to overwrite existing commands.
 {% endnote %}
@@ -417,11 +417,11 @@ Take advantage of the {% url `Cypress.log()` cypress-log %} API. When you're iss
 
 Custom commands work well when you're needing to describe behavior that's desirable across **all of your tests**. Examples would be a `cy.setup()` or `cy.login()` or extending your application's behavior like `cy.get('.dropdown').dropdown('Apples')`. These are specific to your application and can be used everywhere.
 
-However, this pattern can be used and abused. Let's not forget - writing Cypress tests is just **JavaScript**, and it's often much easier just to write a simple function for repeatable behavior that's specific to only **a single spec file**.
+However, this pattern can be used and abused. Let's not forget - writing Cypress tests is **JavaScript**, and it's often more efficient to write a function for repeatable behavior that's specific to only **a single spec file**.
 
 If you're working on a `search_spec.js` file and want to compose several repeatable actions together, you should first ask yourself:
 
-> Can this just be written as a simple function?
+> Can this be written as a function?
 
 The answer is usually **yes**. Here's an example:
 
@@ -429,7 +429,7 @@ The answer is usually **yes**. Here's an example:
 // There's no reason to create something like a cy.search() custom
 // command because this behavior is only applicable to a single spec file
 //
-// Just use a regular ol' javascript function folks!
+// Use a regular ol' javascript function folks!
 const search = (term, options = {}) => {
   // example massaging to defaults
   _.defaults(options, {
@@ -494,7 +494,7 @@ it('paginates many search results', function () {
       search('cypress.io', {
         fixture: 'list',
         headers: {
-          // just trick our app into thinking
+          // trick our app into thinking
           // there's a bunch of pages
           'x-pagination-total': 3,
         }
@@ -521,13 +521,13 @@ Don't do things like:
 - **{% fa fa-exclamation-triangle red %}** `cy.clickButton(selector)`
 - **{% fa fa-exclamation-triangle red %}** `.shouldBeVisible()`
 
-This first custom command is really just wrapping `cy.get(selector).click()`. Going down this route would lead to creating dozens or even hundreds of custom commands to cover every possible combination of element interactions. It's completely unnecessary.
+This first custom command is should be wrapping `cy.get(selector).click()`. Going down this route would lead to creating dozens or even hundreds of custom commands to cover every possible combination of element interactions. It's completely unnecessary.
 
-The `.shouldBeVisible()` custom command isn't worth the trouble or abstraction when it's already as simple as typing: `.should('be.visible')`
+The `.shouldBeVisible()` custom command isn't worth the trouble or abstraction when you can already use: `.should('be.visible')`
 
 Testing in Cypress is all about **readability** and **simplicity**. You don't have to do that much actual programming to get a lot done. You also don't need to worry about keeping your code as DRY as possible. Test code serves a different purpose than app code. Understandability and debuggability should be prioritized above all else.
 
-Try not to overcomplicate things and create too many abstractions. When in doubt, just use a regular function for individual spec files.
+Try not to overcomplicate things and create too many abstractions. When in doubt, use a regular function for individual spec files.
 
 ### 3. Don't do too much in a single command
 

--- a/source/api/events/catalog-of-events.md
+++ b/source/api/events/catalog-of-events.md
@@ -157,7 +157,7 @@ It's important to understand why you'd want to bind to either `Cypress` or `cy`.
 
 Cypress is a global object that persists for the entirety of all of your tests. Any events you bind to Cypress will apply to all tests, and will not be unbound unless you manually unbind them.
 
-This is useful when you're debugging and just want to add a single "catch-all" event to track down things like test failures, or uncaught exceptions from your application.
+This is useful when you're debugging and want to add a single "catch-all" event to track down things like test failures, or uncaught exceptions from your application.
 
 ## cy
 

--- a/source/api/plugins/configuration-api.md
+++ b/source/api/plugins/configuration-api.md
@@ -138,6 +138,6 @@ This would enable you to do things like this:
 
 ## Notes
 
-These are just simple examples. Remember - you have the full power of Node at your disposal.
+These are less complicated examples. Remember - you have the full power of Node at your disposal.
 
 How you choose to organize multiple configurations and sets of environment variables is up to you. You don't even have to read off of the file system - you could store them all in memory inside of your `pluginsFile` if you wanted to.

--- a/source/faq/questions/dashboard-faq.md
+++ b/source/faq/questions/dashboard-faq.md
@@ -84,7 +84,7 @@ Even if your CI setup is very different from the {% url "CI examples we have" co
 cypress run --record --parallel --ci-build-id $CI_RUN_ID
 ```
 
-For reference, here are {% url "the variables" https://github.com/cypress-io/cypress/blob/develop/packages/server/lib/util/ci_provider.coffee %} we extract from the popular CI providers, and for most of them there is some variable that is set to the same value across multiple containers running in parallel. If there is NO common variable, try using the commit SHA string. Assuming you do not run the same tests more than once against the same commit, it might just be good enough for the job.
+For reference, here are {% url "the variables" https://github.com/cypress-io/cypress/blob/develop/packages/server/lib/util/ci_provider.coffee %} we extract from the popular CI providers, and for most of them there is some variable that is set to the same value across multiple containers running in parallel. If there is NO common variable, try using the commit SHA string. Assuming you do not run the same tests more than once against the same commit, it might be good enough for the job.
 
 ## {% fa fa-angle-right %} Can I delete a run from the Dashboard?
 

--- a/source/faq/questions/general-questions-faq.md
+++ b/source/faq/questions/general-questions-faq.md
@@ -45,7 +45,7 @@ Oftentimes Capybara begins to not work as well in complex JavaScript application
 
 ### Protractor
 
-Using {% url "Protractor" http://www.protractortest.org/ %} provides a nice Promise-based interface on top of Selenium, which makes it easy to deal with asynchronous code. Protractor comes with all of the features of Capybara and essentially suffers from the same problems.
+Using {% url "Protractor" http://www.protractortest.org/ %} provides a nice Promise-based interface on top of Selenium, which makes it less complicated to deal with asynchronous code. Protractor comes with all of the features of Capybara and essentially suffers from the same problems.
 
 Cypress replaces Protractor because it does all of these things and much more. One major difference is that Cypress enables you to write your unit tests and integration tests in the same tool, as opposed to splitting up this work across both Karma and Protractor.
 
@@ -94,9 +94,9 @@ No. In fact Cypress' architecture is very different from Selenium in a few criti
 
 Yes, technically; it's sandboxed and has to follow the same rules as every other browser. That's actually a good thing because it doesn't require a browser extension, and it naturally will work across all browsers (which enables cross-browser testing).
 
-But Cypress is actually way beyond just a basic JavaScript application running in the browser. It is also a desktop application and communicates with back end web services.
+But Cypress is actually way beyond a basic JavaScript application running in the browser. It is also a desktop application and communicates with back end web services.
 
-All of these technologies together are coordinated and enable Cypress to work, which extends its capabilities far outside of the browser sandbox. Without these, Cypress would not work at all. For the vast majority of your web development, Cypress will work just fine, and already *does* work.
+All of these technologies together are coordinated and enable Cypress to work, which extends its capabilities far outside of the browser sandbox. Without these, Cypress would not work at all. For the vast majority of your web development, Cypress will work fine, and already *does* work.
 
 ## {% fa fa-angle-right %} We use WebSockets; will Cypress work with that?
 
@@ -104,13 +104,13 @@ Yes.
 
 ## {% fa fa-angle-right %} We have the most complex most outrageous authentication system ever; will Cypress work with that?
 
-If you're using some complex thumb-print, retinal-scan, time-based, key-changing, microphone, audial, decoding mechanism to log in your users, then no, Cypress won't work with that.  But seriously, Cypress is a *development* tool, which makes it easy to test your web applications. If your application is doing 100x things to make it extremely difficult to access, Cypress won't magically make it any easier.
+If you're using some complex thumb-print, retinal-scan, time-based, key-changing, microphone, audial, decoding mechanism to log in your users, then no, Cypress won't work with that.  But seriously, Cypress is a *development* tool, which helps you test your web applications. If your application is doing 100x things to make it extremely difficult to access, Cypress won't magically make it any easier.
 
 Because Cypress is a development tool, you can always make your application more accessible while in your development environment. If you want, disable complex steps in your authentication systems while you're in your testing environment. After all, that's why we have different environments! Normally you already have a development environment, a testing environment, a staging environment, and a production environment.  So expose the parts of your system you want accessible in each appropriate environment.
 
-In doing so, Cypress may not be able to give you 100% coverage without you changing anything, but that's okay. Just use different tools to test the crazier, less accessible parts of your application, and let Cypress test the other 99%.
+In doing so, Cypress may not be able to give you 100% coverage without you changing anything, but that's okay. Use different tools to test the less accessible parts of your application, and let Cypress test the other 99%.
 
-Just remember, Cypress won't make a non-testable application suddenly testable. It's on your shoulders to architect your code in an accessible manner.
+Remember, Cypress won't make a non-testable application suddenly testable. It's on your shoulders to architect your code in an accessible manner.
 
 ## {% fa fa-angle-right %} Is it possible to use cypress on `.jspa`?
 Yes. Cypress works on anything rendered to a browser.
@@ -134,7 +134,7 @@ Cypress does *not* utilize WebDriver for testing, so it does not use or have any
 
 Unit tests are not something we are really trying to solve right now. Most of the `cy` API commands are useless in unit tests. The biggest benefit of writing unit tests in Cypress is that they run in a browser, which has debugger support built in.
 
-We have internally experimented at doing DOM based component unit testing in Cypress - and that has the possibility of being an excellent "sweet spot" for unit tests. You'd get full DOM support, screenshot support, snapshot testing, and you could then use other `cy` commands (if need be). But as I mentioned this isn't something we're actively pushing; it just remains a thing that's possible if we wanted to go down that route.
+We have internally experimented at doing DOM based component unit testing in Cypress - and that has the possibility of being an excellent "sweet spot" for unit tests. You'd get full DOM support, screenshot support, snapshot testing, and you could then use other `cy` commands (if need be). But as I mentioned this isn't something we're actively pushing; it remains a thing that's possible if we wanted to go down that route.
 
 With that said - we actually believe the best form of testing in Cypress is a combination of a "unit test" mixed with an "e2e test". We don't believe in a "hands off" approach. We want you to modify the state of your application, take shortcuts as much as possible (because you have native access to all objects including your app). In other words, we want you to think in unit tests while you write integration tests.
 
@@ -158,10 +158,10 @@ In addition to the above differences, below are a few rules of thumb to decide w
 
 Finally, unit and end-to-end tests are not _that_ different and have common features. Good tests:
 
-- Focus on and test just one thing.
+- Focus on and test only one thing.
 - Are flake-free and do not fail randomly.
 - Give you confidence to refactor code and add new features.
-- Are easy to run both locally and on a {% url "continuous integration" continuous-integration %} server.
+- Are able to run both locally and on a {% url "continuous integration" continuous-integration %} server.
 
 Certainly, unit and end-to-end tests are NOT in opposition to each other and are complementary tools in your toolbox.
 

--- a/source/faq/questions/using-cypress-faq.md
+++ b/source/faq/questions/using-cypress-faq.md
@@ -8,7 +8,7 @@ containerClass: faq
 
 Cypress commands yield jQuery objects, so you can call methods on them.
 
-If you're just trying to assert on an element's text content:
+If you're trying to assert on an element's text content:
 
 ```javascript
 cy.get('div').should('have.text', 'foobarbaz')
@@ -58,7 +58,7 @@ This is the equivalent of Selenium's `getText()` method, which returns the inner
 
 Cypress yields you jQuery objects, so you can call methods on them.
 
-If you're just trying to assert on an input's value:
+If you're trying to assert on an input's value:
 
 ```javascript
 // make an assertion on the value
@@ -107,7 +107,7 @@ For examples how to do this, please read our {% url 'Variables and Aliases guide
 
 ## {% fa fa-angle-right %} How do I get the native DOM reference of an element found using Cypress?
 
-Cypress wraps elements in jQuery so you'd just get the native element from there within a {% url "`.then()`" then %} command.
+Cypress wraps elements in jQuery so you'd get the native element from there within a {% url "`.then()`" then %} command.
 
 ```javascript
 cy.get('button').then(($el) => {
@@ -141,7 +141,7 @@ We have seen many different iterations of this question. The answers can be vari
 
 **_How do I know if my page is done loading?_**
 
-When you load your application using `cy.visit()`, Cypress will wait for the `load` event to fire. It is really this easy. The {% url '`cy.visit()`' visit#Usage %} command loads a remote page and does not resolve until all of the external resources complete their loading phase. Because we expect your applications to observe differing load times, this command's default timeout is set to 60000ms. If you visit an invalid url or a {% url 'second unique domain' web-security#One-Superdomain-per-Test %}, Cypress will log a verbose yet friendly error message.
+When you load your application using `cy.visit()`, Cypress will wait for the `load` event to fire. The {% url '`cy.visit()`' visit#Usage %} command loads a remote page and does not resolve until all of the external resources complete their loading phase. Because we expect your applications to observe differing load times, this command's default timeout is set to 60000ms. If you visit an invalid url or a {% url 'second unique domain' web-security#One-Superdomain-per-Test %}, Cypress will log a verbose yet friendly error message.
 
 
 **_In CI, how do I make sure my server has started?_**
@@ -239,7 +239,7 @@ If you're curious please read:
 
 ## {% fa fa-angle-right %} How do I select or query for elements if my application uses dynamic classes or dynamic IDs?
 
-Easy - you don't use classes or ID's. You add `data-*` attributes to your elements and target them that way.
+Don't use classes or ID's. You add `data-*` attributes to your elements and target them that way.
 
 Read more about the {% url 'best practices for selecting elements here' best-practices#Selecting-Elements %}.
 
@@ -312,7 +312,7 @@ The page object pattern isn't actually anything "special". If you're coming from
 
 The "Page Object Pattern" should really be renamed to: "Using functions and creating custom commands".
 
-If you're looking to abstract behavior or roll up a series of actions you can create reusable {% url 'Custom Commands with our API' custom-commands %}. You can also just use regular ol' JavaScript functions without any of the ceremony typical with "Page Objects".
+If you're looking to abstract behavior or roll up a series of actions you can create reusable {% url 'Custom Commands with our API' custom-commands %}. You can also use regular ol' JavaScript functions without any of the ceremony typical with "Page Objects".
 
 For those wanting to use page objects, we've highlighted the {% url 'best practices ' custom-commands#Best-Practices %} for replicating the page object pattern.
 
@@ -380,7 +380,7 @@ cy.get('#list>li').should('have.length', 20)
 
 You can use {% url `cy.request()` request %}, {% url `cy.exec()` exec %}, or {% url `cy.task()` task %} to talk to your back end to seed data.
 
-You could also just stub XHR requests directly using {% url `cy.route()` route %} which avoids ever even needing to fuss with your database.
+You could also stub XHR requests directly using {% url `cy.route()` route %} which avoids ever even needing to fuss with your database.
 
 ## {% fa fa-angle-right %} How do I test elements inside an iframe?
 
@@ -430,7 +430,7 @@ However, most of the time you don't even have to worry about animations. Why not
 
 Cypress does not and may never have multi-tab support for various reasons.
 
-Luckily there are lots of easy and safe workarounds that enable you to test this behavior in your application.
+Luckily there are lots of clear and safe workarounds that enable you to test this behavior in your application.
 
 {% url 'Read through the recipe on tab handling and links to see how to test anchor links.' recipes#Testing-the-DOM %}
 
@@ -481,7 +481,7 @@ No, Cypress modifies network traffic in real time and therefore must sit between
 
 You can check for the existence of `window.Cypress`, in your **application code**.
 
-Here's a simple example:
+Here's an example:
 
 ```javascript
 if (window.Cypress) {
@@ -509,9 +509,9 @@ There are a lot of ways to test this, so it depends. You'll need to be aware of 
 
 If your server sends specific disposition headers which cause a browser to prompt for download, you can figure out what URL this request is made to, and use {% url "cy.request()" request %} to hit that directly. Then you can test that the server send the right response headers.
 
-If it's just an anchor that initiates the download, you could just test that it has the right `href` property. As long as you can verify that clicking the button is going to make the right HTTP request, there's nothing else to test for.
+If it's an anchor that initiates the download, you could test that it has the right `href` property. As long as you can verify that clicking the button is going to make the right HTTP request, there's nothing else to test for.
 
-In the end, it's up to you to know your implementation and to test just enough to cover everything.
+In the end, it's up to you to know your implementation and to test enough to cover everything.
 
 ## {% fa fa-angle-right %} Is it possible to catch the promise chain in Cypress?
 
@@ -584,7 +584,7 @@ If a test fails, Cypress takes a screenshot image, but does not print the list o
 
 ## {% fa fa-angle-right %} Can my tests interact with Redux / Vuex data store?
 
-Usually your end-to-end tests interact with the application through public browser APIs: DOM, network, storage, etc. But sometimes you might want to make assertions against the data held inside the application's data store. Cypress makes it simple. Tests run right in the same browser instance and can reach into the application's context using {% url `cy.window` window %}. By conditionally exposing the application reference and data store from the application's code, you can allow the tests to make assertions about the data store, and even drive the application via Redux actions.
+Usually your end-to-end tests interact with the application through public browser APIs: DOM, network, storage, etc. But sometimes you might want to make assertions against the data held inside the application's data store. Cypress helps you do this. Tests run right in the same browser instance and can reach into the application's context using {% url `cy.window` window %}. By conditionally exposing the application reference and data store from the application's code, you can allow the tests to make assertions about the data store, and even drive the application via Redux actions.
 
 - see {% url "Testing Redux Store" https://www.cypress.io/blog/2018/11/14/testing-redux-store/ %} blog post and {% url "Redux Testing" recipes#Blogs %} recipe.
 - see {% url "Testing Vue web applications with Vuex data store & REST back end" https://www.cypress.io/blog/2017/11/28/testing-vue-web-application-with-vuex-data-store-and-rest-backend/ %} blog post and {% url 'Vue + Vuex + REST Testing' recipes#Blogs %} recipe.

--- a/source/guides/core-concepts/conditional-testing.md
+++ b/source/guides/core-concepts/conditional-testing.md
@@ -45,7 +45,7 @@ A human also has intuition. If you click a button and see a loading spinner, you
 
 A robot has no intuition - it will do exactly as it is programmed to do.
 
-To illustrate this, let's take a very simple example of trying to conditionally test unstable state.
+To illustrate this, let's take a straightforward example of trying to conditionally test unstable state.
 
 ## The DOM is unstable
 
@@ -98,7 +98,7 @@ Let's explore a few examples.
 
 ## Server side rendering
 
-If your application is server side rendered without JavaScript that asynchronously modifies the DOM - congratulations, you can easily do conditional testing on the DOM!
+If your application is server side rendered without JavaScript that asynchronously modifies the DOM - congratulations, you can do conditional testing on the DOM!
 
 Why? Because if the DOM is not going to change after the `load` event occurs, then it can accurately represent a stable state of truth.
 
@@ -134,7 +134,7 @@ Let's explore some examples of conditional testing that will pass or fail 100% o
 
 In this example let's assume you visit your website and the content will be different based on which A/B campaign your server decides to send. Perhaps it is based on geo-location, IP address, time of day, locale, or other factors that are difficult to control. How can you write tests in this manner?
 
-Easily: control which campaign gets sent, or provide a reliable means to know which one it is.
+Control which campaign gets sent, or provide a reliable means to know which one it is.
 
 ### Use URL query params:
 
@@ -341,7 +341,7 @@ Cypress is built around creating **reliable tests**. The secret to writing good 
 
 Doing conditional testing adds a huge problem - that the test writers themselves are unsure what the given state will be. In those situations, the only reliable way to have accurate tests is to embed this dynamic state in a reliable and consistent way.
 
-If you are not sure if you have written a potentially flaky test, there is an easy way to figure it out. Repeat the test an excessive number of times, and then repeat by modifying the Developer Tools to throttle the Network and the CPU. This will create different loads that simulate different environments (like CI). If you've written a good test, it will pass or fail 100% of the time.
+If you are not sure if you have written a potentially flaky test, there is a way to figure it out. Repeat the test an excessive number of times, and then repeat by modifying the Developer Tools to throttle the Network and the CPU. This will create different loads that simulate different environments (like CI). If you've written a good test, it will pass or fail 100% of the time.
 
 ```js
 Cypress._.times(100, (i) => {

--- a/source/guides/core-concepts/conditional-testing.md
+++ b/source/guides/core-concepts/conditional-testing.md
@@ -114,7 +114,7 @@ This is difficult to do (if not impossible) without making changes to your appli
 
 In other words, you cannot do conditional testing safely if you want your tests to run 100% consistently.
 
-But do not fret - there are better workarounds to still achieve conditional testing **without** relying on the DOM. You just have to *anchor* yourself to another piece of truth that is not mutable.
+But do not fret - there are better workarounds to still achieve conditional testing **without** relying on the DOM. You have to *anchor* yourself to another piece of truth that is not mutable.
 
 # The strategies
 
@@ -156,7 +156,7 @@ Now there is not even a need to do conditional testing since you are able to kno
 
 ### Use the server:
 
-Alternatively, if your server saves the campaign with a session, you could just ask your server to tell you which campaign you are on.
+Alternatively, if your server saves the campaign with a session, you could ask your server to tell you which campaign you are on.
 
 ```js
 // this sends us the session cookies
@@ -175,7 +175,7 @@ cy.request('https://app.com/me')
 
 ### Use session cookies:
 
-Perhaps an even easier way to test this is if your server sent the campaign in a session cookie that you could read off.
+Another way to test this is if your server sent the campaign in a session cookie that you could read off.
 
 ```js
 cy.visit('https://app.com')
@@ -220,7 +220,7 @@ cy.visit('https://app.com?wizard=0')
 cy.visit('https://app.com?wizard=1')
 ```
 
-We would likely just need to update our client side code to check whether this query param is present. Now we know ahead of time whether it will or will not be shown.
+We would likely need to update our client side code to check whether this query param is present. Now we know ahead of time whether it will or will not be shown.
 
 ### Use Cookies to know ahead of time:
 
@@ -243,7 +243,7 @@ cy.getCookie('showWizard')
 
 ### Use your server or database:
 
-If you store and/or persist whether to show the wizard on the server, then just ask it.
+If you store and/or persist whether to show the wizard on the server, then ask it.
 
 ```js
 cy.visit('https://app.com')
@@ -261,7 +261,7 @@ cy.request('https://app.com/me')
   .click()     // more commands here
 ```
 
-Alternatively, if you are creating users, it might just be easier to create the user and set whether you want the wizard to be shown ahead of time. That would avoid this check later.
+Alternatively, if you are creating users, it might take less time to create the user and set whether you want the wizard to be shown ahead of time. That would avoid this check later.
 
 ### Embed data in DOM:
 
@@ -379,11 +379,11 @@ cy.get('body').then(($body) => {
 
 Many of our users ask how they can recover from failed commands.
 
-> If I had error handling, I could just try to find X and if X fails go find Y
+> If I had error handling, I could try to find X and if X fails go find Y
 
 Because error handling is a common idiom in most programming languages, and especially in Node, it seems reasonable to expect to do that in Cypress.
 
-However, this is really the same question as asking to do conditional testing just wrapped up in a slightly different implementation detail.
+However, this is really the same question as asking to do conditional testing, but wrapped up in a slightly different implementation detail.
 
 For instance you may want to do this:
 

--- a/source/guides/core-concepts/interacting-with-elements.md
+++ b/source/guides/core-concepts/interacting-with-elements.md
@@ -153,11 +153,11 @@ When you use the {% url "Command Log" test-runner#Command-Log %} to hover over a
 
 In fact we only ever scroll elements into view when actionable commands are running using the above algorithms. We *do not* scroll elements into view on regular DOM commands like {% url `cy.get()` get %} or {% url `.find()` find %}.
 
-The reason we scroll an element into view when hovering over a snapshot is just to help you to see which element(s) were found by that corresponding command. It's a purely visual feature and does not necessarily reflect what your page looked like when the command ran.
+The reason we scroll an element into view when hovering over a snapshot is to help you to see which element(s) were found by that corresponding command. It's a purely visual feature and does not necessarily reflect what your page looked like when the command ran.
 
 In other words, you cannot get a correct visual representation of what Cypress "saw" when looking at a previous snapshot.
 
-The only way for you to easily "see" and debug why Cypress thought an element was not visible is to use a `debugger` statement.
+The only way for you to "see" and debug why Cypress thought an element was not visible is to use a `debugger` statement.
 
 We recommend placing `debugger` or using the {% url `.debug()` debug %} command directly BEFORE the action.
 
@@ -180,7 +180,7 @@ Imagine you have a nested navigation structure where the user must hover over an
 
 Is this worth trying to replicate when you're testing?
 
-Maybe not! For these scenarios  we give you a simple escape hatch to bypass all of the checks above and just force events to happen!
+Maybe not! For these scenarios, we give you an escape hatch to bypass all of the checks above and force events to happen!
 
 You can pass `{ force: true }` to most action commands.
 

--- a/source/guides/core-concepts/introduction-to-cypress.md
+++ b/source/guides/core-concepts/introduction-to-cypress.md
@@ -17,7 +17,7 @@ title: Introduction to Cypress
 After you're done, we suggest watching some of our {% fa fa-video-camera %} {% url "Tutorial Videos" tutorials %}.
 {% endnote %}
 
-# Cypress Is Simple
+# Cypress Can Be Simple (Sometimes)
 
 Simplicity is all about getting more done with less typing. Let's look at an example:
 
@@ -56,7 +56,7 @@ Can you read this? If you did, it might sound something like this:
 > 8. Grab the browser URL, ensure it includes `/posts/my-first-post`.
 > 9. Find the `h1` tag, ensure it contains the text "My First Post".
 
-This is a relatively simple, straightforward test, but consider how much code has been covered by it, both on the client and the server!
+This is a relatively straightforward test, but consider how much code has been covered by it, both on the client and the server!
 
 For the remainder of this guide, we'll explore the basics of Cypress that make this example work. We'll demystify the rules Cypress follows so you can productively test your application to act as much like a user as possible, as well as discuss how to take shortcuts when it's useful.
 
@@ -313,7 +313,7 @@ To work around the need to reference elements, Cypress has a feature {% url 'kno
 
 Want to jump into the command flow and get your hands on the subject directly? No problem, add a {% url '`.then()`' type %} to your command chain. When the previous command resolves, it will call your callback function with the yielded subject as the first argument.
 
-If you wish to continue chaining commands after your {% url `.then()` then %}, you'll need to specify the subject you want to yield to those commands, which you can achieve with a simple return value other than `null` or `undefined`. Cypress will yield that to the next command for you.
+If you wish to continue chaining commands after your {% url `.then()` then %}, you'll need to specify the subject you want to yield to those commands, which you can achieve with a return value other than `null` or `undefined`. Cypress will yield that to the next command for you.
 
 ### Let's look at an example:
 
@@ -364,7 +364,7 @@ This lets us reuse our DOM queries for faster tests when the element is still in
 
 It is very important to understand that Cypress commands don't do anything at the moment they are invoked, but rather enqueue themselves to be run later. This is what we mean when we say Cypress commands are asynchronous.
 
-### Take this simple test, for example:
+### Take this short test, for example:
 
 ```js
 it('changes the URL when "awesome" is clicked', function() {

--- a/source/guides/core-concepts/introduction-to-cypress.md
+++ b/source/guides/core-concepts/introduction-to-cypress.md
@@ -184,7 +184,7 @@ cy.contains('New Post')
 cy.get('.main').contains('New Post')
 ```
 
-This is helpful when writing tests from the perspective of a user interacting with your app. They just know they want to click the button labeled "Submit", they have no idea that it has a `type` attribute of `submit`, or a CSS class of `my-submit-button`.
+This is helpful when writing tests from the perspective of a user interacting with your app. They only know that they want to click the button labeled "Submit". They have no idea that it has a `type` attribute of `submit`, or a CSS class of `my-submit-button`.
 
 {% note warning Internationalization %}
 If your app is translated into multiple languages for i18n, make sure you consider the implications of using user-facing text to find DOM elements!
@@ -219,7 +219,7 @@ It's very important to understand the mechanism Cypress uses to chain commands t
 
 ## Interacting With Elements
 
-As we saw in the initial example, Cypress makes it easy to click on and type into elements on the page by using {% url `.click()` click %} and {% url `.type()` type %} commands with a {% url `cy.get()` get %} or {% url `cy.contains()` contains %} command. This is a great example of chaining in action. Let's see it again:
+As we saw in the initial example, Cypress allows you to click on and type into elements on the page by using {% url `.click()` click %} and {% url `.type()` type %} commands with a {% url `cy.get()` get %} or {% url `cy.contains()` contains %} command. This is a great example of chaining in action. Let's see it again:
 
 ```js
 cy.get('textarea.post-body')
@@ -255,7 +255,7 @@ Cypress provides a simple but powerful algorithm when {% url " interacting with 
 
 ## Asserting About Elements
 
-Assertions let you do things like ensuring an element is visible or has a particular attribute, CSS class, or state. Assertions are just commands that enable you to describe the *desired* state of your application. Cypress will automatically wait until your elements reach this state, or fail the test if the assertions don't pass.  Here's a quick look at assertions in action:
+Assertions let you do things like ensuring an element is visible or has a particular attribute, CSS class, or state. Assertions are commands that enable you to describe the *desired* state of your application. Cypress will automatically wait until your elements reach this state, or fail the test if the assertions don't pass.  Here's a quick look at assertions in action:
 
 ```js
 cy.get(':checkbox').should('be.disabled')
@@ -558,7 +558,7 @@ You might be wondering:
 
 The problem with this question is that this type of conditional control flow ends up being non-deterministic. This means it's impossible for a script (or robot), to follow it 100% consistently.
 
-In general, there are only a handful of very specific situations where you *can* create control flow. Asking to recover from errors is actually just asking for another `if/else` control flow.
+In general, there are only a handful of very specific situations where you *can* create control flow. Asking to recover from errors is actually the same as asking for another `if/else` control flow.
 
 With that said, as long as you are aware of the potential pitfalls with control flow, it is possible to do this in Cypress!
 
@@ -714,7 +714,7 @@ cy
   .click()
 ```
 
-Cypress will automatically *wait* for elements to pass their default assertions. Just like with explicit assertions you've added, all of these assertions share the *same* timeout values.
+Cypress will automatically *wait* for elements to pass their default assertions. Like with the explicit assertions you've added, all of these assertions share the *same* timeout values.
 
 ### Example #2: Reversing the Default Assertion
 
@@ -776,7 +776,7 @@ Using {% url `.should()` should %} or {% url `.and()` and %} commands is the pre
 cy.get('tbody tr:first').should('have.class', 'active')
 ```
 
-You can chain multiple assertions together using {% url `.and()` and %}, which is just another name for {% url `.should()` should %} that makes things more readable:
+You can chain multiple assertions together using {% url `.and()` and %}, which is another name for {% url `.should()` should %} that makes things more readable:
 
 ```js
 cy.get('#header a')
@@ -820,7 +820,7 @@ Explicit assertions are great when you want to:
 - Perform custom logic prior to making the assertion.
 - Make multiple assertions against the same subject.
 
-The {% url `.should()` should %} command allows us to pass a callback function that takes the yielded subject as its first argument. This works just like {% url `.then()` then %}, except Cypress automatically **waits and retries** for everything inside of the callback function to pass.
+The {% url `.should()` should %} command allows us to pass a callback function that takes the yielded subject as its first argument. This works like {% url `.then()` then %}, except Cypress automatically **waits and retries** for everything inside of the callback function to pass.
 
 {% note info 'Complex Assertions' %}
 The example below is a use case where we are asserting across multiple elements. Using a {% url `.should()` should %} callback function is a great way to query from a **parent** into multiple children elements and assert something about their state.
@@ -839,7 +839,7 @@ cy
     })
 
     // jQuery map returns jQuery object
-    // and .get() converts this to a simple array
+    // and .get() converts this to an array
     texts = texts.get()
 
     // array should have length of 3

--- a/source/guides/core-concepts/variables-and-aliases.md
+++ b/source/guides/core-concepts/variables-and-aliases.md
@@ -16,7 +16,7 @@ title: Variables and Aliases
 New users to Cypress may initially find it challenging to work with the asynchronous nature of our APIs.
 
 {% note success 'Do not worry!' %}
-There are many simple and easy ways to reference, compare and utilize the objects that Cypress commands yield you.
+There are many ways to reference, compare and utilize the objects that Cypress commands yield you.
 
 Once you get the hang of async code you'll realize you can do everything you could do synchronously, without your code doing any backflips.
 

--- a/source/guides/core-concepts/variables-and-aliases.md
+++ b/source/guides/core-concepts/variables-and-aliases.md
@@ -199,12 +199,12 @@ describe('a suite', function () {
 })
 ```
 
-Fortunately, you don't have to make your code do backflips. Cypress makes it easy to handle these situations.
+Fortunately, you don't have to make your code do backflips. With Cypress, we can better handle these situations.
 
 {% note success 'Introducing Aliases' %}
 Aliases are a powerful construct in Cypress that have many uses. We'll explore each of their capabilities below.
 
-At first, we'll use them to make it easy to share objects between your hooks and your tests.
+At first, we'll use them to share objects between your hooks and your tests.
 {% endnote %}
 
 ## Sharing Context
@@ -303,7 +303,7 @@ The same principles we introduced many times before apply to this situation. If 
 // yup all good
 cy.fixture('users.json').then((users) => {
   // now we can avoid the alias altogether
-  // and just use a callback function
+  // and use a callback function
   const user = users[0]
 
   // passes
@@ -401,7 +401,7 @@ cy.get('@firstTodo').should('have.class', 'editing')
 
 When we reference `@firstTodo`, Cypress checks to see if all of the elements it is referencing are still in the DOM. If they are, it returns those existing elements. If they aren't, Cypress replays the commands leading up to the alias definition.
 
-In our case it would re-issue the commands: `cy.get('#todos li').first()`. Everything just works because the new `<li>` is found.
+In our case it would re-issue the commands: `cy.get('#todos li').first()`. Everything works because the new `<li>` is found.
 
 {% note warning  %}
 *Usually*, replaying previous commands will return what you expect, but not always. It is recommended that you **alias elements as soon as possible** instead of further down a chain of commands.

--- a/source/guides/dashboard/organizations.md
+++ b/source/guides/dashboard/organizations.md
@@ -37,7 +37,7 @@ You can delete organizations that you own as long as they do not have any projec
 
 ## Open Source Plan
 
-To support the community, we provide the Open Source (OSS) plan for public projects to take advantage of our Dashboard Service with unlimited test runs. To qualify, your project needs just two things:
+To support the community, we provide the Open Source (OSS) plan for public projects to take advantage of our Dashboard Service with unlimited test runs. To qualify, your project needs two things:
 
 - Your project is a non-commercial entity
 - Source code for your project is available in a public location with an {% url "OSI-approved license" https://opensource.org/licenses %}

--- a/source/guides/dashboard/projects.md
+++ b/source/guides/dashboard/projects.md
@@ -67,7 +67,7 @@ Once you set up your project to record, we generate a unique `projectId` for you
 
 This helps us uniquely identify your project. If you manually alter this, **Cypress will no longer be able to identify your project or find the recorded builds for it**.
 
-If you're using source control, we recommend that you check your `cypress.json`, including the `projectId`, into source control. If you don't want your `projectId` visible in your source code you can set it as an environment variable using the name `CYPRESS_PROJECT_ID`. The exact mechanism for doing so depends on your system but could be as simple as:
+If you're using source control, we recommend that you check your `cypress.json`, including the `projectId`, into source control. If you don't want your `projectId` visible in your source code you can set it as an environment variable using the name `CYPRESS_PROJECT_ID`. The exact mechanism for doing so depends on your system but could be something like:
 
 ```shell
 export CYPRESS_PROJECT_ID={projectId}

--- a/source/guides/getting-started/installing-cypress.md
+++ b/source/guides/getting-started/installing-cypress.md
@@ -23,7 +23,7 @@ Cypress is a desktop application that is installed on your computer. The desktop
 
 ## {% fa fa-terminal %} `npm install`
 
-Installing Cypress via `npm` is easy:
+Install Cypress via `npm`:
 
 ```shell
 cd /your/project/path
@@ -68,7 +68,7 @@ yarn add cypress --dev
 
 ## {% fa fa-download %} Direct download
 
-If you're not using Node or `npm` in your project or you just want to try Cypress out quickly, you can always {% url "download Cypress directly from our CDN" https://download.cypress.io/desktop %}.
+If you're not using Node or `npm` in your project or you want to try Cypress out quickly, you can always {% url "download Cypress directly from our CDN" https://download.cypress.io/desktop %}.
 
 {% note warning %}
 Recording runs to the Dashboard is not possible from the direct download. This download is only intended as a quick way to try out Cypress. To record tests to the Dashboard, you'll need to install Cypress as an `npm` dependency.
@@ -76,13 +76,13 @@ Recording runs to the Dashboard is not possible from the direct download. This d
 
 The direct download will always grab the latest available version. Your platform will be detected automatically.
 
-Just manually unzip and double click. Cypress will run without needing to install any dependencies.
+Then you can manually unzip and double click. Cypress will run without needing to install any dependencies.
 
 {% video local /img/snippets/installing-global.mp4 %}
 
 ## {% fa fa-refresh %} Continuous integration
 
-Please read our {% url 'Continuous Integration' continuous-integration %} docs for help installing Cypress in CI. When running in linux you'll need to install some {% url 'system dependencies' continuous-integration#Dependencies %} or you can just use our {% url 'Docker images' docker %} which have everything you need prebuilt.
+Please read our {% url 'Continuous Integration' continuous-integration %} docs for help installing Cypress in CI. When running in linux you'll need to install some {% url 'system dependencies' continuous-integration#Dependencies %} or you can use our {% url 'Docker images' docker %} which have everything you need prebuilt.
 
 # Opening Cypress
 

--- a/source/guides/getting-started/testing-your-app.md
+++ b/source/guides/getting-started/testing-your-app.md
@@ -41,7 +41,7 @@ Last but not least - trying to shoehorn tests to an already built application is
 
 The last, and probably most important reason why you want to test against local servers, is the ability to **control them**. When your application is running in production you can't control it.
 
-When it's running in development you can easily:
+When it's running in development you can:
 
 - take shortcuts
 - seed data by running executable scripts
@@ -113,7 +113,7 @@ Let's add the `baseUrl` option.
 This will automatically **prefix** {% url `cy.visit()` visit %} and {% url `cy.request()` request %} commands with this baseUrl.
 
 {% note info %}
-Whenever you modify `cypress.json`, Cypress will automatically reboot itself and kill any open browsers. This is normal. Just click on the spec file again to relaunch the browser.
+Whenever you modify `cypress.json`, Cypress will automatically reboot itself and kill any open browsers. This is normal. Click on the spec file again to relaunch the browser.
 {% endnote %}
 
 We can now visit a relative path and omit the hostname and port.
@@ -216,11 +216,11 @@ The good news is that we aren't Selenium, nor are we a traditional e2e testing t
 
 ## Stubbing the server
 
-Another valid approach opposed to seeding and talking to your server is to just bypass it altogether. Much simpler!
+Another valid approach opposed to seeding and talking to your server is to bypass it altogether.
 
 While you'll still receive all of the regular HTML / JS / CSS assets from your server and you'll continue to {% url `cy.visit()` visit %} it in the same way - you can instead **stub** the JSON responses coming from it.
 
-This means that instead of resetting the database, or seeding it with the state we want, you can just force the server to respond with **whatever** you want it to. In this way, we not only prevent needing to synchronize the state between the server and browser, but we also prevent mutating state from our tests. That means tests won't build up state that may affect other tests.
+This means that instead of resetting the database, or seeding it with the state we want, you can force the server to respond with **whatever** you want it to. In this way, we not only prevent needing to synchronize the state between the server and browser, but we also prevent mutating state from our tests. That means tests won't build up state that may affect other tests.
 
 Another upside is that this enables you to **build out your application** without needing the *contract* of the server to exist. You can build it the way you want the data to be structured, and even test all of the edge cases, without needing a server.
 
@@ -234,7 +234,7 @@ You could have the server generate all of the fixture stubs for you ahead of tim
 
 ### Write a single e2e test without stubs, and then stub the rest
 
-Another more balanced approach is just to integrate both strategies. You likely want to have a **single test** that takes a true `e2e` approach and stubs nothing. It'll use the feature for real - including seeding the database and setting up state.
+Another more balanced approach is to integrate both strategies. You likely want to have a **single test** that takes a true `e2e` approach and stubs nothing. It'll use the feature for real - including seeding the database and setting up state.
 
 Once you've established it's working you can then use stubs to test all of the edge cases and additional scenarios. There are no benefits to using real data in the vast majority of cases. We recommend that the vast majority of tests use stub data. They will be orders of magnitude faster, and much less complex.
 
@@ -252,7 +252,7 @@ Nothing slows a test suite down like having to log in, but all the good parts of
 
 It's a great idea to get your signup and login flow under test coverage since it is very important to all of your users and you never want it to break.
 
-As we just mentioned, logging in is one of those features that are **mission critical** and should likely involve your server.  We recommend you test signup and login using your UI as a real user would:
+Logging in is one of those features that are **mission critical** and should likely involve your server.  We recommend you test signup and login using your UI as a real user would:
 
 Here's an example alongside seeding your database:
 
@@ -329,7 +329,7 @@ Don't use your UI to build up state! It's enormously slow, cumbersome, and unnec
 Read about {% url 'best practices' best-practices %} here.
 {% endnote %}
 
-Using your UI to **log in** is the *exact same scenario* as what we just described above. Logging in is just a prerequisite of state that comes before all of your other tests.
+Using your UI to **log in** is the *exact same scenario* as what we described previously. Logging in is a prerequisite of state that comes before all of your other tests.
 
 Because Cypress isn't Selenium, we can actually take a huge shortcut here and skip needing to use our UI by using {% url `cy.request()` request %}.
 

--- a/source/guides/getting-started/writing-your-first-test.md
+++ b/source/guides/getting-started/writing-your-first-test.md
@@ -42,7 +42,7 @@ We are now officially in the {% url 'Cypress Test Runner' test-runner %}. This i
 Notice Cypress displays the message that it couldn't find any tests. This is normal - we haven't written any tests! Sometimes you'll also see this message if there was an error parsing your test file. You can always open your **Dev Tools** to inspect the Console for any syntax or parsing errors that prevented Cypress from reading your tests.
 {% endnote %}
 
-# Write a simple test
+# Write your first test
 
 Now it's time to write our first test. We're going to:
 
@@ -113,7 +113,7 @@ Check out our {% url "Cypress ESLint plugin" https://github.com/cypress-io/eslin
 2. Take an action.
 3. Make an assertion about the resulting application state.
 
-You might also see this phrased as "Given, When, Then", or "Arrange, Act, Assert". The idea is simple: first you put the application into a specific state, then you take some action in the application that causes it to change, and finally you check the resulting application state.
+You might also see this phrased as "Given, When, Then", or "Arrange, Act, Assert". But the idea is: First you put the application into a specific state, then you take some action in the application that causes it to change, and finally you check the resulting application state.
 
 Today, we'll take a narrow view of these steps and map them cleanly to Cypress commands:
 
@@ -126,7 +126,7 @@ Today, we'll take a narrow view of these steps and map them cleanly to Cypress c
 
 First, let's visit a web page. We will visit our {% url 'Kitchen Sink' applications#Kitchen-Sink %} application in this example so that you can try Cypress out without needing to worry about finding a page to test.
 
-Using {% url `cy.visit()` visit %} is easy, we just pass it the URL we want to visit. Let's replace our previous test with the one below that actually visits a page:
+We can pass the URL we want to visit to {% url `cy.visit()` visit %}. Let's replace our previous test with the one below that actually visits a page:
 
 ```js
 describe('My First Test', function() {
@@ -189,7 +189,7 @@ Can you see what Cypress is doing under the hood? It's automatically waiting and
 {% imgTag /img/guides/first-test-failing-contains.png "Test failing to not find content 'hype'" %}
 
 {% note warning 'Error Messages' %}
-We've taken care at Cypress to write hundreds of custom error messages that attempt to explain in simple terms what went wrong. In this case Cypress **timed out retrying** to find the content: `hype` within the entire page.
+We've taken care at Cypress to write hundreds of custom error messages that attempt to clearly explain what went wrong. In this case Cypress **timed out retrying** to find the content: `hype` within the entire page.
 {% endnote %}
 
 Before we add another command - let's get this test back to passing. Replace `hype` with `type`.
@@ -198,7 +198,7 @@ Before we add another command - let's get this test back to passing. Replace `hy
 
 ## {% fa fa-mouse-pointer %} Step 3: Click an element
 
-Ok, now we want to click on the link we found. How do we do that? You could almost guess this one: just add a {% url "`.click()`" click %} command to the end of the previous command, like so:
+Ok, now we want to click on the link we found. How do we do that? Add a {% url "`.click()`" click %} command to the end of the previous command, like so:
 
 ```js
 describe('My First Test', function() {
@@ -219,7 +219,7 @@ Now we can assert something about this new page!
 {% video local /img/snippets/first-test-click-30fps.mp4 %}
 
 {% note info %}
-{% fa fa-magic %} Seeing IntelliSense in your spec files is as easy as adding a single special comment line. Read about {% url 'Intelligent Code Completion' intelligent-code-completion#Triple-slash-directives %}.
+{% fa fa-magic %} You can see IntelliSense in your spec files by adding a single special comment line. Read about {% url 'Intelligent Code Completion' intelligent-code-completion#Triple-slash-directives %}.
 {% endnote %}
 
 ## {% fa fa-check-square-o %} Step 4: Make an assertion
@@ -267,7 +267,7 @@ describe('My First Test', function() {
 })
 ```
 
-And there you have it: a simple test in Cypress that visits a page, finds and clicks a link, verifies the URL and then verifies the behavior of an element on the new page. If we read it out loud, it might sound like:
+And there you have it: a short test in Cypress that visits a page, finds and clicks a link, verifies the URL and then verifies the behavior of an element on the new page. If we read it out loud, it might sound like:
 
 > 1. Visit: `https://example.cypress.io`
 > 2. Find the element with content: `type`
@@ -285,8 +285,6 @@ Or in the Given, When, Then syntax:
 > 3. And they type "fake@email.com" into the `.actions-email` input
 > 3. Then the URL should include `/commands/actions`
 > 4. And the `.actions-email` input has "fake@email.com" as its value
-
-Even your non-technical collaborators can appreciate the way this reads!
 
 And hey, this is a very clean test! We didn't have to say anything about *how* things work, just that we'd like to verify a particular series of events and outcomes.
 
@@ -469,7 +467,7 @@ describe('My First Test', function() {
 })
 ```
 
-We've got some duplication here and could probably make a number of refactoring moves, but for this brief tutorial we'll do a simple and common one. Let's move that initial visit out into a `beforeEach()` block.
+We've got some duplication here and could probably make a number of refactoring moves, but for this brief tutorial we'll do a common one. Let's move that initial visit out into a `beforeEach()` block.
 
 ```js
 describe('My First Test', function() {

--- a/source/guides/guides/continuous-integration.md
+++ b/source/guides/guides/continuous-integration.md
@@ -410,7 +410,7 @@ test:
 
 ## Docker
 
-We have {% url 'created' https://github.com/cypress-io/cypress-docker-images %} an official {% url 'cypress/base' 'https://hub.docker.com/r/cypress/base/' %} container with all of the required dependencies installed. Just add Cypress and go! We are also adding images with browsers pre-installed under {% url 'cypress/browsers' 'https://hub.docker.com/r/cypress/browsers/' %} name. A typical Dockerfile would look like this:
+We have {% url 'created' https://github.com/cypress-io/cypress-docker-images %} an official {% url 'cypress/base' 'https://hub.docker.com/r/cypress/base/' %} container with all of the required dependencies installed. You can add Cypress and go! We are also adding images with browsers pre-installed under {% url 'cypress/browsers' 'https://hub.docker.com/r/cypress/browsers/' %} name. A typical Dockerfile would look like this:
 
 ```text
 FROM cypress/base
@@ -549,9 +549,9 @@ Refer to the dedicated {% url 'Environment Variables Guide' environment-variable
 
 ## Module API
 
-Oftentimes it can be much easier to programmatically control and boot your servers with a Node script.
+Oftentimes it can be less complex to programmatically control and boot your servers with a Node script.
 
-If you're using our {% url 'Module API' module-api %} then you can write a script that boots and then shuts down the server later. As a bonus you can easily work with the results and do other things.
+If you're using our {% url 'Module API' module-api %} then you can write a script that boots and then shuts down the server later. As a bonus, you can work with the results and do other things.
 
 ```js
 // scripts/run-cypress-tests.js

--- a/source/guides/guides/debugging.md
+++ b/source/guides/guides/debugging.md
@@ -5,7 +5,7 @@ title: Debugging
 {% note info %}
 # {% fa fa-graduation-cap %} What you'll learn
 
-- How Cypress runs in the same event loop with your code, keeping debugging simple and understandable
+- How Cypress runs in the same event loop with your code, keeping debugging less demanding and more understandable
 - How Cypress embraces the standard Developer Tools
 - How and when to use `debugger` and the shorthand {% url `.debug()` debug %} command
 - How to troubleshoot issues with Cypress itself
@@ -13,11 +13,11 @@ title: Debugging
 
 # Using `debugger`
 
-Your Cypress test code runs in the same run loop as your application. This means you have access to the code running on the page, as well as the things the browser makes available to you, like `document`, `window`, and, of course, `debugger`.
+Your Cypress test code runs in the same run loop as your application. This means you have access to the code running on the page, as well as the things the browser makes available to you, like `document`, `window`, and `debugger`.
 
 ## Debug just like you always do
 
-Based on those statements, you might be tempted to just throw a `debugger` into your test, like so:
+Based on those statements, you might be tempted to throw a `debugger` into your test, like so:
 
 ```js
 it('let me debug like a fiend', function() {
@@ -95,7 +95,7 @@ All of Cypress's commands, when clicked on within the {% url "Command Log" test-
 
 # Cypress fiddle
 
-While learning Cypress it may be a good idea to try small tests against some simple HTML. We have written a {% url @cypress/fiddle https://github.com/cypress-io/cypress-fiddle %} plugin for this. It can quickly mount any given HTML and run some Cypress test commands against it.
+While learning Cypress it may be a good idea to try small tests against some HTML. We have written a {% url @cypress/fiddle https://github.com/cypress-io/cypress-fiddle %} plugin for this. It can quickly mount any given HTML and run some Cypress test commands against it.
 
 # Troubleshooting Cypress
 

--- a/source/guides/guides/environment-variables.md
+++ b/source/guides/guides/environment-variables.md
@@ -189,7 +189,7 @@ Cypress.env('api_server') // 'http://localhost:8888/api/v1/'
 
 {% note success Benefits %}
 - Does not require any changes to files or configuration.
-- Obvious where environment variables come from.
+- More clear where environment variables come from.
 - Allows for dynamic values between different machines.
 - Overwrites all other forms of setting env variables.
 {% endnote %}

--- a/source/guides/guides/launching-browsers.md
+++ b/source/guides/guides/launching-browsers.md
@@ -105,7 +105,7 @@ This enables you to do things like:
 Cypress generates its own isolated profile apart from your normal browser profile. This means things like `history` entries, `cookies`, and `3rd party extensions` from your regular browsing session will not affect your tests in Cypress.
 
 {% note warning Wait, I need my developer extensions! %}
-That's no problem - you just have to reinstall them **once** in the Cypress launched browser. We'll continue to use this Cypress testing profile on subsequent launches so all of your configuration will be preserved.
+That's no problem - you have to reinstall them **once** in the Cypress launched browser. We'll continue to use this Cypress testing profile on subsequent launches so all of your configuration will be preserved.
 {% endnote %}
 
 ## Disabled Barriers
@@ -137,7 +137,7 @@ You might notice that if you already have the browser open you will see two of t
 
 We understand that when Cypress is running in its own profile it can be difficult to tell the difference between your normal browser and Cypress.
 
-For this reason we recommend {% url "downloading Chromium" https://www.chromium.org/Home %} or {% url "downloading Canary" https://www.google.com/chrome/browser/canary.html %}. These browsers both have different icons from the standard Chrome browser and it'll be much easier to tell the difference. You can also use the bundled {% urlHash "Electron browser" Electron-Browser %}, which does not have a Dock icon.
+For this reason we recommend {% url "downloading Chromium" https://www.chromium.org/Home %} or {% url "downloading Canary" https://www.google.com/chrome/browser/canary.html %}. These browsers both have different icons from the standard Chrome browser, making them more distinguishable. You can also use the bundled {% urlHash "Electron browser" Electron-Browser %}, which does not have a Dock icon.
 
 {% video local /img/snippets/switching-cypress-browser-and-canary-browser.mp4 %}
 

--- a/source/guides/guides/network-requests.md
+++ b/source/guides/guides/network-requests.md
@@ -15,7 +15,7 @@ title: Network Requests
 
 # Testing Strategies
 
-Cypress makes it easy to test the entire lifecycle of Ajax / XHR requests within your application. Cypress provides you direct access to the XHR objects, enabling you to make assertions about its properties. Additionally you can even stub and mock a request's response.
+Cypress helps you test the entire lifecycle of Ajax / XHR requests within your application. Cypress provides you direct access to the XHR objects, enabling you to make assertions about its properties. Additionally you can even stub and mock a request's response.
 
 {% partial network_stubbing_warning %}
 
@@ -76,7 +76,7 @@ Stubbing responses enables you to control every aspect of the response, includin
 You don't have to do any work on the server. Your application will have no idea its requests are being stubbed, so there are *no code changes* needed.
 
 {% note success Benefits %}
-- Easy control of response bodies, status, and headers
+- Control of response bodies, status, and headers
 - Can force responses to take longer to simulate network delay
 - No code changes to your server or client code
 - Fast, < 20ms response times
@@ -96,7 +96,7 @@ You don't have to do any work on the server. Your application will have no idea 
 
 # Stubbing
 
-Cypress makes it easy to stub a response and control the `body`, `status`, `headers`, or even delay.
+Cypress enables you to stub a response and control the `body`, `status`, `headers`, or even delay.
 
 ***To begin stubbing responses you need to do two things.***
 
@@ -143,7 +143,7 @@ Once you start a server with {% url `cy.server()` server %}, all requests will b
 
 A fixture is a fixed set of data located in a file that is used in your tests. The purpose of a test fixture is to ensure that there is a well known and fixed environment in which tests are run so that results are repeatable. Fixtures are accessed within tests by calling the {% url `cy.fixture()` fixture %} command.
 
-Cypress makes it easy to stub a network requests and have it respond instantly with fixture data.
+With Cypress, you can stub network requests and have it respond instantly with fixture data.
 
 When stubbing a response, you typically need to manage potentially large and complex JSON objects. Cypress allows you to integrate fixture syntax directly into responses.
 

--- a/source/guides/guides/parallelization.md
+++ b/source/guides/guides/parallelization.md
@@ -149,7 +149,7 @@ For multiple runs to be grouped into a single run, it is required for CI machine
 
 ## Grouping by browser
 
-You can test your application against different browsers and view the results under a single run within the Dashboard. Below, we simple name our groups the same name as the browser being tested:
+You can test your application against different browsers and view the results under a single run within the Dashboard. Below, we name our groups the same name as the browser being tested:
 
 - The first group can be called `Windows/Chrome 69`.
 
@@ -281,7 +281,7 @@ The Bar Chart View visualizes the **duration** of your spec files relative to ea
 
 ## Machines View
 
-The Machines View charts spec files by the machines that executed them. This view makes it easy to evaluate the contribution of each machine to the overall test run.
+The Machines View charts spec files by the machines that executed them. This view enables you to evaluate the contribution of each machine to the overall test run.
 
 {% imgTag /img/guides/parallelization/machines-view.png "Machines view with parallelization" %}
 

--- a/source/guides/guides/stubs-spies-and-clocks.md
+++ b/source/guides/guides/stubs-spies-and-clocks.md
@@ -175,7 +175,7 @@ expect(user.fail).to.have.thrown('Error')                  // true
 
 # Integration and Extensions
 
-Beyond just integrating these tools together we have also extended and improved collaboration between these tools.
+Beyond integrating these tools together, we have also extended and improved collaboration between these tools.
 
 ***Some examples:***
 

--- a/source/guides/guides/web-security.md
+++ b/source/guides/guides/web-security.md
@@ -31,7 +31,7 @@ It's important to note that although we do our **very best** to ensure your appl
 
 Because Cypress changes its own host URL to match that of your applications, it requires that your application remain on the same superdomain for the entirety of a single test.
 
-If you attempt to visit two different superdomains, Cypress will error. Visiting subdomains works fine. You can visit different superdomains in *different* tests, just not the *same* test.
+If you attempt to visit two different superdomains, Cypress will error. Visiting subdomains works fine. You can visit different superdomains in *different* tests, but not in the *same* test.
 
 ```javascript
 cy.visit('https://www.cypress.io')
@@ -147,7 +147,7 @@ cy.visit('http://localhost:8080')
 cy.get('a').should('have.attr', 'href', 'https://google.com') // no page load!
 ```
 
-Okay but let's say you're worried about `google.com` serving up the right HTML content. How would you test that? Easy! Just make a {% url `cy.request()` request %} directly to it. {% url `cy.request()` request %} is *NOT bound to CORS or same-origin policy*.
+Okay but let's say you're worried about `google.com` serving up the right HTML content. How would you test that? We can make a {% url `cy.request()` request %} directly to it. {% url `cy.request()` request %} is *NOT bound to CORS or same-origin policy*.
 
 ```javascript
 cy.visit('http://localhost:8080')
@@ -197,7 +197,7 @@ A common use case for this is Single sign-on (SSO). In that situation you may `P
 
 If that's the case, don't worry - you can work around it with {% url `cy.request()` request %}. {% url `cy.request()` request %} is special because it is **NOT bound to CORS or same-origin policy**.
 
-In fact we can likely bypass the initial visit altogether and just `POST` directly to your `SSO` server.
+In fact we can likely bypass the initial visit altogether and `POST` directly to your `SSO` server.
 
 ```javascript
 cy.request('POST', 'https://sso.corp.com/auth', { username: 'foo', password: 'bar' })
@@ -214,7 +214,7 @@ cy.request('POST', 'https://sso.corp.com/auth', { username: 'foo', password: 'ba
     cy.visit('http://localhost:8080?token=' + token)
 
     // if you don't need to work with the token you can sometimes
-    // just visit the location header directly
+    // visit the location header directly
     cy.visit(loc)
   })
 ```
@@ -229,9 +229,9 @@ When we say *JavaScript Redirects* we are talking about any kind of code that do
 window.location.href = 'http://some.superdomain.com'
 ```
 
-This is probably the hardest situation to test because it's usually happening due to another cause. You will need to figure out why your JavaScript code is redirecting. Perhaps you're not logged in, and you need to handle that setup elsewhere? Perhaps you're using a Single sign-on (SSO) server and you just need to read the previous section about working around that?
+This is probably the hardest situation to test because it's usually happening due to another cause. You will need to figure out why your JavaScript code is redirecting. Perhaps you're not logged in, and you need to handle that setup elsewhere? Perhaps you're using a Single sign-on (SSO) server and you need to read the previous section about working around that?
 
-If you can't figure out why your JavaScript code is redirecting you to a different superdomain, then you might want to just read about {% url "disabling web security" web-security#Disabling-Web-Security %}.
+If you can't figure out why your JavaScript code is redirecting you to a different superdomain, then you might want to read about {% url "disabling web security" web-security#Disabling-Web-Security %}.
 
 # Disabling Web Security
 

--- a/source/guides/overview/key-differences.md
+++ b/source/guides/overview/key-differences.md
@@ -36,7 +36,7 @@ Having ultimate control over your application, the network traffic, and native a
 - Test edge cases like 'empty views' by forcing your server to send empty responses.
 - Test how your application responds to errors on your server by {% url "modifying response status codes to be 500" route %>.
 - Modify DOM elements directly - like forcing hidden elements to be shown.
-- Use 3rd party plugins programmatically. Instead of fussing with complex UI widgets like multi selects, autocompletes, drop downs, tree views or calendars, just call methods directly from your test code to control them.
+- Use 3rd party plugins programmatically. Instead of fussing with complex UI widgets like multi selects, autocompletes, drop downs, tree views or calendars, you can call methods directly from your test code to control them.
 - <% url "Prevent Google Analytics from loading *before* any of your application code executes" configuration#blacklistHosts %> when testing.
 - Get synchronous notifications whenever your application transitions to a new page or when it begins to unload.
 - {% url "Control time by moving forward or backward" clock %} so that timers or polls automatically fire without having to wait for the required time in your tests.

--- a/source/guides/overview/why-cypress.md
+++ b/source/guides/overview/why-cypress.md
@@ -18,7 +18,7 @@ title: Why Cypress?
 
 Cypress is a next generation front end testing tool built for the modern web. We address the key pain points developers and QA engineers face when testing modern applications.
 
-We make it simple to:
+We make it possible to:
 
 - {% urlHash 'Set up tests' Setting-up-tests %}
 - {% urlHash 'Write tests' Writing-tests %}
@@ -45,14 +45,14 @@ Cypress can test anything that runs in a browser.
 
 Cypress consists of a free, {% url "open source" https://github.com/cypress-io/cypress %}, {% url "locally installed" installing-cypress %} Test Runner **and** a Dashboard Service for {% url 'recording your tests' dashboard-introduction%}.
 
-- ***First:*** Cypress makes it easy to set up and start writing tests every day while you build your application locally. *TDD at its best!*
+- ***First:*** Cypress helps you set up and start writing tests every day while you build your application locally. *TDD at its best!*
 - ***Later:*** After building up a suite of tests and {% url "integrating Cypress" continuous-integration %} with your CI Provider, our  {% url 'Dashboard Service' dashboard-introduction%} can record your test runs. You'll never have to wonder: *Why did this fail?*
 
 # Our mission
 
 Our mission is to build a thriving, open source ecosystem that enhances productivity, makes testing an enjoyable experience, and generates developer happiness. We hold ourselves accountable to champion a testing process **that actually works**.
 
-We believe our documentation should be simple and approachable. This means enabling our readers to understand fully not just the **what** but the **why** as well.
+We believe our documentation should be approachable. This means enabling our readers to understand fully not just the **what** but the **why** as well.
 
 We want to help developers build a new generation of modern applications faster, better, and without the stress and anxiety associated with managing tests.
 
@@ -80,7 +80,7 @@ There are no servers, drivers, or any other dependencies to install or configure
 
 ## {% fa fa-code %} Writing tests
 
-Tests written in Cypress are easy to read and understand. Our API comes fully baked, on top of tools you are familiar with already.
+Tests written in Cypress are meant to be easy to read and understand. Our API comes fully baked, on top of tools you are familiar with already.
 
 {% video local /img/snippets/writing-tests.mp4 %}
 

--- a/source/guides/references/assertions.md
+++ b/source/guides/references/assertions.md
@@ -64,7 +64,7 @@ These chainers are available for BDD assertions (`expect`/`should`). Aliases lis
 | increase(*function*) {% aliases increases %} | `expect(fn).to.increase(obj, 'val')` |
 | decrease(*function*) {% aliases decreases %} | `expect(fn).to.decrease(obj, 'val')` |
 
-These getters are also available for BDD assertions. They don't actually do anything, but they enable you to write simple, english sentences.
+These getters are also available for BDD assertions. They don't actually do anything, but they enable you to write clear, english sentences.
 
 | Chainable getters |
 | --- |
@@ -258,7 +258,7 @@ cy.get('#accordion').should('not.have.css', 'display', 'none')
 
 # Should callback
 
-If built-in assertions are not enough, you can easily write your own assertion function and pass it as a callback to the `.should()` command. Cypress will automatically {% url "retry" retry-ability %} the callback function until it passes or the command times out. See the {% url `.should()` should#Function %} documentation.
+If built-in assertions are not enough, you can write your own assertion function and pass it as a callback to the `.should()` command. Cypress will automatically {% url "retry" retry-ability %} the callback function until it passes or the command times out. See the {% url `.should()` should#Function %} documentation.
 
 ```html
 <div class="main-abc123 heading-xyz987">Introduction</div>

--- a/source/guides/references/best-practices.md
+++ b/source/guides/references/best-practices.md
@@ -34,11 +34,11 @@ Oftentimes we see users run into problems targeting their elements because:
 - Your application may use dynamic classes or ID's that change
 - Your selectors break from development changes to CSS styles or JS behavior
 
-Luckily, it is very easy to avoid both of these problems.
+Luckily, it is possible to avoid both of these problems.
 
 1. Don't target elements based on CSS attributes such as: `id`, `class`, `tag`
 2. Don't target elements that may change their `textContent`
-3. Add `data-*` attributes to make it easy to target elements
+3. Add `data-*` attributes to make it easier to target elements
 
 ### How It Works:
 
@@ -86,7 +86,7 @@ After reading the above rules you may be wondering:
 
 > If I should always use data attributes, then when should I use `cy.contains()`?
 
-A simple rule of thumb is to ask yourself this:
+A rule of thumb is to ask yourself this:
 
 If the content of the element **changed** would you want the test to fail?
 
@@ -186,9 +186,9 @@ Additionally, testing through an OAuth provider is mutable - you will first need
 
 **Here are potential solutions to alleviate these problems:**
 
-1. {% url "Stub" stub %} out the OAuth provider and bypass using their UI altogether. You could just trick your application into believing the OAuth provider has passed its token to your application.
+1. {% url "Stub" stub %} out the OAuth provider and bypass using their UI altogether. You could trick your application into believing the OAuth provider has passed its token to your application.
 2. If you **must** get a real token you can use {% url `cy.request()` request %} and use the **programmatic** API that your OAuth provider provides. These APIs likely change **more** infrequently and you avoid problems like throttling and A/B campaigns.
-3. Instead of having your test code bypass OAuth, you could also ask your server for help. Perhaps all an OAuth token does is generate a user in your database. Oftentimes OAuth is only useful initially and your server establishes its own session with the client. If that is the case, just use {% url `cy.request()` request %} to get the session directly from your server and bypass the provider altogether.
+3. Instead of having your test code bypass OAuth, you could also ask your server for help. Perhaps all an OAuth token does is generate a user in your database. Oftentimes OAuth is only useful initially and your server establishes its own session with the client. If that is the case, use {% url `cy.request()` request %} to get the session directly from your server and bypass the provider altogether.
 
 {% note info Recipes %}
 {% url "We have several examples of doing this in our logging in recipes." recipes %}
@@ -311,7 +311,7 @@ describe('my form', function () {
 
 This above example is ideal because now we are resetting the state between each test and ensuring nothing in previous tests leaks into subsequent ones.
 
-We're also paving the way to make it easy to write multiple tests against the "default" state of the form. That way each test stays lean but each can be run independently and pass.
+We're also paving the way to make it less complicated to write multiple tests against the "default" state of the form. That way each test stays lean but each can be run independently and pass.
 
 ## Creating "tiny" tests with a single assertion
 
@@ -469,7 +469,7 @@ beforeEach(function () {
 })
 ```
 
-That's it! It couldn't be simpler!
+That's it!
 
 ### Is resetting the state necessary?
 
@@ -489,7 +489,7 @@ The only times you **ever** need to clean up state, is if the operations that on
 {% fa fa-check-circle green %} **Best Practice:** Use route aliases or assertions to guard Cypress from proceeding until an explicit condition is met.
 {% endnote %}
 
-In Cypress, you almost never need to use `cy.wait()` for an arbitrary amount of time. If you are finding yourself doing this, there is likely a much better, simpler way.
+In Cypress, you almost never need to use `cy.wait()` for an arbitrary amount of time. If you are finding yourself doing this, there is likely a much simpler way.
 
 Let's imagine the following examples:
 

--- a/source/guides/references/configuration.md
+++ b/source/guides/references/configuration.md
@@ -177,7 +177,7 @@ Cypress.config('pageLoadTimeout') // => 100000
 
 # Resolved Configuration
 
-When you open a Cypress project, clicking on the *Settings* tab will display the resolved configuration to you. This makes it easy to understand and see where different values came from.
+When you open a Cypress project, clicking on the *Settings* tab will display the resolved configuration to you. This helps you to understand and see where different values came from.
 
 {% imgTag /img/guides/configuration/see-resolved-configuration.jpg "See resolved configuration" %}
 

--- a/source/guides/references/error-messages.md
+++ b/source/guides/references/error-messages.md
@@ -97,7 +97,7 @@ Getting this errors means you've tried to interact with a "dead" DOM element - m
 
 {% imgTag /img/guides/cy-method-failed-element-is-detached.png "cy.method() failed because element is detached" %}
 
-Cypress errors because it can't interact with "dead" elements - just like a real user could not do this either. Understanding how this happens is very important - and it is often easy to prevent.
+Cypress errors because it can't interact with "dead" elements - much like a real user could not do this either. Understanding how this happens is very important - and it is often preventable.
 
 Let's take a look at an example below.
 
@@ -160,7 +160,7 @@ You may see a variation of this message for 4 different reasons:
 3. The element's center is hidden from view
 4. The element is disabled
 
-Cypress runs several calculations to ensure an element can *actually* be interacted with like a real user would. If you're seeing this error, the solution is often obvious. You may need to *guard* your commands (due to a timing or an animation issue).
+Cypress runs several calculations to ensure an element can *actually* be interacted with like a real user would. If you're seeing this error, you may need to *guard* your commands (due to a timing or an animation issue).
 
 There have been situations where Cypress does not correctly allow you to interact with an element that should be interactable. If that's the case, {% open_an_issue %}.
 
@@ -211,7 +211,7 @@ Let's examine several different ways you may get this error message. In every si
 Several of these tests are dependent on race conditions. You may have to run these tests multiple times before they will actually fail. You can also try tweaking some of the delays.
 {% endnote %}
 
-### Simple Example
+### Short Example
 
 This first test below will pass and shows you that Cypress tries to prevent leaving commands behind in the queue in every test.
 
@@ -499,13 +499,13 @@ This error means that your application navigated to a superdomain that Cypress w
 
 When your application navigates to a superdomain outside of the current origin-policy, Cypress is unable to communicate with it, and thus fails.
 
-### There are a few simple workarounds to these common situations:
+### There are a few workarounds to these common situations:
 
 1. Don't click `<a>` links in your tests that navigate outside of your application. Likely this isn't worth testing anyway. You should ask yourself: *What's the point of clicking and going to another app?* Likely all you care about is that the `href` attribute matches what you expect. So make an assertion about that. You can see more strategies on testing anchor links {% url 'in our "Tab Handling and Links" example recipe' recipes#Testing-the-DOM %}.
 
 2. You are testing a page that uses Single sign-on (SSO). In this case your web server is likely redirecting you between superdomains, so you receive this error message. You can likely get around this redirect problem by using {% url `cy.request()` request %} to manually handle the session yourself.
 
-If you find yourself stuck and can't work around these issues you can just set this in your `cypress.json` file. But before doing so you should really understand and {% url 'read about the reasoning here' web-security %}.
+If you find yourself stuck and can't work around these issues you can set this in your `cypress.json` file. But before doing so you should really understand and {% url 'read about the reasoning here' web-security %}.
 
 ```javascript
 // cypress.json
@@ -531,7 +531,7 @@ Browsers are enormously complex pieces of software, and from time to time they w
 
 At the moment, we haven't implemented an automatic way to recover from them, but it is actually possible for us to do so. We have an {% issue 349 'open issue documenting the steps' %} we could take to restart the renderer process and continue the run. If you're seeing consistent crashes and would like this implemented, please leave a note in the issue.
 
-If you are running `Docker` {% issue 350 'there is a simple one line fix for this problem documented here' %}.
+If you are running `Docker` {% issue 350 'there is a one line fix for this problem documented here' %}.
 
 # Test Runner errors
 

--- a/source/guides/references/trade-offs.md
+++ b/source/guides/references/trade-offs.md
@@ -54,7 +54,7 @@ In case you missed it before - Cypress tests run inside of the browser! This mea
 
 But what this also means is that your test code **is being evaluated inside the browser**. Test code is not evaluated in Node, or any other server side language. The **only** language we will ever support is the language of the web: JavaScript.
 
-This trade-off means it makes it a little bit harder to communicate with the back end - like your server or database. You will not be able to connect or import those server-side libraries or modules directly. Although you can of course require `node_modules` which can be used in the browser. Additionally, you have the ability to use Node to import or talk directly to your back end scripts using {% url "our Plugins API" writing-a-plugin %} or {% url "`cy.task()`" task %}.
+This trade-off means it makes it a little bit harder to communicate with the back end - like your server or database. You will not be able to connect or import those server-side libraries or modules directly. Although you can require `node_modules` which can be used in the browser. Additionally, you have the ability to use Node to import or talk directly to your back end scripts using {% url "our Plugins API" writing-a-plugin %} or {% url "`cy.task()`" task %}.
 
 To talk to your database or server you need to use the {% url `cy.exec()` exec %}, {% url `cy.task()` task %}, or {% url `cy.request()` request %} commands. That means you will need to expose a way to seed and setup your database. This really is not that hard, but it might take a bit more elbow grease than other testing tools written in your back end language.
 
@@ -70,10 +70,10 @@ Most of the time this use case is needed when users click an `<a>` that opens a 
 
 To take this a step further - we don't believe there is any use case for testing the browser's native behavior. You should ask yourself why you are testing that clicking an `<a href="/foo" target="_blank">` opens a new tab. You already know that is what the browser is designed to do and you already know that it is triggered by the `target="_blank"` attribute.
 
-Since that is the case, just test **the thing** triggering the browser to perform this behavior - as opposed to testing the behavior itself.
+Since that is the case, test **the thing** triggering the browser to perform this behavior - as opposed to testing the behavior itself.
 
 ```js
-cy.get('a[href="/foo"]').should('have.attr', 'target', '_blank') // so simple
+cy.get('a[href="/foo"]').should('have.attr', 'target', '_blank')
 ```
 
 This principle applies to everything in Cypress. Do not test what does not need testing. It is slow, brittle, and adds zero value. Only test the underlying thing that causes the behavior you care about testing.
@@ -140,7 +140,7 @@ server &rightarrow; browser
 
 To do this - you would need a background process outside of the browser to make the underlying WebSocket connection that you can then communicate with and control.
 
-You can do this in many ways and here is a simple example of using an HTTP server to act as the client and exposing a REST interface that enables us to control it.
+You can do this in many ways and here is an example of using an HTTP server to act as the client and exposing a REST interface that enables us to control it.
 
 ```js
 // Cypress tests

--- a/source/guides/tooling/code-coverage.md
+++ b/source/guides/tooling/code-coverage.md
@@ -98,7 +98,7 @@ When the test calls `add(2, 3)`, the counter increments inside the "add" functio
 }
 ```
 
-This single test has achieved 100% code coverage - every function and every statement has been executed at least once. Of course in real world applications, achieving 100% code coverage requires multiple tests.
+This single test has achieved 100% code coverage - every function and every statement has been executed at least once. But, in real world applications, achieving 100% code coverage requires multiple tests.
 
 Once the tests finish, the coverage object can be serialized and saved to disk so that a human-friendly report can be generated. The collected coverage information can also be sent to external services and help during pull request reviews.
 

--- a/source/guides/tooling/intelligent-code-completion.md
+++ b/source/guides/tooling/intelligent-code-completion.md
@@ -28,7 +28,7 @@ Cypress comes with TypeScript {% url "type declarations" https://github.com/cypr
 
 ### Triple slash directives
 
-The simplest way to see IntelliSense when typing a Cypress command or assertion is to add a {% url "triple-slash directive" "http://www.typescriptlang.org/docs/handbook/triple-slash-directives.html" %} to the head of your JavaScript or TypeScript testing file. This will turn the IntelliSense on a per file basis. Just copy the comment line below and paste it into your spec file.
+The simplest way to see IntelliSense when typing a Cypress command or assertion is to add a {% url "triple-slash directive" "http://www.typescriptlang.org/docs/handbook/triple-slash-directives.html" %} to the head of your JavaScript or TypeScript testing file. This will turn the IntelliSense on a per file basis. Copy the comment line below and paste it into your spec file.
 
 ```js
 /// <reference types="Cypress" />

--- a/source/guides/tooling/plugins-guide.md
+++ b/source/guides/tooling/plugins-guide.md
@@ -89,7 +89,7 @@ Cypress maintains an official list of plugins created by us and the community. Y
 
 # Installing plugins
 
-Plugins from our {% url 'official list' plugins %} are just npm modules. This enables them to be versioned and updated separately without needing to update Cypress itself.
+Plugins from our {% url 'official list' plugins %} are npm modules. This enables them to be versioned and updated separately without needing to update Cypress itself.
 
 You can install any published plugin using NPM:
 
@@ -99,14 +99,14 @@ npm install &lt;plugin name&gt; --save-dev
 
 # Using a plugin
 
-Whether you install an npm module, or just want to write your own code - you should do all of that in this file:
+Whether you install an npm module, or want to write your own code - you should do all of that in this file:
 
 ```text
 cypress/plugins/index.js
 ```
 
 {% note info %}
-By default Cypress seeds this file for new projects, but if you have an existing project just create this file yourself.
+By default Cypress seeds this file for new projects, but if you have an existing project create this file yourself.
 {% endnote %}
 
 Inside of this file, you will export a function. Cypress will call this function, pass you the project's configuration, and enable you to bind to the events exposed.

--- a/source/guides/tooling/typescript-support.md
+++ b/source/guides/tooling/typescript-support.md
@@ -12,7 +12,7 @@ Just as you would when writing TypeScript files in your project, you will have t
 
 - {% url "TypeScript with WebPack" https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/preprocessors__typescript-webpack %}
 - {% url "TypeScript with Browserify" https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/preprocessors__typescript-browserify %}
-- {% url "Simple Repo of TypeScript with WebPack" https://github.com/omerose/cypress-support %}
+- {% url "Repo of TypeScript with WebPack" https://github.com/omerose/cypress-support %}
 
 ## Set up your dev environment
 
@@ -106,7 +106,7 @@ it('works', () => {
 ### Examples:
 
 - See {% url "Adding Custom Commands" https://github.com/cypress-io/cypress-example-recipes#fundamentals %} example recipe.
-- You can find a simple example with custom commands written in TypeScript in {% url "omerose/cypress-support" https://github.com/omerose/cypress-support %} repo.
+- You can find an example with custom commands written in TypeScript in {% url "omerose/cypress-support" https://github.com/omerose/cypress-support %} repo.
 - Example project {% url "cypress-example-todomvc custom commands" https://github.com/cypress-io/cypress-example-todomvc#custom-commands %} uses custom commands to avoid boilerplate code.
 
 ## Types for custom assertions

--- a/source/guides/tooling/visual-testing.md
+++ b/source/guides/tooling/visual-testing.md
@@ -40,7 +40,7 @@ cy.get('.completed').should('have.css', 'text-decoration', 'line-through')
 cy.get('.completed').should('have.css', 'color', 'rgb(217,217,217)')
 ```
 
-Your visual styles may also rely on more than just CSS, perhaps you want to ensure an SVG or image has rendered correctly or shapes were correctly drawn to a canvas.
+Your visual styles may also rely on more than CSS, perhaps you want to ensure an SVG or image has rendered correctly or shapes were correctly drawn to a canvas.
 
 Luckily, Cypress gives a stable platform for {% url "writing plugins" plugins-guide %} that _can perform visual testing_.
 


### PR DESCRIPTION
Closes #2120 

As discussed in the issue, this PR attempts to remove as many instances of condescending or isolating language (ie. simple, easy, just, etc) as possible in the documentation.

Disclaimer: I may have ruined some of your marketing text 😂 so feel free to revert. If even a fraction of these changes can be merged then it will be a huge step towards making the documentation more inclusive!


