### PR TITLE
Add warnings that passing force: true to select does not disable some checks

### DIFF
--- a/source/api/commands/select.md
+++ b/source/api/commands/select.md
@@ -128,7 +128,9 @@ cy.get('select')
 
 ## Actionability
 
-`.select()` is an "action command" that follows all the rules {% url 'defined here' interacting-with-elements %}.
+`.select()` is an action command that follows the rules {% url 'defined here' interacting-with-elements %}.
+
+However, passing `{ force: true }` to `.select()` will not override the actionability checks for selecting a disabled `<select>`, a disabled `<option>`, or an option within a disabled `<optgroup>`. See {% issue 107 "this issue" %} for more detail.
 
 # Rules
 

--- a/source/guides/core-concepts/interacting-with-elements.md
+++ b/source/guides/core-concepts/interacting-with-elements.md
@@ -218,3 +218,7 @@ We will NOT perform these:
 {% endnote %}
 
 In summary, `{ force: true }` skips the checks, and it will always fire the event at the desired element.
+
+{% note warning "force `.select()` disabled options" %}
+Passing `{ force: true }` to {% url "`.select()`" select %} will not override the actionability checks for selecting a disabled `<select>`, a disabled `<option>`, or an option within a disabled `<optgroup>`. See {% issue 107 "this issue" %} for more detail.
+{% endnote %}


### PR DESCRIPTION
- close #2775 

Passing `{force: true}` to `.select()` will not override selecting disabled options or optgroups. This notes this behavior in the docs. 