### PR TITLE
added macbook-16 viewport preset

### DIFF
--- a/source/api/commands/viewport.md
+++ b/source/api/commands/viewport.md
@@ -57,6 +57,7 @@ A preset dimension to set the viewport. Preset supports the following options:
 | `macbook-11`  | 1366  | 768    |
 | `macbook-13`  | 1280  | 800    |
 | `macbook-15`  | 1440  | 900    |
+| `macbook-16`  | 1536  | 960    |
 | `samsung-note9` | 414 | 846    |
 | `samsung-s10` | 360   | 760    |
 


### PR DESCRIPTION
Add macbook-16 model in viewportPresets.
Documentation for  https://github.com/cypress-io/cypress/pull/8892 @close #8889 issue