### PR TITLE
Update courses.yml to include 'Add e2e tests with cypress to a React application' on egghead.io

### DIFF
--- a/source/_data/courses.yml
+++ b/source/_data/courses.yml
@@ -2,6 +2,13 @@
 # over multiple videos. The courses appear in the order
 # listed here, so place most recent courses first
 
+- title: "Add e2e tests with cypress to a React application"
+  author: Tomasz Łakomy
+  authorTwitter: tlakomy
+  sourceName: egghead.io
+  sourceUrl: https://egghead.io/playlists/add-e2e-tests-with-cypress-to-a-react-application-7691?af=6p5abz
+  free: true
+
 - title: "Outside-In Frontend Development"
   author: Josh Justice
   authorTwitter: codingitwrong


### PR DESCRIPTION
This is not an issue but I've recently recorded a *free* collection "Add e2e tests with cypress to a React application" on egghead.io and I'd love to see it featured in cypress docs!