### PR TITLE
Add casting to get rid of error

### DIFF
--- a/source/api/utilities/blob.md
+++ b/source/api/utilities/blob.md
@@ -62,7 +62,7 @@ cy.get('input[type=file]').then(function(el) {
   list.items.add(file)
   const myFileList = list.files
 
-  el[0].files = myFileList
+  (<HTMLInputElement>el[0]).files = myFileList
   el[0].dispatchEvent(new Event('change', { bubbles: true }))
 })
 ```


### PR DESCRIPTION
Add Casting as IDE shows error otherwise.
Error: Typescript Error: Property 'files' does not exist on type 'HTMLElement'
Fix reference: https://stackoverflow.com/questions/49827325/typescript-error-property-files-does-not-exist-on-type-htmlelement