### PR TITLE
Add visual regression open source plugin

### DIFF
--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -604,6 +604,12 @@
       keywords: [screenshots, image-diff, visual regression]
       badge: community
 
+    - name: Cypress Image Diff
+      description: Visual regression testing plugin maintained by DIT - UK Gov.
+      link: https://github.com/uktrade/cypress-image-diff
+      keywords: [screenshots, visual regression, image-diff]
+      badge: community
+
 - name: Reporting
   plugins:
     - name: cypress-failed-log


### PR DESCRIPTION
The British government has been investing in enhancing their quality approaches to their digital applications. One of the areas the departments have been investing on is visual testing. After carefully studying the available options, we've decided to create a plugin which would allow us to scale and enhance along the road, and we felt we would be unable to accomplish this using the current open source plugins created by the community.

We also feel that having the community provide feedback and give them a platform to contribute will keep this plugin up to date so it could keep being useful in the long term not only for the government but whomever wishes to use it.