### PR TITLE
docs: add workaround for large windows in headless (#2102)

### DIFF
--- a/source/guides/guides/continuous-integration.md
+++ b/source/guides/guides/continuous-integration.md
@@ -723,6 +723,21 @@ module.exports = (on, config) => {
 }
 ```
 
+In addition, {% issue 2102 "this issue" %} reports that headless runs do not render a full-size image for viewports larger than 1280x720. To test larger viewports, set `viewportWidth` and `viewportHeight` in `cypress.json`, and amend the shared memory fix to set the maximum window size:
+
+```javascript
+module.exports = (on, config) => {
+  on('before:browser:launch', (browser = {}, launchOptions) => {
+    if (browser.family === 'chromium' && browser.name !== 'electron') {
+      launchOptions.args.push('--disable-dev-shm-usage')
+      launchOptions.args.push('--window-size=2560,1080')
+    }
+
+    return launchOptions
+  })
+}
+```
+
 ## Xvfb
 
 When running on Linux, Cypress needs an X11 server; otherwise it spawns its own X11 server during the test run. When running several Cypress instances in parallel, the spawning of multiple X11 servers at once can cause problems for some of them. In this case, you can separately start a single X11 server and pass the server's address to each Cypress instance using `DISPLAY` variable.


### PR DESCRIPTION
Add notes from [#2102](https://github.com/cypress-io/cypress/issues/2102) about working with large window sizes in a headless environment