### PR TITLE
Don't Stub responses

### DIFF
--- a/source/guides/guides/network-requests.md
+++ b/source/guides/guides/network-requests.md
@@ -37,7 +37,7 @@ Within Cypress, you have the ability to choose whether to stub responses or allo
 
 Let's investigate both strategies, why you would use one versus the other, and why you should regularly use both.
 
-## Don't Stub Responses
+## Use Server Responses
 
 Requests that are not stubbed actually reach your server. By *not* stubbing your responses, you are writing true *end-to-end* tests. This means you are driving your application the same way a real user would.
 
@@ -53,7 +53,7 @@ In other words, you can have confidence your server is sending the correct data 
 If you are writing a traditional server-side application where most of the responses are HTML you will likely have few stubbed responses. However, most modern applications that serve JSON can take advantage of stubbing.
 
 {% note success Benefits %}
-- Guaranteed to work in production
+- More likely to work in production
 - Test coverage around server endpoints
 - Great for traditional server-side HTML rendering
 {% endnote %}


### PR DESCRIPTION
This seemed to me to be a mixed-message, the title **Don't Stub responses** is confusing as suggests you shouldn't stub, but then you're actually encouraging stubbing within the same page.

Also doesn't seem accurate to claim this is "Guaranteed to work in production".