### PR TITLE
Add HTML to accompany .check examples to demonstrate selecting by value

### DIFF
--- a/source/api/commands/check.md
+++ b/source/api/commands/check.md
@@ -87,8 +87,8 @@ cy.get('#saveUserName').check()
 
 ```html
 <form>
-  <input type="radio" id="us-canada" value="CA">
-  <label for="us-canada">Canada</label>
+  <input type="radio" id="ca-country" value="CA">
+  <label for="ca-country">Canada</label>
   <input type="radio" id="us-country" value="US">
   <label for="us-country">United States</label>
 </form>

--- a/source/api/commands/check.md
+++ b/source/api/commands/check.md
@@ -85,16 +85,34 @@ cy.get('#saveUserName').check()
 
 ### Select the radio with the value of 'US'
 
+```html
+<form>
+  <input type="radio" id="us-canada" value="CA">
+  <label for="us-canada">Canada</label>
+  <input type="radio" id="us-country" value="US">
+  <label for="us-country">United States</label>
+</form>
+```
+
 ```javascript
 cy.get('[type="radio"]').check('US')
 ```
 
 ## Values
 
-### Check the checkboxes with the values 'ga' and 'ca'
+### Check the checkboxes with the values 'subscribe' and 'accept'
+
+```html
+<form>
+  <input type="checkbox" id="subscribe" value="subscribe">
+  <label for="subscribe">Subscribe to newsletter?</label>
+  <input type="checkbox" id="acceptTerms" value="accept">
+  <label for="acceptTerms">Accept terms and conditions.</label>
+</form>
+```
 
 ```javascript
-cy.get('[type="checkbox"]').check(['ga', 'ca'])
+cy.get('form input').check(['subscribe', 'accept'])
 ```
 
 ## Options


### PR DESCRIPTION
It was not completely clear from the examples what the structure of the HTML was for .check examples. 

Someone was trying to select by label, which is not supported https://github.com/cypress-io/cypress/issues/7379