### PR TITLE
Close test description strings in test-retries.md

### DIFF
--- a/source/guides/guides/test-retries.md
+++ b/source/guides/guides/test-retries.md
@@ -137,11 +137,11 @@ describe('User bank accounts', {
 }, () => {
   // The per-suite configuration is applied to each test
   // If a test fails, it will be retried
-  it('allows a user to view their transactions, () => {
+  it('allows a user to view their transactions', () => {
     // ...
   }
 
-  it('allows a user to edit their transactions, () => {
+  it('allows a user to edit their transactions', () => {
     // ...
   }
 })


### PR DESCRIPTION
Fix the missing closing quotes in the example tests in the section test-suites