### PR TITLE
5.4.0 Release

### DIFF
--- a/source/_changelogs/5.4.0.md
+++ b/source/_changelogs/5.4.0.md
@@ -1,6 +1,6 @@
 # 5.4.0
 
-*Released 10/13/2020*
+*Released 10/14/2020*
 
 **Features:**
 
@@ -23,6 +23,7 @@
 - Re-running failed build steps in Bitbucket will no longer create a new run on the Cypress Dashboard. Fixes {% issue 8720 %}.
 - The forced garbage collection timer will no longer display when using a version of Firefox newer than 80. Fixes {% issue 8725 %}.
 - The browser dropdown is no longer covered when opened from the Runs tab in the Test Runner. Fixed in {% issue 8745 %}.
+- Fixed an issue where preprocessor-related plugins would cause tests not to run and a duplicate instance of Cypress to be spawned. Fixes {% issue 8634 %}.
 
 **Misc:**
 

--- a/source/_changelogs/5.4.0.md
+++ b/source/_changelogs/5.4.0.md
@@ -4,36 +4,34 @@
 
 **Features:**
 
-- feat: Add codeFrame to record data attempt errors https://github.com/cypress-io/cypress/issues/8595
-- Print folder sizes with "cypress cache list" command https://github.com/cypress-io/cypress/issues/6404
-- Cypress `--browser` option not working on Windows when given a `path` argument https://github.com/cypress-io/cypress/issues/6389
-- Add new command: cypress cache prune https://github.com/cypress-io/cypress/issues/5972
-- Add chapters keys in the video sequence for each test start/end. https://github.com/cypress-io/cypress/issues/3626
-- feat(driver): add some iphone viewport https://github.com/cypress-io/cypress/issues/8624
+- You can now run {% url "`cypress cache prune`" command-line#cypress-cache-prune %} to delete all installed Cypress versions from the cache except for the currently-installed version. Addresses {% issue 5972 %}.
+- There's a new `--size` option for the {% url "`cypress cache list`" command-line#cypress-cache-list %} command that prints the sizes of the Cypress cache folders. Addresses {% issue 6404 %}.
+- For video recordings of runs, there is now a video chapter key for each test. If your video player supports chapters, you can move to the start of each test right away. Addresses {% issue 3626 %}.
+- In Windows, you can now append the browser type to the end of the path passed to the `--browser` flag, like `cypress open --browser C:/User/App/browser.exe:chrome`, to help detect the browser type. Addresses {% issue 6389 %}.
+- {% url "`cy.viewport()`" viewport %} has new `iphone-7`, `iphone-8`, and `iphone-se2` presets. Addressed in {% issue 8624 %}
+- When there is a new version of Cypress available, the update modal has a new design with 'copy to clipboard' buttons to copy the upgrade commands. Addressed in {% issue 8751 %}.
 
 **Bugfixes:**
 
-- Spec hangs when error thrown in test:after:run listener https://github.com/cypress-io/cypress/issues/8701
-- When error within 'test:after:run', Cypress hangs instead of throwing the error. https://github.com/cypress-io/cypress/issues/2271
-- Cannot combine within, should, and contains commands as expected https://github.com/cypress-io/cypress/issues/5183
-- `within` does not yield the subject from previous command https://github.com/cypress-io/cypress/issues/2106
-- cy.within does not yield as documented https://github.com/cypress-io/cypress/issues/4757
-- `within` followed by `should` permanently limits scope https://github.com/cypress-io/cypress/issues/4672
-- `.each` changes scope for next dual-command (like `cy.contains()`) https://github.com/cypress-io/cypress/issues/4921
-- "/" is added at end of loaded URLs breaks GET parameters https://github.com/cypress-io/cypress/issues/2101
-- fix: prevent cy.route2 callback timeouts from leaking into next test https://github.com/cypress-io/cypress/issues/8727
-- Re-running failed build step in Bitbucket don't create a new run on the dashboard https://github.com/cypress-io/cypress/issues/8720
-- fix(driver): hide forced GC warning if using FF >= 80 https://github.com/cypress-io/cypress/issues/8725
+- We fixed a regression in {% url "5.0.0" changelog-5-8-0 %}  where the `chromeWebSecurity` option had no effect in Electron. Fixes {% issue 8399 %}.
+- Tests will no longer hang and now properly throw when there is an error thrown from a `test:after:run` event listener. Fixes {% issue 2271 %} and {% issue 8701 %}.
+- When a command is chained after {% url "`.within()`" within %} and {% url "`cy.get()`" %} is called inside it, the scope will no longer permanently change. Fixes {% issue 2106 %}, {% issue 4672 %}, {% issue 4757 %}, and {% issue 5183 %}.
+- Dual commands like {% url "`cy.contains()`" contains %} when used after an {% url "`.each()`" each %} commands now query as expected. Fixes {% issue 4921 %}.
+- `/` is no longer added to the URL when `baseUrl` has param(s). Fixes {% issue 2101 %}.
+- When using {% url "`cy.route2()`" route2 %} the route handler timeouts will no longer leak into other tests and cause random failures. Addressed in {% issue 8727 %}.
+- Re-running failed build steps in Bitbucket will no longer create a new run on the Cypress Dashboard. Fixes {% issue 8720 %}.
+- The forced garbage collection timer will no longer display when using a version of Firefox newer than 80. Fixes {% issue 8725 %}.
+- The browser dropdown is no longer covered when opened from the Runs tab in the Test Runner. Fixed in {% issue 8745 %}.
 
 **Misc:**
-- chore: Update Desktop GUI footer design https://github.com/cypress-io/cypress/issues/8702
-- feat: Redesign Desktop GUI updates modal https://github.com/cypress-io/cypress/issues/8751
-- style: dashboard banner z-index https://github.com/cypress-io/cypress/issues/8745
-- Are the types in net-stubbing correct? https://github.com/cypress-io/cypress/issues/8694
-- fix(types): improve typedocs for cy.route2 https://github.com/cypress-io/cypress/issues/8728
+
+- Improved type definitions for {% url "`cy.route2()`" route2 %}. Addresses {% issue 8694 %} and {% issue 8782 %}.
+- The Test Runner now shows an indicator in the footer if there is a new version available. Addressed in {% issue 8702 %}.
 
 **Dependency Updates:**
 
-- feat(deps): update dependency electron to version 10.1.3 🌟 https://github.com/cypress-io/cypress/issues/8406
-- fix(deps): update dependency firefox-profile to version .x 🌟 https://github.com/cypress-io/cypress/issues/8786
-- fix(deps): update dependency node-forge to version 0.10.0 🌟 https://github.com/cypress-io/cypress/issues/8800
+- Upgraded Chrome browser version used during `cypress run` and when selecting Electron browser in `cypress open` from `83` to `85`. Addressed in {% PR 8406 %}.
+- Upgraded bundled Node.js version from `12.14.1` to `12.16.3`. Addressed in {% PR 8406 %}.
+- Upgraded `electron` from `9.2.1` to `10.1.3`. Addressed in {% PR 8406 %}.
+- Upgraded `firefox-profile` from `2.0.0` to `4.0.0`. Addressed in {% PR 8786 %}.
+- Upgraded `node-forge` from `0.9.0` to `0.10.0`. Addressed in {% PR 8800 %}.

--- a/source/_changelogs/5.4.0.md
+++ b/source/_changelogs/5.4.0.md
@@ -27,7 +27,7 @@
 **Misc:**
 
 - Improved type definitions for {% url "`cy.route2()`" route2 %}. Addresses {% issue 8694 %} and {% issue 8782 %}.
-- The Test Runner now shows an indicator in the footer if there is a new version available. Addressed in {% issue 8702 %}.
+- The Test Runner now shows an indicator in the footer and a toast notification if there is a new version available. Addressed in {% issue 8702 %} and {% issue 8803 %}.
 
 **Dependency Updates:**
 

--- a/source/_changelogs/5.4.0.md
+++ b/source/_changelogs/5.4.0.md
@@ -10,6 +10,7 @@
 - In Windows, you can now append the browser type to the end of the path passed to the `--browser` flag, like `cypress open --browser C:/User/App/browser.exe:chrome`, to help detect the browser type. Addresses {% issue 6389 %}.
 - {% url "`cy.viewport()`" viewport %} has new `iphone-7`, `iphone-8`, and `iphone-se2` presets. Addressed in {% issue 8624 %}
 - When there is a new version of Cypress available, the update modal has a new design with 'copy to clipboard' buttons to copy the upgrade commands. Addressed in {% issue 8751 %}.
+- The {% url "Command Log" test-runner#Command-Log %} can be hidden by passing the `CYPRESS_NO_COMMAND_LOG=1` environment variable during `cypress open` or `cypress run` to be used as a tool to debug performance issues. Addressed in {% issue 8689 %}.
 
 **Bugfixes:**
 

--- a/source/_changelogs/5.4.0.md
+++ b/source/_changelogs/5.4.0.md
@@ -1,11 +1,39 @@
 # 5.4.0
 
-*Released 10/12/2020*
+*Released 10/13/2020*
 
 **Features:**
 
+- feat: Add codeFrame to record data attempt errors https://github.com/cypress-io/cypress/issues/8595
+- Print folder sizes with "cypress cache list" command https://github.com/cypress-io/cypress/issues/6404
+- Cypress `--browser` option not working on Windows when given a `path` argument https://github.com/cypress-io/cypress/issues/6389
+- Add new command: cypress cache prune https://github.com/cypress-io/cypress/issues/5972
+- Add chapters keys in the video sequence for each test start/end. https://github.com/cypress-io/cypress/issues/3626
+- feat(driver): add some iphone viewport https://github.com/cypress-io/cypress/issues/8624
+
 **Bugfixes:**
 
+- Spec hangs when error thrown in test:after:run listener https://github.com/cypress-io/cypress/issues/8701
+- When error within 'test:after:run', Cypress hangs instead of throwing the error. https://github.com/cypress-io/cypress/issues/2271
+- Cannot combine within, should, and contains commands as expected https://github.com/cypress-io/cypress/issues/5183
+- `within` does not yield the subject from previous command https://github.com/cypress-io/cypress/issues/2106
+- cy.within does not yield as documented https://github.com/cypress-io/cypress/issues/4757
+- `within` followed by `should` permanently limits scope https://github.com/cypress-io/cypress/issues/4672
+- `.each` changes scope for next dual-command (like `cy.contains()`) https://github.com/cypress-io/cypress/issues/4921
+- "/" is added at end of loaded URLs breaks GET parameters https://github.com/cypress-io/cypress/issues/2101
+- fix: prevent cy.route2 callback timeouts from leaking into next test https://github.com/cypress-io/cypress/issues/8727
+- Re-running failed build step in Bitbucket don't create a new run on the dashboard https://github.com/cypress-io/cypress/issues/8720
+- fix(driver): hide forced GC warning if using FF >= 80 https://github.com/cypress-io/cypress/issues/8725
+
 **Misc:**
+- chore: Update Desktop GUI footer design https://github.com/cypress-io/cypress/issues/8702
+- feat: Redesign Desktop GUI updates modal https://github.com/cypress-io/cypress/issues/8751
+- style: dashboard banner z-index https://github.com/cypress-io/cypress/issues/8745
+- Are the types in net-stubbing correct? https://github.com/cypress-io/cypress/issues/8694
+- fix(types): improve typedocs for cy.route2 https://github.com/cypress-io/cypress/issues/8728
 
 **Dependency Updates:**
+
+- feat(deps): update dependency electron to version 10.1.3 🌟 https://github.com/cypress-io/cypress/issues/8406
+- fix(deps): update dependency firefox-profile to version .x 🌟 https://github.com/cypress-io/cypress/issues/8786
+- fix(deps): update dependency node-forge to version 0.10.0 🌟 https://github.com/cypress-io/cypress/issues/8800

--- a/source/_changelogs/5.4.0.md
+++ b/source/_changelogs/5.4.0.md
@@ -1,0 +1,11 @@
+# 5.4.0
+
+*Released 10/12/2020*
+
+**Features:**
+
+**Bugfixes:**
+
+**Misc:**
+
+**Dependency Updates:**

--- a/source/api/commands/viewport.md
+++ b/source/api/commands/viewport.md
@@ -49,8 +49,11 @@ A preset dimension to set the viewport. Preset supports the following options:
 | `iphone-5`    | 320   | 568    |
 | `iphone-6`    | 375   | 667    |
 | `iphone-6+`   | 414   | 736    |
+| `iphone-7`    | 375   | 667    |
+| `iphone-8`    | 375   | 667    |
 | `iphone-x`    | 375   | 812    |
 | `iphone-xr`   | 414   | 896    |
+| `iphone-se2`  | 375   | 667    |
 | `macbook-11`  | 1366  | 768    |
 | `macbook-13`  | 1280  | 800    |
 | `macbook-15`  | 1440  | 900    |

--- a/source/api/commands/viewport.md
+++ b/source/api/commands/viewport.md
@@ -274,6 +274,7 @@ When clicking on `viewport` within the command log, the console outputs the foll
 {% imgTag /img/api/viewport/console-log-shows-width-and-height-of-tested-viewport.png "Console Log viewport" %}
 
 {% history %}
+{% url "5.4.0" changelog#5-4-0 %} | Added support for presets `iphone-7`, `iphone-8`, and `iphone-se2`.
 {% url "3.8.0" changelog#3-8-0 %} | Removed max viewport size and lowered min viewport size to `0`.
 {% url "3.5.0" changelog#3-5-0 %} | Added support for presets `iphone-xr`, `iphone-x`, `samsung-s10`, and `samsung-note9`
 {% url "3.5.0" changelog#3-5-0 %} | Increased max viewport size to `4000`

--- a/source/guides/guides/command-line.md
+++ b/source/guides/guides/command-line.md
@@ -612,6 +612,14 @@ Clear the contents of the Cypress cache. This is useful when you want Cypress to
 cypress cache clear
 ```
 
+### `cypress cache prune`
+
+Deletes all installed Cypress versions from the cache except for the currently-installed version.
+
+```shell
+cypress cache prune
+```
+
 # Debugging commands
 
 Cypress is built using the {% url 'debug' https://github.com/visionmedia/debug %} module. That means you can receive helpful debugging output by running Cypress with this turned on prior to running `cypress open` or `cypress run`.
@@ -655,5 +663,6 @@ DEBUG=cypress:server:project cypress run
 ```
 
 {% history %}
+{% url "5.4.0" changelog %} | Added `prune` subcommand to `cypress cache`
 {% url "4.9.0" changelog %} | Added `--quiet` flag to `cypress run`
 {% endhistory %}

--- a/source/guides/guides/command-line.md
+++ b/source/guides/guides/command-line.md
@@ -591,6 +591,19 @@ cypress cache list
 └─────────┴──────────────┘
 ```
 
+You can calculate the size of every Cypress version folder by adding the `--size` argument to the command. Note that calculating the disk size can be slow.
+
+```shell
+cypress cache list --size
+┌─────────┬──────────────┬─────────┐
+│ version │ last used    │ size    │
+├─────────┼──────────────┼─────────┤
+│ 5.0.0   │ 3 months ago │ 425.3MB │
+├─────────┼──────────────┼─────────┤
+│ 5.3.0   │ 5 days ago   │ 436.3MB │
+└─────────┴──────────────┴─────────┘
+```
+
 ### `cypress cache clear`
 
 Clear the contents of the Cypress cache. This is useful when you want Cypress to clear out all installed versions of Cypress that may be cached on your machine. After running this command, you will need to run `cypress install` before running Cypress again.

--- a/source/guides/guides/command-line.md
+++ b/source/guides/guides/command-line.md
@@ -664,5 +664,6 @@ DEBUG=cypress:server:project cypress run
 
 {% history %}
 {% url "5.4.0" changelog %} | Added `prune` subcommand to `cypress cache`
+{% url "5.4.0" changelog %} | Added `--size` flag to `cypress cache list` subcommand
 {% url "4.9.0" changelog %} | Added `--quiet` flag to `cypress run`
 {% endhistory %}

--- a/source/guides/guides/command-line.md
+++ b/source/guides/guides/command-line.md
@@ -422,7 +422,7 @@ cypress open --browser /usr/bin/chromium
 
 If found, the specified browser will be added to the list of available browsers in the Cypress Test Runner.
 
-Currently, only browsers in the Chrome family are supported (including the new Chromium-based Microsoft Edge and Brave).
+Currently, only browsers in the Chrome family (including the new Chromium-based Microsoft Edge and Brave) and Firefox are supported.
 
 {% url "Having trouble launching a browser? Check out our troubleshooting guide" troubleshooting#Launching-browsers %}
 

--- a/source/guides/guides/command-line.md
+++ b/source/guides/guides/command-line.md
@@ -622,6 +622,8 @@ cypress cache prune
 
 # Debugging commands
 
+## Enable Debug Logs
+
 Cypress is built using the {% url 'debug' https://github.com/visionmedia/debug %} module. That means you can receive helpful debugging output by running Cypress with this turned on prior to running `cypress open` or `cypress run`.
 
 **On Mac or Linux:**
@@ -660,6 +662,16 @@ DEBUG=cypress:launcher cypress run
 
 ```shell
 DEBUG=cypress:server:project cypress run
+```
+
+## Disable the Command Log
+
+In some cases the {% url "Command Log" test-runner#Command-Log %}, responsible for rendering test commands, assertions, and status in the Test Runner may cause performance issues resulting in slower tests or the browser crashing. 
+
+In order to isolate these issues, you can disable the Command Log rendering by passing the environment variable below.
+
+```shell
+CYPRESS_NO_COMMAND_LOG=1 cypress run
 ```
 
 {% history %}

--- a/source/guides/guides/command-line.md
+++ b/source/guides/guides/command-line.md
@@ -664,16 +664,6 @@ DEBUG=cypress:launcher cypress run
 DEBUG=cypress:server:project cypress run
 ```
 
-## Disable the Command Log
-
-In some cases the {% url "Command Log" test-runner#Command-Log %}, responsible for rendering test commands, assertions, and status in the Test Runner may cause performance issues resulting in slower tests or the browser crashing. 
-
-In order to isolate these issues, you can disable the Command Log rendering by passing the environment variable below.
-
-```shell
-CYPRESS_NO_COMMAND_LOG=1 cypress run
-```
-
 {% history %}
 {% url "5.4.0" changelog %} | Added `prune` subcommand to `cypress cache`
 {% url "5.4.0" changelog %} | Added `--size` flag to `cypress cache list` subcommand

--- a/source/guides/guides/launching-browsers.md
+++ b/source/guides/guides/launching-browsers.md
@@ -112,13 +112,17 @@ You can launch any supported browser by specifying a path to the binary:
 
 ```shell
 cypress run --browser /usr/bin/chromium
-# or
+```
+
+```shell
 cypress open --browser /usr/bin/chromium
 ```
 
 Cypress will automatically detect the type of browser supplied and launch it for you.
 
 {% url 'See the Command Line guide for more information about the `--browser` arguments' command-line#cypress-run-browser-lt-browser-name-or-path-gt %}
+
+{% url "Having trouble launching a browser? Check out our troubleshooting guide" troubleshooting#Launching-browsers %}
 
 ## Customize available browsers
 

--- a/source/guides/references/troubleshooting.md
+++ b/source/guides/references/troubleshooting.md
@@ -101,6 +101,13 @@ To make a browser installed at a different path be auto-detected, create a symbo
 
 {% url 'Read more about creating symbolic links on Windows' https://www.howtogeek.com/howto/16226/complete-guide-to-symbolic-links-symlinks-on-windows-or-linux/ %}
 
+Occasionally Cypress will have issues detecting the type of browser in Windows environments. To manually
+detect the browser type, append the browser type to the end of the path:
+
+```shell
+cypress open --browser C:/User/Application/browser.exe:chrome
+```
+
 # Allow the Cypress Chrome extension
 
 Cypress utilizes a Chrome extension within the Test Runner in order to run properly. If you or your company block specific Chrome extensions, this may cause problems with running Cypress. You will want to ask your administrator to allow the Cypress extension ID below:

--- a/source/guides/references/troubleshooting.md
+++ b/source/guides/references/troubleshooting.md
@@ -217,6 +217,16 @@ By default, process information is collected and summarized is printed once ever
 
 You can also obtain more detailed per-process information by enabling the verbose `cypress-verbose:server:util:process_profiler` debug stream.
 
+# Disable the Command Log
+
+In some cases the {% url "Command Log" test-runner#Command-Log %}, responsible for displaying test commands, assertions, and statuses in the Test Runner, may cause performance issues resulting in slower tests or the browser crashing.
+
+In order to isolate these issues, you can hide the Command Log by passing the environment variable below during `cypress open` or `cypress run`.
+
+```shell
+CYPRESS_NO_COMMAND_LOG=1 cypress run
+```
+
 # Additional information
 
 ## Write command log to the terminal


### PR DESCRIPTION
- [x] 5.4.0 Changelog
- [x] Document `cypress cache list --size` option https://github.com/cypress-io/cypress-documentation/pull/3217
- [x] Document `cypress cache prune` https://github.com/cypress-io/cypress-documentation/pull/3232#pullrequestreview-507061210
- [x] Document new iphone viewports https://github.com/cypress-io/cypress-documentation/pull/3229
- [x] Document `:browser` type option for Windows https://github.com/cypress-io/cypress-documentation/pull/3215
- [x] Docs for NO_COMMAND command https://github.com/cypress-io/cypress-documentation/pull/3230