### PR TITLE
4.11.0 Release

### DIFF
--- a/source/_changelogs/4.11.0.md
+++ b/source/_changelogs/4.11.0.md
@@ -1,6 +1,6 @@
 # 4.11.0
 
-*Released 7/20/2020*
+*Released 7/21/2020*
 
 **Features:**
 

--- a/source/_changelogs/4.11.0.md
+++ b/source/_changelogs/4.11.0.md
@@ -4,12 +4,32 @@
 
 **Features:**
 
+- You can now pass an `ensureScrollability: false` option to {% url "`.scrollTo()`" scrollto %} to skip checking whether the element is scrollable. Addresses {% issue 1924 %}.
+- {% url "`cy.clock()`" clock %} now accepts Dates as well as a Number for now. Fixes {% issue 7786 %}.
 
 **Bugfixes:**
+
+- Running multiple specs within Firefox during `cypress run` on Windows will no longer fail trying to make a connection to the browser. Fixes {% issue 6392 %}.
+- Fixed an issue where Cypress tests in Chromium-family browsers could randomly fail with the error "WebSocket is already in CLOSING or CLOSED state." Fixes {% issue 7180 %}.
+- Taking a screenshot of an element that changes height upon scroll will no longer throw an `invalid for option "size"` error. Fixes {% issue 6099 %}.
+- Setting `viewportHeight` or `viewportWidth` from within the {% url "test configuration" writing-and-organizing-tests#test-configuration %} now properly changes the viewport size for the duration of the suite or test.
+- Setting deep objects and arrays on `config` within the `pluginsFile` now sets the values correctly. Fixes {% issue 7959 %}.
+- The progress bar for `cy.wait()` now reflects the correct `requestTimeout` and `responseTimeout` of the command. Fixes {% issue 7881 %}.
+- The command's progress bar will not longer restart when its parent test is collapsed in the Command Log. Fixes {% issue 7912 %}.
+- Key value pairs sent to `ELECTRON_EXTRA_LAUNCH_ARGS` as `key=value` will now be properly read in. Fixes {% issue 7994 %}.
 
 
 **Misc:**
 
+- The error messages thrown from `pluginsFile` and `supportFile` now mention that `.ts` extensions are supported. Addresses {% issue 7940 %}.
+- The style when focusing on tests in the Command Log has been updated. Addresses {% issue 7855 %}.
 
 **Dependency Updates:**
 
+- Upgraded `firefox-profile` from `1.3.1` to `2.0.0`. Addressed in {% PR 8000 %}.
+- Upgraded `fix-path` from `2.1.0` to `3.0.0`. Addressed in {% PR 8028 %}.
+- Upgraded `lodash` from `4.17.15` to `4.17.19`. Addressed in {% PR 7954 %}.
+- Upgraded `proxy-from-env` from `1.0.0` to `1.1.0`. Addressed in {% PR 7900 %}.
+- Upgraded `resolve` from `1.13.1` to `1.17.0`. Addressed in {% PR 7989 %}.
+- Upgraded `systeminformation` from `4.21.1` to `4.26.9`. Addressed in {% PR 7975 %}.
+- Upgraded `uuid` from `3.3.2` to `8.2.0`. Addressed in {% PR 7976 %}, {% PR 8002 %}, and {% PR 8011 %}.

--- a/source/_changelogs/4.11.0.md
+++ b/source/_changelogs/4.11.0.md
@@ -1,0 +1,15 @@
+# 4.11.0
+
+*Released 7/20/2020*
+
+**Features:**
+
+
+**Bugfixes:**
+
+
+**Misc:**
+
+
+**Dependency Updates:**
+

--- a/source/_changelogs/4.11.0.md
+++ b/source/_changelogs/4.11.0.md
@@ -10,6 +10,7 @@
 **Bugfixes:**
 
 - Running multiple specs within Firefox during `cypress run` on Windows will no longer fail trying to make a connection to the browser. Fixes {% issue 6392 %}.
+- Cypress will no longer throw a `Cannot read property 'isAttached' of undefined` error during `cypress run` on Firefox versions >= 75. Fixes {% issue 6813 %}.
 - Fixed an issue where Cypress tests in Chromium-family browsers could randomly fail with the error "WebSocket is already in CLOSING or CLOSED state." Fixes {% issue 7180 %}.
 - Taking a screenshot of an element that changes height upon scroll will no longer throw an `invalid for option "size"` error. Fixes {% issue 6099 %}.
 - Setting `viewportHeight` or `viewportWidth` from within the {% url "test configuration" writing-and-organizing-tests#test-configuration %} now properly changes the viewport size for the duration of the suite or test.
@@ -18,7 +19,7 @@
 - The command's progress bar will not longer restart when its parent test is collapsed in the Command Log. Fixes {% issue 7912 %}.
 - Key value pairs sent to `ELECTRON_EXTRA_LAUNCH_ARGS` as `key=value` will now be properly read in. Fixes {% issue 7994 %}.
 - Stubbed responses responding with an empty string to {% url "`cy.route()`" route %} now correctly display as 'xhr stub' in the Test Runner's Command Log. Fixes {% issue 8018 %}.
-
+- Quickly reclicking the "Run All Tests" button in the Test Runners' Command Log will no longer throw errors about undefined properties and the tests will no longer hang. Fixes {% issue 7968 %}.
 
 **Misc:**
 
@@ -27,10 +28,12 @@
 
 **Dependency Updates:**
 
+- Upgraded `@benmalka/foxdriver` from `0.4.0` to `0.4.1`. Addressed in {% PR 8040 %}.
 - Upgraded `firefox-profile` from `1.3.1` to `2.0.0`. Addressed in {% PR 8000 %}.
 - Upgraded `fix-path` from `2.1.0` to `3.0.0`. Addressed in {% PR 8028 %}.
 - Upgraded `human-interval` from `0.1.6` to `1.0.0`. Addressed in {% PR 8031 %}.
 - Upgraded `lodash` from `4.17.15` to `4.17.19`. Addressed in {% PR 7954 %}.
+- Upgraded `plist` from `2.1.0` to `3.0.1`. Addressed in {% PR 8045 %}.
 - Upgraded `proxy-from-env` from `1.0.0` to `1.1.0`. Addressed in {% PR 7900 %}.
 - Upgraded `resolve` from `1.13.1` to `1.17.0`. Addressed in {% PR 7989 %}.
 - Upgraded `systeminformation` from `4.21.1` to `4.26.9`. Addressed in {% PR 7975 %}.

--- a/source/_changelogs/4.11.0.md
+++ b/source/_changelogs/4.11.0.md
@@ -29,6 +29,7 @@
 
 - Upgraded `firefox-profile` from `1.3.1` to `2.0.0`. Addressed in {% PR 8000 %}.
 - Upgraded `fix-path` from `2.1.0` to `3.0.0`. Addressed in {% PR 8028 %}.
+- Upgraded `human-interval` from `0.1.6` to `1.0.0`. Addressed in {% PR 8031 %}.
 - Upgraded `lodash` from `4.17.15` to `4.17.19`. Addressed in {% PR 7954 %}.
 - Upgraded `proxy-from-env` from `1.0.0` to `1.1.0`. Addressed in {% PR 7900 %}.
 - Upgraded `resolve` from `1.13.1` to `1.17.0`. Addressed in {% PR 7989 %}.

--- a/source/_changelogs/4.11.0.md
+++ b/source/_changelogs/4.11.0.md
@@ -17,6 +17,7 @@
 - The progress bar for `cy.wait()` now reflects the correct `requestTimeout` and `responseTimeout` of the command. Fixes {% issue 7881 %}.
 - The command's progress bar will not longer restart when its parent test is collapsed in the Command Log. Fixes {% issue 7912 %}.
 - Key value pairs sent to `ELECTRON_EXTRA_LAUNCH_ARGS` as `key=value` will now be properly read in. Fixes {% issue 7994 %}.
+- Stubbed responses responding with an empty string to {% url "`cy.route()`" route %} now correctly display as 'xhr stub' in the Test Runner's Command Log. Fixes {% issue 8018 %}.
 
 
 **Misc:**

--- a/source/api/commands/scrollto.md
+++ b/source/api/commands/scrollto.md
@@ -175,6 +175,10 @@ When clicking on `scrollTo` within the command log, the console outputs the foll
 
 {% imgTag /img/api/scrollto/console-log-scrollto.png "console.log for scrollTo" %}
 
+{% history %}
+{% url "4.11.0" changelog#4-11-0 %} | Added support for `ensureScrollable` option.
+{% endhistory %}
+
 # See also
 
 - {% url `.scrollIntoView()` scrollintoview %}


### PR DESCRIPTION
- [x] 4.11.0 Changelog
- [x] New `ensureScrollable` option for `scrollTo` https://github.com/cypress-io/cypress-documentation/pull/3006