### PR TITLE
docs: Disable dev shm usage by default

### DIFF
--- a/source/_changelogs/6.0.0.md
+++ b/source/_changelogs/6.0.0.md
@@ -15,6 +15,8 @@
 
 **Features:**
 
+- We now pass `—disable-dev-shm-usage` to the Chrome browser flags by default. This will write shared memory files into `/tmp` instead of `/dev/shm`. Addresses {% issue 5336 %}.
+
 **Bugfixes:**
 
 **Documentation Changes:**

--- a/source/guides/guides/continuous-integration.md
+++ b/source/guides/guides/continuous-integration.md
@@ -710,20 +710,6 @@ See {% url bahmutov/yarn-cypress-cache https://github.com/bahmutov/yarn-cypress-
 
 If you are running long runs on Docker, you need to set the `ipc` to `host` mode. {% issue 350 'This issue' %} describes exactly what to do.
 
-In a Docker container, the default size of the `/dev/shm` shared memory space is 64MB. This is not typically enough to run Chrome and can cause the browser to crash. You can fix this by passing the `--disable-dev-shm-usage` flag to Chrome with the following workaround:
-
-```javascript
-module.exports = (on, config) => {
-  on('before:browser:launch', (browser = {}, launchOptions) => {
-    if (browser.family === 'chromium' && browser.name !== 'electron') {
-      launchOptions.args.push('--disable-dev-shm-usage')
-    }
-
-    return launchOptions
-  })
-}
-```
-
 ## Xvfb
 
 When running on Linux, Cypress needs an X11 server; otherwise it spawns its own X11 server during the test run. When running several Cypress instances in parallel, the spawning of multiple X11 servers at once can cause problems for some of them. In this case, you can separately start a single X11 server and pass the server's address to each Cypress instance using `DISPLAY` variable.


### PR DESCRIPTION
- For https://github.com/cypress-io/cypress/pull/9242