### PR TITLE
add advise on what to do when binary is missing on CI

### DIFF
--- a/source/guides/guides/continuous-integration.md
+++ b/source/guides/guides/continuous-integration.md
@@ -579,19 +579,21 @@ node scripts/run-cypress-tests.js
 
 ## Missing binary
 
-When npm installs `cypress` package, it then executes the `postinstall` hook that downloads the platform-specific Cypress binary. If the hook is skipped for any reason, the Cypress binary will be missing, unless it was already cached. To better diagnose the error add these commands to your CI file to show where the binary is stored and what versions are already present:
+When npm or yarn install the `cypress` package, a `postinstall` hook is executed that downloads the platform-specific Cypress binary. If the hook is skipped for any reason the Cypress binary will be missing (unless it was already cached).
+
+To better diagnose the error, add {% url "commands to get information about the Cypress cache" command-line#cypress-cache-command %} to your CI setup. This will print where the binary is located and what versions are already present.
 
 ```shell
 npx cypress cache path
 npx cypress cache list
 ```
 
-If the required binary version is not found in the cache, you can do the following two things:
+If the required binary version is not found in the cache, you can try the following:
 
-1. You can try cleaning CI cache using project's settings page to force a clean npm install on the next build.
-2. You can safely run the binary install yourself by adding the command `npx cypress install` to your CI script. If there is a binary already present, it will finish quickly.
+1. Clean your CI's cache using your CI's settings to force a clean `npm install` on the next build.
+2. Run the binary install yourself by adding the command `npx cypress install` to your CI script. If there is a binary already present, it should finish quickly.
 
-See {% url bahmutov/yarn-cypress-cache https://github.com/bahmutov/yarn-cypress-cache %} for an example that runs `npx cypress install` command to ensure the Cypress binary is always present before the tests begin.
+See {% url bahmutov/yarn-cypress-cache https://github.com/bahmutov/yarn-cypress-cache %} for an example that runs the `npx cypress install` command to ensure the Cypress binary is always present before the tests begin.
 
 ## In Docker
 

--- a/source/guides/guides/continuous-integration.md
+++ b/source/guides/guides/continuous-integration.md
@@ -577,6 +577,22 @@ node scripts/run-cypress-tests.js
 
 # Common problems and solutions
 
+## Missing binary
+
+When npm installs `cypress` package, it then executes the `postinstall` hook that downloads the platform-specific Cypress binary. If the hook is skipped for any reason, the Cypress binary will be missing, unless it was already cached. To better diagnose the error add these commands to your CI file to show where the binary is stored and what versions are already present:
+
+```shell
+npx cypress cache path
+npx cypress cache list
+```
+
+If the required binary version is not found in the cache, you can do the following two things:
+
+1. You can try cleaning CI cache using project's settings page to force a clean npm install on the next build.
+2. You can safely run the binary install yourself by adding the command `npx cypress install` to your CI script. If there is a binary already present, it will finish quickly.
+
+See {% url bahmutov/yarn-cypress-cache https://github.com/bahmutov/yarn-cypress-cache %} for an example that runs `npx cypress install` command to ensure the Cypress binary is always present before the tests begin.
+
 ## In Docker
 
 If you are running long runs on Docker, you need to set the `ipc` to `host` mode. {% issue 350 'This issue' %} describes exactly what to do.


### PR DESCRIPTION
I often see people struggling to understand the "binary is missing" CI error. This adds an explanation and advice to our CI giude.