### PR TITLE
Document clock restore better

### DIFF
--- a/source/api/commands/clock.md
+++ b/source/api/commands/clock.md
@@ -65,23 +65,6 @@ You can also access the `clock` object via `this.clock` in a {% url `.then()` th
 
 # Examples
 
-## Restore clock
-
-You can restore the clock
-
-```javascript
-cy.clock()
-cy.visit('/index.html')
-cy.tick(1000)
-...
-// restore the clock
-cy.clock().then(clock => {
-  clock.restore()
-})
-// or use this shortcut
-cy.clock().invoke('restore')
-```
-
 ## No Args
 
 ### Create a clock and use it to trigger a `setInterval`
@@ -192,6 +175,30 @@ cy.clock(Date.UTC(2018, 10, 30), ['Date'])
 {% note info %}
 {% url 'Check out our example recipe testing spying, stubbing and time.' recipes#Stubbing-and-spying %}
 {% endnote %}
+
+## Restore clock
+
+You can restore the clock and allow your application to resume normally without manipulating native global functions related to time. This is automatically called between tests.
+
+```javascript
+cy.clock()
+cy.visit('http://localhost:3333')
+cy.get('#search').type('Acme Company')
+cy.tick(1000)
+// more test code here
+
+// restore the clock
+cy.clock().then((clock) => {
+  clock.restore()
+})
+// more test code here
+```
+
+You could also restore by using {% url "`.invoke()` invoke %}  to invoke the `restore` function.
+
+```js
+cy.clock().invoke('restore')
+```
 
 # Notes
 

--- a/source/api/commands/clock.md
+++ b/source/api/commands/clock.md
@@ -65,6 +65,23 @@ You can also access the `clock` object via `this.clock` in a {% url `.then()` th
 
 # Examples
 
+## Restore clock
+
+You can restore the clock
+
+```javascript
+cy.clock()
+cy.visit('/index.html')
+cy.tick(1000)
+...
+// restore the clock
+cy.clock().then(clock => {
+  clock.restore()
+})
+// or use this shortcut
+cy.clock().invoke('restore')
+```
+
 ## No Args
 
 ### Create a clock and use it to trigger a `setInterval`

--- a/source/api/commands/tick.md
+++ b/source/api/commands/tick.md
@@ -71,6 +71,23 @@ cy.get('#header').should('have.text', 'Hello, World')
 {% url "Check out our example recipe testing spying, stubbing and time" recipes#Stubbing-and-spying %}
 {% endnote %}
 
+## Restore clock
+
+You can restore the clock
+
+```javascript
+cy.clock()
+cy.visit('/index.html')
+cy.tick(1000)
+...
+// restore the clock
+cy.tick().then(clock => {
+  clock.restore()
+})
+// or use this shortcut
+cy.tick().invoke('restore')
+```
+
 # Rules
 
 ## Requirements {% helper_icon requirements %}

--- a/source/api/commands/tick.md
+++ b/source/api/commands/tick.md
@@ -73,19 +73,26 @@ cy.get('#header').should('have.text', 'Hello, World')
 
 ## Restore clock
 
-You can restore the clock
+You can restore the clock and allow your application to resume normally without manipulating native global functions related to time. This is automatically called between tests.
 
 ```javascript
 cy.clock()
-cy.visit('/index.html')
+cy.visit('http://localhost:3333')
+cy.get('#search').type('Acme Company')
 cy.tick(1000)
-...
+// more test code here
+
 // restore the clock
-cy.tick().then(clock => {
+cy.clock().then((clock) => {
   clock.restore()
 })
-// or use this shortcut
-cy.tick().invoke('restore')
+// more test code here
+```
+
+You could also restore by using {% url "`.invoke()` invoke %}  to invoke the `restore` function.
+
+```js
+cy.clock().invoke('restore')
 ```
 
 # Rules

--- a/source/guides/guides/stubs-spies-and-clocks.md
+++ b/source/guides/guides/stubs-spies-and-clocks.md
@@ -14,7 +14,7 @@ title: Stubs, Spies, and Clocks
 
 # Capabilities
 
-Cypress comes built in with the ability to stub and spy with {% url `cy.stub()` stub %}, {% url `cy.spy()` spy %} or modify your application's time with {% url `cy.clock()` clock %} - which lets you manipulate `Date`, `setTimeout`, `setInterval`, amongst others.
+Cypress comes built in with the ability to stub and spy with {% url `cy.stub()` stub %}, {% url `cy.spy()` spy %} or modify your application's time with {% url `cy.clock()` clock %} - which lets you manipulate `Date`, `setTimeout`, `clearTimeout`, `setInterval`, or `clearInterval`.
 
 These commands are useful when writing both **unit tests** and **integration tests**.
 
@@ -104,6 +104,8 @@ With {% url "`cy.clock()`" clock %} you can control:
 
 ### Common Scenarios
 
+#### Control `setInterval`
+
 - You're polling something in your application with `setInterval` and want to control that.
 - You have **throttled** or **debounced** functions which you want to control.
 
@@ -112,25 +114,33 @@ Once you've enabled {% url `cy.clock()` clock %} you can control time by **ticki
 ```javascript
 cy.clock()
 cy.visit('http://localhost:3333')
-cy.get('#search').type('foobarbaz')
+cy.get('#search').type('Acme Company')
 cy.tick(1000)
 ```
 
 You can call {% url `cy.clock()` clock %} **prior** to visiting your application and we will automatically bind it to the application on the next {% url `cy.visit()` visit %}. We bind **before** any timers from your application can be invoked. This works identically to {% url `cy.server()` server %} and {% url `cy.route()` route %}.
 
-You can restore the original clock allowing your application to resume normal functions.
+#### Restore the clock
+
+You can restore the clock and allow your application to resume normally without manipulating native global functions related to time. This is automatically called between tests.
 
 ```javascript
 cy.clock()
 cy.visit('http://localhost:3333')
-cy.get('#search').type('foobarbaz')
+cy.get('#search').type('Acme Company')
 cy.tick(1000)
-...
+// more test code here
+
 // restore the clock
-cy.clock().then(clock => {
+cy.clock().then((clock) => {
   clock.restore()
 })
-// or use this shortcut
+// more test code here
+```
+
+You could also restore by using {% url "`.invoke()` invoke %} to invoke the `restore` function.
+
+```js
 cy.clock().invoke('restore')
 ```
 

--- a/source/guides/guides/stubs-spies-and-clocks.md
+++ b/source/guides/guides/stubs-spies-and-clocks.md
@@ -118,6 +118,22 @@ cy.tick(1000)
 
 You can call {% url `cy.clock()` clock %} **prior** to visiting your application and we will automatically bind it to the application on the next {% url `cy.visit()` visit %}. We bind **before** any timers from your application can be invoked. This works identically to {% url `cy.server()` server %} and {% url `cy.route()` route %}.
 
+You can restore the original clock allowing your application to resume normal functions.
+
+```javascript
+cy.clock()
+cy.visit('http://localhost:3333')
+cy.get('#search').type('foobarbaz')
+cy.tick(1000)
+...
+// restore the clock
+cy.clock().then(clock => {
+  clock.restore()
+})
+// or use this shortcut
+cy.clock().invoke('restore')
+```
+
 ## Assertions
 
 Once you have a `stub` or a `spy` in hand, you can then create assertions about them.


### PR DESCRIPTION
- closes #2910

By making examples first-class, adds them to the navigation bar

<img width="1094" alt="Screen Shot 2020-06-23 at 11 12 36 AM" src="https://user-images.githubusercontent.com/2212006/85421965-105a2180-b543-11ea-88d9-8d357596748b.png">

<img width="1030" alt="Screen Shot 2020-06-23 at 11 13 52 AM" src="https://user-images.githubusercontent.com/2212006/85421981-13eda880-b543-11ea-8ce3-6d0c5b69e58b.png">
