### PR TITLE
Remove deprecated shadow-dom plugin

### DIFF
--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -262,12 +262,6 @@
       keywords: [commands, downloading]
       badge: community
 
-    - name: cypress-shadow-dom
-      description: Custom commands for shadow DOM support
-      link: https://github.com/abramenal/cypress-shadow-dom
-      keywords: [shadow, shadow-dom, polymer, lit-html, commands]
-      badge: community
-
     - name: cypress-testing-library
       description: 🐅 Simple and complete custom Cypress commands and utilities that encourage good testing practices.
       link: https://github.com/kentcdodds/cypress-testing-library


### PR DESCRIPTION
- This has been replaced by experimental feature + the plugin is shown as deprecated by the creator.