### PR TITLE
update Plugin Event migration docs to always return launchOptions

### DIFF
--- a/source/guides/references/migration-guide.md
+++ b/source/guides/references/migration-guide.md
@@ -224,6 +224,8 @@ on('before:browser:launch', (browser, args) => {
   // will print a deprecation warning telling you
   // to change your code to the new signature
   args.push('--another-arg')
+
+  return args
 })
 ```
 
@@ -232,6 +234,8 @@ on('before:browser:launch', (browser, args) => {
 ```js
 on('before:browser:launch', (browser, launchOptions) => {
   launchOptions.args.push('--another-arg')
+
+  return launchOptions
 })
 ```
 
@@ -246,6 +250,8 @@ Now, you must pass those options as `launchOptions.preferences`:
 ```js
 on('before:browser:launch', (browser, args) => {
   args.darkTheme = true
+  
+  return args
 })
 ```
 
@@ -254,6 +260,8 @@ on('before:browser:launch', (browser, args) => {
 ```js
 on('before:browser:launch', (browser, launchOptions) => {
   launchOptions.preferences.darkTheme = true
+  
+  return launchOptions
 })
 ```
 

--- a/source/guides/references/migration-guide.md
+++ b/source/guides/references/migration-guide.md
@@ -250,7 +250,7 @@ Now, you must pass those options as `launchOptions.preferences`:
 ```js
 on('before:browser:launch', (browser, args) => {
   args.darkTheme = true
-  
+
   return args
 })
 ```
@@ -260,7 +260,7 @@ on('before:browser:launch', (browser, args) => {
 ```js
 on('before:browser:launch', (browser, launchOptions) => {
   launchOptions.preferences.darkTheme = true
-  
+
   return launchOptions
 })
 ```


### PR DESCRIPTION
We had an engineer at Airbnb follow the migration guide and remove the return statement thinking it wasn't needed. Turns out that it's a crucial piece and it would be good to keep things consistent and include it everywhere.

Happy to add more details here as well! @lencioni @madicap

<!--
Thanks for contributing!

Please explain what changes were made
also reference any fixed issues with "close #[ISSUE]"
-->
