### PR TITLE
docs: fix screenshot blackout wording in documentation 

### DIFF
--- a/source/api/cypress-api/screenshot-api.md
+++ b/source/api/cypress-api/screenshot-api.md
@@ -37,7 +37,7 @@ Option | Default | Description
 
 ## Blackout elements before screenshot
 
-Elements that match the specified selectors will be blacked out from the screenshot, but only when the `capture` option is `viewport`. `blackout` is ignored is `capture` is `runner`.
+Elements that match the specified selectors will be blacked out from the screenshot, but only when the `capture` option is `viewport`. `blackout` is ignored if `capture` option is `runner`.
 
 ```javascript
 Cypress.Screenshot.defaults({


### PR DESCRIPTION
<!--
Thanks for contributing!

Please explain what changes were made
also reference any fixed issues with "close #[ISSUE]"
-->

Fixed wording on cypress documentation regarding blackout of features when taking a screenshot

close #2239  

