### PR TITLE
Update system requirements to also display Linux deps

### DIFF
--- a/source/_partial/linux_dependencies.md
+++ b/source/_partial/linux_dependencies.md
@@ -1,0 +1,13 @@
+#### Ubuntu/Debian
+
+```shell
+apt-get install libgtk2.0-0 libgtk-3-0 libnotify-dev libgconf-2-4 libnss3 libxss1
+libasound2 libxtst6 xauth xvfb
+```
+
+#### CentOS
+
+```shell
+yum install -y xorg-x11-server-Xvfb gtk2-devel gtk3-devel libnotify-devel GConf2
+nss libXScrnSaver alsa-lib
+```

--- a/source/guides/getting-started/installing-cypress.md
+++ b/source/guides/getting-started/installing-cypress.md
@@ -13,15 +13,27 @@ title: Installing Cypress
 
 # System requirements
 
+### Operating System
+
 Cypress is a desktop application that is installed on your computer. The desktop application supports these operating systems:
 
 - **macOS** 10.9 and above *(64-bit only)*
 - **Linux** Ubuntu 12.04 and above, Fedora 21 and Debian 8 *(64-bit only)*
 - **Windows** 7 and above
 
-If using `npm` to install Cypress, we support:
+### Node.js
+
+If you're using `npm` to install Cypress, we support:
 
 - **Node.js** 8 and above
+
+### Linux
+
+If you're using Linux, you'll want to have the required dependencies installed on your system.
+
+We also have an official {% url 'cypress/base' 'https://hub.docker.com/r/cypress/base/' %} Docker container with all of the required dependencies installed.
+
+{% partial linux_dependencies %}
 
 # Installing
 

--- a/source/guides/guides/continuous-integration.md
+++ b/source/guides/guides/continuous-integration.md
@@ -539,13 +539,7 @@ If you are not using one of the above CI providers then make sure your system ha
 
 ### Linux
 
-```shell
-# Ubuntu/Debian
-apt-get install libgtk2.0-0 libgtk-3-0 libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
-
-# CentOS
-yum install -y xorg-x11-server-Xvfb gtk2-devel gtk3-devel libnotify-devel GConf2 nss libXScrnSaver alsa-lib
-```
+{% partial linux_dependencies %}
 
 ## Caching
 


### PR DESCRIPTION
- based on feedback from https://github.com/cypress-io/cypress/issues/1526, I think people aren't finding the Linux deps easily, so this adds them to the initial system requirements for the install doc.
- add partial to be shared for linux deps

<img width="937" alt="Screen Shot 2020-06-29 at 1 28 01 PM" src="https://user-images.githubusercontent.com/1271364/85982771-6845cc00-ba0c-11ea-9586-43fe54ddf62b.png">
