### PR TITLE
Sugesting cy.request() as a resource.

### DIFF
--- a/source/guides/guides/network-requests.md
+++ b/source/guides/guides/network-requests.md
@@ -14,7 +14,7 @@ title: Network Requests
 {% endnote %}
 
 {% note info %}
-{% fa fa-cogs %} If your looking for a resource to make an HTTP request take a look at {% url "`cy.request()`" request %}
+**Note:** If your looking for a resource to make an HTTP request take a look at {% url "`cy.request()`" request %}
 {% endnote %}
 # Testing Strategies
 

--- a/source/guides/guides/network-requests.md
+++ b/source/guides/guides/network-requests.md
@@ -13,6 +13,9 @@ title: Network Requests
 - How to write declarative tests that resist flake
 {% endnote %}
 
+{% note info %}
+{% fa fa-cogs %} If your looking for a resource to make an HTTP request take a look at {% url "`cy.request()`" request %}
+{% endnote %}
 # Testing Strategies
 
 Cypress helps you test the entire lifecycle of Ajax / XHR requests within your application. Cypress provides you direct access to the XHR objects, enabling you to make assertions about its properties. Additionally you can even stub and mock a request's response.
@@ -379,3 +382,4 @@ You can find more examples in our {% url "XHR Assertions" https://github.com/cyp
 # See also
 
 - {% url "Network requests in Kitchen Sink example" https://github.com/cypress-io/cypress-example-kitchensink/blob/master/cypress/integration/examples/network_requests.spec.js %}
+- {% url "See how to make a request with `cy.request()`" request %}


### PR DESCRIPTION
Hey I added some citations about cy.request() at Network Request documentation.
Aiming to close #2538 
The top info note seems like this:
![Screenshot from 2020-04-23 22-39-14](https://user-images.githubusercontent.com/4117683/80166066-63e7d780-85b3-11ea-9cc9-a4b5248f6425.png)

And the bottom:
![Screenshot from 2020-04-23 22-39-33](https://user-images.githubusercontent.com/4117683/80166105-81b53c80-85b3-11ea-8555-5ac62d7537da.png)
