### PR TITLE
Add instruction to check if element never existed

### DIFF
--- a/source/guides/core-concepts/retry-ability.md
+++ b/source/guides/core-concepts/retry-ability.md
@@ -135,15 +135,19 @@ The `.click()` command will automatically wait until multiple built-in assertion
 
 # Timeouts
 
-By default each command that retries, does so for up to 4 seconds - the {% url `defaultCommandTimeout` configuration#Timeouts %} setting. You can change this timeout for _all commands_ using your configuration file, a CLI parameter, via an environment variable, or programmatically.
+By default each command that retries, does so for up to 4 seconds - the {% url `defaultCommandTimeout` configuration#Timeouts %} setting.
 
-For example, to set the default command timeout to 10 seconds via command line:
+## Increase time to retry
+
+You can change this timeout for _all commands_. See {% url 'Configuration: Overriding Options' configuration#Overriding-Options %} for examples of overriding this option.
+
+For example, to set the default command timeout to 10 seconds via the command line:
 
 ```shell
 cypress run --config defaultCommandTimeout=10000
 ```
 
-See {% url 'Configuration: Overriding Options' configuration#Overriding-Options %} for other examples of overriding this option. We do not recommend changing the command timeout globally. Instead, pass the inividual command's `{ timeout: ms }` option to retry for a different period of time. For example:
+ We do not recommend changing the command timeout globally. Instead, pass the individual command's `{ timeout: ms }` option to retry for a different period of time. For example:
 
 ```javascript
 // we've modified the timeout which affects default + added assertions
@@ -153,6 +157,16 @@ cy.get('.mobile-nav', { timeout: 10000 })
 ```
 
 Cypress will retry for up to 10 seconds to find a visible element of class `mobile-nav` with text containing "Home". For more examples, read the {% url 'Timeouts' introduction-to-cypress#Timeouts %} section in the "Introduction to Cypress" guide.
+
+## Disable retry
+
+Overriding the timeout to `0` will essentially disable retrying the command, since it will spend 0 milliseconds retrying.
+
+```javascript
+// check synchronously that the element does not exist (no retry)
+// for example just after a server-side render
+cy.get('#ssr-error', { timeout: 0 }).should('not.exist')
+```
 
 # Only the last command is retried
 

--- a/source/guides/references/assertions.md
+++ b/source/guides/references/assertions.md
@@ -229,19 +229,11 @@ cy.get('a').parent('span.help').should('not.contain', 'click me')
 cy.get('button').should('be.visible')
 ```
 
-## Removal
+## Existence
 
 ```javascript
 // retry until loading spinner no longer exists
 cy.get('#loading').should('not.exist')
-```
-
-## Existence
-
-```javascript
-// check synchronously that the element does not exist (no retry)
-// for example just after a server-side render
-cy.get('#ssr-error', { timeout: 0 }).should('not.exist')
 ```
 
 ## State

--- a/source/guides/references/assertions.md
+++ b/source/guides/references/assertions.md
@@ -241,7 +241,7 @@ cy.get('#loading').should('not.exist')
 ```javascript
 // check synchronously that the element does not exist (no retry)
 // for example just after a server-side render
-cy.get('#ssr-error', { timeout: 0}).should('not.exist')
+cy.get('#ssr-error', { timeout: 0 }).should('not.exist')
 ```
 
 ## State

--- a/source/guides/references/assertions.md
+++ b/source/guides/references/assertions.md
@@ -8,6 +8,7 @@ Cypress bundles the popular {% url 'Chai' assertions#Chai %} assertion library, 
 This document is only a reference to every assertion Cypress supports.
 
 If you're looking to understand **how** to use these assertions please read about assertions in our {% url "Introduction to Cypress" introduction-to-cypress#Assertions guide %}.
+{% endnote %}
 
 # Chai
 

--- a/source/guides/references/assertions.md
+++ b/source/guides/references/assertions.md
@@ -8,7 +8,6 @@ Cypress bundles the popular {% url 'Chai' assertions#Chai %} assertion library, 
 This document is only a reference to every assertion Cypress supports.
 
 If you're looking to understand **how** to use these assertions please read about assertions in our {% url "Introduction to Cypress" introduction-to-cypress#Assertions guide %}.
-{% endnote %}
 
 # Chai
 
@@ -230,11 +229,19 @@ cy.get('a').parent('span.help').should('not.contain', 'click me')
 cy.get('button').should('be.visible')
 ```
 
-## Existence
+## Removal
 
 ```javascript
 // retry until loading spinner no longer exists
 cy.get('#loading').should('not.exist')
+```
+
+## Existence
+
+```javascript
+// check synchronously that the element does not exist (no retry)
+// for example just after a server-side render
+cy.get('#ssr-error', { timeout: 0}).should('not.exist')
 ```
 
 ## State


### PR DESCRIPTION
See discussion at https://github.com/cypress-io/cypress/issues/7651#issuecomment-642442799

"Existence" might be ambiguous: you may want an element to be removed, but you may also check that an element never existed. For example check that a loader does not appear immediately, or that a server-side render was successful.