### PR TITLE
Document `sameSite` support for cookies commands

### DIFF
--- a/source/api/commands/getcookie.md
+++ b/source/api/commands/getcookie.md
@@ -45,6 +45,7 @@ Option | Default | Description
 - `httpOnly`
 - `secure`
 - `expiry`
+- `sameSite` (will only be returned if `experimentalGetCookiesSameSite` config value is `true`)
 
 ### When a cookie matching the name could not be found:
 

--- a/source/api/commands/getcookie.md
+++ b/source/api/commands/getcookie.md
@@ -139,6 +139,10 @@ When clicking on `getCookie` within the command log, the console outputs the fol
 
 {% imgTag /img/api/getcookie/inspect-cookie-object-properties-in-console.png "Console Log getcookie" %}
 
+{% history %}
+{% url "4.3.0" changelog#4-3-0 %} | Added `sameSite` property when the {% url "`experimentalGetCookiesSameSite`" configuration#Experimental-features %} configuration value is `true`.
+{% endhistory %}
+
 # See also
 
 - {% url `cy.clearCookie()` clearcookie %}

--- a/source/api/commands/getcookie.md
+++ b/source/api/commands/getcookie.md
@@ -45,7 +45,7 @@ Option | Default | Description
 - `httpOnly`
 - `secure`
 - `expiry`
-- `sameSite` (will only be returned if `experimentalGetCookiesSameSite` config value is `true`)
+- `sameSite` *(will only be returned if the {% url "`experimentalGetCookiesSameSite`" configuration#Experimental-features %} configuration value is `true`)*
 
 ### When a cookie matching the name could not be found:
 

--- a/source/api/commands/getcookies.md
+++ b/source/api/commands/getcookies.md
@@ -97,6 +97,10 @@ When clicking on `getCookies` within the command log, the console outputs the fo
 
 {% imgTag /img/api/getcookies/test-application-cookies.png "Console Log getcookies" %}
 
+{% history %}
+{% url "4.3.0" changelog#4-3-0 %} | Added `sameSite` property when the {% url "`experimentalGetCookiesSameSite`" configuration#Experimental-features %} configuration value is `true`.
+{% endhistory %}
+
 # See also
 
 - {% url `cy.clearCookie()` clearcookie %}

--- a/source/api/commands/getcookies.md
+++ b/source/api/commands/getcookies.md
@@ -41,7 +41,7 @@ Option | Default | Description
 - `httpOnly`
 - `secure`
 - `expiry`
-- `sameSite` (will only be returned if `experimentalGetCookiesSameSite` config value is `true`)
+- `sameSite` *(will only be returned if the {% url "`experimentalGetCookiesSameSite`" configuration#Experimental-features %} configuration value is `true`)*
 
 # Examples
 

--- a/source/api/commands/getcookies.md
+++ b/source/api/commands/getcookies.md
@@ -41,6 +41,7 @@ Option | Default | Description
 - `httpOnly`
 - `secure`
 - `expiry`
+- `sameSite` (will only be returned if `experimentalGetCookiesSameSite` config value is `true`)
 
 # Examples
 

--- a/source/api/commands/setcookie.md
+++ b/source/api/commands/setcookie.md
@@ -42,7 +42,7 @@ Option | Default | Description
 `path` | `/` | The cookie path
 `secure` | `false` | Whether the cookie is a secure cookie
 `timeout` | {% url `responseTimeout` configuration#Timeouts %} | {% usage_options timeout cy.setCookie %}
-`sameSite` | `undefined` | Cookie's SameSite value. If set, should be one of `lax`, `strict`, or `no_restriction`. Pass `undefined` to use the browser's default.
+`sameSite` | `undefined` | Cookie's SameSite value. If set, should be one of `lax`, `strict`, or `no_restriction`. Pass `undefined` to use the browser's default. Note: `no_restriction` can only be used if the `secure` flag is set to `true`.
 
 ## Yields {% helper_icon yields %}
 

--- a/source/api/commands/setcookie.md
+++ b/source/api/commands/setcookie.md
@@ -42,7 +42,7 @@ Option | Default | Description
 `path` | `/` | The cookie path
 `secure` | `false` | Whether the cookie is a secure cookie
 `timeout` | {% url `responseTimeout` configuration#Timeouts %} | {% usage_options timeout cy.setCookie %}
-`sameSite` | Firefox: `no_restriction` / Others: `unspecified` | Cookie's SameSite value, one of `lax`, `strict`, `unspecified`, or `no_restriction` (`unspecified` is only supported in Chromium-family browsers)
+`sameSite` | `undefined` | Cookie's SameSite value. If set, should be one of `lax`, `strict`, or `no_restriction`. Pass `undefined` to use the browser's default.
 
 ## Yields {% helper_icon yields %}
 

--- a/source/api/commands/setcookie.md
+++ b/source/api/commands/setcookie.md
@@ -42,6 +42,7 @@ Option | Default | Description
 `path` | `/` | The cookie path
 `secure` | `false` | Whether the cookie is a secure cookie
 `timeout` | {% url `responseTimeout` configuration#Timeouts %} | {% usage_options timeout cy.setCookie %}
+`sameSite` | Firefox: `no_restriction` / Others: `unspecified` | Cookie's SameSite value, one of `lax`, `strict`, `unspecified`, or `no_restriction` (`unspecified` is only supported in Chromium-family browsers)
 
 ## Yields {% helper_icon yields %}
 
@@ -54,6 +55,7 @@ Option | Default | Description
 - `httpOnly`
 - `secure`
 - `expiry`
+- `sameSite` (will only be returned if `experimentalGetCookiesSameSite` config value is `true`)
 
 # Examples
 

--- a/source/guides/references/configuration.md
+++ b/source/guides/references/configuration.md
@@ -120,7 +120,7 @@ If you'd like to try out what we're working on, you can enable beta features for
 
 Option | Default | Description
 ----- | ---- | ----
-`experimentalGetCookiesSameSite` | `false` | Adds `sameSite` property to object yielded from {% url "`cy.getCookie()`" getcookie %} and {% url "`cy.getCookies()`" getcookies %}. This will become the default behavior in Cypress 5.0.
+`experimentalGetCookiesSameSite` | `false` | Adds `sameSite` values to the objects yielded from {% url "`cy.setCookie()`" setcookie %}, {% url "`cy.getCookie()`" getcookie %}, and {% url "`cy.getCookies()`" getcookies %}. This will become the default behavior in Cypress 5.0.
 
 # Overriding Options
 

--- a/source/guides/references/configuration.md
+++ b/source/guides/references/configuration.md
@@ -116,7 +116,9 @@ You may want to use a different Node version if the code executing from the plug
 
 ## Experimental features
 
-If you'd like to try out what we're working on, you can enable beta features for your project by setting configuration using the following options.
+If you'd like to try out what we're working on, you can enable beta features for your project by setting configuration using the options below.
+
+When you open a Cypress project, clicking on the **Settings** tab and clicking into the **Experimental features** panel will display the experimental features that are available and whether they are enabled for your project.
 
 Option | Default | Description
 ----- | ---- | ----
@@ -209,7 +211,7 @@ Cypress.config('pageLoadTimeout') // => 100000
 
 # Resolved Configuration
 
-When you open a Cypress project, clicking on the *Settings* tab will display the resolved configuration to you. This helps you to understand and see where different values came from. Each set value is highlighted to show where the value has been set via the following ways:
+When you open a Cypress project, clicking on the **Settings** tab will display the resolved configuration to you. This helps you to understand and see where different values came from. Each set value is highlighted to show where the value has been set via the following ways:
 
 - Default value
 - The {% url "configuration file" configuration %}

--- a/source/guides/references/configuration.md
+++ b/source/guides/references/configuration.md
@@ -120,7 +120,7 @@ If you'd like to try out what we're working on, you can enable beta features for
 
 Option | Default | Description
 ----- | ---- | ----
-`experimentalGetCookiesSameSite` | `false` | Adds `sameSite` values to the objects yielded from {% url "`cy.setCookie()`" setcookie %}, {% url "`cy.getCookie()`" getcookie %}, and {% url "`cy.getCookies()`" getcookies %}. This will become the default behavior in Cypress 5.0.
+`experimentalGetCookiesSameSite` | `false` | If `true`, Cypress will add `sameSite` values to the objects yielded from {% url "`cy.setCookie()`" setcookie %}, {% url "`cy.getCookie()`" getcookie %}, and {% url "`cy.getCookies()`" getcookies %}. This will become the default behavior in Cypress 5.0.
 
 # Overriding Options
 

--- a/source/guides/references/configuration.md
+++ b/source/guides/references/configuration.md
@@ -114,6 +114,14 @@ You may want to use a different Node version if the code executing from the plug
 
 {% imgTag /img/guides/test-runner-settings-nodejs-version.jpg "Node version in Settings in Test Runner" %}
 
+## Experimental features
+
+If you'd like to try out what we're working on, you can enable beta features for your project by setting configuration using the following options.
+
+Option | Default | Description
+----- | ---- | ----
+`experimentalGetCookiesSameSite` | `false` | Adds `sameSite` property to object yielded from {% url "`cy.getCookie()`" getcookie %} and {% url "`cy.getCookies()`" getcookies %}. This will become the default behavior in Cypress 5.0.
+
 # Overriding Options
 
 Cypress gives you the option to dynamically alter configuration values. This is helpful when running Cypress in multiple environments and on multiple developer machines.


### PR DESCRIPTION
For cypress-io/cypress#6828

### cy.getCookie() and cy.getCookies()

<img width="886" alt="Screen Shot 2020-03-30 at 12 01 30 PM" src="https://user-images.githubusercontent.com/1271364/77878606-acdf9100-727e-11ea-94de-6977255a731f.png">

<img width="904" alt="Screen Shot 2020-03-30 at 12 01 38 PM" src="https://user-images.githubusercontent.com/1271364/77878624-bbc64380-727e-11ea-953c-a93d59aca098.png">


### Configuration - new Experimental features section

<img width="916" alt="Screen Shot 2020-03-30 at 12 01 53 PM" src="https://user-images.githubusercontent.com/1271364/77878615-b537cc00-727e-11ea-9b97-deda9152f137.png">


