### PR TITLE
details.name include file extension '.png'

### DIFF
--- a/source/api/plugins/after-screenshot-api.md
+++ b/source/api/plugins/after-screenshot-api.md
@@ -25,7 +25,7 @@ module.exports = (on, config) => {
     //   dimensions: { width: 1000, height: 660 }
     //   multipart: false
     //   pixelRatio: 1
-    //   name: 'my-screenshot'
+    //   name: 'my-screenshot.png'
     //   specName: 'integration/my-spec.js'
     //   testFailure: true
     //   path: '/path/to/my-screenshot.png'


### PR DESCRIPTION
Very minor, but hope makes it clear since .png added in path: but not in name:

Basically I tried to append 'takenAt' time stamp to the file to make it distinct.

Error: ENOENT: no such file or directory, rename 'C:\Users\<user>\Repo\<project>\ui\cypress\screenshots\01.feature\my-screenshot (3).png' -> 'C:\Users\<user>\Repo\<project>\ui\cypress\screenshots\01.feature\my-screenshot (3)**.png_**2020-01-10T16:55:19.809Z'
