### PR TITLE
Improve TypeScript doc

### DIFF
--- a/source/guides/tooling/IDE-integration.md
+++ b/source/guides/tooling/IDE-integration.md
@@ -114,7 +114,6 @@ Adding a {% url "`tsconfig.json`" http://www.typescriptlang.org/docs/handbook/ts
 {
   "compilerOptions": {
     "allowJs": true,
-    "baseUrl": "../node_modules",
     "types": [
       "cypress"
     ]

--- a/source/guides/tooling/typescript-support.md
+++ b/source/guides/tooling/typescript-support.md
@@ -8,10 +8,15 @@ Cypress ships with {% url "official type declarations" https://github.com/cypres
 
 You'll need to have TypeScript 3.4+ installed within your project to have TypeScript support within Cypress.
 
-```bash
-# with npm
+### With npm
+
+```shell
 npm install --save-dev typescript
-# with yarn
+```
+
+### With yarn
+
+```shell
 yarn add --dev typescript
 ```
 

--- a/source/guides/tooling/typescript-support.md
+++ b/source/guides/tooling/typescript-support.md
@@ -9,7 +9,10 @@ Cypress ships with {% url "official type declarations" https://github.com/cypres
 You'll need to have TypeScript 3.4+ installed within your project to have TypeScript support within Cypress.
 
 ```bash
-npm install typescript
+# with npm
+npm install --save-dev typescript
+# with yarn
+yarn add --dev typescript
 ```
 
 ## Set up your dev environment
@@ -23,8 +26,6 @@ We recommend the following configuration in a {% url "`tsconfig.json`" http://ww
 ```json
 {
   "compilerOptions": {
-    "strict": true,
-    "baseUrl": "../node_modules",
     "target": "es5",
     "lib": ["es5", "dom"],
     "types": ["cypress"]


### PR DESCRIPTION
- Adds yarn install
- Removes `strict: true` from tsconfig recommendation. It has no effect since Cypress only transpiles spec files, so it's confusing to have it recommended.
- Removes `baseUrl: '../node_modules'` from tsconfig recommendation. It can causes issues such as [this one](https://github.com/cypress-io/cypress/issues/8380). 
