### PR TITLE
Add link to Mocha custom reporters docs

### DIFF
--- a/source/guides/tooling/reporters.md
+++ b/source/guides/tooling/reporters.md
@@ -21,7 +21,7 @@ Once you've read through the documentation below, we invite you to experience th
 
 ## Installed locally
 
-Custom reporters can be loaded through a relative or absolute path. These can be specified in your configuration file (`cypress.json` by default) or via the {% url "command line" command-line %}.
+{% url "Custom Mocha reporters" https://mochajs.org/api/tutorial-custom-reporter.html %} can be loaded through a relative or absolute path. These can be specified in your configuration file (`cypress.json` by default) or via the {% url "command line" command-line %}.
 
 For example, if you have the following directory structure:
 


### PR DESCRIPTION
To make clear what the API of such reporters is.
We were trying to write a custom cucumber reporter, not adhering to the requirements of Mocha reporters. We go an error "Could not load reporter by name" even though the correct paths was listed in "We searched for the reporter in these paths".