### PR TITLE
update link in FAQ to parallelization

### DIFF
--- a/source/faq/questions/using-cypress-faq.md
+++ b/source/faq/questions/using-cypress-faq.md
@@ -318,7 +318,7 @@ For those wanting to use page objects, we've highlighted the {% url 'best practi
 
 ## {% fa fa-angle-right %} How can I parallelize my runs?
 
-You can read more about parallelization {% issue 64 'here' %}.
+You can read more about parallelization {% url 'here' parallelization %}.
 
 ## {% fa fa-angle-right %} Is Cypress compatible with Sauce Labs and BrowserStack?
 


### PR DESCRIPTION
This closes #2170 

Current FAQ links to old GH issue. Needs to point to current parallelization docs. 