### PR TITLE
Adding cypress-iframe to custom command plugins

### DIFF
--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -254,6 +254,11 @@
       link: https://github.com/javierbrea/cypress-localstorage-commands
       keywords: [commands, localstorage, persistence]
 
+    - name: cypress-iframe
+      description: Custom commands for interacting with iframes
+      link:https://gitlab.com/kgroat/cypress-iframe
+      keywords: [commands, iframe]
+
 - name: Extending other testing frameworks
   plugins:
     - name: cyphell

--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -256,7 +256,7 @@
 
     - name: cypress-iframe
       description: Custom commands for interacting with iframes
-      link:https://gitlab.com/kgroat/cypress-iframe
+      link: https://gitlab.com/kgroat/cypress-iframe
       keywords: [commands, iframe]
 
 - name: Extending other testing frameworks


### PR DESCRIPTION
<!--
Thanks for contributing!

Please explain what changes were made
also reference any fixed issues with "close #[ISSUE]"
-->
This PR adds `cypress-iframe` to the list of custom command plugins.  This plugin allows users to interact with iframes, as well as with the elements inside of them.

This plugin was inspired by this issue in the `cypress` repository:
https://github.com/cypress-io/cypress/issues/136