### PR TITLE
adds link to workaround for hover command entry

### DIFF
--- a/source/api/commands/hover.md
+++ b/source/api/commands/hover.md
@@ -26,6 +26,8 @@ If the hover behavior depends on a JavaScript event like `mouseover`, you can tr
 Using `.trigger()` will only affect events in JavaScript and will not trigger any effects in CSS. 
 {% endnote %}
 
+As a workaround, check out the {$ url 'recipe leveraging Chrome remote debugging' recipes#Fundamentals} to set pseudo classes like `hover`.
+
 ### Simulating `mouseover` event to get popover to display
 
 ```javascript

--- a/source/api/commands/hover.md
+++ b/source/api/commands/hover.md
@@ -26,7 +26,7 @@ If the hover behavior depends on a JavaScript event like `mouseover`, you can tr
 Using `.trigger()` will only affect events in JavaScript and will not trigger any effects in CSS. 
 {% endnote %}
 
-As a workaround, check out the {$ url 'recipe leveraging Chrome remote debugging' recipes#Fundamentals} to set pseudo classes like `hover`.
+As a workaround, check out the {% url 'recipe leveraging Chrome remote debugging' recipes#Fundamentals %} to set pseudo classes like `hover`.
 
 ### Simulating `mouseover` event to get popover to display
 


### PR DESCRIPTION
links to Chrome remote debugging recipe which is being added in #2642 

https://github.com/cypress-io/cypress-documentation/pull/2645 must merge first for link to make sense. It's not broken, but the recipe referenced isn't there yet :)
<!--
Thanks for contributing!

Please explain what changes were made
also reference any fixed issues with "close #[ISSUE]"
-->
Closes #2617 