### PR TITLE
Make route2 routeMatcher example clearer.

### DIFF
--- a/source/api/commands/route2.md
+++ b/source/api/commands/route2.md
@@ -174,11 +174,11 @@ cy.wait('@getSettings')
 cy.route2({
   url: 'http://example.com/search',
   query: { q: 'expected terms' },
-}).as('login')
+}).as('search')
 
-// once a POST request to http://example.com/login with a querystring containing
+// once a GET request to http://example.com/search with a querystring containing
 // 'q=expected+terms' responds, this 'cy.wait' will resolve
-cy.wait('@login')
+cy.wait('@search')
 ```
 
 ### Using the yielded object

--- a/source/api/commands/route2.md
+++ b/source/api/commands/route2.md
@@ -83,7 +83,7 @@ All properties are optional. All properties that are set must match for the rout
   https?: boolean
   /**
    * Match against the request's HTTP method.
-   * @default 'GET'
+   * @default '*'
    */
   method?: string | RegExp
   /**
@@ -176,7 +176,7 @@ cy.route2({
   query: { q: 'expected terms' },
 }).as('search')
 
-// once a GET request to http://example.com/search with a querystring containing
+// once any type of request to http://example.com/search with a querystring containing
 // 'q=expected+terms' responds, this 'cy.wait' will resolve
 cy.wait('@search')
 ```


### PR DESCRIPTION
```js
cy.route2({
  url: 'http://example.com/search',
  query: { q: 'expected terms' },
}).as('login')

// once a POST request to http://example.com/login with a querystring containing
// 'q=expected+terms' responds, this 'cy.wait' will resolve
cy.wait('@login')
```

The alias name and comments sound wrong.

* url uses `search` but the comment says `http://example.com/login`
* By default, routeMatcher uses `GET` method, not `POST`.
* The better name for the alias is search, not login. 

I changed 3 of them.