### PR TITLE
docs: add `quiet` cli arg/module api flag

### DIFF
--- a/source/guides/guides/command-line.md
+++ b/source/guides/guides/command-line.md
@@ -93,6 +93,7 @@ Option | Description
 `--parallel` | {% urlHash "Run recorded specs in parallel across multiple machines" cypress-run-parallel %}
 `--port`,`-p`  | {% urlHash "Override default port" cypress-run-port-lt-port-gt %}
 `--project`, `-P` | {% urlHash "Path to a specific project" cypress-run-project-lt-project-path-gt %}
+`--quiet`, `-q` | If passed, Cypress will not output to `stdout`. Only output from the configured reporter will print.
 `--record`  | {% urlHash "Whether to record the test run" cypress-run-record-key-lt-record-key-gt %}
 `--reporter`, `-r`  | {% urlHash "Specify a Mocha reporter" cypress-run-reporter-lt-reporter-gt %}
 `--reporter-options`, `-o`  | {% urlHash "Specify Mocha reporter options" cypress-run-reporter-lt-reporter-gt %}

--- a/source/guides/guides/command-line.md
+++ b/source/guides/guides/command-line.md
@@ -93,7 +93,7 @@ Option | Description
 `--parallel` | {% urlHash "Run recorded specs in parallel across multiple machines" cypress-run-parallel %}
 `--port`,`-p`  | {% urlHash "Override default port" cypress-run-port-lt-port-gt %}
 `--project`, `-P` | {% urlHash "Path to a specific project" cypress-run-project-lt-project-path-gt %}
-`--quiet`, `-q` | If passed, Cypress will not output to `stdout`. Only output from the configured reporter will print.
+`--quiet`, `-q` | If passed, Cypress output will not be printed to `stdout`. Only output from the configured reporter will print.
 `--record`  | {% urlHash "Whether to record the test run" cypress-run-record-key-lt-record-key-gt %}
 `--reporter`, `-r`  | {% urlHash "Specify a Mocha reporter" cypress-run-reporter-lt-reporter-gt %}
 `--reporter-options`, `-o`  | {% urlHash "Specify Mocha reporter options" cypress-run-reporter-lt-reporter-gt %}

--- a/source/guides/guides/command-line.md
+++ b/source/guides/guides/command-line.md
@@ -93,7 +93,7 @@ Option | Description
 `--parallel` | {% urlHash "Run recorded specs in parallel across multiple machines" cypress-run-parallel %}
 `--port`,`-p`  | {% urlHash "Override default port" cypress-run-port-lt-port-gt %}
 `--project`, `-P` | {% urlHash "Path to a specific project" cypress-run-project-lt-project-path-gt %}
-`--quiet`, `-q` | If passed, Cypress output will not be printed to `stdout`. Only output from the configured reporter will print.
+`--quiet`, `-q` | If passed, Cypress output will not be printed to `stdout`. Only output from the configured {% url "Mocha reporter" reporters %} will print.
 `--record`  | {% urlHash "Whether to record the test run" cypress-run-record-key-lt-record-key-gt %}
 `--reporter`, `-r`  | {% urlHash "Specify a Mocha reporter" cypress-run-reporter-lt-reporter-gt %}
 `--reporter-options`, `-o`  | {% urlHash "Specify Mocha reporter options" cypress-run-reporter-lt-reporter-gt %}

--- a/source/guides/guides/module-api.md
+++ b/source/guides/guides/module-api.md
@@ -31,7 +31,7 @@ Option | Type | Description
 `parallel` | *boolean* | Run recorded specs in {% url "parallel" parallelization %} across multiple machines
 `port` | *number* | Override default port
 `project` | *string* | Path to a specific project
-`quiet`| *boolean* | If passed, Cypress output will not be printed to `stdout`. Only output from the configured reporter will print.
+`quiet`| *boolean* | If passed, Cypress output will not be printed to `stdout`. Only output from the configured {% url "Mocha reporter" reporters %} will print.
 `record` | *boolean* | Whether to record the test run
 `reporter` | *string* | Specify a {% url "Mocha reporter" reporters %}
 `reporterOptions` | *object* | Specify {% url "Mocha reporter" reporters %} options

--- a/source/guides/guides/module-api.md
+++ b/source/guides/guides/module-api.md
@@ -31,7 +31,7 @@ Option | Type | Description
 `parallel` | *boolean* | Run recorded specs in {% url "parallel" parallelization %} across multiple machines
 `port` | *number* | Override default port
 `project` | *string* | Path to a specific project
-`quiet`| *boolean* | If passed, Cypress will not output to `stdout`. Only output from the configured reporter will print.
+`quiet`| *boolean* | If passed, Cypress output will not be printed to `stdout`. Only output from the configured reporter will print.
 `record` | *boolean* | Whether to record the test run
 `reporter` | *string* | Specify a {% url "Mocha reporter" reporters %}
 `reporterOptions` | *object* | Specify {% url "Mocha reporter" reporters %} options

--- a/source/guides/guides/module-api.md
+++ b/source/guides/guides/module-api.md
@@ -31,6 +31,7 @@ Option | Type | Description
 `parallel` | *boolean* | Run recorded specs in {% url "parallel" parallelization %} across multiple machines
 `port` | *number* | Override default port
 `project` | *string* | Path to a specific project
+`quiet`| *boolean* | If passed, Cypress will not output to `stdout`. Only output from the configured reporter will print.
 `record` | *boolean* | Whether to record the test run
 `reporter` | *string* | Specify a {% url "Mocha reporter" reporters %}
 `reporterOptions` | *object* | Specify {% url "Mocha reporter" reporters %} options


### PR DESCRIPTION
From cypress-io/cypress#7714