### PR TITLE
Fix URL for netlify plugin in 4.3 changelog

### DIFF
--- a/source/_changelogs/4.3.0.md
+++ b/source/_changelogs/4.3.0.md
@@ -29,7 +29,7 @@
 - Security warnings no longer show in Mac OS when opening Cypress since our application now undergoes notarization from Apple. Addresses {% issue 5791 %}.
 - The previously used spec filter in the Test Runner is now saved and restored for projects without an ID.Addresses {% issue 6739 %}.
 - We collect more env information from Travis builds for potential use in the Cypress Dashboard. Addresses {% issue 6808 %}.
-- We now collect env information from Netlify builds (for example when using {% url "cypress-io/netlify-plugin-cypress" https://github.com/cypress-io/netlify-plugin-cypress) to send along to the Cypress Dashboard. Addresses {% issue 6780 %}.
+- We now collect env information from Netlify builds (for example when using {% url "cypress-io/netlify-plugin-cypress" https://github.com/cypress-io/netlify-plugin-cypress %} to send along to the Cypress Dashboard. Addresses {% issue 6780 %}.
 - Type added for `tag` property when using Module API. Addresses {% issue 6795 %}.
 - We're continuing to make progress in converting our codebase from CoffeeScript to JavaScript. Addresses {% issue 2690 %} in {% PR 6833 %}.
 

--- a/source/_changelogs/4.3.0.md
+++ b/source/_changelogs/4.3.0.md
@@ -29,7 +29,7 @@
 - Security warnings no longer show in Mac OS when opening Cypress since our application now undergoes notarization from Apple. Addresses {% issue 5791 %}.
 - The previously used spec filter in the Test Runner is now saved and restored for projects without an ID.Addresses {% issue 6739 %}.
 - We collect more env information from Travis builds for potential use in the Cypress Dashboard. Addresses {% issue 6808 %}.
-- We now collect env information from Netlify builds (for example when using {% url "cypress-io/netlify-plugin-cypress" https://github.com/cypress-io/netlify-plugin-cypress %} to send along to the Cypress Dashboard. Addresses {% issue 6780 %}.
+- We now collect env information from Netlify builds (for example when using {% url "cypress-io/netlify-plugin-cypress" https://github.com/cypress-io/netlify-plugin-cypress %}) to send along to the Cypress Dashboard. Addresses {% issue 6780 %}.
 - Type added for `tag` property when using Module API. Addresses {% issue 6795 %}.
 - We're continuing to make progress in converting our codebase from CoffeeScript to JavaScript. Addresses {% issue 2690 %} in {% PR 6833 %}.
 


### PR DESCRIPTION
In the current changelog, the link to the netlify plugin is missing a closing %}.