### PR TITLE
Update explanation of cross-origin domain docs

### DIFF
--- a/source/guides/guides/web-security.md
+++ b/source/guides/guides/web-security.md
@@ -2,45 +2,62 @@
 title: Web Security
 ---
 
-Browsers adhere to a strict {% url "`same-origin policy`" https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy %}. This means that browsers restrict access between `<iframes>` when their origin policies do not match.
+Browsers adhere to a strict {% url "same-origin policy" https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy %}. This means that browsers restrict access between `<iframes>` when their origin policies do not match.
 
 Because Cypress works from within the browser, Cypress must be able to directly communicate with your remote application at all times. Unfortunately, browsers naturally try to prevent Cypress from doing this.
 
-To get around these restrictions, Cypress implements some strategies involving JavaScript code, the browser's internal APIs, and `network proxying` to *play by the rules* of `same-origin policy`. It is our goal to fully automate the application under test without you needing to modify your application's code - and we are *mostly* able to do this.
+To get around these restrictions, Cypress implements some strategies involving JavaScript code, the browser's internal APIs, and network proxying to *play by the rules* of same-origin policy. It is our goal to fully automate the application under test without you needing to modify your application's code - and we are *mostly* able to do this.
 
 ### Examples of what Cypress does under the hood:
 
 - Injects {% url "`document.domain`" https://developer.mozilla.org/en-US/docs/Web/API/Document/domain %} into `text/html` pages.
 - Proxies all HTTP / HTTPS traffic.
-- Changes the hosted url to match that of the application under test.
+- Changes the hosted URL to match that of the application under test.
 - Uses the browser's internal APIs for network level traffic.
 
 When Cypress first loads, the internal Cypress web application is hosted on a random port: something like `http://localhost:65874/__/`.
 
-After the first {% url `cy.visit()` visit %} command is issued in a test, Cypress changes its URL to match the origin of your remote application, thereby solving the first major hurdle of `same-origin policy`. Your application's code executes the same as it does outside of Cypress, and everything works as expected.
+After the first {% url `cy.visit()` visit %} command is issued in a test, Cypress changes its URL to match the origin of your remote application, thereby solving the first major hurdle of same-origin policy. Your application's code executes the same as it does outside of Cypress, and everything works as expected.
 
 {% note info How is HTTPS supported? %}
-Cypress does some pretty interesting things under the hood to make testing HTTPs sites work. Cypress enables you to control and stub at the network level. Therefore, Cypress must assign and manage browser certificates to be able to modify the traffic in real time. You'll notice Chrome display a warning that the 'SSL certificate does not match'. This is normal and correct. Under the hood we act as our own CA authority and issue certificates dynamically in order to intercept requests otherwise impossible to access. We only do this for the superdomain currently under test, and bypass other traffic. That's why if you open a tab in Cypress to another host, the certificates match as expected.
+Cypress does some pretty interesting things under the hood to make testing HTTPs sites work. Cypress enables you to control and stub at the network level. Therefore, Cypress must assign and manage browser certificates to be able to modify the traffic in real time.
+
+You'll notice Chrome display a warning that the 'SSL certificate does not match'. This is normal and correct. Under the hood we act as our own CA authority and issue certificates dynamically in order to intercept requests otherwise impossible to access. We only do this for the superdomain currently under test, and bypass other traffic. That's why if you open a tab in Cypress to another host, the certificates match as expected.
 {% endnote %}
 
 # Limitations
 
 It's important to note that although we do our **very best** to ensure your application works normally inside of Cypress, there *are* some limitations you need to be aware of.
 
-## One Superdomain per Test
+## Same superdomain per test
 
-Because Cypress changes its own host URL to match that of your applications, it requires that your application remain on the same superdomain for the entirety of a single test.
+Because Cypress changes its own host URL to match that of your applications, it requires that the URLs navigated to have the same superdomain for the entirety of a single test.
 
 If you attempt to visit two different superdomains, Cypress will error. Visiting subdomains works fine. You can visit different superdomains in *different* tests, but not in the *same* test.
 
 ```javascript
-cy.visit('https://www.cypress.io')
-cy.visit('https://docs.cypress.io') // yup all good
+it('navigates', () => {
+  cy.visit('https://www.cypress.io')
+  cy.visit('https://docs.cypress.io') // yup all good
+})
 ```
 
 ```javascript
-cy.visit('https://apple.com')
-cy.visit('https://google.com')      // this will immediately error
+it('navigates', () => {
+  cy.visit('https://apple.com')
+  cy.visit('https://google.com')      // this will error
+})
+```
+
+```javascript
+it('navigates', () => {
+  cy.visit('https://apple.com')
+})
+
+// split visiting different origin in another test
+it('navigates to new origin', () => {
+  cy.visit('https://google.com')      // yup all good
+})
 ```
 
 Although Cypress tries to enforce this limitation, it is possible for your application to bypass Cypress's ability to detect this.
@@ -97,12 +114,12 @@ Cypress will immediately fail with the following test code:
 ```javascript
 // Test code
 cy.visit('https://app.corp.com')
-cy.get('a').click()               // will immediately fail
+cy.get('a').click()               // will fail
 ```
 
 Browsers refuse to display insecure content on a secure page. Because Cypress initially changed its URL to match `https://app.corp.com` when the browser followed the `href` to `http://app.corp.com/page2`, the browser will refuse to display the contents.
 
-Now you may be thinking, *This sounds like a problem with Cypress because when I work with my application outside of Cypress it works just fine.*😒
+Now you may be thinking, *This sounds like a problem with Cypress because when I work with my application outside of Cypress it works just fine.*
 
 However, the truth is, Cypress is exposing a *security vulnerability* in your application, and you *want* it to fail in Cypress.
 
@@ -115,6 +132,10 @@ This security vulnerability exists **even if** your web server forces a `301 red
 Update your HTML or JavaScript code to not navigate to an insecure HTTP page and instead only use HTTPS. Additionally make sure that cookies have their `secure` flag set to `true`.
 
 If you're in a situation where you don't control the code, or otherwise cannot work around this, you can bypass this restriction in Cypress by {% url "disabling web security" web-security#Disabling-Web-Security %}.
+
+## Same port per test
+
+Cypress requires that the URLs navigated to have the same port (if specified) for the entirety of a single test. This matches the behavior of the browser's normal {% url "same-origin policy" https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy %}.
 
 # Common Workarounds
 
@@ -137,12 +158,12 @@ cy.visit('http://localhost:8080') // where your web server + HTML is hosted
 cy.get('a').click()               // browser attempts to load google.com, Cypress errors
 ```
 
-There is essentially never any reason to visit a site that you don't control in your tests. It's prone to error and slow.
+We do not recommend visiting a superdomain that you don't control in your tests which you can read more about {% url "here" best-practices#Visiting-external-sites %}
 
-Instead, all you need to test is that the `href` property is correct!
+Instead, all you can test is that the `href` property is correct!
 
 ```javascript
-// this is much easier to do and will run considerably faster
+// this test verifies the behavior and will run considerably faster
 cy.visit('http://localhost:8080')
 cy.get('a').should('have.attr', 'href', 'https://google.com') // no page load!
 ```
@@ -160,11 +181,11 @@ cy.get('a').then(($a) => {
 })
 ```
 
-Still not satisfied? Do you really want to click through to another application? Okay then read about {% url "disabling web security" web-security#Disabling-Web-Security %}.
+If you still require visiting a different origin URL then read about {% url "disabling web security" web-security#Disabling-Web-Security %}.
 
 ## Form Submission Redirects
 
-When you submit a regular HTML form, the browser will follow this `HTTP(s) request`.
+When you submit a regular HTML form, the browser will follow the HTTP(s) request.
 
 ```html
 <!-- Application code that is served at `localhost:8080`-->
@@ -181,7 +202,7 @@ cy.visit('http://localhost:8080')
 cy.get('form').submit()           // submit the form!
 ```
 
-If your back end server handling the `/submit` route does a `30x` redirect to a different superdomain, you will get a `cross origin` error.
+If your back end server handling the `/submit` route does a `30x` redirect to a different superdomain, you will get a cross-origin error.
 
 ```javascript
 // imagine this is some node / express code
@@ -195,9 +216,9 @@ app.post('/submit', (req, res) => {
 
 A common use case for this is Single sign-on (SSO). In that situation you may `POST` to a different server and are redirected elsewhere (typically with the session token in the URL).
 
-If that's the case, don't worry - you can work around it with {% url `cy.request()` request %}. {% url `cy.request()` request %} is special because it is **NOT bound to CORS or same-origin policy**.
+If that's the case, you can still test this behavior with {% url `cy.request()` request %}. {% url `cy.request()` request %} is **NOT bound to CORS or same-origin policy**.
 
-In fact we can likely bypass the initial visit altogether and `POST` directly to your `SSO` server.
+In fact we can likely bypass the initial visit altogether and `POST` directly to your SSO server.
 
 ```javascript
 cy.request('POST', 'https://sso.corp.com/auth', { username: 'foo', password: 'bar' })
@@ -219,25 +240,25 @@ cy.request('POST', 'https://sso.corp.com/auth', { username: 'foo', password: 'ba
   })
 ```
 
-Not working for you? Don't know how to set your token? If you still need to be able to be redirected to your SSO server, you can read about {% url "disabling web security" web-security#Disabling-Web-Security %}.
+If you still want to be able to be redirected to your SSO server, you can read about {% url "disabling web security" web-security#Disabling-Web-Security %}.
 
 ## JavaScript Redirects
 
-When we say *JavaScript Redirects* we are talking about any kind of code that does something like this:
+When we say JavaScript Redirects we are talking about any kind of code that does something like this:
 
 ```javascript
 window.location.href = 'http://some.superdomain.com'
 ```
 
-This is probably the hardest situation to test because it's usually happening due to another cause. You will need to figure out why your JavaScript code is redirecting. Perhaps you're not logged in, and you need to handle that setup elsewhere? Perhaps you're using a Single sign-on (SSO) server and you need to read the previous section about working around that?
+This is probably the hardest situation to test because it's usually happening due to another cause. You will need to figure out why your JavaScript code is redirecting. Perhaps you're not logged in, and you need to handle that setup elsewhere. Perhaps you're using a Single sign-on (SSO) server and you can read the previous section about working around that.
 
-If you can't figure out why your JavaScript code is redirecting you to a different superdomain, then you might want to read about {% url "disabling web security" web-security#Disabling-Web-Security %}.
+If you want to continue using the code to navigate to a different superdomain, then you might want to read about {% url "disabling web security" web-security#Disabling-Web-Security %}.
 
 # Disabling Web Security
 
 So if you cannot work around any of the issues using the suggested workarounds above, you may want to disable web security.
 
-One last thing to consider here is that every once in a while we discover bugs in Cypress that lead to `cross origin` errors that can otherwise be fixed. If you think you're experiencing a bug, {% url "come into our chat" https://gitter.im/cypress-io/cypress %} or {% open_an_issue 'open an issue' %}.
+One last thing to consider here is that every once in a while we discover bugs in Cypress that lead to cross-origin errors that can otherwise be fixed. If you think you're experiencing a bug, {% open_an_issue 'open an issue' %}.
 
 To start, you will need to understand that *not all browsers expose a way to turn off web security*. Some do, some don't. If you rely on disabling web security, you will not be able to run tests on browsers that do not support this feature.
 
@@ -245,7 +266,7 @@ To start, you will need to understand that *not all browsers expose a way to tur
 
 - Display insecure content
 - Navigate to any superdomain without cross-origin errors
-- Access cross-origin iframes that are embedded in your application.
+- Access cross-origin iframes that are embedded in your application
 
 One thing you may notice though is that Cypress still enforces visiting a single superdomain with {% url `cy.visit()` visit %}, but there is an {% issue 944 'issue open' %} to change this restriction.
 

--- a/source/guides/references/configuration.md
+++ b/source/guides/references/configuration.md
@@ -76,7 +76,7 @@ Option | Default | Description
 
 Option | Default | Description
 ----- | ---- | ----
-`chromeWebSecurity`    | `true`    | Whether Chrome Web Security for `same-origin policy` and `insecure mixed content` is enabled. {% url 'Read more about this here' web-security %}
+`chromeWebSecurity`    | `true`    | Whether Chrome Web Security for same-origin policy and insecure mixed content is enabled. {% url 'Read more about this here' web-security %}
 `userAgent` | `null` | Enables you to override the default user agent the browser sends in all request headers. User agent values are typically used by servers to help identify the operating system, browser, and browser version. See {% url "User-Agent MDN Documentation" https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent %} for example user agent values.
 `blacklistHosts` | `null` | A String or Array of hosts that you wish to block traffic for. {% urlHash 'Please read the notes for examples on using this.' blacklistHosts %}
 `modifyObstructiveCode` | `true` | Whether Cypress will search for and replace obstructive JS code in `.js` or `.html` files. {% urlHash 'Please read the notes for more information on this setting.' modifyObstructiveCode %}

--- a/source/guides/references/error-messages.md
+++ b/source/guides/references/error-messages.md
@@ -309,7 +309,11 @@ See our {% url "Web Security" web-security#Limitations %} documentation.
 
 ## {% fa fa-exclamation-triangle red %} `cy.visit()` failed because you are attempting to visit a different origin domain
 
-See our {% url "Web Security" web-security#Limitations %} documentation.
+Two URLs have the same origin if the `protocol`, `port` (if specified), and `host` are the same for both. You can only visit domains that are of the same-origin within a single test. You can read more about same-origin policy in general {% url "here" https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy %}.
+
+You can visit urls that are of different origin across different tests, so you may consider splitting your `cy.visit()` of different origin domains into separate tests.
+
+See our {% url "Web Security" web-security#Limitations %} documentation for more information and workarounds.
 
 ## {% fa fa-exclamation-triangle red %} `Cypress.addParentCommand()` / `Cypress.addDualCommand()` / `Cypress.addChildCommand()` has been removed and replaced by `Cypress.Commands.add()`
 

--- a/source/guides/references/error-messages.md
+++ b/source/guides/references/error-messages.md
@@ -307,6 +307,10 @@ it('does not forget to return a promise', function () {
 
 See our {% url "Web Security" web-security#Limitations %} documentation.
 
+## {% fa fa-exclamation-triangle red %} `cy.visit()` failed because you are attempting to visit a different origin domain
+
+See our {% url "Web Security" web-security#Limitations %} documentation.
+
 ## {% fa fa-exclamation-triangle red %} `Cypress.addParentCommand()` / `Cypress.addDualCommand()` / `Cypress.addChildCommand()` has been removed and replaced by `Cypress.Commands.add()`
 
 In version {% url "`0.20.0`" changelog %}, we removed the commands for adding custom commands and replaced them with, what we believe to be, a simpler interface.

--- a/source/guides/references/trade-offs.md
+++ b/source/guides/references/trade-offs.md
@@ -198,21 +198,25 @@ This avoids ever needing a second open browser, but still gives you an end-to-en
 
 ## Same-origin
 
-Each test is limited to only visiting a single superdomain.
+Each test is limited to only visiting a domains that are determined to be of the same-origin.
 
-What is a superdomain? Given the urls below, all have the same superdomain of `cypress.io`.
+What is same-origin? Two URLs have the same origin if the protocol, port (if specified), and host are the same for both. You can read more about same-origin in general {% url "here" https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy %}.
 
-- `http://cypress.io`
-- `https://cypress.io`
+Given the URLs below, all have the same-origin compared to `https://cypress.io`.
+
 - `https://www.cypress.io`
 - `https://docs.cypress.io`
 - `https://example.cypress.io/commands/querying`
 
+The URLs below, however, all have the different origins compared to `https://cypress.io`.
+
+- `http://cypress.io` (Different protocol)
+- `https://www.cypress.io:81` (Different port)
+
 The rules are:
 
-- {% fa fa-warning red %} You **cannot** {% url "visit" visit %} two different superdomains in the same test.
-- {% fa fa-check-circle green %} You **can** {% url "visit" visit %} different subdomains in the same test.
-- {% fa fa-check-circle green %} You **can** {% url "visit" visit %} different superdomains in **different** tests.
+- {% fa fa-warning red %} You **cannot** {% url "visit" visit %} two domains of different origin in the same test.
+- {% fa fa-check-circle green %} You **can** {% url "visit" visit %} two or more domains if different origin in **different** tests.
 
 ```javascript
 cy.visit('https://www.cypress.io')

--- a/source/guides/references/trade-offs.md
+++ b/source/guides/references/trade-offs.md
@@ -200,39 +200,57 @@ This avoids ever needing a second open browser, but still gives you an end-to-en
 
 Each test is limited to only visiting a domains that are determined to be of the same-origin.
 
-What is same-origin? Two URLs have the same origin if the protocol, port (if specified), and host are the same for both. You can read more about same-origin in general {% url "here" https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy %}.
+What is same-origin? Two URLs have the same origin if the protocol, port (if specified), and host are the same for both. Cypress automatically handles hosts of the same superdomain by injecting {% url "`document.domain`" https://developer.mozilla.org/en-US/docs/Web/API/Document/domain %} into `text/html` pages, so a host of the same superdomain is considered fine.
 
-Given the URLs below, all have the same-origin compared to `https://cypress.io`.
+Given the URLs below, all have the same-origin compared to `https://www.cypress.io`.
 
-- `https://www.cypress.io`
+- `https://cypress.io`
 - `https://docs.cypress.io`
 - `https://example.cypress.io/commands/querying`
 
-The URLs below, however, all have the different origins compared to `https://cypress.io`.
+The URLs below, however, will have different origins compared to `https://www.cypress.io`.
 
-- `http://cypress.io` (Different protocol)
-- `https://www.cypress.io:81` (Different port)
+- `http://www.cypress.io` (Different protocol)
+- `https://docs.cypress.io:81` (Different port)
+- `https://www.auth0.com/` (Different host of different superdomain)
 
 The rules are:
 
 - {% fa fa-warning red %} You **cannot** {% url "visit" visit %} two domains of different origin in the same test.
-- {% fa fa-check-circle green %} You **can** {% url "visit" visit %} two or more domains if different origin in **different** tests.
+- {% fa fa-check-circle green %} You **can** {% url "visit" visit %} two or more domains of different origin in **different** tests.
 
 ```javascript
-cy.visit('https://www.cypress.io')
-cy.visit('https://docs.cypress.io') // yup all good
+it('navigates', () => {
+  cy.visit('https://www.cypress.io')
+  cy.visit('https://docs.cypress.io') // yup all good
+})
 ```
 
 ```javascript
-cy.visit('https://apple.com')
-cy.visit('https://google.com')      // this will immediately error
+it('navigates', () => {
+  cy.visit('https://apple.com')
+  cy.visit('https://google.com')      // this will error
+})
+```
+
+```javascript
+it('navigates', () => {
+  cy.visit('https://apple.com')
+})
+
+// split visiting different origin in another test
+it('navigates to new origin', () => {
+  cy.visit('https://google.com')      // yup all good
+})
 ```
 
 This limitation exists because Cypress switches to the domain under each specific test when it runs.
 
-The good news here is that it is extremely rare to need to visit two different superdomains in a single test. Why? Because the browser has a natural security barrier called `origin policy` that means that state like `localStorage`, `cookies`, `service workers` and many other APIs are not shared between them.
+### Other workarounds
 
-Therefore what you do on one site could not possibly affect another.
+There are other ways of testing the interaction between 2 superdomains. Because the browser has a natural security barrier called `origin policy` this means that state like `localStorage`, `cookies`, `service workers` and many other APIs are not shared between them anyways.
+
+So what you do on one site does not directly affect another.
 
 As a best practice, you should not visit or interact with a 3rd party service not under your control. However, there are exceptions! If your organization uses Single Sign On (SSO) or OAuth then you might involve a 3rd party service other than your superdomain.
 


### PR DESCRIPTION
- close #2364 

This was written to clear up confusion in this issue over visiting HTTP url after visiting an HTTPS url. https://github.com/cypress-io/cypress/issues/6048 and to supplement this PR in the Test Runner.  https://github.com/cypress-io/cypress/pull/6118