### PR TITLE
exclude electron from downloads directory workaround that only applies to Chrome

### DIFF
--- a/source/api/plugins/browser-launch-api.md
+++ b/source/api/plugins/browser-launch-api.md
@@ -228,7 +228,7 @@ module.exports = (on) => {
   on('before:browser:launch', (browser, options) => {
     const downloadDirectory = path.join(__dirname, '..', 'downloads')
 
-    if (browser.family === 'chromium') {
+    if (browser.family === 'chromium' && browser.name !== 'electron') {
       options.preferences.default['download'] = { default_directory: downloadDirectory }
 
       return options


### PR DESCRIPTION
Based off feedback from https://github.com/cypress-io/cypress/issues/4675#issuecomment-656340599