### PR TITLE
document movetoend and movetostart special chars for type

### DIFF
--- a/source/api/commands/type.md
+++ b/source/api/commands/type.md
@@ -50,6 +50,8 @@ Sequence | Notes
 `{home}` | Moves cursor to the start of the line
 `{insert}` | Inserts character to the right of the cursor
 `{leftarrow}` | Moves cursor left
+`{movetoend}` | Moves cursor to end of typeable element
+`{movetostart}` | Moves cursor to the start of typeable element
 `{pagedown}` | Scrolls down
 `{pageup}` | Scrolls up
 `{rightarrow}` | Moves cursor right

--- a/source/api/commands/type.md
+++ b/source/api/commands/type.md
@@ -32,7 +32,7 @@ cy.url().type('www.cypress.io')      // Errors, 'url' does not yield DOM element
 
 The text to be typed into the DOM element.
 
-Text passed to `.type()` may include any of the special character sequences below. These characters will pass along the correct `keyCode`, `key`, and `which` codes to any events issued during `.type()`.
+Text passed to `.type()` may include any of the special character sequences below. These characters will pass along the correct `keyCode`, `key`, and `which` codes to any events issued during `.type()`. Some of the special character sequences may perform actions during typing such as `{movetoend}`, `{movetostart}`, or `{selectall}`.
 
 {% note info %}
 To disable parsing special characters sequences, set the `parseSpecialCharSequences` option to `false`.
@@ -50,18 +50,13 @@ Sequence | Notes
 `{home}` | Moves cursor to the start of the line
 `{insert}` | Inserts character to the right of the cursor
 `{leftarrow}` | Moves cursor left
+`{movetoend}` | Moves cursor to end of typeable element
+`{movetostart}` | Moves cursor to the start of typeable element
 `{pagedown}` | Scrolls down
 `{pageup}` | Scrolls up
 `{rightarrow}` | Moves cursor right
-`{uparrow}` | Moves cursor up
-
-Text passed to `.type()` may include special actions to be performed during typing:
-
-Sequence | Notes
---- | ---
-`{movetoend}` | Moves cursor to end of typeable element
-`{movetostart}` | Moves cursor to the start of typeable element
 `{selectall}` | Selects all text by creating a `selection range`
+`{uparrow}` | Moves cursor up
 
 Text passed to `.type()` may also include any of these modifier character sequences:
 

--- a/source/api/commands/type.md
+++ b/source/api/commands/type.md
@@ -32,7 +32,7 @@ cy.url().type('www.cypress.io')      // Errors, 'url' does not yield DOM element
 
 The text to be typed into the DOM element.
 
-Text passed to `.type()` may include any of the special character sequences below.
+Text passed to `.type()` may include any of the special character sequences below. These characters will pass along the correct `keyCode`, `key`, and `which` codes to any events issued during `.type()`.
 
 {% note info %}
 To disable parsing special characters sequences, set the `parseSpecialCharSequences` option to `false`.
@@ -50,13 +50,18 @@ Sequence | Notes
 `{home}` | Moves cursor to the start of the line
 `{insert}` | Inserts character to the right of the cursor
 `{leftarrow}` | Moves cursor left
-`{movetoend}` | Moves cursor to end of typeable element
-`{movetostart}` | Moves cursor to the start of typeable element
 `{pagedown}` | Scrolls down
 `{pageup}` | Scrolls up
 `{rightarrow}` | Moves cursor right
-`{selectall}` | Selects all text by creating a `selection range`
 `{uparrow}` | Moves cursor up
+
+Text passed to `.type()` may include special actions to be performed during typing:
+
+Sequence | Notes
+--- | ---
+`{movetoend}` | Moves cursor to end of typeable element
+`{movetostart}` | Moves cursor to the start of typeable element
+`{selectall}` | Selects all text by creating a `selection range`
 
 Text passed to `.type()` may also include any of these modifier character sequences:
 


### PR DESCRIPTION
Awaiting some clarification on how this is different from end and home special chars https://github.com/cypress-io/cypress/pull/7970