### PR TITLE
Makes `wrap(promise)`  more prominent

### DIFF
--- a/source/api/commands/wrap.md
+++ b/source/api/commands/wrap.md
@@ -2,7 +2,8 @@
 title: wrap
 ---
 
-Yield the object passed into `.wrap()`.
+- Yield the object passed into `.wrap()`. 
+- `.wrap(promise)` forces the test commands to wait until promise resolves
 
 # Syntax
 


### PR DESCRIPTION
As indicated in #1322 and ff,  it needs to be immediately communicated  to new user that using `.wrap` helps immensely with promises.

just spend a few days ripping my hair out because I didn't see this before

<!--
Thanks for contributing!

Please explain what changes were made
also reference any fixed issues with "close #[ISSUE]"
-->
