### PR TITLE
Fix markdown rendering issue within custom reporters section

### DIFF
--- a/source/guides/tooling/reporters.md
+++ b/source/guides/tooling/reporters.md
@@ -21,7 +21,7 @@ Once you've read through the documentation below, we invite you to experience th
 
 ## Installed locally
 
-{% url "Custom Mocha reporters" https://mochajs.org/api/tutorial-custom-reporter.html %} can be loaded through a relative or absolute path. These can be specified in your configuration file (`cypress.json` by default) or via the {% url "command line" command-line %}.
+You can load {% url "custom Mocha reporters" https://mochajs.org/api/tutorial-custom-reporter.html %} through a relative or absolute path. These can be specified in your configuration file (`cypress.json` by default) or via the {% url "command line" command-line %}.
 
 For example, if you have the following directory structure:
 


### PR DESCRIPTION
If you put a hexo link at the beginning of a paragraph, sometimes it renders all the following markdown raw. 🤷‍♀️🤷‍♀️🤷‍♀️

- close #3334 