### PR TITLE
Fix broken links to old cypress-webpack-preprocessor

### DIFF
--- a/source/_changelogs/1.1.0.md
+++ b/source/_changelogs/1.1.0.md
@@ -14,7 +14,7 @@
 - You can now customize the default Babe; configuration options for the Browserify preprocessor. Fixes {% issue 343 %} and {% issue 905 %}.
 - CoffeeScript 2 is supported via modifying the default options for the Browserify preprocessor. Fixes {% issue 663 %}.
 - You can swap out or extend the default preprocessor to do exotic things like compile ClojureScript into JavaScript. Fixes {% issue 533 %}.
-- We have created a {% url `@cypress/webpack-preprocessor` https://github.com/cypress-io/cypress-webpack-preprocessor %} preprocessor npm package for you webpack users (because we are nice ￰ﾟﾘﾉ). Fixes {% issue 676 %}.
+- We have created a {% url `@cypress/webpack-preprocessor` https://github.com/cypress-io/cypress/tree/master/npm/webpack-preprocessor %} preprocessor npm package for you webpack users (because we are nice ￰ﾟﾘﾉ). Fixes {% issue 676 %}.
 
 **Bugfixes:**
 

--- a/source/_changelogs/5.0.0.md
+++ b/source/_changelogs/5.0.0.md
@@ -18,7 +18,7 @@ Cypress now includes support for test retries! Similar to how Cypress will retry
 - Values yielded by {% url "`cy.setCookie()`" setcookie %}, {% url "`cy.getCookie()`" getcookie %}, and {% url "`cy.getCookies()`" getcookies %} will now contain the `sameSite` property if specified. Addresses {% issue 6892 %}.
 - The `experimentalGetCookiesSameSite` configuration flag has been removed, since this behavior is now the default. Addresses {% issue 6892 %}.
 - The return type of the {% url "`Cypress.Blob`" blob %} methods `arrayBufferToBlob`, `base64StringToBlob`, `binaryStringToBlob`, and `dataURLToBlob` have changed from `Promise<Blob>` to `Blob`. Addresses {% issue 6001 %}.
-- Cypress no longer supports file paths with a question mark `?` or exclamation mark `!` in them. We now use the {% url "webpack preprocessor" https://github.com/cypress-io/cypress-webpack-preprocessor %} by default and it does not support files with question marks or exclamation marks. Addressed in {% PR 7982 %}.
+- Cypress no longer supports file paths with a question mark `?` or exclamation mark `!` in them. We now use the {% url "webpack preprocessor" https://github.com/cypress-io/cypress/tree/master/npm/webpack-preprocessor %} by default and it does not support files with question marks or exclamation marks. Addressed in {% PR 7982 %}.
 - For TypeScript compilation of spec, support, and plugins files, the `esModuleInterop` option is no longer coerced to `true`. If you need to utilize `esModuleInterop`, set it in your `tsconfig.json`. Addresses {% issue 7575 %}.
 - Cypress now requires TypeScript 3.4+. Addressed in {% issue 7856 %}.
 - Installing Cypress on your system now requires Node.js 10+. Addresses {% issue 6574 %}.
@@ -53,7 +53,7 @@ Cypress now includes support for test retries! Similar to how Cypress will retry
 
 **Misc:**
 
-- Cypress now uses the {% url "webpack preprocessor" https://github.com/cypress-io/cypress-webpack-preprocessor %} by default to preprocess spec files.
+- Cypress now uses the {% url "webpack preprocessor" https://github.com/cypress-io/cypress/tree/master/npm/webpack-preprocessor %} by default to preprocess spec files.
 - The **Runs** tab within the Test Runner has a new improved design when the project has not been set up or login is required. Addressed in {% PR 8141 %}.
 - The type for the `Window` object returned from {% url "`cy.window()`" window %} is now correct. Addresses {% issue 7856 %}.
 - The type definition for Cypress's `ApplicationWindow` can now be extended. Addresses {% issue 7856 %}.

--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -32,7 +32,7 @@
 
     - name: Webpack
       description: Watches and bundles your spec files via webpack.
-      link: https://github.com/cypress-io/cypress-webpack-preprocessor
+      link: https://github.com/cypress-io/cypress/tree/master/npm/webpack-preprocessor
       keywords: [webpack]
       badge: official
 

--- a/source/api/plugins/preprocessors-api.md
+++ b/source/api/plugins/preprocessors-api.md
@@ -14,7 +14,7 @@ We've created three preprocessors as examples for you to look at. These are full
 
 The code contains comments that explain how it utilizes the preprocessor API.
 
-* {% url 'webpack preprocessor' https://github.com/cypress-io/cypress-webpack-preprocessor %}
+* {% url 'webpack preprocessor' https://github.com/cypress-io/cypress/tree/master/npm/webpack-preprocessor %}
 * {% url 'Browserify preprocessor' https://github.com/cypress-io/cypress-browserify-preprocessor %}
 * {% url 'Watch preprocessor' https://github.com/cypress-io/cypress-watch-preprocessor %}
 
@@ -33,9 +33,9 @@ The webpack preprocessor handles:
 Are you looking to change the **default options** for webpack?
 {% endnote %}
 
-If you already use webpack in your project, you can pass in your webpack config as {% url 'shown here' https://github.com/cypress-io/cypress-webpack-preprocessor#options %}.
+If you already use webpack in your project, you can pass in your webpack config as {% url 'shown here' https://github.com/cypress-io/cypress/tree/master/npm/webpack-preprocessor#options %}.
 
-If you don't use webpack in your project or would like to keep the majority of the default options, you can {% url 'modify the default options' https://github.com/cypress-io/cypress-webpack-preprocessor#modifying-default-options %}. Editing the options allows you to do things like:
+If you don't use webpack in your project or would like to keep the majority of the default options, you can {% url 'modify the default options' https://github.com/cypress-io/cypress/tree/master/npm/webpack-preprocessor#modifying-default-options %}. Editing the options allows you to do things like:
 
 - Add your own Babel plugins
 - Modify options for TypeScript compilation

--- a/source/faq/questions/general-questions-faq.md
+++ b/source/faq/questions/general-questions-faq.md
@@ -120,7 +120,7 @@ You may also find the following resources helpful when writing end-to-end tests:
 
 ## {% fa fa-angle-right %} Are there driver bindings in my language?
 
-Cypress does *not* utilize WebDriver for testing, so it does not use or have any notion of driver bindings. If your language can be somehow transpiled to JavaScript, then you can configure {% url "Cypress webpack preprocessor" https://github.com/cypress-io/cypress-webpack-preprocessor %} or {% url "Cypress Browserify preprocessor" https://github.com/cypress-io/cypress-browserify-preprocessor %} to transpile your tests to JavaScript that Cypress can run.
+Cypress does *not* utilize WebDriver for testing, so it does not use or have any notion of driver bindings. If your language can be somehow transpiled to JavaScript, then you can configure {% url "Cypress webpack preprocessor" https://github.com/cypress-io/cypress/tree/master/npm/webpack-preprocessor %} or {% url "Cypress Browserify preprocessor" https://github.com/cypress-io/cypress-browserify-preprocessor %} to transpile your tests to JavaScript that Cypress can run.
 
 ## {% fa fa-angle-right %} So what benefits would one get for converting one's unit tests from Karma or Jest to Cypress?
 

--- a/source/guides/core-concepts/writing-and-organizing-tests.md
+++ b/source/guides/core-concepts/writing-and-organizing-tests.md
@@ -523,11 +523,11 @@ Set the {% url `watchForFileChanges` configuration#Global %} configuration prope
 The `watchForFileChanges` property is only in effect when running Cypress using {% url "`cypress open`" command-line#cypress-open %}.
 {% endnote %}
 
-The component responsible for the file-watching behavior in Cypress is the {% url '`cypress-webpack-preprocessor`' https://github.com/cypress-io/cypress-webpack-preprocessor %}. This is the default file-watcher packaged with Cypress.
+The component responsible for the file-watching behavior in Cypress is the {% url '`webpack-preprocessor`' https://github.com/cypress-io/cypress/tree/master/npm/webpack-preprocessor %}. This is the default file-watcher packaged with Cypress.
 
 If you need further control of the file-watching behavior you can configure this preprocessor explicitly: it exposes options that allow you to configure behavior such as _what_ is watched and the delay before emitting an "update" event after a change.
 
 Cypress also ships other {% url "file-watching preprocessors" plugins %}; you'll have to configure these explicitly if you want to use them.
 
 - {% url 'Cypress Watch Preprocessor' https://github.com/cypress-io/cypress-watch-preprocessor %}
-- {% url 'Cypress webpack Preprocessor' https://github.com/cypress-io/cypress-webpack-preprocessor %}
+- {% url 'Cypress webpack Preprocessor' https://github.com/cypress-io/cypress/tree/master/npm/webpack-preprocessor %}

--- a/source/guides/guides/debugging.md
+++ b/source/guides/guides/debugging.md
@@ -129,7 +129,7 @@ The center of the `<li>Users</li>` element is hidden from view in our applicatio
 
 Cypress utilizes source maps to enhance the error experience. Stack traces are translated so that your source files are shown instead of the generated file that is loaded by the browser. This also enables displaying code frames. Without inline source maps, you will not see code frames.
 
-By default, Cypress will include an inline source map in your spec file, so you will get the most out of the error experience. If you {% url "modify the preprocessor" preprocessors-api %}, ensure that inline source maps are enabled to get the same experience. With webpack and the {% url "webpack preprocessor" https://github.com/cypress-io/cypress-webpack-preprocessor %}, for example, set {% url "the `devtool` option" https://webpack.js.org/configuration/devtool/ %} to `inline-source-map`.
+By default, Cypress will include an inline source map in your spec file, so you will get the most out of the error experience. If you {% url "modify the preprocessor" preprocessors-api %}, ensure that inline source maps are enabled to get the same experience. With webpack and the {% url "webpack preprocessor" https://github.com/cypress-io/cypress/tree/master/npm/webpack-preprocessor %}, for example, set {% url "the `devtool` option" https://webpack.js.org/configuration/devtool/ %} to `inline-source-map`.
 
 # Debugging flake
 


### PR DESCRIPTION
https://github.com/cypress-io/cypress-webpack-preprocessor becomes https://github.com/cypress-io/cypress/tree/master/npm/webpack-preprocessor