### PR TITLE
Add cypress-fill-command to plugins list

### DIFF
--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -231,6 +231,12 @@
       link: https://github.com/abramenal/cypress-file-upload
       keywords: [fileupload, file, upload, commands]
       badge: community
+      
+      - name: cypress-fill-command
+      description: A Cypress command for fill inputs
+      link: https://github.com/DanielFerrariR/cypress-fill-command
+      keywords: [commands]
+      badge: community
 
     - name: cypress-firebase
       description: Custom commands for Firebase including Authentication and Database communication (both Real Time Database and Firestore).

--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -232,7 +232,7 @@
       keywords: [fileupload, file, upload, commands]
       badge: community
       
-      - name: cypress-fill-command
+    - name: cypress-fill-command
       description: A Cypress command for fill inputs
       link: https://github.com/DanielFerrariR/cypress-fill-command
       keywords: [commands]


### PR DESCRIPTION
Adds [cypress-fill-command plugin](https://github.com/DanielFerrariR/cypress-fill-command) to the Cypress documentation.

- [X] 🚀 Works with the latest major version of Cypress
- [x] 🛠 Plugin purpose is clearly documented (in a README or docs website)
- [X] 📝 Well-written documentation - A great example ([link](https://github.com/Fredx87/cypress-keycloak-commands#cypress-keycloak-commands))
- [X] 🔬 Tested using Cypress - tests using Cypress can act as both example usage _and_ test coverage
- [X] 👷‍♀️ CI pipeline that's passing (CircleCI and [Github Actions](https://github.com/cypress-io/cypress-tutorial-build-todo/blob/master/.github/workflows) are both free for Open Source)