### PR TITLE
update ci deps based off of docker image

### DIFF
--- a/source/guides/guides/continuous-integration.md
+++ b/source/guides/guides/continuous-integration.md
@@ -538,7 +538,7 @@ See our {% url 'examples' docker %} for additional information on our maintained
 If you are not using one of the above CI providers then make sure your system has these dependencies installed.
 
 ```shell
-apt-get install xvfb libgtk-3-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2
+apt-get install libgtk2.0-0 libgtk-3-0 libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
 ```
 
 ## Caching


### PR DESCRIPTION
I was updating the dependency list from this docker image: https://github.com/cypress-io/cypress-docker-images/blob/master/base/12.13.0/Dockerfile#L3 (mentioned from this issue https://github.com/cypress-io/cypress/issues/5965)

Is this correct? I would prefer a better source of truth for this because I feel like this will get out of date quickly and be forgotten. 

