### PR TITLE
Improve grammar in IDE integration document

### DIFF
--- a/source/guides/tooling/IDE-integration.md
+++ b/source/guides/tooling/IDE-integration.md
@@ -15,7 +15,7 @@ The first time you click a file path, Cypress will prompt you to select which lo
 - A specified application path
 
 {% note warning %}
-Cypress attempts to find available file editors on your system and display those as options. If your preferred editor is not list, you can specify the (full) path to it by selecting **Other**. Cypress will make every effort to open the file, *but it is not guaranteed to work with every application*.
+Cypress attempts to find available file editors on your system and display those as options. If your preferred editor is not listed, you can specify the (full) path to it by selecting **Other**. Cypress will make every effort to open the file, *but it is not guaranteed to work with every application*.
 {% endnote %}
 
 After setting your file opener preference, any files will automatically open in your selected application without prompting you to choose. If you want to change your selection, you can do so in the **Settings** tab of the Cypress Test Runner by clicking under **File Opener Preference**.


### PR DESCRIPTION
While reading through the documentation at https://docs.cypress.io/guides/tooling/IDE-integration.html#File-Opener-Preference I noticed a minor grammatical mistake:

> If your preferred editor is not **list**, you can specify ...

I'm no English major, but being a native English speaker, that above sentence doesn't read well. This PR attempts to improve how that reads:

> If your preferred editor is not **listed**, you can specify ...

<img width="639" alt="Screen Shot 2020-11-17 at 9 18 44 PM" src="https://user-images.githubusercontent.com/7561061/99474395-7e501c80-291a-11eb-9ba7-ed5e52edef7e.png">
