### PR TITLE
add network request example and recipe link

### DIFF
--- a/source/guides/guides/network-requests.md
+++ b/source/guides/guides/network-requests.md
@@ -329,8 +329,9 @@ cy.route('POST', '/users').as('new-user')
 // trigger network calls by manipulating web app's user interface, then
 cy.wait('@new-user')
   .should('have.property', 'status', 201)
-// we can grab the XHR object again to run more assertions
-cy.wait('@new-user') // yields XHR object
+// we can grab the completed XHR object again to run more assertions
+// using cy.get(<alias>)
+cy.get('@new-user') // yields the same XHR object
   .its('request.body')
   .should('deep.equal', {
     id: '101',
@@ -338,7 +339,7 @@ cy.wait('@new-user') // yields XHR object
     lastName: 'Black'
   })
 // and we can place multiple assertions in a single "should" callback
-cy.wait('@new-user')
+cy.get('@new-user')
   .should((xhr) => {
     expect(xhr.url).to.match(/\/users$/)
     expect(xhr.method).to.equal('POST')

--- a/source/guides/guides/network-requests.md
+++ b/source/guides/guides/network-requests.md
@@ -294,6 +294,8 @@ In our example above we can assert about the request object to verify that it se
 
 ```javascript
 cy.server()
+// any request to "search/*" endpoint will automatically receive
+// an array with two book objects
 cy.route('search/*', [{ item: 'Book 1' }, { item: 'Book 2' }]).as('getSearch')
 
 cy.get('#autocomplete').type('Book')
@@ -317,6 +319,47 @@ cy.get('#results')
 - Request Headers
 - Response Body
 - Response Headers
+
+**Examples**
+
+```javascript
+cy.server()
+// spy on POST requests to /users endpoint
+cy.route('POST', '/users').as('new-user')
+// trigger network calls by manipulating web app's user interface, then
+cy.wait('@new-user')
+  .should('have.property', 'status', 201)
+// we can grab the XHR object again to run more assertions
+cy.wait('@new-user') // yields XHR object
+  .its('request.body')
+  .should('deep.equal', {
+    id: '101',
+    firstName: 'Joe',
+    lastName: 'Black'
+  })
+// and we can place multiple assertions in a single "should" callback
+cy.wait('@new-user')
+  .should((xhr) => {
+    expect(xhr.url).to.match(/\/users$/)
+    expect(xhr.method).to.equal('POST')
+    // it is a good practice to add assertion messages
+    // as the 2nd argument to expect()
+    expect(xhr.response.headers, 'response headers').to.include({
+      'cache-control': 'no-cache',
+      expires: '-1',
+      'content-type': 'application/json; charset=utf-8',
+      location: '<domain>/users/101'
+    })
+  })
+```
+
+**Tip:** you can inspect the full XHR object by logging it to the console
+
+```javascript
+cy.wait('@new-user').then(console.log)
+```
+
+You can find more examples in our {% url "XHR Assertions" https://github.com/cypress-io/cypress-example-recipes#server-communication %} recipe.
 
 # See also
 


### PR DESCRIPTION
Adds a little bit more to the Network requests guide that is missing assertion examples
