### PR TITLE
add cypress-cy-select plugin to documentation

### DIFF
--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -199,6 +199,11 @@
       link: https://github.com/NoriSte/cypress-wait-until
       keywords: [commands, wait, wait-until, recursive-promise, check-async-value, check-value, open-source-saturday]
 
+    - name: cypress-cy-select
+      description: data-cy shorthand notation for cypress get and find functions
+      link: https://github.com/FlorianGoussin/cypress-cy-select
+      keywords: [commands, shorthand]
+
 - name: Extending other testing frameworks
   plugins:
     - name: cyphell
@@ -280,7 +285,7 @@
       description: A project template to learn how Elm, Parcel, Cypress and Netlify work together.
       link: https://github.com/cedricss/elm-batteries
       keywords: [elm, parcel, netlify]
-      
+
     - name: cypress-rails
       description: Ruby gem to run Cypress against Rails apps, replacing Capybara in system tests
       link: https://github.com/testdouble/cypress-rails


### PR DESCRIPTION
add cypress-cy-select plugin (https://www.npmjs.com/package/cypress-cy-select)
data-cy shorthand notation for cypress get and find functions