### PR TITLE
Add example use-cases of `encoding` option in `cy.request()`

### DIFF
--- a/source/api/commands/request.md
+++ b/source/api/commands/request.md
@@ -197,6 +197,33 @@ cy.request({
   })
 ```
 
+### Download a binary file (.pdf, .zip, .doc, …)
+
+```javascript
+cy.request({
+  url: 'http://localhost:8080/some-document.pdf', // or .zip, …
+  encoding: 'binary', // response.body will be a serialized binary content of the file
+})
+  .then((response) => {
+    cy.writeFile('path/to/save/document.pdf', response.body, 'binary');
+  });
+```
+
+### Get DataURI of an image
+
+```javascript
+cy.request({
+  url: 'https://docs.cypress.io/img/logo.png',
+  encoding: 'base64', // response.body will be a base64-encoded content of the image
+})
+  .then((response) => {
+    const base64Content = response.body;
+    const mime = response.headers['content-type']; // or 'image/png'
+    // see: https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs
+    const imageDataUri = `data:${mime};base64,${base64Content}`
+  })
+```
+
 ### HTML form submissions using form option
 
 Oftentimes, once you have a proper e2e test around logging in, there's no reason to continue to `cy.visit()` the login and wait for the entire page to load all associated resources before running any other commands. Doing so can slow down our entire test suite.

--- a/source/api/commands/request.md
+++ b/source/api/commands/request.md
@@ -197,31 +197,35 @@ cy.request({
   })
 ```
 
-### Download a binary file (.pdf, .zip, .doc, …)
+### Download a PDF file
+
+By passing the `encoding: binary` option, the `response.body` will be serialized binary content of the file. You can use this to access various file types via `.request()` like `.pdf`, `.zip`, or `.doc` files.
 
 ```javascript
 cy.request({
-  url: 'http://localhost:8080/some-document.pdf', // or .zip, …
-  encoding: 'binary', // response.body will be a serialized binary content of the file
+  url: 'http://localhost:8080/some-document.pdf',
+  encoding: 'binary',
 })
-  .then((response) => {
-    cy.writeFile('path/to/save/document.pdf', response.body, 'binary');
-  });
+.then((response) => {
+  cy.writeFile('path/to/save/document.pdf', response.body, 'binary')
+})
 ```
 
-### Get DataURI of an image
+### Get Data URL of an image
+
+By passing the `encoding: base64` option, the `response.body` will be base64-encoded content of the image. You can use this to construct a {% url "Data URI" https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs %} for use elsewhere.
 
 ```javascript
 cy.request({
   url: 'https://docs.cypress.io/img/logo.png',
-  encoding: 'base64', // response.body will be a base64-encoded content of the image
+  encoding: 'base64',
 })
-  .then((response) => {
-    const base64Content = response.body;
-    const mime = response.headers['content-type']; // or 'image/png'
-    // see: https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs
-    const imageDataUri = `data:${mime};base64,${base64Content}`
-  })
+.then((response) => {
+  const base64Content = response.body
+  const mime = response.headers['content-type'] // or 'image/png'
+  // see https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs
+  const imageDataUrl = `data:${mime};base64,${base64Content}`
+})
 ```
 
 ### HTML form submissions using form option


### PR DESCRIPTION
<!--
Thanks for contributing!

Please explain what changes were made
also reference any fixed issues with "close #[ISSUE]"
-->

For the [encoding option](https://github.com/cypress-io/cypress-documentation/pull/2805), and for anyone facing [this issue](https://github.com/cypress-io/cypress/issues/3576) or [this issue](https://github.com/cypress-io/cypress/issues/2029) or similar ones, it might be a good idea to include in the official documentation of `cy.request()` a couple of clear and useful examples/use cases utilizing the `encoding` option.