### PR TITLE
remove mention of cy.request() from cy.server()

### DIFF
--- a/source/api/commands/server.md
+++ b/source/api/commands/server.md
@@ -2,7 +2,7 @@
 title: server
 ---
 
-Start a server to begin routing responses to {% url `cy.route()` route %} and {% url `cy.request()` request %}.
+Start a server to begin routing responses to {% url "`cy.route()`" route %} and to change the behavior of network requests.
 
 {% note info %}
 **Note:** `cy.server()` assumes you are already familiar with core concepts such as {% url 'network requests' network-requests %}.
@@ -267,7 +267,5 @@ You can {% url 'read more about XHR strategy here' network-requests %}.
 # See also
 
 - {% url 'Network Requests' network-requests %}
-- {% url `cy.request()` request %}
 - {% url `cy.route()` route %}
-- {% url `cy.visit()` visit %}
 - {% url `cy.wait()` wait %}


### PR DESCRIPTION
Addressing this fundamental flaw in our `cy.server()` doc - that it does not affect `cy.request()`. https://github.com/cypress-io/cypress/issues/6244#issuecomment-580375345