### PR TITLE
Improve 'Experiments' page

### DIFF
--- a/source/guides/references/experiments.md
+++ b/source/guides/references/experiments.md
@@ -2,32 +2,57 @@
 title: Experiments
 ---
 
-# Configuration
-
-If you'd like to try out what we're working on, you can enable beta features for your project by setting configuration using the options below.
+If you'd like to try out what we're working on in the {% url "Test Runner" test-runner %}, you can enable beta features for your project by turning on the experimental features you'd like to try.
 
 {% note warning %}
 ⚠️ The experimental features might change or ultimately be removed without making it into the core product. Our primary goal for experiments is to collect real-world feedback during the development.
 {% endnote %}
 
-When you open a Cypress project, clicking on the **Settings** tab and clicking into the **Experiments** panel will display the experimental features that are available and whether they are enabled for your project.
+# Configuration
+
+You can pass the {% url "configuration" configuration %} options below to enable or disable experiments. See our {% url "Configuration Guide" configuration %} on how to pass configuration to Cypress.
 
 Option | Default | Description
 ----- | ---- | ----
-`experimentalGetCookiesSameSite` | `false` | If `true`, Cypress will add `sameSite` values to the objects yielded from {% url "`cy.setCookie()`" setcookie %}, {% url "`cy.getCookie()`" getcookie %}, and {% url "`cy.getCookies()`" getcookies %}. This will become the default behavior in Cypress 5.0.
-`experimentalComponentTesting` | `false` | When set to `true`, Cypress allows you to execute component tests using framework-specific adaptors. By default  `cypress/component` is the path for component tests. You can change this setting by setting the `componentFolder` configuration option. For more details see the {% url "cypress-react-unit-test" https://github.com/bahmutov/cypress-react-unit-test %} and {% url "cypress-vue-unit-test" https://github.com/bahmutov/cypress-vue-unit-test %} repos.
+`experimentalGetCookiesSameSite` | `false` | Adds `sameSite` values to the objects yielded from {% url "`cy.setCookie()`" setcookie %}, {% url "`cy.getCookie()`" getcookie %}, and {% url "`cy.getCookies()`" getcookies %}. This will become the default behavior in a later Cypress version.
+`experimentalComponentTesting` | `false` | Enables component testing using framework-specific adaptors. See {% urlHash "Component Testing" Component-Testing %} for more detail.
 `experimentalSourceRewriting` | `false` | Enables AST-based JS/HTML rewriting. This may fix issues caused by the existing regex-based JS/HTML replacement algorithm. See {% issue 5273 %} for details.
-`experimentalShadowDomSupport` | `false` | Enables shadow DOM support. Adds the `cy.shadow()` command and the `includeShadowDom` option to some DOM commands.
+`experimentalShadowDomSupport` | `false` | Enables shadow DOM support. Adds the `cy.shadow()` command and the `includeShadowDom` option to some DOM commands. See {% urlHash "Shadow DOM" Shadow-DOM %} for more detail.
+
+When you open a Cypress project, clicking on the **Settings** tab and clicking into the **Experiments** panel will display the experimental features that are available and whether they are enabled for your project.
 
 # Component Testing
 
-Component testing is a feature that is experimental. Here you'll find some guidance on how to do component testing.
+Component testing is a feature that is experimental. You can enable component testing by setting the `experimentalComponentTesting` configuration to `true`.
 
-An example component test may look like the code below. This test would execute in the browser, similar to the full end-to-end test, except with no URL website being visited.
+## Component Libraries
+
+Component testing can be used with the libraries below. You can find more details on integration with each library in their respective repo.
+
+- **React:** {% url "cypress-react-unit-test" https://github.com/bahmutov/cypress-react-unit-test %}
+- **Vue:** {% url "cypress-vue-unit-test" https://github.com/bahmutov/cypress-vue-unit-test %}
+
+## Component Folder
+
+By default `cypress/component` is the path for component tests. You can change this path by setting the `componentFolder` configuration option.
+
+**Example `cypress.json`**
+
+```json
+{
+  "experimentalComponentTesting": true,
+  "componentFolder": "cypress/component"
+}
+```
+
+## Example
+
+An example of a component test may look like the code below. This test would execute in the browser, similar to the full end-to-end test, except with no URL website being visited.
 
 ```js
 import { mount } from 'cypress-react-unit-test'
 import Post from './Post.jsx'
+
 describe('Post skeletons', () => {
   it('loads title after timeout', () => {
     mount(<Post title={title} children={text} />)
@@ -41,32 +66,15 @@ describe('Post skeletons', () => {
 
 {% imgTag /img/guides/references/component-test.gif "Example React component test" %}
 
-Feature | Other testing libraries * | Cypress component testing
---- | --- | ---
-Test runs in real browser | ❌ | ✅
-Mounts realistic components | ❌ | ✅
-Test speed | 🏎 | as fast as the app works in the browser
-Test can use additional plugins | maybe | use any {% url "Cypress plugin" plugins %}
-Test can interact with component | synthetic limited API | use any {% url "Cypress command" table-of-contents %}
-Test can be debugged | via terminal and Node debugger | use browser DevTools
-Built-in time traveling debugger | ❌ | Cypress time traveling debugger
-Re-run tests on file or test change | ✅ | ✅
-Test output on CI | terminal | terminal, screenshots, videos
-Tests can be run in parallel | ✅ | ✅ via {% url "parallelization" parallelization %}
-Spying and mocking | Jest mocks / 3rd party | Built-in via Sinon library
-Code coverage | ✅ / maybe | ✅
-
-\* Most common libraries: React Testing Library, Enzyme, Vue Testing Library, Vue Test Utils
-
 # Shadow DOM
 
-Support for shadow DOM is currently experimental and includes the addition of a new command `.shadow()` and an `includeShadowDom` option for some DOM commands.
+Support for shadow DOM is currently experimental and includes the addition of a new command `.shadow()` and an `includeShadowDom` option for some DOM commands. You can enable component testing by setting the `experimentalShadowDomSupport` configuration to `true`.
 
-## .shadow()
+## `.shadow()`
 
 `.shadow()` will traverse into an element's shadow root, so that further DOM commands will find elements within that shadow root.
 
-## includeShadowDom
+## `includeShadowDom`
 
 Enabling the `includeShadowDom` option allows using existing commands to query the DOM, finding elements within the shadow DOM that would normally not be found due to the shadow DOM's boundary hiding them. It is supported by the following commands:
 
@@ -105,12 +113,12 @@ cy
 .click()
 ```
 
-## Cross-boundary selectors
+## {% fa fa-warning red %} Cross-boundary selectors
 
 Note that cross-boundary selectors are not supported. This is best illustrated with an example (using the html above):
 
 ```javascript
-// INVALID CODE - WILL NOT WORK
+// ❗️INVALID CODE - WILL NOT WORK
 cy.get('.container .my-button', { includeShadowDom: true })
 ```
 


### PR DESCRIPTION
I realize we will likely improve upon this later, but these were just some quick fixes from our docs meeting discussion. 

- Move main explanation above ‘configuration’ section
- Link to relevant sections from within configuration table
- Link to main ‘configuration’ page to show how they set configuration
- Add sections to component testing - linking to libraries that are supported
- Remove ‘comparison’ table from component testing
- Make it more clear that cross-boundary selectors are not supported.

![localhost_2222_guides_references_experiments html](https://user-images.githubusercontent.com/1271364/84752681-105a9e80-afe4-11ea-81cf-2bf86da84b4b.png)
