### PR TITLE
Suggest cypress-multi-reporters

### DIFF
--- a/source/guides/tooling/reporters.md
+++ b/source/guides/tooling/reporters.md
@@ -93,7 +93,7 @@ The solution here is to use multiple reporters. You will have the benefit of bot
 
 We suggest using the excellent npm module:
 
-{% fa fa-github %} {% url 'https://github.com/stanleyhlng/mocha-multi-reporters' %}
+{% fa fa-github %} {% url 'https://github.com/you54f/cypress-multi-reporters' %}
 
 We use multiple reporters for every single one of our internal projects.
 
@@ -108,7 +108,7 @@ We want to output a "spec" report to `STDOUT`, while saving Mochawesome JSON rep
 We need to install additional dependencies including Mocha itself.
 
 ```shell
-npm install --save-dev mocha mocha-multi-reporters mocha-junit-reporter
+npm install --save-dev mocha cypress-multi-reporters mocha-junit-reporter
 ```
 
 Then add a separate `reporter-config.json` file that enables `spec` and `junit` reporters and directs the `junit` reporter to save a separate XML files.
@@ -122,10 +122,10 @@ Then add a separate `reporter-config.json` file that enables `spec` and `junit` 
 }
 ```
 
-The CLI command tells Cypress to use the `mocha-multi-reporters` module and points at the config file.
+The CLI command tells Cypress to use the `cypress-multi-reporters` module and points at the config file.
 
 ```shell
-cypress run --reporter mocha-multi-reporters \
+cypress run --reporter cypress-multi-reporters \
   --reporter-options configFile=reporter-config.json
 ```
 
@@ -136,7 +136,7 @@ Note: we recommend deleting all files from the `cypress/results` folder before r
   "scripts": {
     "delete:reports": "rm cypress/results/* || true",
     "prereport": "npm run delete:reports",
-    "report": "cypress run"
+    "report": "cypress run --reporter cypress-multi-reporters --reporter-options configFile=reporter-config.json"
   }
 }
 ```


### PR DESCRIPTION
When I tried to set up multi-reporters, I found out that mocha-multi-reporters is broken for mocha 6+, which is what users will get if they run the suggested command:

```
npm install --save-dev mocha mocha-multi-reporters mocha-junit-reporter
```

However, there's a maintained fork of mocha-multi-reporters which supports mocha v6+, cypress-multi-reporters.  This commit changes the docs to suggest that newer package instead of the broken one.

I also made a tweak to the suggested npm script, to actually use the reporter.
