### PR TITLE
Update environment variable for AWS CodeBuild to be $CODEBUILD_INITIATOR

### DIFF
--- a/source/guides/guides/parallelization.md
+++ b/source/guides/guides/parallelization.md
@@ -243,7 +243,7 @@ Cypress currently uses the following CI environment variables to determine a CI 
 Provider  | Environment Variable
 --|--
 AppVeyor  | `APPVEYOR_BUILD_NUMBER`
-AWS CodeBuild | `CODEBUILD_BUILD_ID`
+AWS CodeBuild | `CODEBUILD_INITIATOR`
 Bamboo  | `bamboo_buildNumber`
 Circle  |  `CIRCLE_WORKFLOW_ID`, `CIRCLE_BUILD_NUMBER`
 Codeship  | `CI_BUILD_NUMBER`


### PR DESCRIPTION
`$CODEBUILD_BUILD_ID` should not be use as a CI Build ID to the Cypress Dashboard.

The newly released [batched feature of AWS CodeBuild](https://aws.amazon.com/about-aws/whats-new/2020/07/aws-codebuild-now-supports-parallel-and-coordinated-executions-of-a-build-project/) allows for parallel runs.

Per [Environment variables in build environments - AWS CodeBuild](https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-env-vars.html)
 `$CODEBUILD_INITIATOR` provides the entity that started the build which is unique and can be used as the `--ci-build-id` sent to the Cypress Dashboard.  e.g. `awsCodeBuild-cypress-kitchen-sink/AWSCodeBuild-a14fc8e3-b5d6-42f9-9067-345d48a8f0fd`

Reference:

- https://github.com/cypress-io/cypress-example-kitchensink/pull/450
- https://docs.aws.amazon.com/codebuild/latest/userguide/batch-build-buildspec.html
