### PR TITLE
Update visit.md to show that options can only be set as single parameter

### DIFF
--- a/source/api/commands/visit.md
+++ b/source/api/commands/visit.md
@@ -14,7 +14,7 @@ Read about {% url 'best practices' best-practices#Setting-a-global-baseUrl %} he
 
 ```javascript
 cy.visit(url)
-cy.visit(url, options)
+cy.visit(url, body)
 cy.visit(options)
 ```
 
@@ -37,6 +37,10 @@ Cypress will prefix the URL with the `baseUrl` configured in your {% url 'networ
 
 You may also specify the relative path of an html file.  The path is relative to the root
 directory of the Cypress installation. Note that the `file://` prefix is not needed.
+
+**{% fa fa-angle-right %} body** ***(Object)***
+
+Pass in the body of the request to `cy.visit()`.
 
 **{% fa fa-angle-right %} options** ***(Object)***
 


### PR DESCRIPTION
The 2 parameter form of cy.visit() generates the body of the HTTP request. Not as currently stated, which is that the second parameter is for options. This most probably is only half the story, but without going through the code in detail, this is what appears to be happening