### PR TITLE
Add section for migration cy.route to cy.intercept

### DIFF
--- a/source/_changelogs/6.0.0.md
+++ b/source/_changelogs/6.0.0.md
@@ -4,7 +4,7 @@
 
 **Summary:**
 
-Cypress now offers full network stubbing support with the introduction of the {% url "`cy.intercept()`" intercept %} command (previously `cy.route2()`). With {% url "`cy.intercept()`" intercept %} your tests can intercept, modify and wait on any type of HTTP request originating from your app.
+Cypress now offers full network stubbing support with the introduction of the {% url "`cy.intercept()`" intercept %} command (previously `cy.route2()`). With {% url "`cy.intercept()`" intercept %} your tests can intercept, modify and wait on any type of HTTP request originating from your app. See our guide on {% url "Migrating `cy.route()` to `cy.intercept()`" migration-guide#Migrating-cy-route-to-cy-intercept %}.
 
 **Breaking Changes:**
 
@@ -23,7 +23,7 @@ Cypress now offers full network stubbing support with the introduction of the {%
 
 Deprecations still work as before but will be removed from Cypress in a future release. We encourage you to update your code now to remove uses of deprecations.
 
-- `cy.server()` and `cy.route()` have been deprecated. In a future release, support for `cy.server()` and `cy.route()` will be moved to a plugin. We encourage you to use {% url "`cy.intercept()`" intercept %} instead. Addressed in {% issue 9185 %}.
+- `cy.server()` and `cy.route()` have been deprecated. In a future release, support for `cy.server()` and `cy.route()` will be moved to a plugin. We encourage you to use {% url "`cy.intercept()`" intercept %} instead. See our guide on {% url "Migrating `cy.route()` to `cy.intercept()`" migration-guide#Migrating-cy-route-to-cy-intercept %}. Addressed in {% issue 9185 %}.
 - `experimentalFetchPolyfill` has been deprecated. We encourage you to use {% url "`cy.intercept()`" intercept %} to intercept requests using the Fetch API instead.
 - `cy.route2()` was renamed to {% url "`cy.intercept()`" intercept %}. We encourage you to update usages of `cy.route2()` to use {% url "`cy.intercept()`" intercept %}. Addressed in {% issue 9182 %}.
 

--- a/source/_partial/xhr_stubbing_deprecated.md
+++ b/source/_partial/xhr_stubbing_deprecated.md
@@ -1,3 +1,3 @@
 {% note warning %}
-⚠️ **`cy.server()` and `cy.route()` are deprecated in Cypress 6.0.0**. In a future release, support for `cy.server()` and `cy.route()` will be moved to a plugin. Consider using [`cy.intercept()`](/api/commands/intercept.html) instead.
+⚠️ **`cy.server()` and `cy.route()` are deprecated in Cypress 6.0.0**. In a future release, support for `cy.server()` and `cy.route()` will be moved to a plugin. Consider using [`cy.intercept()`](/api/commands/intercept.html) instead. See our guide on [Migrating `cy.route()` to `cy.intercept()`](/guides/references/migration-guide.html#Migrating-cy-route-to-cy-intercept)
 {% endnote %}

--- a/source/api/commands/intercept.md
+++ b/source/api/commands/intercept.md
@@ -611,7 +611,11 @@ The available functions on `res` are:
 
 # See also
 
+* {% url `.as()` as %}
+* {% url `cy.fixture()` fixture %}
+* {% url `cy.wait()` wait %}
+* {% url "Migrating `cy.route()` to `cy.intercept()`" migration-guide#Migrating-cy-route-to-cy-intercept %}
 * {% url "`cy.intercept()` example recipes with real-world examples" https://github.com/cypress-io/cypress-example-recipes#stubbing-and-spying %}
 * {% url "`cy.route()` vs `cy.route2()`" https://glebbahmutov.com/blog/cy-route-vs-route2/ %} blog post
 * {% url "Smart GraphQL Stubbing in Cypress" https://glebbahmutov.com/blog/smart-graphql-stubbing/ %} blog post
-* {% url "open issues for `net stubbing`" https://github.com/cypress-io/cypress/issues?q=is%3Aissue+is%3Aopen+label%3Apkg%2Fnet-stubbing %} and {% url "closed issues for `net stubbing`" https://github.com/cypress-io/cypress/issues?q=is%3Aissue+is%3Aclosed+label%3Apkg%2Fnet-stubbing %}
+* {% url "Open issues for `net stubbing`" https://github.com/cypress-io/cypress/issues?q=is%3Aissue+is%3Aopen+label%3Apkg%2Fnet-stubbing %} and {% url "closed issues for `net stubbing`" https://github.com/cypress-io/cypress/issues?q=is%3Aissue+is%3Aclosed+label%3Apkg%2Fnet-stubbing %}

--- a/source/api/commands/route.md
+++ b/source/api/commands/route.md
@@ -498,6 +498,7 @@ When clicking on `XHR Stub` within the Command Log, the console outputs the foll
 
 # See also
 
+- {% url "Migrating `cy.route()` to `cy.intercept()`" migration-guide#Migrating-cy-route-to-cy-intercept %}
 - {% url `.as()` as %}
 - {% url `cy.fixture()` fixture %}
 - {% url `cy.server()` server %}

--- a/source/guides/references/migration-guide.md
+++ b/source/guides/references/migration-guide.md
@@ -2,6 +2,87 @@
 title: Migration Guide
 ---
 
+# Migrating `cy.route()` to `cy.intercept()`
+
+This guide details how to change your test code to migrate from `cy.route()` to `cy.intercept()`. `cy.server()` and `cy.route()` are deprecated in Cypress 6.0.0. In a future release, support for `cy.server()` and `cy.route()` will be removed.
+
+Please also refer to the full documentation for {% url "`cy.intercept()`" intercept %}.
+
+## Simple route matching
+
+In many use cases, you can replace `cy.route()` with {% url "`cy.intercept()`" intercept %} and remove the call to `cy.server()` (which is no longer necessary).
+
+{% badge danger Before %}
+
+```js
+// Set up XHR listeners using cy.route()
+cy.server()
+cy.route('/users').as('getUsers')
+cy.route('POST', '/project').as('createProject')
+cy.route('PATCH', '/projects/*').as('updateProject')
+```
+
+{% badge success After %}
+
+```js
+// Intercept HTTP requests
+cy.intercept('/users').as('getUsers')
+cy.intercept('POST', '/project').as('createProject')
+cy.intercept('PATCH', '/projects/*').as('updateProject')
+```
+
+## `cy.wait()` object
+
+The object returned by `cy.wait()` is different from intercepted HTTP requests using `cy.intercept()` than the object returned from an awaited `cy.route()` XHR.
+
+{% badge danger Before %}
+
+```js
+// Wait for XHR from cy.route()
+cy.route('POST', '/users').as('createUser')
+// ...
+cy.wait('@createUser')
+  .then(({ requestBody, responseBody, status }) => {
+    expect(status).to.eq(200)
+    expect(requestBody.firstName).to.eq('Jane')
+    expect(responseBody.firstName).to.eq('Jane')
+  })
+```
+
+{% badge success After %}
+
+```js
+// Wait for intercepted HTTP request
+cy.intercept('POST', '/users').as('createUser')
+// ...
+cy.wait('@createUser')
+  .then(({ request, response }) => {
+    expect(response.statusCode).to.eq(200)
+    expect(request.body.name).to.eq('Jane')
+    expect(response.body.name).to.eq('Jane')
+  })
+```
+
+## Fixtures
+
+You can stub requests and response with fixture data by defining a `fixture` property in the `routeHandler` argument for `cy.intercept()`.
+
+{% badge danger Before %}
+
+```js
+// Stub response with fixture data using cy.route()
+cy.route('GET', '/projects', 'fx:projects')
+```
+
+{% badge success After %}
+
+```js
+// Stub response with fixture data using cy.intercept()
+cy.intercept('GET', '/projects', {
+  fixture: 'projects'
+})
+```
+
 # Migrating to Cypress 6.0
 
 This guide details the changes and how to change your code to migrate to Cypress 6.0. {% url "See the full changelog for 6.0" changelog#6-0-0 %}.


### PR DESCRIPTION
TR-553

- Added a section to the migration guide for migration cy.route() to cy.intercept(). 
- I think these examples are pretty minimal and I'd probably like more complicated examples added.
- Mostly to just allow us to have a place to link and share with people, but I imagine this section will move into the 7.0 migration guide when that is released.