### PR TITLE
docs: route2 docs v2

### DIFF
--- a/source/api/commands/route2.md
+++ b/source/api/commands/route2.md
@@ -4,7 +4,7 @@ containerClass: experimental
 ---
 
 {% note warning %}
-{% fa fa-warning orange %} **This is an experimental feature. In order to use it, you must set the {% url "`experimentalNetworkStubbing`" experiments %} configuration option to `true`.** See {% issue 687 %} for more details.
+{% fa fa-warning orange %} **This is an experimental feature. In order to use it, you must set the {% url "`experimentalNetworkStubbing`" experiments %} configuration option to `true`.**
 {% endnote %}
 
 Use `cy.route2()` to manage the behavior of HTTP requests at the network layer.

--- a/source/api/commands/route2.md
+++ b/source/api/commands/route2.md
@@ -171,7 +171,7 @@ cy.route2('http://example.com/foo').as('getFoo')
 cy.wait('@getFoo')
 ```
 
-### With RouteMatcher
+### With [`RouteMatcher`][routeMatcher]
 
 ```js
 cy.route2({

--- a/source/api/commands/route2.md
+++ b/source/api/commands/route2.md
@@ -9,56 +9,56 @@ containerClass: experimental
 
 Use `cy.route2()` to manage the behavior of HTTP requests at the network layer.
 
-With `cy.route2()`, you can...
+With `cy.route2()`, you can:
 
-* stub or spy on any type of HTTP request
-* [modify an HTTP request's body, headers, and URL](#Intercepting-a-request) before it is sent to the destination server
-* stub the response to an HTTP request, either dynamically or statically
-* [modify real HTTP responses](#Intercepting-a-response), changing the body, headers, or HTTP status code before they are received by the browser
-* and much much more - `cy.route2()` gives full access to all HTTP requests at all stages
+* stub or spy on any type of HTTP request.
+* {% urlHash "modify an HTTP request's body, headers, and URL" Intercepting-a-request %} before it is sent to the destination server.
+* stub the response to an HTTP request, either dynamically or statically.
+* {% urlHash "modify real HTTP responses" Intercepting-a-response %}, changing the body, headers, or HTTP status code before they are received by the browser.
+* and much more - `cy.route2()` gives full access to all HTTP requests at all stages.
 
 # Comparison to `cy.route()`
 
-Unlike {% url `cy.route()` route %}, `cy.route2()`:
+Unlike {% url "`cy.route()`" route %}, `cy.route2()`:
 
-* can intercept all types of network requests including Fetch API, page loads, XMLHttpRequests, reosurce loads...
-* does not require calling {% url `cy.server()` server %} before use - in fact, `cy.server()` does not influence `cy.route2()` at all
+* can intercept all types of network requests including Fetch API, page loads, XMLHttpRequests, resource loads, etc.
+* does not require calling {% url "`cy.server()`" server %} before use - in fact, `cy.server()` does not influence `cy.route2()` at all.
 
 # Usage
 
 ```ts
-cy.route2(routeMatcher)
-cy.route2(routeMatcher, routeHandler)
-
-// using shorthand instead of `RouteMatcher`
 cy.route2(url, routeHandler?)
 cy.route2(method, url, routeHandler?)
+cy.route2(routeMatcher, routeHandler?)
 ```
 
 ## Arguments
 
-**{% fa fa-angle-right %} url** **_(`string | RegExp`)_**
+### **{% fa fa-angle-right %} url** **_(`string | RegExp`)_**
 
-Instead of passing a [`routeMatcher`][routeMatcher] object, you can use shorthand to specify the URL to match. See the documentation for [`routeMatcher`][routeMatcher] to get an idea of how URLs are matched. Usage example:
+Specify the URL to match. See the documentation for {% urlHash "`routeMatcher`" routeMatcher-RouteMatcher %} to see how URLs are matched.
 
 ```ts
 cy.route2('http://example.com/widgets')
 cy.route2('http://example.com/widgets', { fixture: 'widgets.json' })
 ```
 
-**{% fa fa-angle-right %} method** **_(`string`)_**
+### **{% fa fa-angle-right %} method** **_(`string`)_**
 
-Instead of passing a [`routeMatcher`][routeMatcher] object, you can use shorthand to specify the HTTP method to match on. Usage example:
+Specify the HTTP method to match on.
 
 ```ts
-cy.route2('POST', 'http://example.com/widgets', { statusCode: 200, body: 'it worked!' })
+cy.route2('POST', 'http://example.com/widgets', {
+  statusCode: 200,
+  body: 'it worked!'
+})
 ```
 
-<a name="routeMatcher"></a>**{% fa fa-angle-right %} routeMatcher** **_(`RouteMatcher`)_**
+### **{% fa fa-angle-right %} routeMatcher** **_(`RouteMatcher`)_**
 
-`routeMatcher` is an object that defines how to decide which incoming HTTP requests will be handled by this route.
+`routeMatcher` is an object used to match which incoming HTTP requests will be handled by this route.
 
-All properties are optional. All properties that are set must match for the route to handle a request. The available `routeMatcher` properties are listed below:
+All properties are optional. All properties that are set must match for the route to handle a request. If a `string` is passed to any property, it will be glob-matched against the request using {% url "`minimatch`" https://github.com/isaacs/minimatch %}.The available `routeMatcher` properties are listed below:
 
 ```ts
 {
@@ -77,8 +77,8 @@ All properties are optional. All properties that are set must match for the rout
    */
   hostname?: string | RegExp
   /**
-   * If `true`, only HTTPS requests will be matched.
-   * If `false`, only HTTP requests will be matched.
+   * If 'true', only HTTPS requests will be matched.
+   * If 'false', only HTTP requests will be matched.
    */
   https?: boolean
   /**
@@ -91,11 +91,12 @@ All properties are optional. All properties that are set must match for the rout
    */
   path?: string | RegExp
   /**
-   * Matches like `path`, but without query params.
+   * Matches like 'path', but without query params.
    */
   pathname?: string | RegExp
   /**
-   * Match based on requested port, or pass an array of ports to match against any in that array.
+   * Match based on requested port, or pass an array of ports
+   * to match against any in that array.
    */
   port?: number | number[]
   /**
@@ -106,13 +107,12 @@ All properties are optional. All properties that are set must match for the rout
   }
   /**
    * Match against the full request URL.
-   * If a string is passed, it will be used as a substring match, not an equality match.
+   * If a string is passed, it will be used as a substring match,
+   * not an equality match.
    */
   url?: string | RegExp
 }
 ```
-
-If a `string` is passed in any property, it will be glob-matched against the request using [`minimatch`][minimatch].
 
 `routeMatcher` usage examples:
 
@@ -123,55 +123,52 @@ cy.route2({
     q: 'some terms'
   }
 }).as('searchForTerms')
-// this `cy.wait` will only resolve once a request is made to `/search` including
-// the query paramater `q=some+terms`
+// this 'cy.wait' will only resolve once a request is made to '/search'
+// with the query paramater 'q=some+terms'
 cy.wait('@searchForTerms')
 
 cy.route2({
-  // this RegExp matches any URL beginning with `http://api.example.com/widgets`
+  // this RegExp matches any URL beginning with 'http://api.example.com/widgets'
   url: /^http:\/\/api\.example\.com\/widgets/
   headers: {
-    'x-requested-with': 'fooClient'
+    'x-requested-with': 'exampleClient'
   }
 }, (req) => {
-  // only requests to URLs starting with `http://api.example.com/widgets` will be received
-  // here, and only if they have the header `x-requested-with: fooClient`
+  // only requests to URLs starting with 'http://api.example.com/widgets'
+  // having the header 'x-requested-with: exampleClient' will be received
 })
 ```
 
-**{% fa fa-angle-right %} routeHandler** **_(`string | object | Function | StaticResponse`)_**
+### **{% fa fa-angle-right %} routeHandler** **_(`string | object | Function | StaticResponse`)_**
 
-The `routeHandler` defines what will happen with a request if the [`routeMatcher`][routeMatcher] matches. It can be used to [statically define a response](#Stubbing-a-response) for matching requests, or a function can be passed to [dynamically intercept the outgoing request](#Intercepting-a-request).
+The `routeHandler` defines what will happen with a request if the {% urlHash "`routeMatcher`" routeMatcher-RouteMatcher %} matches. It can be used to {% urlHash "statically define a response" Stubbing-a-response %} for matching requests, or a function can be passed to {% urlHash "dynamically intercept the outgoing request" Intercepting-a-request %}.
 
-If a string is passed, requests to the route will be fulfilled with that string as the body. Passing `"foo"` is equivalent to using a `StaticResponse` object with `{ body: "foo" }`.
-
-If a `StaticResponse` object is passed, requests to the route will be fulfilled with a response using the values supplied in the `StaticResponse`. A `StaticResponse` can define the body of the response, as well as the headers, HTTP status code, and more. See ["Stubbing a response with a `StaticResponse` object"](#With-a-StaticResponse-object) for an example of how this is used.
-
-If an object with no `StaticResponse` keys is passed, it will be sent as a JSON response body. For example, passing `{ foo: 'bar' }` is equivalent to passing `{ body: { foo: 'bar' } }`.
-
-If a function callback is passed, it will be called whenever a request matching this route is received, with the first parameter being the request object. From inside the callback, you can modify the outgoing request, send a response, access the real response, and much more. See ["Intercepting a request"](#Intercepting-a-request) and ["Intercepting a response"](#Intercepting-a-response) for examples of dynamic interception.
+* If a **string** is passed, requests to the route will be fulfilled with that string as the body. Passing `"foo"` is equivalent to using a `StaticResponse` object with `{ body: "foo" }`.
+* If a **`StaticResponse` object** is passed, requests to the route will be fulfilled with a response using the values supplied in the `StaticResponse`. A `StaticResponse` can define the body of the response, as well as the headers, HTTP status code, and more. See {% urlHash "Stubbing a response with a `StaticResponse` object" With-a-StaticResponse-object %} for an example of how this is used.
+* If an **object with no `StaticResponse` keys** is passed, it will be sent as a JSON response body. For example, passing `{ foo: 'bar' }` is equivalent to passing `{ body: { foo: 'bar' } }`.
+* If a **function callback** is passed, it will be called whenever a request matching this route is received, with the first parameter being the request object. From inside the callback, you can modify the outgoing request, send a response, access the real response, and much more. See {% urlHash "Intercepting a request" Intercepting-a-request %} and {% urlHash "Intercepting a response" Intercepting-a-response %} for examples of dynamic interception.
 
 ## Yields {% helper_icon yields %}
 
 * `cy.route2()` yields `null`.
 * `cy.route2()` can be aliased, but otherwise cannot be chained further.
-* Waiting on an aliased `cy.route2()` route will yield an object that contains information about the matching request/response cycle. See ["Using the yielded object"](#Using-the-yielded-object) for examples of how to use this object.
+* Waiting on an aliased `cy.route2()` route using {% url "`cy.wait()`" wait %} will yield an object that contains information about the matching request/response cycle. See {% urlHash "Using the yielded object" Using-the-yielded-object %} for examples of how to use this object.
 
 # Examples
 
 ## Waiting on a request
 
-{% url `cy.wait()` wait %} can be used on `cy.route2()` aliases to wait for the request/response cycle to complete.
+Use {% url "`cy.wait()`" wait %} with `cy.route2()` aliases to wait for the request/response cycle to complete.
 
 ### With URL
 
 ```js
-cy.route2('http://example.com/foo').as('getFoo')
-// once a request is completed to http://example.com/foo, this `cy.wait` will complete
-cy.wait('@getFoo')
+cy.route2('http://example.com/settings').as('getSettings')
+// once a request to http://example.com/settings responds, this 'cy.wait' will resolve
+cy.wait('@getSettings')
 ```
 
-### With [`RouteMatcher`][routeMatcher]
+### With {% urlHash "`RouteMatcher`" routeMatcher-RouteMatcher %}
 
 ```js
 cy.route2({
@@ -179,32 +176,32 @@ cy.route2({
   query: { q: 'expected terms' },
 }).as('login')
 
-// once a POST request is completed to http://example.com/login with a querystring containing
-// `q=expected+terms`, this `cy.wait` will complete
+// once a POST request to http://example.com/login with a querystring containing
+// 'q=expected+terms' responds, this 'cy.wait' will resolve
 cy.wait('@login')
 ```
 
 ### Using the yielded object
 
-Using {% url `cy.wait()` wait %} on a `cy.route2()` route alias yields an object which represents the request/response cycle:
+Using {% url "`cy.wait()`" wait %} on a `cy.route2()` route alias yields an object which represents the request/response cycle:
 
 ```js
 cy.wait('@someRoute').then((request) => {
-  // `request` is an object with properties `id`, `request` and `response`
+  // 'request' is an object with properties 'id', 'request' and 'response'
 })
 ```
 
-You can chain {% url `cy.its()` its %} and {% url `cy.should()` should %} to assert against request/response cycles:
+You can chain {% url `.its()` its %} and {% url `.should()` should %} to assert against request/response cycles:
 
 ```js
-// assert that a request to this route was made with a body that included `foo`
-cy.wait('@someRoute').its('request.body').should('include', 'foo')
+// assert that a request to this route was made with a body that included 'user'
+cy.wait('@someRoute').its('request.body').should('include', 'user')
 
 // assert that a request to this route received a response with HTTP status 500
 cy.wait('@someRoute').its('response.statusCode').should('eq', 500)
 
-// assert that a request to this route received a response with a body that included `foo`
-cy.wait('@someRoute').its('response.body').should('include', 'foo')
+// assert that a request to this route received a response body that includes 'id'
+cy.wait('@someRoute').its('response.body').should('include', 'id')
 ```
 
 ## Stubbing a response
@@ -212,15 +209,16 @@ cy.wait('@someRoute').its('response.body').should('include', 'foo')
 ### With a string
 
 ```js
-// requests to `/foo` will be fulfilled with a body of "success"
-cy.route2('/foo', 'success')
+// requests to '/update' will be fulfilled with a body of "success"
+cy.route2('/update', 'success')
 ```
 
 ### With a fixture
 
 ```js
-// requests to `/foo.json` will be fulfilled with the contents of the "foo.json" fixture
-cy.route2('/foo.json', { fixture: 'foo.json' })
+// requests to '/users.json' will be fulfilled
+// with the contents of the "users.json" fixture
+cy.route2('/users.json', { fixture: 'users.json' })
 ```
 
 ### With a `StaticResponse` object
@@ -230,7 +228,7 @@ A `StaticResponse` object represents a response to an HTTP request, and can be u
 ```js
 const staticResponse = { /* some StaticResponse properties here... */ }
 
-cy.route2('/foo', staticResponse)
+cy.route2('/projects', staticResponse)
 ```
 
 Here are the available properties on `StaticResponse`:
@@ -238,15 +236,15 @@ Here are the available properties on `StaticResponse`:
 ```ts
 {
   /**
-   * If set, serve a fixture as the response body.
+   * Serve a fixture as the response body.
    */
   fixture?: string
   /**
-   * If set, serve a static string/JSON object as the response body.
+   * Serve a static string/JSON object as the response body.
    */
   body?: string | object | object[]
   /**
-   * If set, these HTTP headers will accompany the response.
+   * HTTP headers to accompany the response.
    * @default {}
    */
   headers?: { [key: string]: string }
@@ -256,17 +254,17 @@ Here are the available properties on `StaticResponse`:
    */
   statusCode?: number
   /**
-   * If `forceNetworkError` is truthy, Cypress will destroy the connection to the browser
-   * and send no response. Useful for simulating a server that is not reachable. Must not
-   * be set in combination with other options.
+   * If 'forceNetworkError' is truthy, Cypress will destroy the browser connection
+   * and send no response. Useful for simulating a server that is not reachable.
+   * Must not be set in combination with other options.
    */
   forceNetworkError?: boolean
   /**
-   * If set, `delayMs` will pass before the response is sent.
+   * Milliseconds to delay before the response is sent.
    */
   delayMs?: number
   /**
-   * If set, the `body` will be sent at `throttleKbps` kbps.
+   * Kilobits per second to send 'body'.
    */
   throttleKbps?: number
 }
@@ -277,8 +275,8 @@ Here are the available properties on `StaticResponse`:
 ### Asserting on a request
 
 ```js
-cy.route2('POST', '/foo', (req) => {
-  expect(req.body).to.include('someExpectedString')
+cy.route2('POST', '/organization', (req) => {
+  expect(req.body).to.include('Acme Company')
 })
 ```
 
@@ -288,8 +286,8 @@ You can use the route callback to modify the request before it is sent.
 
 ```js
 cy.route2('POST', '/login', (req) => {
-  // set the request body to something different before it is sent to the destination
-  req.body = 'username=foo&password=bar
+  // set the request body to something different before it's sent to the destination
+  req.body = 'username=janelane&password=secret123'
 })
 ```
 
@@ -298,19 +296,19 @@ cy.route2('POST', '/login', (req) => {
 You can use the `req.reply()` function to dynamically control the response to a request.
 
 ```js
-cy.route2('/foo', (req) => {
-  // functions on `req` can be used to dynamically respond to a request here
+cy.route2('/billing', (req) => {
+  // functions on 'req' can be used to dynamically respond to a request here
 
   // send the request to the destination server
   req.reply()
 
   // respond to the request with a JSON object
-  req.reply({ foo: 'bar' })
+  req.reply({ plan: 'starter' })
 
   // send the request to the destination server, and intercept the response
   req.reply((res) => {
-    // `res` represents the real destination's response - see "Intercepting a response"
-    // for more details + examples of this
+    // 'res' represents the real destination's response
+    // See "Intercepting a response" for more details and examples
   })
 })
 ```
@@ -325,10 +323,10 @@ The available functions on `req` are:
   destroy(): void
   /**
    * Control the response to this request.
-   * If a function is passed, the request will be sent outgoing, and the function will be called
-   * with the response from the upstream server.
-   * If a `StaticResponse` is passed, it will be used as the response, and no request will be made
-   * to the upstream server.
+   * If a function is passed, the request will be sent outgoing,
+   * and the function will be called with the response from the upstream server.
+   * If a 'StaticResponse' is passed, it will be used as the response
+   * and no request will be made to the upstream server.
    */
   reply(interceptor?: StaticResponse | HttpResponseInterceptor): void
   /**
@@ -336,11 +334,12 @@ The available functions on `req` are:
    */
   reply(body: string | object, headers?: { [key: string]: string }): void
   /**
-   * Shortcut to reply to the request with an HTTP status code and optional body and headers.
+   * Shortcut to reply to the request with an HTTP status code
+   * and optional body and headers.
    */
   reply(status: number, body?: string | object, headers?: { [key: string]: string }): void
   /**
-   * Respond to this request with a redirect to a new `location`.
+   * Respond to this request with a redirect to a new 'location'.
    * @param statusCode HTTP status code to redirect with. Default: 302
    */
   redirect(location: string, statusCode?: number): void
@@ -353,7 +352,7 @@ If a Promise is returned from the route callback, it will be awaited before cont
 
 ```js
 cy.route2('POST', '/login', (req) => {
-  // for example, you could asynchronously fetch test data...
+  // you could asynchronously fetch test data...
   return getLoginCredentials()
   .then((credentials) => {
     // ...and then, use it to supplement the outgoing request
@@ -367,18 +366,19 @@ cy.route2('POST', '/login', (req) => {
 If `req.reply()` is not explicitly called inside of a route callback, requests will pass to the next route callback until none are left.
 
 ```js
-// for example, you could have a top-level route2 that sets an auth token on all requests
-cy.route2('http://api.foo.com/', (req) => {
+// you could have a top-level route2 that sets an auth token on all requests
+cy.route2('http://api.company.com/', (req) => {
   req.headers['authorization'] = `token ${token}`
 })
 
 // and then another route2 that more narrowly asserts on certain requests
-cy.route2('POST', 'http://api.foo.com/widgets', (req) => {
-  expect(req.body).to.include('someExpectedString')
+cy.route2('POST', 'http://api.company.com/widgets', (req) => {
+  expect(req.body).to.include('analytics')
 })
 
-// a POST request to http://api.foo.com/widgets would hit both of those callbacks in order
-// then, it would be sent out with the modified request headers to the real destination
+// a POST request to http://api.company.com/widgets would hit both
+// of those callbacks in order then it would be sent out
+// with the modified request headers to the real destination
 ```
 
 ## Intercepting a response
@@ -386,11 +386,11 @@ cy.route2('POST', 'http://api.foo.com/widgets', (req) => {
 Inside of a callback passed to `req.reply()`, you can access the destination server's real response.
 
 ```js
-cy.route2('/foo', (req) => {
+cy.route2('/integrations', (req) => {
   // req.reply() with a callback will send the request to the destination server
   req.reply((res) => {
-    // here, `res` represents the real destination response. you can manipulate `res` before
-    // it is sent to the browser
+    // 'res' represents the real destination response
+    // you can manipulate 'res' before it's sent to the browser
   })
 })
 ```
@@ -398,9 +398,9 @@ cy.route2('/foo', (req) => {
 ### Asserting on a response
 
 ```js
-cy.route2('/foo', (req) => {
+cy.route2('/projects', (req) => {
   req.reply((res) => {
-    expect(res.body).to.include('someDesiredString')
+    expect(res.body).to.include('My Project')
   })
 })
 ```
@@ -410,9 +410,9 @@ cy.route2('/foo', (req) => {
 If a Promise is returned from the route callback, it will be awaited before sending the response to the browser.
 
 ```js
-cy.route2('/foo', (req) => {
+cy.route2('/users', (req) => {
   req.reply((res) => {
-    // the response will not be sent to the browser until `waitForSomething()` resolves
+    // the response will not be sent to the browser until 'waitForSomething()' resolves
     return waitForSomething()
   })
 })
@@ -425,13 +425,13 @@ You can use the `res.send()` function to dynamically control the incoming respon
 `res.send()` is implicitly called after the `req.reply` callback finishes if it has not already been called.
 
 ```js
-cy.route2('/foo', (req) => {
+cy.route2('/notification', (req) => {
   req.reply((res) => {
-    // replaces `res.body` with "new body here" and sends the response to the browser
-    res.send('new body here')
+    // replaces 'res.body' with "Success" and sends the response to the browser
+    res.send('Success')
 
-    // sends a fixture body instead of the existing `res.body`
-    res.send({ fixture: 'foo.json' })
+    // sends a fixture body instead of the existing 'res.body'
+    res.send({ fixture: 'success.json' })
 
     // delays the response by 1000ms
     res.delay(1000)
@@ -453,15 +453,16 @@ The available functions on `res` are:
   send(body: string | object, headers?: { [key: string]: string }): void
   send(staticResponse: StaticResponse): void
   /**
-    * Continue the HTTP response to the browser, including any modifications made to `res`.
+    * Continue the HTTP response to the browser,
+    * including any modifications made to 'res'.
     */
   send(): void
   /**
-    * Wait for `delayMs` milliseconds before sending the response to the client.
+    * Wait for 'delayMs' milliseconds before sending the response to the client.
     */
   delay: (delayMs: number) => IncomingHttpResponse
   /**
-    * Serve the response at `throttleKbps` kilobytes per second.
+    * Serve the response at 'throttleKbps' kilobytes per second.
     */
   throttle: (throttleKbps: number) => IncomingHttpResponse
 }
@@ -469,9 +470,6 @@ The available functions on `res` are:
 
 # See also
 
-* [cy.route2 example recipes with real-world examples](https://github.com/cypress-io/cypress-example-recipes#stubbing-and-spying)
-* [open issues for experimentalNetworkStubbing](https://github.com/cypress-io/cypress/issues?q=is%3Aissue+is%3Aopen+label%3Apkg%2Fnet-stubbing) and [closed issues for experimentalNetworkStubbing](https://github.com/cypress-io/cypress/issues?q=is%3Aissue+is%3Aclosed+label%3Apkg%2Fnet-stubbing)
+* {% url "`cy.route2()` example recipes with real-world examples" https://github.com/cypress-io/cypress-example-recipes#stubbing-and-spying %}
+* {% url "open issues for `experimentalNetworkStubbing`" https://github.com/cypress-io/cypress/issues?q=is%3Aissue+is%3Aopen+label%3Apkg%2Fnet-stubbing %} and {% url "closed issues for `experimentalNetworkStubbing`" https://github.com/cypress-io/cypress/issues?q=is%3Aissue+is%3Aclosed+label%3Apkg%2Fnet-stubbing %}
 
-
-[routeMatcher]: #routeMatcher
-[minimatch]: https://github.com/isaacs/minimatch

--- a/themes/cypress/source/css/_partial/base.scss
+++ b/themes/cypress/source/css/_partial/base.scss
@@ -162,11 +162,14 @@ button, select, input, input[type="submit"]::-moz-focus-inner, input[type="butto
 
   .note.warning {
     border: 5px solid #f0ad4e;
+  }
+
+  code, .dashboard-ad, .note.warning {
     background-color: white;
   }
 
-  code {
-    background-color: white;
+  .dashboard-ad {
+    border: 1px solid #ddd;
   }
 
   pre code {


### PR DESCRIPTION
Rewrote the route2 docs from scratch with a little more emphasis on the functionality of route2. Previously, it still closely followed the cy.route docs, which were completely different.

I think the general layout of these new docs is much more intuitive. Also, this fixes several technical errors in the route2 docs which I didn't notice when it was initially created.