### PR TITLE
Auto-merge develop to master after successful PR merges into develop

### DIFF
--- a/.github/workflows/automerge-pr-develop-master.yml
+++ b/.github/workflows/automerge-pr-develop-master.yml
@@ -13,4 +13,4 @@ jobs:
       - uses: maxkomarychev/merge-pal-action@v0.3.0
         if: github.event.pull_request.head.ref == 'develop'
         with:
-          token: ${{ secrets.GH_TOKEN}}
+          token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/automerge-pr-develop-master.yml
+++ b/.github/workflows/automerge-pr-develop-master.yml
@@ -1,0 +1,16 @@
+name: Merge PR - develop -> master
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  merge-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: maxkomarychev/merge-pal-action@v0.3.0
+        if: github.event.pull_request.head.ref == 'develop'
+        with:
+          token: ${{ secrets.GH_TOKEN}}

--- a/.github/workflows/create-pr-develop-to-master.yml
+++ b/.github/workflows/create-pr-develop-to-master.yml
@@ -1,0 +1,18 @@
+name: Create PR - develop -> master
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - develop
+
+jobs:
+    pull-request:
+      runs-on: ubuntu-latest
+      steps:
+      - uses: actions/checkout@master
+      - name: pull-request
+        uses: repo-sync/pull-request@v2
+        if: github.event.pull_request.merged == true
+        with:
+          github_token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
- closes #2233 
- [x] @jennifer-shehane we have to disable `master` branch protections to allow for auto-merging from develop to master
- we have to land this into master so all the new PRs would go through this new workflow