### PR TITLE
Phrase "log out" can be confusing in this doc

### DIFF
--- a/source/api/cypress-api/cookies.md
+++ b/source/api/cypress-api/cookies.md
@@ -4,7 +4,7 @@ title: Cypress.Cookies
 
 `Cookies.preserveOnce()` and `Cookies.defaults()` enable you to control Cypress' cookie behavior.
 
-`Cookies.debug()` enables you to log out whenever any cookies are modified.
+`Cookies.debug()` enables you to log (to the console) whenever any cookies are modified.
 
 Cypress automatically clears all cookies **before** each test to prevent state from building up.
 

--- a/source/api/cypress-api/cookies.md
+++ b/source/api/cypress-api/cookies.md
@@ -4,7 +4,7 @@ title: Cypress.Cookies
 
 `Cookies.preserveOnce()` and `Cookies.defaults()` enable you to control Cypress' cookie behavior.
 
-`Cookies.debug()` enables you to log (to the console) whenever any cookies are modified.
+`Cookies.debug()` enables you to generate logs to the console whenever any cookies are modified.
 
 Cypress automatically clears all cookies **before** each test to prevent state from building up.
 


### PR DESCRIPTION
Because this doc is for cypress' module for cookies, the phrase "log out" can be confusing as cookies are commonly used for auth - login/log-out but in this context "log out" means logging...

Making just one change for now even though multiple changes are required in this doc. Want to confirm if maintainers agree with me on this or not.