### PR TITLE
Use auto-generated GitHub token for GH automerge actions

### DIFF
--- a/.github/workflows/automerge-pr-develop-master.yml
+++ b/.github/workflows/automerge-pr-develop-master.yml
@@ -13,4 +13,4 @@ jobs:
       - uses: maxkomarychev/merge-pal-action@v0.3.0
         if: github.event.pull_request.head.ref == 'develop'
         with:
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/create-pr-develop-to-master.yml
+++ b/.github/workflows/create-pr-develop-to-master.yml
@@ -15,4 +15,4 @@ jobs:
         uses: repo-sync/pull-request@v2
         if: github.event.pull_request.merged == true
         with:
-          github_token: ${{ secrets.GH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Switched to using the auto-generated GITHUB_TOKEN instead of using the personal token of GH_TOKEN so the PR merges are attributed properly.