### PR TITLE
Update plugins.yml to include cypress-lighthouse

### DIFF
--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -139,6 +139,10 @@
 
 - name: Custom Commands
   plugins:
+    - name: cypress-lighthouse
+      description: Run a lighthouse audit and assert scores from within Cypress.
+      link: https://github.com/gkemp94/cypress-lighthouse
+      keywords: [commands, lighthouse]
     - name: cy-view
       description: Run tests on multiple URLs at various viewport sizes.
       link: https://github.com/andrewmcoupe/cy-view


### PR DESCRIPTION
Hi all, just published a cypress plugin that allows you to run lighthouse audits from within cypress and assert based on the returned scores. Adding to the plugins.yml

<!--
Thanks for contributing!

Please explain what changes were made
also reference any fixed issues with "close #[ISSUE]"
-->
