### PR TITLE
Added mention about lack of default method

### DIFF
--- a/source/api/commands/route2.md
+++ b/source/api/commands/route2.md
@@ -23,6 +23,7 @@ Unlike {% url "`cy.route()`" route %}, `cy.route2()`:
 
 * can intercept all types of network requests including Fetch API, page loads, XMLHttpRequests, resource loads, etc.
 * does not require calling {% url "`cy.server()`" server %} before use - in fact, `cy.server()` does not influence `cy.route2()` at all.
+* does not have method set to `GET` by default
 
 # Usage
 


### PR DESCRIPTION
One difference that was not described before. Took me a moment to find out why my migration to `route2` failed ;).