### PR TITLE
added new graphql plugin to plugins file

### DIFF
--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -277,7 +277,7 @@
     - name: cypress-graphql-mock-network
       description: Custom commands to mock your GraphQL API at the network level. Using service-workers for complete isolation of the mock server.
       link: https://github.com/warrenday/cypress-graphql-mock-network
-      keywords: [graphql]
+      keywords: [graphql, mocking, networking]
       badge: community
 
     - name: cypress-graphql-mock

--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -274,6 +274,12 @@
       keywords: [firebase, database, commands]
       badge: community
 
+    - name: cypress-graphql-mock-network
+      description: Custom commands to mock your GraphQL API at the network level. Using service-workers for complete isolation of the mock server.
+      link: https://github.com/warrenday/cypress-graphql-mock-network
+      keywords: [graphql]
+      badge: community
+
     - name: cypress-graphql-mock
       description: Adds commands for executing a mocked GraphQL server using only the client
       link: https://github.com/tgriesser/cypress-graphql-mock

--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -277,7 +277,7 @@
     - name: cypress-graphql-mock-network
       description: Custom commands to mock your GraphQL API at the network level. Using service-workers for complete isolation of the mock server.
       link: https://github.com/warrenday/cypress-graphql-mock-network
-      keywords: [graphql, mocking, networking]
+      keywords: [graphql, mocking, networking, commands]
       badge: community
 
     - name: cypress-graphql-mock


### PR DESCRIPTION
Adds a new GraphQL plugin to the plugins.yml file of cypress documentation.

This plugin mocks GraphQL requests at the network level via service workers. Meaning no need to monkey patch fetch or override in-built methods to achieve mocking.