### PR TITLE
Update image url for switching browser in Chinese doc

### DIFF
--- a/source/zh-cn/guides/getting-started/installing-cypress.md
+++ b/source/zh-cn/guides/getting-started/installing-cypress.md
@@ -122,7 +122,7 @@ yarn run cypress open
 
 Cypress测试执行器会尝试在用户的机器上找到所有兼容的浏览器。你可以在程序的右上角下拉列表选择不同的浏览器。
 
-{% imgTag /img/guides/select-browser.png "Select a different browser" %}
+{% imgTag /img/guides/browser-list-dropdown.png "Select a different browser" %}
 
 阅读{% url "启动浏览器" launching-browsers %}，了解Cypress是如何在端对端测试中控制一个真实的浏览器。
 


### PR DESCRIPTION
I found there is a 404 for `/img/guides/select-browser.png` in Chinese doc, and it has already updated to `/img/guides/browser-list-dropdown.png` in English doc.
