### PR TITLE
Update environment-variables.md CYPRESS_baseUrl

### DIFF
--- a/source/guides/guides/environment-variables.md
+++ b/source/guides/guides/environment-variables.md
@@ -32,7 +32,7 @@ However, you **do not** need to use environment variables to point to the origin
 `baseUrl` can be set in your configuration file (`cypress.json` by default) - and then you can use an environment variable to override it.
 
 ```shell
-CYPRESS_baseUrl=https://staging.app.com cypress run
+CYPRESS_BASE_URL=https://staging.app.com cypress run
 ```
 
 {% endnote %}


### PR DESCRIPTION
The current doc has two different naming conventions for setting the baseUrl via the environment

1) CYPRESS_baseUrl 
2) CYPRESS_BASE_URL

Both the values are able to overwrite the baseUrl configuration value.

Since it's an environment variable the convention should be to use CYPRESS_BASE_URL and not CYPRESS_baseUrl.

<!--
Thanks for contributing!

Please explain what changes were made
also reference any fixed issues with "close #[ISSUE]"
-->
