### PR TITLE
Add docs for  visibility check

### DIFF
--- a/source/guides/core-concepts/interacting-with-elements.md
+++ b/source/guides/core-concepts/interacting-with-elements.md
@@ -47,9 +47,7 @@ Whenever Cypress cannot interact with an element, it could fail at any of the ab
 
 ## Visibility
 
-Cypress checks a lot of things to determine an element's visibility.
-
-The following calculations factor in CSS translations and transforms.
+Cypress checks a lot of things to determine an element's visibility. The following calculations factor in CSS translations and transforms.
 
 ### An element is considered hidden if:
 
@@ -57,10 +55,6 @@ The following calculations factor in CSS translations and transforms.
 - Its CSS property (or ancestors) is `visibility: hidden`.
 - Its CSS property (or ancestors) is `display: none`.
 - Its CSS property is `position: fixed` and it's offscreen or covered up.
-- Its CSS property (or ancestors) is `opacity: 0`. There is a specific exception made for this check when determining actionability, since elements with `opacity: 0` are invisible to the eye but can be interacted with.
-
-### Additionally an element is considered hidden if:
-
 - Any of its ancestors **hides overflow**\*
   - AND that ancestor has a `width` or `height` of `0`
   - AND an element between that ancestor and the element is `position: absolute`
@@ -71,7 +65,13 @@ The following calculations factor in CSS translations and transforms.
   - AND the element is `position: relative`
   - AND it is positioned outside that ancestor's bounds
 
-\***hides overflow** means it has `overflow: hidden`, `overflow-x: hidden`, `overflow-y : hidden`, `overflow: scroll`, or `overflow: auto`
+\***hides overflow** means it has `overflow: hidden`, `overflow-x: hidden`, `overflow-y: hidden`, `overflow: scroll`, or `overflow: auto`
+
+{% note info "Opacity" %}
+Elements where the CSS property (or ancestors) is `opacity: 0` are considered hidden when {% url "asserting on the element's visibility directly" assertions#Visibility %}.
+
+However elements where the CSS property (or ancestors) is `opacity: 0` are considered actionable and any commands used to interact with the hidden element will perform the action.
+{% endnote %}
 
 ## Disability
 

--- a/source/guides/core-concepts/interacting-with-elements.md
+++ b/source/guides/core-concepts/interacting-with-elements.md
@@ -57,6 +57,7 @@ The following calculations factor in CSS translations and transforms.
 - Its CSS property (or ancestors) is `visibility: hidden`.
 - Its CSS property (or ancestors) is `display: none`.
 - Its CSS property is `position: fixed` and it's offscreen or covered up.
+- Its CSS property (or ancestors) is `opacity: 0`. There is a specific exception made for this check when determining actionability, since elements with `opacity: 0` are invisible to the eye but can be interacted with.
 
 ### Additionally an element is considered hidden if:
 

--- a/source/zh-cn/guides/core-concepts/interacting-with-elements.md
+++ b/source/zh-cn/guides/core-concepts/interacting-with-elements.md
@@ -55,6 +55,7 @@ The following calculations factor in CSS translations and transforms.
 - 它的CSS属性（或祖先）是 `visibility: hidden`.
 - 它的CSS属性（或祖先）是 `display: none`.
 - 它的CSS属性是 `position: fixed` 并且它在屏幕外或被掩盖。
+- 它的CSS属性（或祖先）是 `opacity: 0`. 有一个特别的例外。`opacity:0` 的元素是看不到但是会互动。
 
 ### 此外，在以下情况，元素也会被视为隐藏：
 

--- a/source/zh-cn/guides/core-concepts/interacting-with-elements.md
+++ b/source/zh-cn/guides/core-concepts/interacting-with-elements.md
@@ -55,7 +55,6 @@ The following calculations factor in CSS translations and transforms.
 - 它的CSS属性（或祖先）是 `visibility: hidden`.
 - 它的CSS属性（或祖先）是 `display: none`.
 - 它的CSS属性是 `position: fixed` 并且它在屏幕外或被掩盖。
-- 它的CSS属性（或祖先）是 `opacity: 0`. 有一个特别的例外。`opacity:0` 的元素是看不到但是会互动。
 
 ### 此外，在以下情况，元素也会被视为隐藏：
 


### PR DESCRIPTION
Adds documentation for `opacity: 0` now being considered invisible, with additional explanation regarding the exception for actionability.

Chinese roughly translates to "There is a special exception. The element of `opacity:0` is invisible but interactive” which I feel communicates the message well enough.

Contingent on https://github.com/cypress-io/cypress/pull/8244 being merged in a future major release