### PR TITLE
support beforeinput event

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14881,7 +14881,7 @@
     },
     "next-tick": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -14881,7 +14881,7 @@
     },
     "next-tick": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
     },

--- a/source/api/commands/type.md
+++ b/source/api/commands/type.md
@@ -343,7 +343,7 @@ The following events will be fired based on what key was pressed identical to th
 - `input`
 - `keyup`
 
-<div >\* Firefox does not support the `beforeinput` event [MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/beforeinput_event)</figcaption>
+\* Firefox does not support the `beforeinput` event [MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/beforeinput_event)
 
 Additionally `change` events will be fired either when the `{enter}` key is pressed (and the value has changed since the last focus event), or whenever the element loses focus. This matches browser behavior.
 

--- a/source/api/commands/type.md
+++ b/source/api/commands/type.md
@@ -338,11 +338,12 @@ The following events will be fired based on what key was pressed identical to th
 
 - `keydown`
 - `keypress`
+- `beforeinput`*
 - `textInput`
 - `input`
 - `keyup`
 
-`beforeinput` is *not* fired even though it is in the spec because no browser has adopted it.
+<div >\* Firefox does not support the `beforeinput` event [MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/beforeinput_event)</figcaption>
 
 Additionally `change` events will be fired either when the `{enter}` key is pressed (and the value has changed since the last focus event), or whenever the element loses focus. This matches browser behavior.
 
@@ -486,6 +487,7 @@ When clicking on `type` within the command log, the console outputs the followin
 {% imgTag /img/api/type/console-log-of-typing-with-entire-key-events-table-for-each-character.png "Console Log type" %}
 
 {% history %}
+{% url "5.5.0" changelog#5.5.0 %} | Support `beforeinput` event 
 {% url "3.4.1" changelog#3-4-1 %} | Added `parseSpecialCharSequences` option
 {% url "3.3.0" changelog#3-3-0 %} | Added `{insert}`, `{pageup}` and `{pagedown}` character sequences
 {% url "3.2.0" changelog#3-2-0 %} | Added `{home}` and `{end}` character sequences

--- a/source/api/cypress-api/cookies.md
+++ b/source/api/cypress-api/cookies.md
@@ -36,12 +36,12 @@ Set defaults for all cookies, such as preserving a set of cookies to bypass bein
 
 ## Debug
 
-### Log out when cookie values are created, modified or deleted
+### Log when cookie values are created, modified or deleted
 
-By turning on debugging, Cypress will automatically log out to the console when it *sets* or *clears* cookie values. This is useful to help you understand how Cypress clears cookies before each test, and is useful to visualize how to handle preserving cookies in between tests.
+By turning on debugging, Cypress will automatically generate logs to the console when it *sets* or *clears* cookie values. This is useful to help you understand how Cypress clears cookies before each test, and is useful to visualize how to handle preserving cookies in between tests.
 
 ```javascript
-Cypress.Cookies.debug(true) // now Cypress will log out when it alters cookies
+Cypress.Cookies.debug(true) // now Cypress will log when it alters cookies
 
 cy.clearCookie('foo')
 cy.setCookie('foo', 'bar')
@@ -51,7 +51,7 @@ cy.setCookie('foo', 'bar')
 
 ### Turn off verbose debugging output
 
-By default Cypress will log out the cookie object which allows you to inspect all of its properties. However you may not need that level of detail and you can turn this off.
+By default Cypress will log the cookie object which allows you to inspect all of its properties. However you may not need that level of detail and you can turn this off.
 
 ```javascript
 Cypress.Cookies.debug(true, { verbose: false })

--- a/source/guides/references/configuration.md
+++ b/source/guides/references/configuration.md
@@ -108,7 +108,7 @@ Option | Default | Description
 The Node version printed in the Node.js Version panel is used in Cypress to:
 
 - Build files in the {% url "`integrationFolder`" configuration#Folders-Files %}.
-- Build files in the {% url "`supportFolder`" configuration#Folders-Files %}.
+- Build files in the {% url "`supportFile`" configuration#Folders-Files %}.
 - Execute code in the {% url "`pluginsFile`" configuration#Folders-Files %}.
 
 Cypress comes automatically bundled with a set Node version by default.


### PR DESCRIPTION
close #3278 
docs for https://github.com/cypress-io/cypress/pull/8411

I would have liked to style the `* Firefox doesn't support the beforeinput event` as a smaller caption, but didn't want to complicate things with a new hexo tag 