### PR TITLE
Documented that cy.invoke will wait for promises

### DIFF
--- a/lib/tags/assertions.js
+++ b/lib/tags/assertions.js
@@ -44,6 +44,7 @@ module.exports = function yields (hexo, args) {
   const invoke = () => {
     return render(`<ul>
       <li><p>${cmd} will wait for the <code>function</code> to exist on the subject before running.</p></li>
+      <li><p>${cmd} will wait for the promise to resolve if the invoked <code>function</code> returns a promise.</p></li>
       <li><p>${retryAssertions}.</p></li>
     </ul>`)
   }

--- a/lib/tags/timeouts.js
+++ b/lib/tags/timeouts.js
@@ -18,6 +18,7 @@ module.exports = function yields (hexo, args) {
   const cmd = `<code>${args[1]}()</code>`
 
   const assertion = `${cmd} can time out waiting for assertions you've added to pass`
+  const promise = `${cmd} can time out waiting for a promise you've returned to resolve`
 
   const render = (str) => {
     return rawRender.call(this, hexo, str)
@@ -99,7 +100,7 @@ module.exports = function yields (hexo, args) {
 
   const promises = () => {
     return `<ul>
-      <li><p>${cmd} can time out waiting for a promise you've returned to resolve.</p></li>
+      <li><p>${promise}.</p></li>
     </ul>`
   }
 
@@ -107,6 +108,14 @@ module.exports = function yields (hexo, args) {
     return render(`<ul>
     <li><p>${cmd} will continue to ${urls.retry} its specified assertions until it times out.</p></li>
     </ul>`)
+  }
+  
+  const invoke = () => {
+    return render(`<ul>
+      <li><p>${assertion}.</p></li>
+      <li><p>${promise}.</p></li>
+    </ul>`
+    )
   }
 
   switch (type) {
@@ -136,6 +145,8 @@ module.exports = function yields (hexo, args) {
       return promises()
     case 'timeouts':
       return timeouts()
+    case 'invoke':
+      return invoke()
     default:
       // error when an invalid usage option was provided
       throw new Error(`{% timeouts %} tag helper was provided an invalid option: ${type}`)

--- a/source/api/commands/invoke.md
+++ b/source/api/commands/invoke.md
@@ -153,7 +153,7 @@ function disableElementAsync (element) {
   })
 }
 
-cy.get('[data-cy=my-text-input]').then(textElements => {
+cy.get('[data-cy=my-text-input]').then((textElements) => {
   cy.wrap({ disableElementAsync }).invoke('disableElementAsync', textElements[0])
 })
 

--- a/source/api/commands/invoke.md
+++ b/source/api/commands/invoke.md
@@ -154,7 +154,8 @@ function disableElementAsync (element) {
 }
 
 cy.get('[data-cy=my-text-input]').then((textElements) => {
-  cy.wrap({ disableElementAsync }).invoke('disableElementAsync', textElements[0])
+  cy.wrap({ disableElementAsync })
+    .invoke('disableElementAsync', textElements[0])
 })
 
 // log message appears after 3 seconds

--- a/source/api/commands/invoke.md
+++ b/source/api/commands/invoke.md
@@ -2,7 +2,7 @@
 title: invoke
 ---
 
-Invoke a function on the previously yielded subject. If the invoked function returns a promise, it will automatically wait for it until it resolves.
+Invoke a function on the previously yielded subject.
 
 {% note info %}
 If you want to get a property that is not a function on the previously yielded subject, use {% url `.its()` its %}.
@@ -233,7 +233,7 @@ cy
 
 ## Timeouts {% helper_icon timeout %}
 
-{% timeouts assertions .invoke %}
+{% timeouts invoke .invoke %}
 
 # Command Log
 

--- a/source/api/commands/invoke.md
+++ b/source/api/commands/invoke.md
@@ -2,7 +2,7 @@
 title: invoke
 ---
 
-Invoke a function on the previously yielded subject.
+Invoke a function on the previously yielded subject. If the invoked function returns a promise, it will automatically wait for it until it resolves.
 
 {% note info %}
 If you want to get a property that is not a function on the previously yielded subject, use {% url `.its()` its %}.
@@ -130,6 +130,22 @@ const double = (n) => n * n
 
 // picks function with index 1 and calls it with argument 4
 cy.wrap([reverse, double]).invoke(1, 4).should('eq', 16)
+```
+
+## Invoking an async function
+
+In this example we invoke a Vuex action that returns a Promise. `cy.invoke` will wait until the Promise resolves after the specified delay which we pass as an argument and only then will continue executing. 
+
+```javascript
+getVuex().invoke('dispatch', 'addTodoAfterDelay', {
+  milliseconds: 2000,
+  title: 'async task'
+})
+// log message appears after 2 seconds
+cy.log('after invoke')
+
+// assert UI
+getTodoItems().should('have.length', 1).first().contains('async task')
 ```
 
 # Notes

--- a/source/api/commands/invoke.md
+++ b/source/api/commands/invoke.md
@@ -161,6 +161,7 @@ const store = new Vuex.Store({
             completed: false,
             id: randomId(),
           }
+          
           commit('ADD_TODO', todo)
           resolve()
         }, milliseconds)
@@ -168,7 +169,6 @@ const store = new Vuex.Store({
     },
   },
 })
-
 ```
 
 The Cypress Test with `cy.inkoke()` awaiting the promise:
@@ -178,7 +178,7 @@ The Cypress Test with `cy.inkoke()` awaiting the promise:
 // if (isCypress) {
 //    window.store = store
 // }
-const getVuex = () => cy.window({log: false}).its('store')
+const getVuex = () => cy.window({ log: false }).its('store')
 
 getVuex().invoke('dispatch', 'addTodoAfterDelay', {
   milliseconds: 2000,

--- a/source/api/commands/invoke.md
+++ b/source/api/commands/invoke.md
@@ -134,7 +134,7 @@ cy.wrap([reverse, double]).invoke(1, 4).should('eq', 16)
 
 ## Invoking an async function
 
-In this example we invoke a Vuex action that returns a Promise. `cy.invoke` will wait until the Promise resolves after the specified delay which we pass as an argument and only then will continue executing. 
+In this example we invoke a Vuex action that returns a Promise. `.invoke()` will wait until the Promise resolves after the specified delay which we pass as an argument and only then will continue executing. 
 
 A minimal Vuex store:
 ```javascript

--- a/source/api/commands/invoke.md
+++ b/source/api/commands/invoke.md
@@ -161,7 +161,7 @@ const store = new Vuex.Store({
             completed: false,
             id: randomId(),
           }
-          
+
           commit('ADD_TODO', todo)
           resolve()
         }, milliseconds)

--- a/source/api/commands/invoke.md
+++ b/source/api/commands/invoke.md
@@ -134,66 +134,38 @@ cy.wrap([reverse, double]).invoke(1, 4).should('eq', 16)
 
 ## Invoking an async function
 
-In this example we invoke a Vuex action that returns a Promise. `.invoke()` will wait until the Promise resolves after the specified delay which we pass as an argument and only then will continue executing. 
+In this example we have a little text input field and we invoke an async action which will disable this input field.
+`.invoke()` will then wait until the Promise resolves and only then will continue executing to check if it really has been disabled.
 
-A minimal Vuex store:
-```javascript
-function randomId () {
-  return Math.random().toString().substr(2, 10)
-}
-
-const store = new Vuex.Store({
-  state: {
-    todos: []
-  },
-  mutations: {
-    ADD_TODO (state, todoObject) {
-      state.todos.push(todoObject)
-    }
-  },
-  actions: {
-    // example promise-returning action
-    addTodoAfterDelay ({ commit }, { milliseconds, title }) {
-      return new Promise((resolve) => {
-        setTimeout(() => {
-          const todo = {
-            title,
-            completed: false,
-            id: randomId(),
-          }
-
-          commit('ADD_TODO', todo)
-          resolve()
-        }, milliseconds)
-      })
-    },
-  },
-})
+Our input field
+```html
+<input type="text" name="text" data-cy="my-text-input">
 ```
 
 The Cypress Test with `cy.inkoke()` awaiting the promise:
 ```javascript
-// For this command to work you have to expose your vuex store under window.store for cypress to be able to access it
-// e.g. like this
-// if (isCypress) {
-//    window.store = store
-// }
-const getVuex = () => cy.window({ log: false }).its('store')
+function disableElementAsync (element) {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      element.disabled = true
+      resolve()
+    }, 3000)
+  })
+}
 
-getVuex().invoke('dispatch', 'addTodoAfterDelay', {
-  milliseconds: 2000,
-  title: 'async task'
+cy.get('[data-cy=my-text-input]').then(textElements => {
+  cy.wrap({ disableElementAsync }).invoke('disableElementAsync', textElements[0])
 })
 
-// log message appears after 2 seconds
+// log message appears after 3 seconds
 cy.log('after invoke')
 
 // assert UI
-getTodoItems().should('have.length', 1).first().contains('async task')
+cy.get('[data-cy=my-text-input]').should('be.disabled')
 ```
 
 {% note info %}
-This example comes from the recipe {% url "Vue + Vuex + REST" https://github.com/cypress-io/cypress-example-recipes %}
+For a full example where invoke is used to await async Vuex store actions, visit the recipe: {% url "Vue + Vuex + REST" https://github.com/cypress-io/cypress-example-recipes %}
 {% endnote %}
 
 # Notes

--- a/source/api/commands/invoke.md
+++ b/source/api/commands/invoke.md
@@ -141,12 +141,19 @@ getVuex().invoke('dispatch', 'addTodoAfterDelay', {
   milliseconds: 2000,
   title: 'async task'
 })
+
 // log message appears after 2 seconds
 cy.log('after invoke')
 
 // assert UI
 getTodoItems().should('have.length', 1).first().contains('async task')
 ```
+
+`getVuex()` in this example is a function that returns the Vuex data store wrapped inside Cypress object to allow E2E tests to access the application state. For that the application saved itself as "window.app".
+
+{% note info %}
+This example comes from the recipe {% url "Vue + Vuex + REST" https://github.com/cypress-io/cypress-example-recipes %}
+{% endnote %}
 
 # Notes
 


### PR DESCRIPTION
<!--
Thanks for contributing!

Please explain what changes were made
also reference any fixed issues with "close #[ISSUE]"
-->
# Documented that cy.invoke will wait for promises
As mentioned in this issue https://github.com/cypress-io/cypress-documentation/issues/495 the `cy.invoke` function will await if the invoked function returns a promise but it is not yet documented. 
This PR expands the documentation to reflect exactly this behaviour

**Issue: https://github.com/cypress-io/cypress-documentation/issues/495**
**First seen in: https://github.com/cypress-io/cypress-example-recipes/issues/133**