### PR TITLE
Fix example aliasing example; Add "Aliasing individual GraphQL requests" section with additional examples

### DIFF
--- a/source/api/commands/intercept.md
+++ b/source/api/commands/intercept.md
@@ -217,7 +217,7 @@ cy.wait('@gqlMutation')
 
 ### Aliasing individual GraphQL requests
 
-Aliases can be set on a per-request basis by setting the `alias` property of the intercepted request:
+Aliases can be set on a per-request basis by setting the `alias` property of the intercepted request.
 
 This is useful against GraphQL endpoints to wait for specific Queries and Mutations.
 

--- a/source/api/commands/intercept.md
+++ b/source/api/commands/intercept.md
@@ -200,19 +200,58 @@ cy.wait('@someRoute').its('response.statusCode').should('eq', 500)
 cy.wait('@someRoute').its('response.body').should('include', 'id')
 ```
 
-### Aliasing individual requests
+### Aliasing individual GraphQL requests
 
 Aliases can be set on a per-request basis by setting the `alias` property of the intercepted request:
 
+With`operationName` property:
+
 ```js
 cy.intercept('POST', '/graphql', (req) => {
-  if (req.body.includes('mutation')) {
-    req.alias = 'gqlMutation'
+  if (req.body.operationName.includes('ListPosts')) {
+    req.alias = 'gqlListPostsQuery'
   }
 })
 
-// assert that a matching request has been made
-cy.wait('@gqlMutation')
+// assert that a matching request for the ListPosts Query has been made
+cy.wait('@gqlListPostsQuery')
+```
+
+```js
+cy.intercept('POST', '/graphql', (req) => {
+  if (req.body.operationName.includes('CreatePost')) {
+    req.alias = 'gqlCreatePostMutation'
+  }
+})
+
+// assert that a matching request for the CreatePost Mutation has been made
+cy.wait('@gqlCreatePostMutation')
+```
+
+Without `operationName` property:
+
+```js
+cy.intercept('POST', '/graphql', (req) => {
+  const { body } = req
+  if (body.hasOwnProperty('query') && body.query.includes('ListPosts')) {
+    req.alias = 'gqlListPostsQuery'
+  }
+})
+
+// assert that a matching request for the ListPosts Query has been made
+cy.wait('@gqlListPostsQuery')
+```
+
+```js
+cy.intercept('POST', '/graphql', (req) => {
+  const { body } = req
+  if (body.hasOwnProperty('mutation') && body.query.includes('CreatePost')) {
+    req.alias = 'gqlCreatePostMutation'
+  }
+})
+
+// assert that a matching request for the CreatePost Mutation has been made
+cy.wait('@gqlCreatePostMutation')
 ```
 
 ## Stubbing a response

--- a/source/api/commands/intercept.md
+++ b/source/api/commands/intercept.md
@@ -200,11 +200,30 @@ cy.wait('@someRoute').its('response.statusCode').should('eq', 500)
 cy.wait('@someRoute').its('response.body').should('include', 'id')
 ```
 
+### Aliasing individual requests
+
+Aliases can be set on a per-request basis by setting the `alias` property of the intercepted request:
+
+```js
+cy.intercept('POST', '/graphql', (req) => {
+  if (req.body.hasOwnProperty('mutation')) {
+    req.alias = 'gqlMutation'
+  }
+})
+
+// assert that a matching request has been made
+cy.wait('@gqlMutation')
+```
+
 ### Aliasing individual GraphQL requests
 
 Aliases can be set on a per-request basis by setting the `alias` property of the intercepted request:
 
-With`operationName` property:
+This is useful against GraphQL endpoints to wait for specific Queries and Mutations.
+
+Given that the `operationName` attribute is optional in GraphQL requests, we can `alias` with or without this attribute.
+
+With `operationName` property:
 
 ```js
 cy.intercept('POST', '/graphql', (req) => {

--- a/source/api/commands/intercept.md
+++ b/source/api/commands/intercept.md
@@ -233,6 +233,7 @@ Without `operationName` property:
 ```js
 cy.intercept('POST', '/graphql', (req) => {
   const { body } = req
+
   if (body.hasOwnProperty('query') && body.query.includes('ListPosts')) {
     req.alias = 'gqlListPostsQuery'
   }
@@ -245,6 +246,7 @@ cy.wait('@gqlListPostsQuery')
 ```js
 cy.intercept('POST', '/graphql', (req) => {
   const { body } = req
+
   if (body.hasOwnProperty('mutation') && body.query.includes('CreatePost')) {
     req.alias = 'gqlCreatePostMutation'
   }

--- a/source/api/commands/intercept.md
+++ b/source/api/commands/intercept.md
@@ -221,7 +221,7 @@ Aliases can be set on a per-request basis by setting the `alias` property of the
 
 This is useful against GraphQL endpoints to wait for specific Queries and Mutations.
 
-Given that the `operationName` attribute is optional in GraphQL requests, we can `alias` with or without this attribute.
+Given that the `operationName` property is optional in GraphQL requests, we can `alias` with or without this property.
 
 With `operationName` property:
 


### PR DESCRIPTION
Fix original aliasing example (`req.body.includes("mutation") to req.body.hasOwnProperty("mutation")`) since `req.body.includes` throws an "includes is not a function" error if run in Cypress.

Rename section to be GraphQL specific and add variations of `routeMatcher` for queries and mutations with and without an `operationName` attribute.

> The operation name is a meaningful and explicit name for your operation. It is only required in multi-operation documents, but its use is encouraged because it is very helpful for debugging and server-side logging.

 [Operation Name | GraphQL](https://graphql.org/learn/queries/#operation-name)
