### PR TITLE
Remove dead links & misleading information from typescript-support.md

### DIFF
--- a/source/guides/tooling/typescript-support.md
+++ b/source/guides/tooling/typescript-support.md
@@ -128,16 +128,6 @@ module.exports = (on, config) => {
 }
 ```
 
-## Additional information
-
-See the excellent advice on {% url "setting Cypress using TypeScript" https://basarat.gitbooks.io/typescript/docs/testing/cypress.html %} in the {% url "TypeScript Deep Dive" https://basarat.gitbooks.io/typescript/content/ %} e-book by {% url "Basarat Syed" https://twitter.com/basarat %}. Take a look at {% url "this video" https://www.youtube.com/watch?v=1Vr1cAN_CLA %} Basarat has recorded and the accompanying repo {% url basarat/cypress-ts https://github.com/basarat/cypress-ts %}.
-
-{% fa fa-github %} We have published a utility npm module, {% url "add-typescript-to-cypress" https://github.com/bahmutov/add-typescript-to-cypress %}, that sets TypeScript test transpilation for you with a single command.
-
-{% history %}
-{% url "4.4.0" changelog#4-4-0 %} | Added support for TypeScript without needing your own transpilation through preprocessors.
-{% endhistory %}
-
 # See also
 
 - {% url "IDE Integration" IDE-integration %}

--- a/source/guides/tooling/typescript-support.md
+++ b/source/guides/tooling/typescript-support.md
@@ -128,6 +128,10 @@ module.exports = (on, config) => {
 }
 ```
 
+{% history %}
+{% url "4.4.0" changelog#4-4-0 %} | Added support for TypeScript without needing your own transpilation through preprocessors.
+{% endhistory %}
+
 # See also
 
 - {% url "IDE Integration" IDE-integration %}


### PR DESCRIPTION
Remove section "Additional information", that shows links that are partially dead (https://basarat.gitbooks.io/typescript/docs/testing/cypress.html) or not relevant anymore due to the native typescript support of Cypress@4.4.0
