### PR TITLE
Update key-differences.md: configuration#blockhosts url

### DIFF
--- a/source/guides/overview/key-differences.md
+++ b/source/guides/overview/key-differences.md
@@ -37,7 +37,7 @@ Having ultimate control over your application, the network traffic, and native a
 - Test how your application responds to errors on your server by {% url "modifying response status codes to be 500" route %}.
 - Modify DOM elements directly - like forcing hidden elements to be shown.
 - Use 3rd party plugins programmatically. Instead of fussing with complex UI widgets like multi selects, autocompletes, drop downs, tree views or calendars, you can call methods directly from your test code to control them.
-- {% url "Prevent Google Analytics from loading *before* any of your application code executes" configuration#blockhosts %} when testing.
+- {% url "Prevent Google Analytics from loading *before* any of your application code executes" configuration#blockHosts %} when testing.
 - Get synchronous notifications whenever your application transitions to a new page or when it begins to unload.
 - {% url "Control time by moving forward or backward" clock %} so that timers or polls automatically fire without having to wait for the required time in your tests.
 - Add your own event listeners to respond to your application. You could update your application code to behave differently when under tests in Cypress. You can control WebSocket messages from within Cypress, conditionally load 3rd party scripts, or call functions directly on your application.


### PR DESCRIPTION
https://docs.cypress.io/guides/overview/configuration#blockhosts
should be:
https://docs.cypress.io/guides/references/configuration.html#blockHosts
I **guess** is this commit fixes the url correctly? (I wonder how the '{% url' find the relative links?)
Please review!