### PR TITLE
Fix typo in changelog 3.3.2

### DIFF
--- a/source/_changelogs/3.3.2.md
+++ b/source/_changelogs/3.3.2.md
@@ -23,7 +23,7 @@
 - If a site's `content-type` is `null`, `undefined` or cannot be determined during {% url `cy.visit()` visit %}, we now look at the content of the site and evaluate whether it looks like HTML. If it does look like HTML we no longer error and continue as if it the site's `content-type` is `text/html`. {% issue 1727 %} {% issue 773 %} {% issue 3101 %}.
 - Previously Cypress would send the `auth` header to any URLs that match the CORS origin of the original `auth` header. We now correctly only send the `auth` headers when there is an exact match on the {% url "protection space" https://tools.ietf.org/html/rfc7235#section-2.2 %}. Fixes {% issue 4267 %}.
 - Requests that go through {% url "`cy.visit()`" visit %} or  {% url "`cy.request()`" request %} are now automatically retried on `ENOTFOUND` errors. Fixes {% issue 4424 %} and {% issue 1755 %}.
-- Cypress now errors when the `body` paramater passed to {% url "`cy.request()`" request %} contains a circular reference. Fixed in {% PR 4407 %}.
+- Cypress now errors when the `body` parameter passed to {% url "`cy.request()`" request %} contains a circular reference. Fixed in {% PR 4407 %}.
 - We fixed an issue where the `ignoreTestFiles` configuration was being filtered out when passed via a command line flag, so in effect being ignored. Fixes {% issue 1696 %}.
 - Setting `NO_PROXY` is now respected for HTTPS urls, as it should be. Fixes {% issue 4303 %}.
 - When running tests with non-string test titles, the screenshots now automatically stringify the test titles instead of throwing an error. Fixes {% issue 4310 %}.


### PR DESCRIPTION
Fixes a small typo: "paramater" -> "parameter"