### PR TITLE
docs: add dashboard CTAs

### DIFF
--- a/source/guides/dashboard/introduction.md
+++ b/source/guides/dashboard/introduction.md
@@ -90,7 +90,6 @@ Once you log in to the {% url 'Dashboard Service' https://on.cypress.io/dashboar
 
 # Next Steps
 
-<!-- Line breaks removed to prevent random br elements -->
 {% note info %}
 ### Test and debug faster with the Cypress Dashboard
 

--- a/source/guides/dashboard/introduction.md
+++ b/source/guides/dashboard/introduction.md
@@ -92,5 +92,11 @@ Once you log in to the {% url 'Dashboard Service' https://on.cypress.io/dashboar
 
 <!-- Line breaks removed to prevent random br elements -->
 {% note info %}
-<p class="section-title">Test and debug faster with the Cypress Dashboard</p><ul class="mb-2"><li>See exact point of failure of tests running in CI</li><li>Supercharge test times by running tests in parallel</li><li>Get instant test failure alerts via Slack or GitHub</li></ul><a href="https://www.cypress.io/dashboard" class="button">Get Started Free</a>
+### Test and debug faster with the Cypress Dashboard
+
+- See exact point of failure of tests running in CI
+- Supercharge test times by running tests in parallel
+- Get instant test failure alerts via Slack or GitHub
+
+<a href="https://www.cypress.io/dashboard" class="button">Get Started Free</a>
 {% endnote %} 

--- a/source/guides/dashboard/introduction.md
+++ b/source/guides/dashboard/introduction.md
@@ -87,3 +87,10 @@ Once you log in to the {% url 'Dashboard Service' https://on.cypress.io/dashboar
 - [{% fa fa-folder-open-o %} cypress-example-kitchensink](https://dashboard.cypress.io/#/projects/4b7344)
 - [{% fa fa-folder-open-o %} cypress-example-todomvc](https://dashboard.cypress.io/#/projects/245obj)
 - [{% fa fa-folder-open-o %} cypress-example-piechopper](https://dashboard.cypress.io/#/projects/fuduzp)
+
+# Next Steps
+
+<!-- Line breaks removed to prevent random br elements -->
+{% note info %}
+<p class="section-title">Test and debug faster with the Cypress Dashboard</p><ul class="mb-2"><li>See exact point of failure of tests running in CI</li><li>Supercharge test times by running tests in parallel</li><li>Get instant test failure alerts via Slack or GitHub</li></ul><a href="https://www.cypress.io/dashboard" class="button">Get Started Free</a>
+{% endnote %} 

--- a/source/guides/guides/continuous-integration.md
+++ b/source/guides/guides/continuous-integration.md
@@ -124,7 +124,12 @@ When working with local `https` in webpack, set an environment variable to allow
 
 ## Record tests
 
-Cypress can record your tests and make the results available in the {% url 'Cypress Dashboard' https://on.cypress.io/dashboard %}.
+<!-- Line breaks removed to prevent random br elements -->
+{% note info %}
+<p class="section-title">Test and debug faster with the Cypress Dashboard</p><ul class="mb-2"><li>See exact point of failure of tests running in CI</li><li>Supercharge test times by running tests in parallel</li><li>Get instant test failure alerts via Slack or GitHub</li></ul><a href="https://www.cypress.io/dashboard" class="button">Get Started Free</a>
+{% endnote %} 
+
+Cypress can record your tests and make the results available in the {% url 'Cypress Dashboard' https://on.cypress.io/dashboard %}, which is a service that gives you access to recorded tests - typically when running Cypress tests from your {% url 'CI provider' continuous-integration %}. The Dashboard provides you insight into what happened when your tests ran.
 
 ### Recording tests allow you to:
 

--- a/source/guides/guides/continuous-integration.md
+++ b/source/guides/guides/continuous-integration.md
@@ -124,9 +124,14 @@ When working with local `https` in webpack, set an environment variable to allow
 
 ## Record tests
 
-<!-- Line breaks removed to prevent random br elements -->
 {% note info %}
-<p class="section-title">Test and debug faster with the Cypress Dashboard</p><ul class="mb-2"><li>See exact point of failure of tests running in CI</li><li>Supercharge test times by running tests in parallel</li><li>Get instant test failure alerts via Slack or GitHub</li></ul><a href="https://www.cypress.io/dashboard" class="button">Get Started Free</a>
+### Test and debug faster with the Cypress Dashboard
+
+- See exact point of failure of tests running in CI
+- Supercharge test times by running tests in parallel
+- Get instant test failure alerts via Slack or GitHub
+
+<a href="https://www.cypress.io/dashboard" class="button">Get Started Free</a>
 {% endnote %} 
 
 Cypress can record your tests and make the results available in the {% url 'Cypress Dashboard' dashboard-introduction %}, which is a service that gives you access to recorded tests - typically when running Cypress tests from your {% url 'CI provider' continuous-integration %}. The Dashboard provides you insight into what happened when your tests ran.

--- a/source/guides/guides/continuous-integration.md
+++ b/source/guides/guides/continuous-integration.md
@@ -129,7 +129,7 @@ When working with local `https` in webpack, set an environment variable to allow
 <p class="section-title">Test and debug faster with the Cypress Dashboard</p><ul class="mb-2"><li>See exact point of failure of tests running in CI</li><li>Supercharge test times by running tests in parallel</li><li>Get instant test failure alerts via Slack or GitHub</li></ul><a href="https://www.cypress.io/dashboard" class="button">Get Started Free</a>
 {% endnote %} 
 
-Cypress can record your tests and make the results available in the {% url 'Cypress Dashboard' https://on.cypress.io/dashboard %}, which is a service that gives you access to recorded tests - typically when running Cypress tests from your {% url 'CI provider' continuous-integration %}. The Dashboard provides you insight into what happened when your tests ran.
+Cypress can record your tests and make the results available in the {% url 'Cypress Dashboard' dashboard-introduction %}, which is a service that gives you access to recorded tests - typically when running Cypress tests from your {% url 'CI provider' continuous-integration %}. The Dashboard provides you insight into what happened when your tests ran.
 
 ### Recording tests allow you to:
 

--- a/source/guides/guides/parallelization.md
+++ b/source/guides/guides/parallelization.md
@@ -293,7 +293,12 @@ The Machines View charts spec files by the machines that executed them. This vie
 
 {% imgTag /img/guides/parallelization/machines-view.png "Machines view with parallelization" %}
 
-# See also
+# Next Steps
+
+<!-- Line breaks removed to prevent random br elements -->
+{% note info %}
+<p class="section-title">Test and debug faster with the Cypress Dashboard</p><ul class="mb-2"><li>See exact point of failure of tests running in CI</li><li>Supercharge test times by running tests in parallel</li><li>Get instant test failure alerts via Slack or GitHub</li></ul><a href="https://www.cypress.io/dashboard" class="button">Get Started Free</a>
+{% endnote %} 
 
 - {% url "Continuous Integration Guide" continuous-integration %}
 - {% url "Cross Browser Testing Guide" cross-browser-testing %}

--- a/source/guides/guides/parallelization.md
+++ b/source/guides/guides/parallelization.md
@@ -295,9 +295,14 @@ The Machines View charts spec files by the machines that executed them. This vie
 
 # Next Steps
 
-<!-- Line breaks removed to prevent random br elements -->
 {% note info %}
-<p class="section-title">Test and debug faster with the Cypress Dashboard</p><ul class="mb-2"><li>See exact point of failure of tests running in CI</li><li>Supercharge test times by running tests in parallel</li><li>Get instant test failure alerts via Slack or GitHub</li></ul><a href="https://www.cypress.io/dashboard" class="button">Get Started Free</a>
+### Test and debug faster with the Cypress Dashboard
+
+- See exact point of failure of tests running in CI
+- Supercharge test times by running tests in parallel
+- Get instant test failure alerts via Slack or GitHub
+
+<a href="https://www.cypress.io/dashboard" class="button">Get Started Free</a>
 {% endnote %} 
 
 - {% url "Continuous Integration Guide" continuous-integration %}

--- a/source/guides/guides/screenshots-and-videos.md
+++ b/source/guides/guides/screenshots-and-videos.md
@@ -75,7 +75,13 @@ So you are capturing screenshots and recording videos of your test runs, now wha
 
 <!-- Line breaks removed to prevent random br elements -->
 {% note info %}
-<p class="section-title">Test and debug faster with the Cypress Dashboard</p><ul class="mb-2"><li>See exact point of failure of tests running in CI</li><li>Supercharge test times by running tests in parallel</li><li>Get instant test failure alerts via Slack or GitHub</li></ul><a href="https://www.cypress.io/dashboard" class="button">Get Started Free</a>
+### Test and debug faster with the Cypress Dashboard
+
+- See exact point of failure of tests running in CI
+- Supercharge test times by running tests in parallel
+- Get instant test failure alerts via Slack or GitHub
+
+<a href="https://www.cypress.io/dashboard" class="button">Get Started Free</a>
 {% endnote %} 
 
 Something you can take advantage of today is the {% url 'Cypress Dashboard Service' dashboard-introduction%}: our companion enterprise service that stores your artifacts for you and lets you view them from any web browser, as well as share them with your team.

--- a/source/guides/guides/screenshots-and-videos.md
+++ b/source/guides/guides/screenshots-and-videos.md
@@ -73,6 +73,11 @@ So you are capturing screenshots and recording videos of your test runs, now wha
 
 ## Share Them With Your Team
 
+<!-- Line breaks removed to prevent random br elements -->
+{% note info %}
+<p class="section-title">Test and debug faster with the Cypress Dashboard</p><ul class="mb-2"><li>See exact point of failure of tests running in CI</li><li>Supercharge test times by running tests in parallel</li><li>Get instant test failure alerts via Slack or GitHub</li></ul><a href="https://www.cypress.io/dashboard" class="button">Get Started Free</a>
+{% endnote %} 
+
 Something you can take advantage of today is the {% url 'Cypress Dashboard Service' dashboard-introduction%}: our companion enterprise service that stores your artifacts for you and lets you view them from any web browser, as well as share them with your team.
 
 ## Visual Regression Test / Screenshot Diffing

--- a/source/guides/overview/why-cypress.md
+++ b/source/guides/overview/why-cypress.md
@@ -43,9 +43,14 @@ Cypress can test anything that runs in a browser.
 
 # Cypress ecosystem
 
-<!-- Line breaks removed to prevent random br elements -->
 {% note info %}
-<p class="section-title">Test and debug faster with the Cypress Dashboard</p><ul class="mb-2"><li>See exact point of failure of tests running in CI</li><li>Supercharge test times by running tests in parallel</li><li>Get instant test failure alerts via Slack or GitHub</li></ul><a href="https://www.cypress.io/dashboard" class="button">Get Started Free</a>
+### Test and debug faster with the Cypress Dashboard
+
+- See exact point of failure of tests running in CI
+- Supercharge test times by running tests in parallel
+- Get instant test failure alerts via Slack or GitHub
+
+<a href="https://www.cypress.io/dashboard" class="button">Get Started Free</a>
 {% endnote %} 
 
 Cypress consists of a free, {% url "open source" https://github.com/cypress-io/cypress %}, {% url "locally installed" installing-cypress %} Test Runner **and** a Dashboard Service for {% url 'recording your tests' dashboard-introduction%}.

--- a/source/guides/overview/why-cypress.md
+++ b/source/guides/overview/why-cypress.md
@@ -43,6 +43,11 @@ Cypress can test anything that runs in a browser.
 
 # Cypress ecosystem
 
+<!-- Line breaks removed to prevent random br elements -->
+{% note info %}
+<p class="section-title">Test and debug faster with the Cypress Dashboard</p><ul class="mb-2"><li>See exact point of failure of tests running in CI</li><li>Supercharge test times by running tests in parallel</li><li>Get instant test failure alerts via Slack or GitHub</li></ul><a href="https://www.cypress.io/dashboard" class="button">Get Started Free</a>
+{% endnote %} 
+
 Cypress consists of a free, {% url "open source" https://github.com/cypress-io/cypress %}, {% url "locally installed" installing-cypress %} Test Runner **and** a Dashboard Service for {% url 'recording your tests' dashboard-introduction%}.
 
 - ***First:*** Cypress helps you set up and start writing tests every day while you build your application locally. *TDD at its best!*

--- a/themes/cypress/source/css/_mixins.scss
+++ b/themes/cypress/source/css/_mixins.scss
@@ -4,3 +4,13 @@
     @content;
   }
 }
+
+// Typography
+@mixin article-title() {
+  font-family: $font-title;
+  font-weight: bold;
+  text-decoration: none;
+  color: $color-default;
+  line-height: 1.7em;
+  color: #282C34;
+}

--- a/themes/cypress/source/css/_partial/button.scss
+++ b/themes/cypress/source/css/_partial/button.scss
@@ -1,0 +1,30 @@
+.button {
+  background-color: $color-green;
+  color: rgb(255, 255, 255);
+  align-self: center;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1rem;
+  font-weight: bold;
+  line-height: 3rem;
+  text-decoration: none;
+  padding: 0 1rem;
+  border-radius: 30px;
+  border-width: 2px;
+  border-style: solid;
+  border-color: transparent;
+  transition: background-color 0.2s cubic-bezier(0.6, 0.41, 0.47, 1.18) 0s, color 0.3s cubic-bezier(0.6, 0.41, 0.47, 1.18) 0s;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.article-content .note.info a.button {
+  color: #fff;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}

--- a/themes/cypress/source/css/_partial/button.scss
+++ b/themes/cypress/source/css/_partial/button.scss
@@ -17,7 +17,7 @@
   transition: background-color 0.2s cubic-bezier(0.6, 0.41, 0.47, 1.18) 0s, color 0.3s cubic-bezier(0.6, 0.41, 0.47, 1.18) 0s;
 
   &:hover {
-    text-decoration: underline;
+    background-color: $color-green-dark;
   }
 }
 
@@ -25,6 +25,6 @@
   color: #fff;
 
   &:hover {
-    text-decoration: underline;
+    background-color: $color-green-dark;
   }
 }

--- a/themes/cypress/source/css/_partial/page.scss
+++ b/themes/cypress/source/css/_partial/page.scss
@@ -145,10 +145,6 @@ a.article-edit-link {
     padding-left: 30px;
     list-style: disc;
 
-    &.mb-2 {
-      margin-bottom: 2rem;
-    }
-
     ul {
       margin-top: 0;
       margin-bottom: 0;
@@ -631,11 +627,6 @@ a.article-edit-link {
   font-size: 2.6em;
 }
 
-.section-title {
-  @include article-title;
-  font-size: 1.2rem;
-}
-
 .article-inner {
   @include clearfix;
 }
@@ -648,7 +639,7 @@ a.article-edit-link {
   height: auto;
   margin: 2em 0;
   border: 1px solid #ddd;
-  box-shadow: 0 0px 3px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 0 3px rgba(0, 0, 0, 0.3);
 }
 
 .embed-container iframe {

--- a/themes/cypress/source/css/_partial/page.scss
+++ b/themes/cypress/source/css/_partial/page.scss
@@ -145,6 +145,10 @@ a.article-edit-link {
     padding-left: 30px;
     list-style: disc;
 
+    &.mb-2 {
+      margin-bottom: 2rem;
+    }
+
     ul {
       margin-top: 0;
       margin-bottom: 0;
@@ -635,6 +639,11 @@ a.article-edit-link {
   line-height: 1.7em;
   color: #282C34;
   font-size: 2.6em;
+}
+
+.section-title {
+  @include article-title;
+  font-size: 1.2rem;
 }
 
 .article-inner {

--- a/themes/cypress/source/css/_partial/page.scss
+++ b/themes/cypress/source/css/_partial/page.scss
@@ -273,12 +273,7 @@ a.article-edit-link {
   }
 
   h1.article-title {
-    font-family: $font-title;
-    font-weight: bold;
-    text-decoration: none;
-    color: $color-default;
-    line-height: 1.7em;
-    color: #282C34;
+    @include article-title;
     font-size: 2.6em;
   }
 
@@ -632,12 +627,7 @@ a.article-edit-link {
 }
 
 .article-title {
-  font-family: $font-title;
-  font-weight: bold;
-  text-decoration: none;
-  color: $color-default;
-  line-height: 1.7em;
-  color: #282C34;
+  @include article-title;
   font-size: 2.6em;
 }
 

--- a/themes/cypress/source/css/_partial/utilities.scss
+++ b/themes/cypress/source/css/_partial/utilities.scss
@@ -1,0 +1,3 @@
+.mb-2 {
+  margin-bottom: 2rem;
+}

--- a/themes/cypress/source/css/_partial/utilities.scss
+++ b/themes/cypress/source/css/_partial/utilities.scss
@@ -1,3 +1,0 @@
-.mb-2 {
-  margin-bottom: 2rem;
-}

--- a/themes/cypress/source/css/_variables.scss
+++ b/themes/cypress/source/css/_variables.scss
@@ -8,7 +8,8 @@ $white-80: rgba(255,255,255,0.8);
 $white-60: rgba(255,255,255,0.6);
 
 $color-gray: #999;
-$color-green: #04C38E;
+$color-green: hsl(163, 96%, 39%); // #04c38e
+$color-green-dark: hsl(160, 92%, 28%); // #06885d
 $color-red: #EA4D5C;
 $color-orange: #f0ad4e;
 $color-default: #2e3138;


### PR DESCRIPTION
## Previews:

<img width="1006" alt="01-why-cypress" src="https://user-images.githubusercontent.com/4836334/87584664-da284180-c6ab-11ea-9f6c-686962bb315d.png">
<img width="996" alt="02-screenshots-and-videos" src="https://user-images.githubusercontent.com/4836334/87584665-da284180-c6ab-11ea-8d34-745a5f00b37f.png">
<img width="1013" alt="03-parallelization" src="https://user-images.githubusercontent.com/4836334/87584666-da284180-c6ab-11ea-9867-8baeceffa4df.png">
<img width="1006" alt="04-dashboard-intro" src="https://user-images.githubusercontent.com/4836334/87584668-dac0d800-c6ab-11ea-9446-9866e85e463c.png">
<img width="977" alt="05-continuous-integration" src="https://user-images.githubusercontent.com/4836334/87584669-dac0d800-c6ab-11ea-8d00-c12cd23cc59e.png">

## Note:

Tried doing this with a partial but it kept rendering random `<br>` elements. 