### PR TITLE
Add note about Chrome not being supported below 64 in Cypress

### DIFF
--- a/source/guides/guides/launching-browsers.md
+++ b/source/guides/guides/launching-browsers.md
@@ -47,7 +47,7 @@ Because Electron is the default browser - it is typically run in CI. If you are 
 
 ## Chrome Browsers
 
-All Chrome* flavored browsers will be detected and are supported.
+All Chrome* flavored browsers will be detected and are supported above Chrome 64.
 
 You can launch Chrome like this:
 


### PR DESCRIPTION
- We don’t support Chrome less than 64 as shown in this line https://github.com/cypress-io/cypress/blob/develop/packages/server/lib/browsers/chrome.ts#L461:L461