### PR TITLE
Add example projects page

### DIFF
--- a/cypress/integration/projects_spec.js
+++ b/cypress/integration/projects_spec.js
@@ -1,0 +1,13 @@
+/// <reference types="cypress" />
+describe('Projects using Cypress page', () => {
+  beforeEach(() => {
+    cy.visit('/')
+    cy.contains('.main-nav-link', 'Examples').click()
+    cy.contains('.sidebar-link', 'Projects').click()
+    cy.contains('.article-title', 'Projects').should('be.visible')
+  })
+
+  it('lists a few projects', () => {
+    cy.get('.projects-list li').should('have.length.gt', 2)
+  })
+})

--- a/source/_data/projects.yml
+++ b/source/_data/projects.yml
@@ -8,7 +8,7 @@
   description: "Generation of diagram and flowchart from text in a similar manner as markdown"
   url: https://github.com/mermaid-js/mermaid
 
-- name: WithSpectrum
+- name: Spectrum
   description: "Simple, powerful online communities at spectrum.chat"
   url: https://github.com/withspectrum/spectrum
 

--- a/source/_data/projects.yml
+++ b/source/_data/projects.yml
@@ -26,8 +26,12 @@
 
 - name: "octokit/rest.js"
   description: GitHub REST API client for JavaScript
-  url: https://github.com/octokit/rest.js/tree/master/test
+  url: https://github.com/octokit/rest.js
 
 - name: "For All Beautiful Earth"
   description: End-to-end browser tests for fab.earth using Cypress.io test runner
   url: https://github.com/forallabeautifulearth/fabe-browser-tests
+
+- name: GraphiQL
+  description: A graphical interactive in-browser GraphQL IDE
+  url: https://github.com/graphql/graphiql/tree/master/packages/graphiql

--- a/source/_data/projects.yml
+++ b/source/_data/projects.yml
@@ -2,7 +2,7 @@
 
 - name: Redash
   description: "Connect and query your data sources, build dashboards to visualize data and share them with your company."
-  url: https://github.com/getredash/redash/tree/master/client
+  url: https://github.com/getredash/redash
 
 - name: Mermaid.js
   description: "Generation of diagram and flowchart from text in a similar manner as markdown"
@@ -14,20 +14,20 @@
 
 - name: Vue Storefront
   description: "PWA for eCommerce that is 100% offline, platform agnostic, and headless"
-  url: https://github.com/DivanteLtd/vue-storefront/tree/master/test/e2e
+  url: https://github.com/DivanteLtd/vue-storefront
 
 - name: Netlify CMS
   description: "A CMS for Static Site Generators at netlifycms.org"
-  url: https://github.com/netlify/netlify-cms/tree/master/cypress
+  url: https://github.com/netlify/netlify-cms
 
 - name: ngx-bootstrap
   description: Fast and reliable Bootstrap widgets in Angular
-  url: https://github.com/valor-software/ngx-bootstrap/tree/development/cypress
+  url: https://github.com/valor-software/ngx-bootstrap
 
 - name: "octokit/rest.js"
   description: GitHub REST API client for JavaScript
   url: https://github.com/octokit/rest.js/tree/master/test
 
-- name: For All Beautiful Earth
+- name: "For All Beautiful Earth"
   description: End-to-end browser tests for fab.earth using Cypress.io test runner
   url: https://github.com/forallabeautifulearth/fabe-browser-tests

--- a/source/_data/projects.yml
+++ b/source/_data/projects.yml
@@ -1,0 +1,33 @@
+# open source projects that use Cypress to write end-to-end tests
+
+- name: Redash
+  description: "Connect and query your data sources, build dashboards to visualize data and share them with your company."
+  url: https://github.com/getredash/redash/tree/master/client
+
+- name: Mermaid.js
+  description: "Generation of diagram and flowchart from text in a similar manner as markdown"
+  url: https://github.com/mermaid-js/mermaid
+
+- name: WithSpectrum
+  description: "Simple, powerful online communities at spectrum.chat"
+  url: https://github.com/withspectrum/spectrum
+
+- name: Vue Storefront
+  description: "PWA for eCommerce that is 100% offline, platform agnostic, and headless"
+  url: https://github.com/DivanteLtd/vue-storefront/tree/master/test/e2e
+
+- name: Netlify CMS
+  description: "A CMS for Static Site Generators at netlifycms.org"
+  url: https://github.com/netlify/netlify-cms/tree/master/cypress
+
+- name: ngx-bootstrap
+  description: Fast and reliable Bootstrap widgets in Angular
+  url: https://github.com/valor-software/ngx-bootstrap/tree/development/cypress
+
+- name: "octokit/rest.js"
+  description: GitHub REST API client for JavaScript
+  url: https://github.com/octokit/rest.js/tree/master/test
+
+- name: For All Beautiful Earth
+  description: End-to-end browser tests for fab.earth using Cypress.io test runner
+  url: https://github.com/forallabeautifulearth/fabe-browser-tests

--- a/source/_data/sidebar.yml
+++ b/source/_data/sidebar.yml
@@ -181,6 +181,7 @@ examples:
     applications: applications.html
     docker: docker.html
     workshop: workshop.html
+    projects-media: projects-media.html
   media:
     courses-media: courses-media.html
     webinars-media: webinars-media.html

--- a/source/examples/examples/projects-media.md
+++ b/source/examples/examples/projects-media.md
@@ -1,0 +1,12 @@
+---
+title: Projects
+containerClass: examples
+layout: media
+dataType: projects
+---
+
+<!--
+  If you're looking to add content to our Projects page,
+  Go to ../source/_data/projects.yml and add your course.
+  See media.swig file that renders projects.yml into HTML markup
+-->

--- a/themes/cypress/languages/en.yml
+++ b/themes/cypress/languages/en.yml
@@ -207,6 +207,7 @@ sidebar:
     podcasts-media: Podcasts
     screencasts-media: Screencasts
     workshop: Workshop
+    projects-media: Projects
   faq:
     questions: FAQ
     general-questions-faq: General Questions

--- a/themes/cypress/languages/ja.yml
+++ b/themes/cypress/languages/ja.yml
@@ -207,6 +207,7 @@ sidebar:
     podcasts-media: ポッドキャスト
     screencasts-media: スクリーンキャスト
     workshop: Workshop
+    projects-media: Projects
   faq:
     questions: FAQ
     general-questions-faq: 一般的な質問

--- a/themes/cypress/languages/pt-br.yml
+++ b/themes/cypress/languages/pt-br.yml
@@ -207,6 +207,7 @@ sidebar:
     podcasts-media: Podcasts
     screencasts-media: Screencasts
     workshop: Workshop
+    projects-media: Projects
   faq:
     questions: FAQ
     general-questions-faq: Perguntas gerais

--- a/themes/cypress/languages/zh-cn.yml
+++ b/themes/cypress/languages/zh-cn.yml
@@ -209,6 +209,7 @@ sidebar:
     podcasts-media: Podcasts
     screencasts-media: Screencasts
     workshop: Workshop
+    projects-media: Projects
   faq:
     questions: FAQ
     general-questions-faq: General Questions

--- a/themes/cypress/layout/media.swig
+++ b/themes/cypress/layout/media.swig
@@ -58,7 +58,7 @@
                       <h3>
                         <a href="{{project.url}}" target="_blank" rel="noopener noreferrer">{{ project.name }}</a>
                       </h3>
-                      <p>{{ course.description }}</p>
+                      <p>{{ project.description }}</p>
                     </li>
                   {% endfor %}
                 </ul>

--- a/themes/cypress/layout/media.swig
+++ b/themes/cypress/layout/media.swig
@@ -53,10 +53,10 @@
               {% if page.dataType === 'projects' %}
                 <p>Open source projects that use Cypress to run their end-to-end tests.</p>
                 <ul class="projects-list">
-                  {% for course in site.data.projects %}
+                  {% for project in site.data.projects %}
                     <li>
                       <h3>
-                        <a href="{{course.url}}" target="_blank" rel="noopener noreferrer">{{ course.name }}</a>
+                        <a href="{{project.url}}" target="_blank" rel="noopener noreferrer">{{ project.name }}</a>
                       </h3>
                       <p>{{ course.description }}</p>
                     </li>

--- a/themes/cypress/layout/media.swig
+++ b/themes/cypress/layout/media.swig
@@ -50,6 +50,20 @@
                 </ul>
               {% endif %}
 
+              {% if page.dataType === 'projects' %}
+                <p>Open source projects that use Cypress to run their end-to-end tests.</p>
+                <ul class="projects-list">
+                  {% for course in site.data.projects %}
+                    <li>
+                      <h3>
+                        <a href="{{course.url}}" target="_blank" rel="noopener noreferrer">{{ course.name }}</a>
+                      </h3>
+                      <p>{{ course.description }}</p>
+                    </li>
+                  {% endfor %}
+                </ul>
+              {% endif %}
+
               {% if site.data[page.dataType].small %}
                 <div class="small-media">
                   <ul>


### PR DESCRIPTION
- closes #2267

Adds one more page with links to open source projects that use Cypress

<img width="1181" alt="Screen Shot 2019-12-02 at 2 33 49 PM" src="https://user-images.githubusercontent.com/2212006/69989092-e68ece00-1510-11ea-81b5-1ce3a423cf59.png">
