### PR TITLE
Compare paths for urls in i18n tests

### DIFF
--- a/cypress/integration/i18n_spec.js
+++ b/cypress/integration/i18n_spec.js
@@ -11,14 +11,14 @@ describe('i18n', () => {
     it('provides an alternate link for available English languages', function () {
       cy.wrap(this.langValues).each((lang) => {
         cy.get(`link[hreflang="${lang}"]`).should(($linkTag) => {
-          let expectedHref = `https://docs.cypress.io/${lang}/guides/overview/why-cypress.html`
+          let expectedPath = `${lang}/guides/overview/why-cypress.html`
 
           if (lang === 'en') {
-            expectedHref = 'https://docs.cypress.io/guides/overview/why-cypress.html'
+            expectedPath = 'guides/overview/why-cypress.html'
           }
 
           expect($linkTag[0].rel).to.eq('alternate')
-          expect($linkTag[0].href).to.eq(expectedHref)
+          expect($linkTag[0].href).to.include(expectedPath)
         })
       })
     })


### PR DESCRIPTION
- Previously this was comparing the entire url - which would fail when these tests were run in staging because it would compare `docs-staging.io` to `docs.io`. Should only compare paths. 
- Close #2634 