### PR TITLE
Update launching-browsers.md

### DIFF
--- a/source/guides/guides/launching-browsers.md
+++ b/source/guides/guides/launching-browsers.md
@@ -206,7 +206,7 @@ Cypress automatically disables certain functionality in the Cypress launched bro
 - Disables prompts requesting permission to use devices like cameras or mics
 - Disables user gesture requirements for autoplaying videos.
 
-You can see all of the default chrome command line switches we send {% url "here" https://github.com/cypress-io/cypress/blob/develop/packages/server/lib/browsers/chrome.js#L24 %}.
+You can see all of the default chrome command line switches we send {% url "here" https://github.com/cypress-io/cypress/blob/develop/packages/server/lib/browsers/chrome.ts#L36 %}.
 
 # Browser Icon
 


### PR DESCRIPTION
Per this PR (https://github.com/cypress-io/cypress/pull/5953), the file `packages/server/lib/browsers/chrome.js` has been renamed to `packages/server/lib/browsers/chrome.ts`. This commit updates that link (also updates the line number to the desired information).

<!--
Thanks for contributing!

Please explain what changes were made
also reference any fixed issues with "close #[ISSUE]"
-->
