### PR TITLE
Fix typo in spanish translation

### DIFF
--- a/themes/cypress/languages/es.yml
+++ b/themes/cypress/languages/es.yml
@@ -44,7 +44,7 @@ sidebar:
     debugging: Depuración
     variables-and-aliases: Variables y alias
     stubs-spies-and-clocks: Stub, Spy y Clock
-    network-requests: Soliciudes de red
+    network-requests: Solicitudes de red
     screenshots-and-videos: Capturas de pantalla y videos
     guides: Guías
     command-line: Línea de comandos


### PR DESCRIPTION
I found this error in the live documentation and just fixed it in github itself. I didn't find any open issue or PR regarding this.