### PR TITLE
docs(plugins): add cypress-redux

### DIFF
--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -139,6 +139,11 @@
       link: https://github.com/RcKeller/cypress-unfetch
       keywords: [commands, routing, networking]
 
+    - name: cypress-redux
+      description: Run assertions against Redux stores.
+      link: https://github.com/RcKeller/cypress-redux
+      keywords: [commands, redux]
+
     - name: cypress-axe
       description: Helps test your applications for accessibility issues using axe-core.
       link: https://github.com/avanslaars/cypress-axe


### PR DESCRIPTION
Submitting [cypress-redux]() as a plugin, which allows users to assert against Redux stores w/ custom commands. It's fully tested [here](https://circleci.com/workflow-run/ba27f44c-47f9-4e97-8df7-f76fcb867923). Thanks, and LMK if you have any questions!