### PR TITLE
Remove cypress-graphql-mock

### DIFF
--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -189,11 +189,6 @@
       link: https://github.com/prescottprue/cypress-firebase
       keywords: [firebase, database, commands]
 
-    - name: cypress-graphql-mock
-      description: Adds commands for executing a mocked GraphQL server using only the client
-      link: https://github.com/tgriesser/cypress-graphql-mock
-      keywords: [graphql]
-
     - name: cypress-pipe
       description: Create custom commands using plain-old functions. Similar to `cy.then` but with retriability.
       link: https://github.com/NicholasBoll/cypress-pipe


### PR DESCRIPTION
Cypress-graphql-mock does not seem to be maintained anymore. Following [issue](https://github.com/tgriesser/cypress-graphql-mock/pull/28) shows that there is a blocking bug which is still not merged after half a year.