### PR TITLE
Improve test configuration section

### DIFF
--- a/source/api/cypress-api/config.md
+++ b/source/api/cypress-api/config.md
@@ -123,9 +123,9 @@ Some configuration values cannot be changed while running a test. Anything that'
 
 ## Test Configuration
 
-To apply a specific Cypress {% url "configuration" configuration %} value to a suite or test you can pass an {% url "test configuration", configuration#Test-Configuration %} to the test or suite function.
+To apply specific Cypress {% url "configuration" configuration %} values to a suite or test, you can pass a {% url "test configuration" configuration#Test-Configuration %} object to the test or suite function.
 
-`Cypress.config()` changes the configuration value through the entire spec file. But using test configuration will only change the configuration value during the suite or tests where they are set then return to their previous default values after the suite or tests are complete.
+While `Cypress.config()` changes configuration values through the entire spec file, using test configuration will only change configuration values during the suite or test where they are set. The values will then reset to the previous default values after the suite or test is complete.
 
 See the full guide on {% url "test configuration", configuration#Test-Configuration %}.
 

--- a/source/guides/references/configuration.md
+++ b/source/guides/references/configuration.md
@@ -207,13 +207,13 @@ Cypress.config('pageLoadTimeout') // => 100000
 
 ## Test Configuration
 
-To apply a specific Cypress {% url "configuration" configuration %} value to a suite or test, pass a configuration object to the test or suite function as the second argument.
+To apply specific Cypress {% url "configuration" configuration %} values to a suite or test, pass a configuration object to the test or suite function as the second argument.
 
-This configuration will take effect during the suite or tests where they are set then return to their previous default values after the suite or tests are complete.
+The configuration values passed in will only take effect during the suite or test where they are set. The values will then reset to the previous default values after the suite or test is complete.
 
 {% partial test_config_whitelist %}
 
-### Suite of test configuration
+### Suite configuration
 
 You can configure the size of the viewport height and width within a suite.
 
@@ -237,7 +237,7 @@ describe('page display on medium size screen', {
 If you want to target a test to run or be excluded when run in a specific browser, you can override the `browser` configuration within the test configuration. The `browser` option accepts the same arguments as {% url "`Cypress.isBrowser()`" isbrowser %}.
 
 ```js
-it('Show warning outside Chrome', {  browser: '!chrome' } => {
+it('Show warning outside Chrome', {  browser: '!chrome' }, () => {
   cy.get('.browser-warning')
     .should('contain', 'For optimal viewing, use Chrome browser')
 })


### PR DESCRIPTION
I found a couple typos, including a code block with invalid code, in the test configuration sections. While fixing those, I went ahead and updated the prose a bit to make it a little clearer and standardize use of plurals.