### PR TITLE
Update answer about code coverage

### DIFF
--- a/source/faq/questions/general-questions-faq.md
+++ b/source/faq/questions/general-questions-faq.md
@@ -110,8 +110,11 @@ No. There are already lots of tools to do that. Using Cypress to test against a 
 
 ## {% fa fa-angle-right %} Is there code coverage?
 
-There is nothing currently built into Cypress to do this. Adding code coverage around end-to-end tests is much harder than unit tests and it may not be feasible to do in a generic way. You can read in more detail about code coverage {% issue 346 'here' %}. You may find some other coverage utilities useful when writing end-to-end tests like:
+There is a plugin and detailed documentation how to get end-to-end, unit and full-stack code coverage
+- read our {% url "Code Coverage guide" https://on.cypress.io/code-coverage %}
+- use {% url @cypress/code-coverage https://github.com/cypress-io/code-coverage %} plugin
 
+You may also find the following resources helpful when writing end-to-end tests:
 - {% url "element coverage" https://glebbahmutov.com/blog/element-coverage/ %}
 - {% url "application state coverage" https://glebbahmutov.com/blog/hyperapp-state-machine/ %}
 

--- a/source/faq/questions/general-questions-faq.md
+++ b/source/faq/questions/general-questions-faq.md
@@ -110,7 +110,7 @@ No. There are already lots of tools to do that. Using Cypress to test against a 
 
 ## {% fa fa-angle-right %} Is there code coverage?
 
-There is a plugin and detailed documentation how to get end-to-end, unit and full-stack code coverage
+There is a plugin and detailed documentation how to get end-to-end, unit and full stack code coverage
 - read our {% url "Code Coverage guide" https://on.cypress.io/code-coverage %}
 - use {% url @cypress/code-coverage https://github.com/cypress-io/code-coverage %} plugin
 

--- a/source/faq/questions/general-questions-faq.md
+++ b/source/faq/questions/general-questions-faq.md
@@ -110,9 +110,9 @@ No. There are already lots of tools to do that. Using Cypress to test against a 
 
 ## {% fa fa-angle-right %} Is there code coverage?
 
-There is a plugin and detailed documentation how to get end-to-end, unit and full stack code coverage
-- read our {% url "Code Coverage guide" https://on.cypress.io/code-coverage %}
-- use {% url @cypress/code-coverage https://github.com/cypress-io/code-coverage %} plugin
+There is a plugin and detailed documentation on how to get end-to-end, unit and full stack code coverage.
+- Read our {% url "Code Coverage guide" https://on.cypress.io/code-coverage %}
+- Use the {% url @cypress/code-coverage https://github.com/cypress-io/code-coverage %} plugin
 
 You may also find the following resources helpful when writing end-to-end tests:
 - {% url "element coverage" https://glebbahmutov.com/blog/element-coverage/ %}


### PR DESCRIPTION
Since linked issue was closed I took the [closing comment](https://github.com/cypress-io/cypress/issues/346#issuecomment-530967799) and made it the new answer (with minimal wording tweaks suitable in the context of this document).

I left the related resources in, since they still seems to be helpful and related to "coverage" in general. But I slightly modified the wording to
- no longer sound like code coverage is not there
- invite more links should anybody have one