### PR TITLE
added an example for partial match selector

### DIFF
--- a/source/api/commands/get.md
+++ b/source/api/commands/get.md
@@ -85,10 +85,10 @@ cy.get('.dropdown-menu').click()
 cy.get('[data-test-id="test-example"]').should('have.length', 5)
 ```
 
-### Find the link with an href attribute containing the word "questions"
+### Find the link with an href attribute containing the word "questions" and click it
 
 ```javascript
-cy.get('a[href*="questions"]').should('contain.text', 'FAQ')
+cy.get('a[href*="questions"]').click()
 ```
 
 ## Get in `.within()`

--- a/source/api/commands/get.md
+++ b/source/api/commands/get.md
@@ -85,6 +85,12 @@ cy.get('.dropdown-menu').click()
 cy.get('[data-test-id="test-example"]').should('have.length', 5)
 ```
 
+### Find the link with an href attribute containing the word "questions"
+
+```javascript
+cy.get('a[href*="questions"]').should('contain.text', 'FAQ')
+```
+
 ## Get in `.within()`
 
 ### `cy.get()` in the {% url `.within()` within %} command


### PR DESCRIPTION
for get() command page (.../api/commands/get.md), added an example that shows how one can find an element with an attribute (ex: href) given a partial value (ex: questions)

closes #2092