### PR TITLE
docs: remove duplicate comment in route2.md

### DIFF
--- a/source/api/commands/route2.md
+++ b/source/api/commands/route2.md
@@ -52,8 +52,6 @@ cy.route2(/users\/\d+/)
 // Match all paths in a given pattern
 // Cypress uses minimatch to match glob patterns
 // https://github.com/isaacs/minimatch
-// Cypress uses minimatch to match glob patterns
-// https://github.com/isaacs/minimatch
 cy.route2('/users/**')
 
 // The following would match the previous glob:


### PR DESCRIPTION
Hi there! The route2 glob example has the same comment twice. So I removed the extra one. That's it. This PR is not very interesting.