### PR TITLE
Expand support files to include TypeScript file ext

### DIFF
--- a/source/guides/references/configuration.md
+++ b/source/guides/references/configuration.md
@@ -145,7 +145,7 @@ cypress run --browser firefox --config viewportWidth=1280,viewportHeight=720
 For more complex configuration objects, you may want to consider passing a {% url "JSON.stringified" https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify %} object surrounded by single quotes.
 
 ```shell
-cypress open --config '{"watchForFileChanges":false,"testFiles":["**/*.js","**/*.coffee"]}'
+cypress open --config '{"watchForFileChanges":false,"testFiles":["**/*.js","**/*.ts"]}'
 ```
 
 ## Plugins

--- a/source/guides/references/error-messages.md
+++ b/source/guides/references/error-messages.md
@@ -52,9 +52,10 @@ It's still useful to load a setup file before your test code. If you are setting
 To include code before your test files, set the {% url `supportFile` configuration#Folders-Files %} path. By default, {% url `supportFile` configuration#Folders-Files %} is set to look for one of the following files:
 
 - `cypress/support/index.js`
+- `cypress/support/index.ts`
 - `cypress/support/index.coffee`
 
-Just like with your test files, the {% url `supportFile` configuration#Folders-Files %} can use ES2015+ (or CoffeeScript) and modules, so you can import/require other files as needed.
+Just like with your test files, the {% url `supportFile` configuration#Folders-Files %} can use ES2015+, {% url "TypeScript" typescript-support %} or CoffeeScript and modules, so you can import/require other files as needed.
 
 # Command Errors
 


### PR DESCRIPTION
Just something I noticed about the support file not mentioning supporting TypeScript.