### PR TITLE
Fix typo on experiments.md

### DIFF
--- a/source/guides/references/experiments.md
+++ b/source/guides/references/experiments.md
@@ -68,7 +68,7 @@ describe('Post skeletons', () => {
 
 # Shadow DOM
 
-Support for shadow DOM is currently experimental and includes the addition of a new command `.shadow()` and an `includeShadowDom` option for some DOM commands. You can enable component testing by setting the `experimentalShadowDomSupport` configuration to `true`.
+Support for shadow DOM is currently experimental and includes the addition of a new command `.shadow()` and an `includeShadowDom` option for some DOM commands. You can enable shadow DOM by setting the `experimentalShadowDomSupport` configuration to `true`.
 
 ## `.shadow()`
 


### PR DESCRIPTION
Fix a typo on the Experiments page