### PR TITLE
Convert dependencies to a single line in Getting Started

### DIFF
--- a/source/_partial/linux_dependencies.md
+++ b/source/_partial/linux_dependencies.md
@@ -1,13 +1,11 @@
 #### Ubuntu/Debian
 
 ```shell
-apt-get install libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4
-libnss3 libxss1 libasound2 libxtst6 xauth xvfb
+apt-get install libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
 ```
 
 #### CentOS
 
 ```shell
-yum install -y xorg-x11-server-Xvfb gtk2-devel gtk3-devel libnotify-devel
-GConf2 nss libXScrnSaver alsa-lib
+yum install -y xorg-x11-server-Xvfb gtk2-devel gtk3-devel libnotify-devel GConf2 nss libXScrnSaver alsa-lib
 ```


### PR DESCRIPTION
Dependencies in a single line would be easier to copy and paste in the terminal though might need to ignore the 70/84 character limit per line. Not sure if the right way to make this change, but let me happy to fix up as you wish. 