### PR TITLE
Update options for all headless browsers to change screen size

### DIFF
--- a/source/api/plugins/browser-launch-api.md
+++ b/source/api/plugins/browser-launch-api.md
@@ -167,7 +167,7 @@ If you are running Cypress tests using a Chromium-based browser, you can see ALL
 When a browser runs headless, there is no physical display. You can override the default screen size of 1280x720 when running headless as shown below. This will affect the size of screenshots and videos taken during the run.
 
 {% note warning %}
-This setting changes the display size of the screen and does not affect the `viewportWidth` and `viewportHeight` set in the configuration. The `viewportWidth` and `viewportHeight` only affect the size of the application under test displayed inside the Test Runner.
+This setting changes the display size of the screen and does not affect the `viewportWidth` and `viewportHeight` set in the {% url "configuration" configuration %}. The `viewportWidth` and `viewportHeight` only affect the size of the application under test displayed inside the Test Runner.
 {% endnote %}
 
 ```js

--- a/source/api/plugins/browser-launch-api.md
+++ b/source/api/plugins/browser-launch-api.md
@@ -166,6 +166,10 @@ If you are running Cypress tests using a Chromium-based browser, you can see ALL
 
 When a browser runs headless, there is no physical display. You can override the default screen size of 1280x720 when running headless as shown below. This will affect the size of screenshots and videos taken during the run.
 
+{% note warning %}
+This setting changes the display size of the screen and does not affect the `viewportWidth` and `viewportHeight` set in the configuration. The `viewportWidth` and `viewportHeight` only affect the size of the application under test displayed inside the Test Runner.
+{% endnote %}
+
 ```js
 // cypress/plugins/index.js
 module.exports = (on, config) => {

--- a/source/api/plugins/browser-launch-api.md
+++ b/source/api/plugins/browser-launch-api.md
@@ -2,7 +2,7 @@
 title: Browser Launch API
 ---
 
-Before Cypress launches a browser, it gives you the opportunity to modify the browser preferences, install extensions, add and remove command-line arguments, and modify other options.
+Before Cypress launches a browser, it gives you the opportunity to modify the browser preferences, install extensions, add and remove command-line arguments, and modify other options from your {% url "`pluginsFile`" plugins-guide %}.
 
 # Syntax
 
@@ -55,6 +55,7 @@ Here are args available for the currently supported browsers:
 * {% url 'Firefox' "https://developer.mozilla.org/docs/Mozilla/Command_Line_Options" %}
 
 ```js
+// cypress/plugins/index.js
 module.exports = (on, config) => {
   on('before:browser:launch', (browser = {}, launchOptions) => {
     // `args` is an array of all the arguments that will
@@ -82,6 +83,7 @@ module.exports = (on, config) => {
 ### Add browser extensions:
 
 ```js
+// cypress/plugins/index.js
 module.exports = (on, config) => {
   on('before:browser:launch', (browser, launchOptions) => {
     // supply the absolute path to an unpacked extension's folder
@@ -102,6 +104,7 @@ Here are preferences available for the currently supported browsers:
 * Firefox: visit `about:config` URL within your Firefox browser to see all available preferences.
 
 ```js
+// cypress/plugins/index.js
 module.exports = (on, config) => {
   on('before:browser:launch', (browser, launchOptions) => {
     if (browser.family === 'chromium' && browser.name !== 'electron') {
@@ -159,18 +162,40 @@ If you are running Cypress tests using a Chromium-based browser, you can see ALL
 
 # Examples
 
-## Set screen size when running headless Chrome
+## Set screen size when running headless
 
-When a browser runs headless, there is no physical display. You can override the default screen size of 1280x720 when running headless as shown below.
+When a browser runs headless, there is no physical display. You can override the default screen size of 1280x720 when running headless as shown below. This will affect the size of screenshots and videos taken during the run.
 
 ```js
+// cypress/plugins/index.js
 module.exports = (on, config) => {
   on('before:browser:launch', (browser, launchOptions) => {
     if (browser.name === 'chrome' && browser.isHeadless) {
+      // fullPage screenshot size is 1400x1200 on non-retina screens
+      // and 2800x2400 on retina screens
       launchOptions.args.push('--window-size=1400,1200')
 
-      return launchOptions
+      // force screen to be non-retina (1400x1200 size)
+      launchOptions.args.push('--force-device-scale-factor=1')
+
+      // force screen to be retina (2800x2400 size)
+      // launchOptions.args.push('--force-device-scale-factor=2')
     }
+
+    if (browser.name === 'electron' && browser.isHeadless) {
+      // fullPage screenshot size is 1400x1200
+      launchOptions.preferences.width = 1400
+      launchOptions.preferences.height = 1200
+    }
+
+    if (browser.name === 'firefox' && browser.isHeadless) {
+      // menubars take up height on the screen
+      // so fullPage screenshot size is 1400x1126
+      launchOptions.args.push('--width=1400')
+      launchOptions.args.push('--height=1200')
+    }
+
+    return launchOptions
   })
 }
 ```
@@ -178,6 +203,7 @@ module.exports = (on, config) => {
 ## Start fullscreen
 
 ```js
+// cypress/plugins/index.js
 module.exports = (on, config) => {
   on('before:browser:launch', (browser = {}, launchOptions) => {
     if (browser.family === 'chromium' && browser.name !== 'electron') {
@@ -204,6 +230,7 @@ By default, Cypress passes the Chrome command line switch to enable a fake video
 You can however send your own video file for testing by passing a Chrome command line switch pointing to a video file.
 
 ```js
+// cypress/plugins/index.js
 module.exports = (on, config) => {
   on('before:browser:launch', (browser = {}, launchOptions) => {
     if (browser.family === 'chromium' && browser.name !== 'electron') {
@@ -224,6 +251,7 @@ module.exports = (on, config) => {
 Change the download directory of files downloaded during Cypress tests.
 
 ```js
+// cypress/plugins/index.js
 module.exports = (on) => {
   on('before:browser:launch', (browser, options) => {
     const downloadDirectory = path.join(__dirname, '..', 'downloads')


### PR DESCRIPTION
- Close #3034
- Got options for Electron and Firefox now
- Add note about retina screens with Chrome
- Add warning about how this doesn't have to do with `viewportHeight` and `viewportWidth`
- Also add note about us being in cypress/plugins/index.js file since people
just jump to the section they need and don’t know where to add the code.