### PR TITLE
remind the reader of the referenced example in Commands Run Serially

### DIFF
--- a/source/guides/core-concepts/introduction-to-cypress.md
+++ b/source/guides/core-concepts/introduction-to-cypress.md
@@ -526,7 +526,21 @@ Cypress's APIs are built very differently from what you're likely used to: but t
 
 ## Commands Run Serially
 
-After a test function is finished running, Cypress goes to work executing the commands that were enqueued using the `cy.*` command chains. The test above would cause an execution in this order:
+After a test function is finished running, Cypress goes to work executing the commands that were enqueued using the `cy.*` command chains. 
+
+### Let's take another look at an example
+
+```js
+it('changes the URL when "awesome" is clicked', () => {
+  cy.visit('/my/resource/path')
+  cy.get('.awesome-selector')
+    .click()
+  cy.url()
+    .should('include', '/my/resource/path#awesomeness')
+})
+```
+
+The test above would cause an execution in this order:
 
 1. Visit a URL.
 2. Find an element by its selector.

--- a/source/guides/core-concepts/introduction-to-cypress.md
+++ b/source/guides/core-concepts/introduction-to-cypress.md
@@ -533,8 +533,10 @@ After a test function is finished running, Cypress goes to work executing the co
 ```js
 it('changes the URL when "awesome" is clicked', () => {
   cy.visit('/my/resource/path')                          // 1.
+
   cy.get('.awesome-selector')                            // 2.
     .click()                                             // 3.
+
   cy.url()                                               // 4.
     .should('include', '/my/resource/path#awesomeness')  // 5.
 })

--- a/source/guides/core-concepts/introduction-to-cypress.md
+++ b/source/guides/core-concepts/introduction-to-cypress.md
@@ -532,11 +532,11 @@ After a test function is finished running, Cypress goes to work executing the co
 
 ```js
 it('changes the URL when "awesome" is clicked', () => {
-  cy.visit('/my/resource/path')
-  cy.get('.awesome-selector')
-    .click()
-  cy.url()
-    .should('include', '/my/resource/path#awesomeness')
+  cy.visit('/my/resource/path')                          // 1.
+  cy.get('.awesome-selector')                            // 2.
+    .click()                                             // 3.
+  cy.url()                                               // 4.
+    .should('include', '/my/resource/path#awesomeness')  // 5.
 })
 ```
 


### PR DESCRIPTION
The Commands Run Serially section references an example test that's quite far away, now that there are several other examples in the previous section. Including the example again makes it easier for the reader to understand the concepts described in this section.