### PR TITLE
Issue 2234 notes missing

### DIFF
--- a/cypress/integration/notes_spec.js
+++ b/cypress/integration/notes_spec.js
@@ -1,0 +1,9 @@
+describe('notes plugin', () => {
+  beforeEach(() => {
+    cy.visit('guides/references/configuration.html')
+  })
+
+  it('notes render', () => {
+    cy.get('blockquote.note')
+  })
+})

--- a/lib/tags/note.js
+++ b/lib/tags/note.js
@@ -49,7 +49,7 @@ module.exports = function note (hexo, args, content) {
     })
   }
 
-  Promise.all([
+  return Promise.all([
     toMarkdown(content),
     renderHeader(args),
   ])

--- a/lib/tags/note.js
+++ b/lib/tags/note.js
@@ -29,7 +29,7 @@ module.exports = function note (hexo, args, content) {
     rawRender(hexo, text, { engine: 'markdown' })
 
   const stripSurroundingParagraph = (text) => {
-    return text.replace(/^<p>/, '').replace(/<\/p>$/, '')
+    return text.replace(/^<p>/, '').replace(/<\/p>\n?$/, '')
   }
 
   const renderHeader = (params) => {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "predeploy": "NODE_ENV=production npm run build",
     "scrape": "node ./cy_scripts/scrape.js",
     "start-server": "node --stack-size=8192 ./index.js server --port 2222",
+    "prestart": "gulp pre:build",
     "start": "npm run start-server -- --no-validate",
     "test-e2e": "start-server-and-test start http://localhost:2222 cypress:run",
     "dev": "start-test 2222 cypress:open",


### PR DESCRIPTION
#2196 introduced #2234; where no notes were rendered throughout the docs site. This PR addresses this; primarily by actually returning the parsed notes' value.

The issue is may be seen on the [configuration page of the docs site](https://docs.cypress.io/guides/references/configuration.html#Options) or [locally](http://localhost:2222/guides/references/configuration.html)

Before screenshot (without notes)
![image](https://user-images.githubusercontent.com/1578436/68709411-a2d52400-0563-11ea-8a1a-095b9ac24f02.png)

and, correctly working, after:
![image](https://user-images.githubusercontent.com/1578436/68709459-bbddd500-0563-11ea-8ab5-f43c3dccefb8.png)
