### PR TITLE
Add cypress-rollup-preprocessor to plugins list

### DIFF
--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -42,6 +42,12 @@
       keywords: [rollup]
       badge: community
 
+    - name: cypress-rollup-preprocessor
+      description: Cypress preprocessor for bundling JavaScript via rollup
+      link: https://github.com/lmarqs/cypress-rollup-preprocessor
+      keywords: [rollup]
+      badge: community
+
 - name: Development Tools
   plugins:
     - name: CircleCI Cypress Orb


### PR DESCRIPTION
<!-- PLUGIN PULL REQUEST TEMPLATE -->
<!-- 👋 Hello and thank you for your contribution! -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

Adds [cypress-rollup-preprocessor](https://github.com/lmarqs/cypress-rollup-preprocessor) plugin to the Cypress documentation.

- [x] 🚀 Works with the latest major version of Cypress
- [x] 🛠 Plugin purpose is clearly documented (in a README or docs website)
- [x] 📝 Well-written documentation - A great example ([link 1](https://github.com/lmarqs/cypress-rollup-preprocessor/tree/master/examples/basic)) ([link 2](https://github.com/lmarqs/cypress-rollup-preprocessor/tree/master/examples/typescript))
- [x] 🔬 Tested using Cypress - tests using Cypress can act as both example usage _and_ test coverage
- [x] 👷‍♀️ CI pipeline that's passing (CircleCI and [Github Actions](https://github.com/cypress-io/cypress-tutorial-build-todo/blob/master/.github/workflows) are both free for Open Source)
