### PR TITLE
Update docs to mention exclamation marks not being supported.

### DIFF
--- a/source/_changelogs/5.0.0.md
+++ b/source/_changelogs/5.0.0.md
@@ -18,7 +18,7 @@ Cypress now includes support for test retries! Similar to how Cypress will retry
 - Values yielded by {% url "`cy.setCookie()`" setcookie %}, {% url "`cy.getCookie()`" getcookie %}, and {% url "`cy.getCookies()`" getcookies %} will now contain the `sameSite` property if specified. Addresses {% issue 6892 %}.
 - The `experimentalGetCookiesSameSite` configuration flag has been removed, since this behavior is now the default. Addresses {% issue 6892 %}.
 - The return type of the {% url "`Cypress.Blob`" blob %} methods `arrayBufferToBlob`, `base64StringToBlob`, `binaryStringToBlob`, and `dataURLToBlob` have changed from `Promise<Blob>` to `Blob`. Addresses {% issue 6001 %}.
-- Cypress no longer supports file paths with a question mark `?` in them. We now use the {% url "webpack preprocessor" https://github.com/cypress-io/cypress-webpack-preprocessor %} by default and it does not support files with question marks. Addressed in {% PR 7982 %}.
+- Cypress no longer supports file paths with a question mark `?` or exclamation mark `!` in them. We now use the {% url "webpack preprocessor" https://github.com/cypress-io/cypress-webpack-preprocessor %} by default and it does not support files with question marks or exclamation marks. Addressed in {% PR 7982 %}.
 - For TypeScript compilation of spec, support, and plugins files, the `esModuleInterop` option is no longer coerced to `true`. If you need to utilize `esModuleInterop`, set it in your `tsconfig.json`. Addresses {% issue 7575 %}.
 - Cypress now requires TypeScript 3.4+. Addressed in {% issue 7856 %}.
 - Installing Cypress on your system now requires Node.js 10+. Addresses {% issue 6574 %}.


### PR DESCRIPTION
Related to https://github.com/cypress-io/cypress/issues/8683