### PR TITLE
Fixed getSessionStorage command example

### DIFF
--- a/source/api/cypress-api/custom-commands.md
+++ b/source/api/cypress-api/custom-commands.md
@@ -126,9 +126,7 @@ cy.downloadFile('https://path_to_file.pdf', 'mydownloads', 'demo.pdf')
 
 ```js
 Cypress.Commands.add('getSessionStorage', (key) => {
-  cy.window().then((window) => {
-    window.sessionStorage.getItem(key)
-  })
+  cy.window().then((window) => window.sessionStorage.getItem(key))
 })
 
 Cypress.Commands.add('setSessionStorage', (key, value) => {


### PR DESCRIPTION
Removed the inner curly braces in the getSessionStorage example in order to make it yield the value from session storage.