### PR TITLE
Fix broken imgTag url

### DIFF
--- a/source/api/commands/url.md
+++ b/source/api/commands/url.md
@@ -121,7 +121,7 @@ cy.url().should('contain', '#users/new')
 
 The commands above will display in the Command Log as:
 
-{% imgTag img/api/url/test-url-of-website-or-web-application.png "Command Log url" %}
+{% imgTag /img/api/url/test-url-of-website-or-web-application.png "Command Log url" %}
 
 When clicking on URL within the command log, the console outputs the following:
 

--- a/source/api/commands/url.md
+++ b/source/api/commands/url.md
@@ -123,7 +123,7 @@ The commands above will display in the Command Log as:
 
 {% imgTag /img/api/url/test-url-of-website-or-web-application.png "Command Log url" %}
 
-When clicking on URL within the command log, the console outputs the following:
+When clicking on URL within the Command Log, the console outputs the following:
 
 {% imgTag /img/api/url/console-log-of-browser-url-string.png "Console Log url" %}
 


### PR DESCRIPTION
## What I did:
* Fix broken image URL in https://docs.cypress.io/api/commands/url.html#Timeouts section.
* Titleize `Command log`.

### Before
<img width="1444" alt="Screen Shot 2019-10-12 at 12 57 22 PM" src="https://user-images.githubusercontent.com/10498035/66707141-f4825880-ecf0-11e9-90f4-e1a9d02e6570.png">

### After
<img width="1282" alt="Screen Shot 2019-10-12 at 12 57 02 PM" src="https://user-images.githubusercontent.com/10498035/66707143-fa783980-ecf0-11e9-8441-0996baff0f22.png">
