### PR TITLE
Add link to "Translating" section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,7 @@ Thanks for taking the time to contribute! :smile:
   - [Adding Plugins](#adding-plugins)
   - [Adding Pages](#adding-pages)
   - [Writing the Changelog](#writing-the-changelog)
+  - [Translating](#translating)
 - [Committing Code](#committing-code)
   - [Linting](#linting)
   - [Pull Requests](#pull-requests)


### PR DESCRIPTION
I think it's good to have a fast way to access this section

<!--
Thanks for contributing!

Please explain what changes were made
also reference any fixed issues with "close #[ISSUE]"
-->
