### PR TITLE
Fix a typo of "crucial"

### DIFF
--- a/source/guides/tooling/code-coverage.md
+++ b/source/guides/tooling/code-coverage.md
@@ -108,7 +108,7 @@ If you are unfamiliar with code coverage or want to learn more, take a look at t
 
 This guide explains how to instrument the application source code using common tools. Then we show how to save the coverage information and generate reports using the {% url "`@cypress/code-coverage`" https://github.com/cypress-io/code-coverage %} Cypress plugin. After reading this guide you should be able to better target your tests using the code coverage information.
 
-This guide explains how to find what parts of your application code are covered by Cypress tests so you can have 100% confidence that your tests aren't missing cruicial parts of your application. The collected information can be sent to external services, automatically run during pull request reviews, and integrated into CI.
+This guide explains how to find what parts of your application code are covered by Cypress tests so you can have 100% confidence that your tests aren't missing crucial parts of your application. The collected information can be sent to external services, automatically run during pull request reviews, and integrated into CI.
 
 {% note info %}
 The full source code for this guide can be found in the {% url 'cypress-io/cypress-example-todomvc-redux' https://github.com/cypress-io/cypress-example-todomvc-redux %} repository.


### PR DESCRIPTION
<!--
Thanks for contributing!

Please explain what changes were made
also reference any fixed issues with "close #[ISSUE]"
-->

Hi.
I've found a spelling that might be a typo of `crucial`.
