### PR TITLE
Clarification on return value

### DIFF
--- a/source/api/commands/get.md
+++ b/source/api/commands/get.md
@@ -58,6 +58,8 @@ Option | Default | Description
 
 {% yields sets_dom_subject cy.get %}
 
+Keep in mind, that cy.get() **always** returns an Array of DOM elements. (Same as JQuery does.) All chained methods work on all returned elements.
+
 # Examples
 
 ## Selector


### PR DESCRIPTION
There are many situations when beginners might stumble over this. Here is one example:

cy.get('#domElemWithTextContent').should('have.length.of.at.least', 5)      <= DOES NOT WORK!!!   this checks for the length of the array not the length of the text!
cy.get('#domElemWithTextContent').invoke('text').should('have.length.of.at.least', 5)         <= Only this works.