### PR TITLE
Document animationDistanceThreshold and waitForAnimations options to actionable commands.

### DIFF
--- a/lib/tags/usage.js
+++ b/lib/tags/usage.js
@@ -9,6 +9,11 @@ module.exports = function usageOptions (hexo, args) {
   }
 
   const blurbs = {
+    animationDistanceThreshold () {
+      const url = `{% url 'considered animating' interacting-with-elements#Animations %}`
+
+      return render(`The distance in pixels an element must exceed over time to be ${url}.`)
+    },
     log () {
       /* eslint-disable quotes */
       const url = `{% url 'Command log' test-runner#Command-Log %}`
@@ -64,6 +69,12 @@ module.exports = function usageOptions (hexo, args) {
 
     includeShadowDom () {
       return 'Whether to traverse shadow DOM boundaries and include elements within the shadow DOM in the yielded results.'
+    },
+
+    waitForAnimations () {
+      const url = `{% url 'finish animating' interacting-with-elements#Animations %}`
+
+      return render(`Whether to wait for elements to ${url} before executing the command.`)
     },
   }
 

--- a/source/api/commands/check.md
+++ b/source/api/commands/check.md
@@ -51,9 +51,11 @@ Pass in an options object to change the default behavior of `.check()`.
 
 Option | Default | Description
 --- | --- | ---
+`animationDistanceThreshold` | {% url `animationDistanceThreshold` configuration#Animations %} | {% usage_options animationDistanceThreshold %}
 `log` | `true` | {% usage_options log %}
 `force` | `false` | {% usage_options force check %}
 `timeout` | {% url `defaultCommandTimeout` configuration#Timeouts %} | {% usage_options timeout .check %}
+`waitForAnimations` | {% url `waitForAnimations` configuration#Animations %} | {% usage_options waitForAnimations %}
 
 ## Yields {% helper_icon yields %}
 

--- a/source/api/commands/check.md
+++ b/source/api/commands/check.md
@@ -51,11 +51,9 @@ Pass in an options object to change the default behavior of `.check()`.
 
 Option | Default | Description
 --- | --- | ---
-`animationDistanceThreshold` | {% url `animationDistanceThreshold` configuration#Animations %} | {% usage_options animationDistanceThreshold %}
 `log` | `true` | {% usage_options log %}
 `force` | `false` | {% usage_options force check %}
 `timeout` | {% url `defaultCommandTimeout` configuration#Timeouts %} | {% usage_options timeout .check %}
-`waitForAnimations` | {% url `waitForAnimations` configuration#Animations %} | {% usage_options waitForAnimations %}
 
 ## Yields {% helper_icon yields %}
 

--- a/source/api/commands/clear.md
+++ b/source/api/commands/clear.md
@@ -41,9 +41,11 @@ Pass in an options object to change the default behavior of `.clear()`.
 
 Option | Default | Description
 --- | --- | ---
-`log` | `true` | {% usage_options log %}
+`animationDistanceThreshold` | {% url `animationDistanceThreshold` configuration#Animations %} | {% usage_options animationDistanceThreshold %}
 `force` | `false` | {% usage_options force clear %}
+`log` | `true` | {% usage_options log %}
 `timeout` | {% url `defaultCommandTimeout` configuration#Timeouts %} | {% usage_options timeout .clear %}
+`waitForAnimations` | {% url `waitForAnimations` configuration#Animations %} | {% usage_options waitForAnimations %}
 
 ## Yields {% helper_icon yields %}
 

--- a/source/api/commands/clear.md
+++ b/source/api/commands/clear.md
@@ -41,11 +41,9 @@ Pass in an options object to change the default behavior of `.clear()`.
 
 Option | Default | Description
 --- | --- | ---
-`animationDistanceThreshold` | {% url `animationDistanceThreshold` configuration#Animations %} | {% usage_options animationDistanceThreshold %}
 `force` | `false` | {% usage_options force clear %}
 `log` | `true` | {% usage_options log %}
 `timeout` | {% url `defaultCommandTimeout` configuration#Timeouts %} | {% usage_options timeout .clear %}
-`waitForAnimations` | {% url `waitForAnimations` configuration#Animations %} | {% usage_options waitForAnimations %}
 
 ## Yields {% helper_icon yields %}
 

--- a/source/api/commands/click.md
+++ b/source/api/commands/click.md
@@ -62,6 +62,7 @@ Option | Default | Description
 `multiple` | `false` | {% usage_options multiple click %}
 `shiftKey` | `false` | {% usage_options shiftKey %}
 `timeout` | {% url `defaultCommandTimeout` configuration#Timeouts %} | {% usage_options timeout .click %}
+`waitForAnimations` | {% url `waitForAnimations` configuration#Animations %} | {% usage_options waitForAnimations %}
 
 ## Yields {% helper_icon yields %}
 

--- a/source/api/commands/dblclick.md
+++ b/source/api/commands/dblclick.md
@@ -55,6 +55,7 @@ Pass in an options object to change the default behavior of `.dblclick()`.
 Option | Default | Description
 --- | --- | ---
 `altKey` | `false` | {% usage_options altKey %}
+`animationDistanceThreshold` | {% url `animationDistanceThreshold` configuration#Animations %} | {% usage_options animationDistanceThreshold %}
 `ctrlKey` | `false` | {% usage_options ctrlKey %}
 `log` | `true` | {% usage_options log %}
 `force` | `false` | {% usage_options force dblclick %}
@@ -62,6 +63,7 @@ Option | Default | Description
 `multiple` | `true` | {% usage_options multiple dblclick %}
 `shiftKey` | `false` | {% usage_options shiftKey %}
 `timeout` | {% url `defaultCommandTimeout` configuration#Timeouts %} | {% usage_options timeout .dblclick %}
+`waitForAnimations` | {% url `waitForAnimations` configuration#Animations %} | {% usage_options waitForAnimations %}
 
 ## Yields {% helper_icon yields %}
 

--- a/source/api/commands/rightclick.md
+++ b/source/api/commands/rightclick.md
@@ -59,13 +59,15 @@ Pass in an options object to change the default behavior of `.rightclick()`.
 Option | Default | Description
 --- | --- | ---
 `altKey` | `false` | {% usage_options altKey %}
+`animationDistanceThreshold` | {% url `animationDistanceThreshold` configuration#Animations %} | {% usage_options animationDistanceThreshold %}
 `ctrlKey` | `false` | {% usage_options ctrlKey %}
-`log` | `true` | {% usage_options log %}
 `force` | `false` | {% usage_options force rightclick %}
+`log` | `true` | {% usage_options log %}
 `metaKey` | `false` | {% usage_options metaKey %}
 `multiple` | `false` | {% usage_options multiple rightclick %}
 `shiftKey` | `false` | {% usage_options shiftKey %}
 `timeout` | {% url `defaultCommandTimeout` configuration#Timeouts %} | {% usage_options timeout .rightclick %}
+`waitForAnimations` | {% url `waitForAnimations` configuration#Animations %} | {% usage_options waitForAnimations %}
 
 ## Yields {% helper_icon yields %}
 

--- a/source/api/commands/select.md
+++ b/source/api/commands/select.md
@@ -44,11 +44,9 @@ Pass in an options object to change the default behavior of `.select()`.
 
 Option | Default | Description
 --- | --- | ---
-`animationDistanceThreshold` | {% url `animationDistanceThreshold` configuration#Animations %} | {% usage_options animationDistanceThreshold %}
 `force` | `false` | {% usage_options force select %}
 `log` | `true` | {% usage_options log %}
 `timeout` | {% url `defaultCommandTimeout` configuration#Timeouts %} | {% usage_options timeout .select %}
-`waitForAnimations` | {% url `waitForAnimations` configuration#Animations %} | {% usage_options waitForAnimations %}
 
 ## Yields {% helper_icon yields %}
 

--- a/source/api/commands/select.md
+++ b/source/api/commands/select.md
@@ -44,9 +44,11 @@ Pass in an options object to change the default behavior of `.select()`.
 
 Option | Default | Description
 --- | --- | ---
-`log` | `true` | {% usage_options log %}
+`animationDistanceThreshold` | {% url `animationDistanceThreshold` configuration#Animations %} | {% usage_options animationDistanceThreshold %}
 `force` | `false` | {% usage_options force select %}
+`log` | `true` | {% usage_options log %}
 `timeout` | {% url `defaultCommandTimeout` configuration#Timeouts %} | {% usage_options timeout .select %}
+`waitForAnimations` | {% url `waitForAnimations` configuration#Animations %} | {% usage_options waitForAnimations %}
 
 ## Yields {% helper_icon yields %}
 

--- a/source/api/commands/trigger.md
+++ b/source/api/commands/trigger.md
@@ -56,12 +56,14 @@ Pass in an options object to change the default behavior of `.trigger()`.
 
 Option | Default | Description
 --- | --- | ---
-`log` | `true` | {% usage_options log %}
-`force` | `false` | {% usage_options force trigger %}
+`animationDistanceThreshold` | {% url `animationDistanceThreshold` configuration#Animations %} | {% usage_options animationDistanceThreshold %}
 `bubbles` | `true` | Whether the event bubbles
 `cancelable` | `true` | Whether the event is cancelable
 `eventConstructor` | `Event` | The constructor for creating the event object (e.g. `MouseEvent`, `KeyboardEvent`)
+`force` | `false` | {% usage_options force trigger %}
+`log` | `true` | {% usage_options log %}
 `timeout` | {% url `defaultCommandTimeout` configuration#Timeouts %} | {% usage_options timeout .trigger %}
+`waitForAnimations` | {% url `waitForAnimations` configuration#Animations %} | {% usage_options waitForAnimations %}
 
 You can also include arbitrary event properties (e.g. `clientX`, `shiftKey`) and they will be attached to the event. Passing in coordinate arguments (`clientX`, `pageX`, etc) will override the position coordinates.
 

--- a/source/api/commands/type.md
+++ b/source/api/commands/type.md
@@ -73,12 +73,14 @@ Pass in an options object to change the default behavior of `.type()`.
 
 Option | Default | Description
 --- | --- | ---
-`log` | `true` | {% usage_options log %}
+`animationDistanceThreshold` | {% url `animationDistanceThreshold` configuration#Animations %} | {% usage_options animationDistanceThreshold %}
 `delay` | `10` | Delay after each keypress
 `force` | `false` | {% usage_options force type %}
+`log` | `true` | {% usage_options log %}
 `parseSpecialCharSequences` | `true` | Parse special characters for strings surrounded by `{}`, such as `{esc}`. Set to `false` to type the literal characters instead
 `release` | `true` | Keep a modifier activated between commands
 `timeout` | {% url `defaultCommandTimeout` configuration#Timeouts %} | {% usage_options timeout .type %}
+`waitForAnimations` | {% url `waitForAnimations` configuration#Animations %} | {% usage_options waitForAnimations %}
 
 ## Yields {% helper_icon yields %}
 

--- a/source/api/commands/uncheck.md
+++ b/source/api/commands/uncheck.md
@@ -46,11 +46,9 @@ Pass in an options object to change the default behavior of `.uncheck()`.
 
 Option | Default | Description
 --- | --- | ---
-`animationDistanceThreshold` | {% url `animationDistanceThreshold` configuration#Animations %} | {% usage_options animationDistanceThreshold %}
 `force` | `false` | {% usage_options force uncheck %}
 `log` | `true` | {% usage_options log %}
 `timeout` | {% url `defaultCommandTimeout` configuration#Timeouts %} | {% usage_options timeout .uncheck %}
-`waitForAnimations` | {% url `waitForAnimations` configuration#Animations %} | {% usage_options waitForAnimations %}
 
 ## Yields {% helper_icon yields %}
 

--- a/source/api/commands/uncheck.md
+++ b/source/api/commands/uncheck.md
@@ -46,9 +46,11 @@ Pass in an options object to change the default behavior of `.uncheck()`.
 
 Option | Default | Description
 --- | --- | ---
-`log` | `true` | {% usage_options log %}
+`animationDistanceThreshold` | {% url `animationDistanceThreshold` configuration#Animations %} | {% usage_options animationDistanceThreshold %}
 `force` | `false` | {% usage_options force uncheck %}
+`log` | `true` | {% usage_options log %}
 `timeout` | {% url `defaultCommandTimeout` configuration#Timeouts %} | {% usage_options timeout .uncheck %}
+`waitForAnimations` | {% url `waitForAnimations` configuration#Animations %} | {% usage_options waitForAnimations %}
 
 ## Yields {% helper_icon yields %}
 


### PR DESCRIPTION
Document `animationDistanceThreshold` and `waitForAnimations` as available options for the commands below. Found while investigating https://github.com/cypress-io/cypress/issues/8854 

- .click()
- .dblclick()
- .rightclick()
- .type()
- ~.clear()~
- ~.check()~
- ~.uncheck()~
- ~.select()~
- .trigger()

Also alphabetized the options list.

**Preview**

<img width="884" alt="Screen Shot 2020-10-16 at 2 50 48 PM" src="https://user-images.githubusercontent.com/1271364/96234672-c0a2d880-0fbf-11eb-9208-a181a1cfed81.png">

