### PR TITLE
Fix incorrect JS in "Change headers" paragraph

### DIFF
--- a/source/api/commands/route.md
+++ b/source/api/commands/route.md
@@ -346,7 +346,7 @@ If you'd like to override this, explicitly pass in `headers` as an object litera
 ```javascript
 cy.route({
   url: '**/user-image.png',
-  response: 'fx:logo.png,binary' // binary encoding
+  response: 'fx:logo.png,binary', // binary encoding
   headers: {
     // set content-type headers
     'content-type': 'binary/octet-stream'


### PR DESCRIPTION
A comma is missing in the code sample here:
![image](https://user-images.githubusercontent.com/6616955/90795851-dcb33200-e30e-11ea-942d-e4604a640433.png)

This PR fixes it.