### PR TITLE
6.2.0 Release

### DIFF
--- a/source/_changelogs/6.2.0.md
+++ b/source/_changelogs/6.2.0.md
@@ -5,6 +5,7 @@
 **Features:**
 
 - You can now listen to a `before:spec` and `after:spec` events in the plugins file. See the {% url "`before:spec`" before-spec-api %} and {% url "`after:spec`" after-spec-api %} docs for more information. Addressed in {% issue 9646 %} and {% issue 14178 %}.
+- The `Timed out retrying` error message now displays the amount of time Cypress retried. Addresses {% issue 5781 %}.
 
 **Bugfixes:**
 

--- a/source/_changelogs/6.2.0.md
+++ b/source/_changelogs/6.2.0.md
@@ -1,0 +1,26 @@
+# 6.2.0
+
+*Released 12/21/2020*
+
+**Features:**
+
+- You can now listen to a `before:spec` and `after:spec` events in the plugins file. See the {% url "`before:spec`" before-spec-api %} and {% url "`after:spec`" after-spec-api %} docs for more information. Addressed in {% issue 9646 %} and {% issue 14178 %}.
+
+**Bugfixes:**
+
+- Getting an alias of {% url "`cy.intercept()`" intercept %} using {% url "`cy.get()`" get %} will no longer always yield `null`. Fixes {% issue 9306 %}.
+- {% url "`cy.intercept()`" intercept %} will now automatically responds to CORS preflight requests (HTTP `OPTIONS` requests) that match defined routes. Fixes {% issue 9599 %}.
+- Response errors from `forceNetworkError` can now be awaited using {% url "`cy.intercept()`" intercept %} and {% url "`cy.wait()`" wait %}. Fixes {% issue 9062 %}.
+- Using {% url "`cy.log()`" log %} inside {% url "`.then()`" then %} no longer breaks the subject value in the command chain. Fixes {% issue 8084 %}.
+- Using {% url "`Cypress.Commands.overwrite`" custom-commands#Overwrite-Existing-Commands %} to overwrite {% url "`.then()`" then %} now preserves the proper `this` context and sets aliases correctly. Fixes {% issue 5101 %}.
+- Using {% url "`Cypress.Commands.overwrite`" custom-commands#Overwrite-Existing-Commands %} to overwrite {% url "`cy.route()`" route %} or {% url "`cy.intercept()`" intercept %} and wait on its alias now properly works. Fixes {% issue 3890 %} and {% issue 9580 %}.
+- Cypress no longer fails to find specs if you set the fixtures folder to be the same as the integration folder. Fixes {% issue 14226 %}.
+
+**Misc:**
+
+- `scrollBehavior` is now an allowed type when passed as test configuration. Addresses {% issue 9643 %}.
+- The `FileObject` type for the file argument of the `file:preprocessor` event now includes the `EventEmitter` type. Addresses {% issue 9276 %}.
+
+**Dependency Updates:**
+
+- Upgraded `electron` from `11.0.2` to `11.0.3`. Addressed in {% issue 9409 %}.

--- a/source/_changelogs/6.2.0.md
+++ b/source/_changelogs/6.2.0.md
@@ -4,7 +4,8 @@
 
 **Features:**
 
-- You can now listen to a `before:spec` and `after:spec` events in the plugins file. See the {% url "`before:spec`" before-spec-api %} and {% url "`after:spec`" after-spec-api %} docs for more information. Addressed in {% issue 9646 %} and {% issue 14178 %}.
+- You can now listen to `before:run` and `after:run` events in the plugins file. See the {% url "`before:run`" before-run-api %} and {% url "`after:run`" after-run-api %} docs for more information. Addressed in {% issue 14238 %} and {% issue 14263 %}.
+- You can now listen to `before:spec` and `after:spec` events in the plugins file. See the {% url "`before:spec`" before-spec-api %} and {% url "`after:spec`" after-spec-api %} docs for more information. Addressed in {% issue 9646 %} and {% issue 14178 %}.
 - The `Timed out retrying` error message now displays the amount of time Cypress retried. Addresses {% issue 5781 %}.
 
 **Bugfixes:**

--- a/source/_data/sidebar.yml
+++ b/source/_data/sidebar.yml
@@ -181,6 +181,7 @@ api:
     writing-a-plugin: writing-a-plugin.html
     configuration-api: configuration-api.html
     preprocessors-api: preprocessors-api.html
+    before-spec-api: before-spec-api.html
     browser-launch-api: browser-launch-api.html
     after-screenshot-api: after-screenshot-api.html
 

--- a/source/_data/sidebar.yml
+++ b/source/_data/sidebar.yml
@@ -183,6 +183,7 @@ api:
     configuration-api: configuration-api.html
     preprocessors-api: preprocessors-api.html
     before-run-api: before-run-api.html
+    after-run-api: after-run-api.html
     before-spec-api: before-spec-api.html
     after-spec-api: after-spec-api.html
     browser-launch-api: browser-launch-api.html

--- a/source/_data/sidebar.yml
+++ b/source/_data/sidebar.yml
@@ -182,6 +182,7 @@ api:
     configuration-api: configuration-api.html
     preprocessors-api: preprocessors-api.html
     before-spec-api: before-spec-api.html
+    after-spec-api: after-spec-api.html
     browser-launch-api: browser-launch-api.html
     after-screenshot-api: after-screenshot-api.html
 

--- a/source/_data/sidebar.yml
+++ b/source/_data/sidebar.yml
@@ -182,6 +182,7 @@ api:
     writing-a-plugin: writing-a-plugin.html
     configuration-api: configuration-api.html
     preprocessors-api: preprocessors-api.html
+    before-run-api: before-run-api.html
     before-spec-api: before-spec-api.html
     after-spec-api: after-spec-api.html
     browser-launch-api: browser-launch-api.html

--- a/source/api/commands/intercept.md
+++ b/source/api/commands/intercept.md
@@ -7,7 +7,7 @@ Use `cy.intercept()` to manage the behavior of HTTP requests at the network laye
 With `cy.intercept()`, you can:
 
 * stub or spy on any type of HTTP request.
-  * If `cy.intercept` provides a response object, or a fixture, or calls `req.reply()` then the request will NOT go to the server, and instead will be mocked from the test.
+  * If `cy.intercept()` provides a response object, or a fixture, or calls `req.reply()` then the request will NOT go to the server, and instead will be mocked from the test.
   * Otherwise the request will go out to the server, and the test spies on the network call. The spying intercept can even modify the real response from the server before it is returned to the web application under test.
 * {% urlHash "modify an HTTP request's body, headers, and URL" Intercepting-a-request %} before it is sent to the destination server.
 * stub the response to an HTTP request, either dynamically or statically.
@@ -37,7 +37,7 @@ cy.intercept(routeMatcher, routeHandler?)
 
 ### **{% fa fa-angle-right %} url** **_(`string | RegExp`)_**
 
-Specify the URL to match. See the documentation for {% urlHash "`routeMatcher`" routeMatcher-RouteMatcher %} to see how URLs are matched.
+Specify the URL to match. See the examples for {% urlHash "Matching URL" Matching-URL %} to see how URLs are matched.
 
 ```ts
 cy.intercept('http://example.com/widgets')
@@ -82,6 +82,11 @@ All properties are optional. All properties that are set must match for the rout
    * If 'false', only HTTP requests will be matched.
    */
   https?: boolean
+  /**
+   * If `true`, will match the supplied `url` against incoming `path`s.
+   * Requires a `url` argument. Cannot be used with a `path` argument.
+   */
+  matchUrlAgainstPath?: boolean
   /**
    * Match against the request's HTTP method.
    * @default '*'
@@ -158,6 +163,19 @@ The `routeHandler` defines what will happen with a request if the {% urlHash "`r
 # Examples
 
 ## Matching URL
+
+{% note info %}
+**Note:** passing a URL as a string or RegExp to `cy.intercept()` will automatically set `matchUrlAgainstPath` to `true`. This means that the supplied string or RegExp will be matched against the **path** if matching against the **URL** fails.
+{% endnote %}
+
+You can provide the entire URL to match
+
+```js
+// will match any request that exactly matches the URL
+//   matches GET https://prod.cypress.io/users
+//   won't match GET https://staging.cypress.io/users
+cy.intercept('https://prod.cypress.io/users')
+```
 
 You can provide a substring of the URL to match
 
@@ -615,6 +633,7 @@ The available functions on `res` are:
 ```
 
 {% history %}
+{% url "6.2.0" changelog#6-2-0 %} | Added `matchUrlAgainstPath` option to `RouteMatcher`.
 {% url "6.0.0" changelog#6-0-0 %} | Renamed `cy.route2()` to `cy.intercept()`.
 {% url "6.0.0" changelog#6-0-0 %} | Removed `experimentalNetworkStubbing` option and made it the default behavior.
 {% url "5.1.0" changelog#5-1-0 %} | Added experimental `cy.route2()` command under `experimentalNetworkStubbing` option.

--- a/source/api/commands/intercept.md
+++ b/source/api/commands/intercept.md
@@ -339,6 +339,17 @@ cy.intercept('POST', '/graphql', (req) => {
 cy.wait('@gqlCreatePostMutation')
 ```
 
+### Waiting on errors
+
+You can use {% url "`cy.wait()`" wait %} to wait on requests that end with network errors:
+
+```js
+cy.intercept('GET', '/should-err', { forceNetworkError: true }).as('err')
+
+// assert that this request happened, and that it ended in an error
+cy.wait('@err').should('have.property', 'error')
+```
+
 ## Stubbing a response
 
 ### With a string

--- a/source/api/plugins/after-run-api.md
+++ b/source/api/plugins/after-run-api.md
@@ -1,0 +1,69 @@
+---
+title: After Run API
+containerClass: experimental
+---
+
+The `after:run` event fires after a run is finished. The event only fires when running via `cypress run`.
+
+The event will fire each time `cypress run` executes. As a result, if running your specs in {% url "parallel" parallelization %}, the event will fire once for each machine on which `cypress run` is called.
+
+{% note warning %}
+{% fa fa-warning orange %} **This is an experimental feature. In order to use it, you must set the {% url "`experimentalRunEvents`" experiments %} configuration option to `true`.**
+{% endnote %}
+
+# Syntax
+
+```js
+on('after:run', (results) => { /* ... */ })
+```
+
+**{% fa fa-angle-right %} results** ***(Object)***
+
+Results of the run, including the total number of passes/failures/etc, the project config, and details about the browser and system. It is the same as the results object resolved by the {% url "Module API" module-api#Results %}.
+
+# Usage
+
+You can return a promise from the `after:run` event handler and it will be awaited before Cypress proceeds running your specs.
+
+## Log the number of passed tests of a run
+
+```javascript
+module.exports = (on, config) => {
+  on('after:run', (results) => {
+    // results will look something like this:
+    // {
+    //   totalDuration: 81,
+    //   totalSuites: 0,
+    //   totalTests: 1,
+    //   totalFailed: 0,
+    //   totalPassed: 1,
+    //   totalPending: 0,
+    //   totalSkipped: 0,
+    //   browserName: 'electron',
+    //   browserVersion: '59.0.3071.115',
+    //   osName: 'darwin',
+    //   osVersion: '16.7.0',
+    //   cypressVersion: '3.1.0',
+    //   config: {
+    //     projectId: '1qv3w7',
+    //     baseUrl: 'http://example.com',
+    //     viewportWidth: 1000,
+    //     viewportHeight: 660,
+    //     // ... more properties...
+    //   }
+    //   // ... more properties...
+    //   }
+    // }
+
+    console.log(results.totalPassed, 'out of', results.totalTests, 'passed')
+  })
+}
+```
+
+# See also
+
+- {% url "Before Run API" before-run-api %}
+- {% url "Before Spec API" before-spec-api %}
+- {% url "After Spec API" after-spec-api %}
+- {% url "Plugins Guide" plugins-guide %}
+- {% url "Writing a Plugin" writing-a-plugin %}

--- a/source/api/plugins/after-spec-api.md
+++ b/source/api/plugins/after-spec-api.md
@@ -99,5 +99,6 @@ module.exports = (on, config) => {
 # See also
 
 - {% url "Before Spec API" before-spec-api %}
+- {% url "Before Run API" before-run-api %}
 - {% url "Plugins Guide" plugins-guide %}
 - {% url "Writing a Plugin" writing-a-plugin %}

--- a/source/api/plugins/after-spec-api.md
+++ b/source/api/plugins/after-spec-api.md
@@ -1,0 +1,103 @@
+---
+title: After Spec API
+---
+
+The `after:spec` event fires after a spec file is run. The event only fires when running via `cypress run`.
+
+{% note warning %}
+{% fa fa-warning orange %} **This is an experimental feature. In order to use it, you must set the {% url "`experimentalRunEvents`" experiments %} configuration option to `true`.**
+{% endnote %}
+
+# Syntax
+
+```js
+on('after:spec', (spec, results) => { /* ... */ })
+```
+
+**{% fa fa-angle-right %} spec** ***(Object)***
+
+Details of the spec file, including the following properties:
+
+Property | Description
+--- | ---
+`name` | The base name of the spec file (e.g. `login_spec.js`)
+`relative` | The path to the spec file, relative to the project root (e.g. `cypress/integration/login_spec.js`)
+`absolute` | The absolute path to the spec file (e.g. `/Users/janelane/my-app/cypress/integration/login_spec.js`)
+
+**{% fa fa-angle-right %} results** ***(Object)***
+
+Details of the spec file's results, including numbers of passes/failures/etc and details on the tests themselves.
+
+# Usage
+
+You can return a promise from the `after:spec` event handler and it will be awaited before Cypress proceeds with processing the spec's video or moving on to further specs if there are any.
+
+## Log the relative spec path to stdout after the spec is run
+
+```javascript
+module.exports = (on, config) => {
+  on('after:spec', (spec, results) => {
+    // spec will look something like this:
+    // {
+    //   name: 'login_spec.js',
+    //   relative: 'cypress/integration/login_spec.js',
+    //   absolute: '/Users/janelane/my-app/cypress/integration/login_spec.js',
+    // }
+
+    // results will look something like this:
+    // {
+    //   stats: {
+    //     suites: 0,
+    //     tests: 1,
+    //     passes: 1,
+    //     pending: 0,
+    //     skipped: 0,
+    //     failures: 0,
+    //     // ...more properties
+    //   }
+    //   reporter: 'spec',
+    //   tests: [
+    //     {
+    //       title: ['login', 'logs user in'],
+    //       state: 'passed',
+    //       body: 'function () {}',
+    //       // ...more properties...
+    //     }
+    //   ],
+    //   error: null,
+    //   video: '/Users/janelane/my-app/cypress/videos/login_spec.js.mp4',
+    //   screenshots: [],
+    //   // ...more properties...
+    // }
+    console.log('Finished running', spec.relative)
+  })
+}
+```
+
+# Examples
+
+## Delete the recorded video if the spec passed
+
+You can delete the recorded video for a spec. This will skip the compression and uploading of the video when recording to the Dashboard.
+
+The example below shows how to delete the recorded video for a spec with no failing tests.
+
+```javascript
+const del = require('del')
+
+module.exports = (on, config) => {
+  on('after:spec', (spec, results) => {
+    if (results.stats.failures === 0 && results.video) {
+      // `del()` returns a promise, so it's important to return it to ensure
+      // deleting the video is finished before moving on
+      return del(result.video)
+    }
+  })
+}
+```
+
+# See also
+
+- {% url "Before Spec API" before-spec-api %}
+- {% url "Plugins Guide" plugins-guide %}
+- {% url "Writing a Plugin" writing-a-plugin %}

--- a/source/api/plugins/after-spec-api.md
+++ b/source/api/plugins/after-spec-api.md
@@ -1,5 +1,6 @@
 ---
 title: After Spec API
+containerClass: experimental
 ---
 
 The `after:spec` event fires after a spec file is run. The event only fires when running via `cypress run`.
@@ -100,5 +101,6 @@ module.exports = (on, config) => {
 
 - {% url "Before Spec API" before-spec-api %}
 - {% url "Before Run API" before-run-api %}
+- {% url "After Run API" after-run-api %}
 - {% url "Plugins Guide" plugins-guide %}
 - {% url "Writing a Plugin" writing-a-plugin %}

--- a/source/api/plugins/before-run-api.md
+++ b/source/api/plugins/before-run-api.md
@@ -1,0 +1,78 @@
+---
+title: Before Run API
+---
+
+The `before:run` event fires before a run starts. The event only fires when running via `cypress run`.
+
+The event will fire each time `cypress run` executes. As a result, if running your specs in {% url "parallel" parallelization %}, the event will fire once for each machine on which the tests are run.
+
+{% note warning %}
+{% fa fa-warning orange %} **This is an experimental feature. In order to use it, you must set the {% url "`experimentalRunEvents`" experiments %} configuration option to `true`.**
+{% endnote %}
+
+# Syntax
+
+```js
+on('before:run', (details) => { /* ... */ })
+```
+
+**{% fa fa-angle-right %} details** ***(Object)***
+
+Details of the run, including the project config, details about the browser and system, and the specs that will be run.
+
+# Usage
+
+You can return a promise from the `before:run` event handler and it will be awaited before Cypress proceeds running your specs.
+
+## Log the browser and the number of specs that will be run
+
+```javascript
+module.exports = (on, config) => {
+  on('before:run', (details) => {
+    // details will look something like this:
+    // {
+    //   config: {
+    //     projectId: '12345',
+    //     baseUrl: 'http://example.com/',
+    //     viewportWidth: 1000,
+    //     viewportHeight: 660,
+    //     // ...more properties...
+    //   },
+    //   browser: {
+    //     name: 'electron',
+    //     version: '59.0.3071.115',
+    //     // ...more properties...
+    //   },
+    //   system:
+    //   {
+    //     osName: 'darwin',
+    //     osVersion: '16.7.0',
+    //   }
+    //   cypressVersion: '6.1.0',
+    //   specs: [
+    //     {
+    //       name: 'login_spec.js',
+    //       relative: 'cypress/integration/login_spec.js',
+    //       absolute: '/Users/janelane/app/cypress/integration/login_spec.js',
+    //     },
+    //     // ... more specs
+    //   ],
+    //   specPattern: [
+    //     '**/*_spec.js'
+    //   ],
+    //   parallel: false,
+    //   group: 'group-1',
+    //   tag: 'tag-1'
+    // }
+
+    console.log('Running', details.specs.length, 'specs in', details.browser.name)
+  })
+}
+```
+
+# See also
+
+- {% url "Before Spec API" before-spec-api %}
+- {% url "After Spec API" after-spec-api %}
+- {% url "Plugins Guide" plugins-guide %}
+- {% url "Writing a Plugin" writing-a-plugin %}

--- a/source/api/plugins/before-run-api.md
+++ b/source/api/plugins/before-run-api.md
@@ -1,5 +1,6 @@
 ---
 title: Before Run API
+containerClass: experimental
 ---
 
 The `before:run` event fires before a run starts. The event only fires when running via `cypress run`.
@@ -72,6 +73,7 @@ module.exports = (on, config) => {
 
 # See also
 
+- {% url "After Run API" after-run-api %}
 - {% url "Before Spec API" before-spec-api %}
 - {% url "After Spec API" after-spec-api %}
 - {% url "Plugins Guide" plugins-guide %}

--- a/source/api/plugins/before-spec-api.md
+++ b/source/api/plugins/before-spec-api.md
@@ -1,5 +1,6 @@
 ---
 title: Before Spec API
+containerClass: experimental
 ---
 
 The `before:spec` event fires before a spec file is run. The event only fires when running via `cypress run`.
@@ -49,5 +50,6 @@ module.exports = (on, config) => {
 
 - {% url "After Spec API" after-spec-api %}
 - {% url "Before Run API" before-run-api %}
+- {% url "After Run API" after-run-api %}
 - {% url "Plugins Guide" plugins-guide %}
 - {% url "Writing a Plugin" writing-a-plugin %}

--- a/source/api/plugins/before-spec-api.md
+++ b/source/api/plugins/before-spec-api.md
@@ -1,0 +1,51 @@
+---
+title: Before Spec API
+---
+
+The `before:spec` event fires before a spec file is run. The event only fires when running via `cypress run`.
+
+{% note warning %}
+{% fa fa-warning orange %} **This is an experimental feature. In order to use it, you must set the {% url "`experimentalRunEvents`" experiments %} configuration option to `true`.**
+{% endnote %}
+
+# Syntax
+
+```js
+on('before:spec', (spec) => { /* ... */ })
+```
+
+**{% fa fa-angle-right %} spec** ***(Object)***
+
+Details of the spec file, including the following properties:
+
+Property | Description
+--- | ---
+`name` | The base name of the spec file (e.g. `login_spec.js`)
+`relative` | The path to the spec file, relative to the project root (e.g. `cypress/integration/login_spec.js`)
+`absolute` | The absolute path to the spec file (e.g. `/Users/janelane/my-app/cypress/integration/login_spec.js`)
+
+# Usage
+
+You can return a promise from the `before:spec` event handler and it will be awaited before Cypress proceeds running the spec.
+
+## Log the relative spec path to stdout before the spec is run
+
+```javascript
+module.exports = (on, config) => {
+  on('before:spec', (spec) => {
+    // spec will look something like this:
+    // {
+    //   name: 'login_spec.js',
+    //   relative: 'cypress/integration/login_spec.js',
+    //   absolute: '/Users/janelane/app/cypress/integration/login_spec.js',
+    // }
+
+    console.log('Running', spec.relative)
+  })
+}
+```
+
+# See also
+
+- {% url "Plugins Guide" plugins-guide %}
+- {% url "Writing a Plugin" writing-a-plugin %}

--- a/source/api/plugins/before-spec-api.md
+++ b/source/api/plugins/before-spec-api.md
@@ -47,5 +47,6 @@ module.exports = (on, config) => {
 
 # See also
 
+- {% url "After Spec API" after-spec-api %}
 - {% url "Plugins Guide" plugins-guide %}
 - {% url "Writing a Plugin" writing-a-plugin %}

--- a/source/api/plugins/before-spec-api.md
+++ b/source/api/plugins/before-spec-api.md
@@ -48,5 +48,6 @@ module.exports = (on, config) => {
 # See also
 
 - {% url "After Spec API" after-spec-api %}
+- {% url "Before Run API" before-run-api %}
 - {% url "Plugins Guide" plugins-guide %}
 - {% url "Writing a Plugin" writing-a-plugin %}

--- a/source/api/plugins/writing-a-plugin.md
+++ b/source/api/plugins/writing-a-plugin.md
@@ -79,11 +79,12 @@ The `config` object also includes the following extra values that are not part o
 
 Event | Description
 --- | ---
+{% url `after:run` after-run-api %} | Occurs after the run is finished.
 {% url `after:screenshot` after-screenshot-api %} | Occurs after a screenshot is taken.
-{% url `after:spec` after-spec-api %} | Occurs after spec is finished running.
+{% url `after:spec` after-spec-api %} | Occurs after a spec is finished running.
 {% url `before:browser:launch` browser-launch-api %} | Occurs immediately before launching a browser.
 {% url `before:run` before-run-api %} | Occurs before the run starts.
-{% url `before:spec` before-spec-api %} | Occurs when spec is about to be run.
+{% url `before:spec` before-spec-api %} | Occurs when a spec is about to be run.
 {% url `file:preprocessor` preprocessors-api %} | Occurs when a spec or spec-related file needs to be transpiled for the browser.
 {% url `task` task %} | Occurs in conjunction with the `cy.task` command.
 

--- a/source/api/plugins/writing-a-plugin.md
+++ b/source/api/plugins/writing-a-plugin.md
@@ -79,10 +79,11 @@ The `config` object also includes the following extra values that are not part o
 
 Event | Description
 --- | ---
-{% url `file:preprocessor` preprocessors-api %} | Occurs when a spec or spec-related file needs to be transpiled for the browser.
-{% url `before:browser:launch` browser-launch-api %} | Occurs immediately before launching a browser.
-{% url `task` task %} | Occurs in conjunction with the `cy.task` command.
 {% url `after:screenshot` after-screenshot-api %} | Occurs after a screenshot is taken.
+{% url `before:browser:launch` browser-launch-api %} | Occurs immediately before launching a browser.
+{% url `before:spec` before-spec-api %} | Occurs when spec is about to be run.
+{% url `file:preprocessor` preprocessors-api %} | Occurs when a spec or spec-related file needs to be transpiled for the browser.
+{% url `task` task %} | Occurs in conjunction with the `cy.task` command.
 
 # Execution context
 

--- a/source/api/plugins/writing-a-plugin.md
+++ b/source/api/plugins/writing-a-plugin.md
@@ -80,6 +80,7 @@ The `config` object also includes the following extra values that are not part o
 Event | Description
 --- | ---
 {% url `after:screenshot` after-screenshot-api %} | Occurs after a screenshot is taken.
+{% url `after:spec` after-spec-api %} | Occurs after spec is finished running.
 {% url `before:browser:launch` browser-launch-api %} | Occurs immediately before launching a browser.
 {% url `before:spec` before-spec-api %} | Occurs when spec is about to be run.
 {% url `file:preprocessor` preprocessors-api %} | Occurs when a spec or spec-related file needs to be transpiled for the browser.

--- a/source/api/plugins/writing-a-plugin.md
+++ b/source/api/plugins/writing-a-plugin.md
@@ -82,6 +82,7 @@ Event | Description
 {% url `after:screenshot` after-screenshot-api %} | Occurs after a screenshot is taken.
 {% url `after:spec` after-spec-api %} | Occurs after spec is finished running.
 {% url `before:browser:launch` browser-launch-api %} | Occurs immediately before launching a browser.
+{% url `before:run` before-run-api %} | Occurs before the run starts.
 {% url `before:spec` before-spec-api %} | Occurs when spec is about to be run.
 {% url `file:preprocessor` preprocessors-api %} | Occurs when a spec or spec-related file needs to be transpiled for the browser.
 {% url `task` task %} | Occurs in conjunction with the `cy.task` command.

--- a/source/guides/references/experiments.md
+++ b/source/guides/references/experiments.md
@@ -16,7 +16,7 @@ Option | Default | Description
 ----- | ---- | ----
 `experimentalComponentTesting` | `false` | Enables component testing using framework-specific adaptors. See {% url "Component Testing" component-testing-introduction %} for more detail.
 `experimentalFetchPolyfill` | `false` | Automatically replaces `window.fetch` with a polyfill that Cypress can spy on and stub. Note: `experimentalFetchPolyfill` has been deprecated in Cypress 6.0.0 and will be removed in a future release. Consider using {% url "`cy.intercept()`" intercept %} to intercept `fetch` requests instead.
-`experimentalRunEvents` | `false` | Allows listening to the {% url "`before:run`" before-run-api %}, {% url "`before:spec`" before-spec-api %}, and {% url "`after:spec`" after-spec-api %} events in the plugins file.
+`experimentalRunEvents` | `false` | Allows listening to the {% url "`before:run`" before-run-api %}, {% url "`after:run`" after-run-api %}, {% url "`before:spec`" before-spec-api %}, and {% url "`after:spec`" after-spec-api %} events in the plugins file.
 `experimentalSourceRewriting` | `false` | Enables AST-based JS/HTML rewriting. This may fix issues caused by the existing regex-based JS/HTML replacement algorithm. See {% issue 5273 %} for details.
 
 {% history %}

--- a/source/guides/references/experiments.md
+++ b/source/guides/references/experiments.md
@@ -16,7 +16,7 @@ Option | Default | Description
 ----- | ---- | ----
 `experimentalComponentTesting` | `false` | Enables component testing using framework-specific adaptors. See {% url "Component Testing" component-testing-introduction %} for more detail.
 `experimentalFetchPolyfill` | `false` | Automatically replaces `window.fetch` with a polyfill that Cypress can spy on and stub. Note: `experimentalFetchPolyfill` has been deprecated in Cypress 6.0.0 and will be removed in a future release. Consider using {% url "`cy.intercept()`" intercept %} to intercept `fetch` requests instead.
-`experimentalRunEvents` | `false` | Allows listening to the {% url "`before:spec` event" %} in the plugins file.
+`experimentalRunEvents` | `false` | Allows listening to the {% url "`before:spec`" before-spec-api %} and {% url "`after:spec`" after-spec-api %} events in the plugins file.
 `experimentalSourceRewriting` | `false` | Enables AST-based JS/HTML rewriting. This may fix issues caused by the existing regex-based JS/HTML replacement algorithm. See {% issue 5273 %} for details.
 
 {% history %}

--- a/source/guides/references/experiments.md
+++ b/source/guides/references/experiments.md
@@ -5,7 +5,7 @@ title: Experiments
 If you'd like to try out what we're working on in the {% url "Test Runner" test-runner %}, you can enable beta features for your project by turning on the experimental features you'd like to try.
 
 {% note warning %}
-⚠️ The experimental features might change or ultimately be removed without making it into the core product. Our primary goal for experiments is to collect real-world feedback during the development.
+⚠️ The experimental features might change or ultimately be removed without making it into the core product. Our primary goal for experiments is to collect real-world feedback during their development.
 {% endnote %}
 
 # Configuration
@@ -16,6 +16,7 @@ Option | Default | Description
 ----- | ---- | ----
 `experimentalComponentTesting` | `false` | Enables component testing using framework-specific adaptors. See {% url "Component Testing" component-testing-introduction %} for more detail.
 `experimentalFetchPolyfill` | `false` | Automatically replaces `window.fetch` with a polyfill that Cypress can spy on and stub. Note: `experimentalFetchPolyfill` has been deprecated in Cypress 6.0.0 and will be removed in a future release. Consider using {% url "`cy.intercept()`" intercept %} to intercept `fetch` requests instead.
+`experimentalRunEvents` | `false` | Allows listening to the {% url "`before:spec` event" %} in the plugins file.
 `experimentalSourceRewriting` | `false` | Enables AST-based JS/HTML rewriting. This may fix issues caused by the existing regex-based JS/HTML replacement algorithm. See {% issue 5273 %} for details.
 
 {% history %}

--- a/source/guides/references/experiments.md
+++ b/source/guides/references/experiments.md
@@ -16,7 +16,7 @@ Option | Default | Description
 ----- | ---- | ----
 `experimentalComponentTesting` | `false` | Enables component testing using framework-specific adaptors. See {% url "Component Testing" component-testing-introduction %} for more detail.
 `experimentalFetchPolyfill` | `false` | Automatically replaces `window.fetch` with a polyfill that Cypress can spy on and stub. Note: `experimentalFetchPolyfill` has been deprecated in Cypress 6.0.0 and will be removed in a future release. Consider using {% url "`cy.intercept()`" intercept %} to intercept `fetch` requests instead.
-`experimentalRunEvents` | `false` | Allows listening to the {% url "`before:spec`" before-spec-api %} and {% url "`after:spec`" after-spec-api %} events in the plugins file.
+`experimentalRunEvents` | `false` | Allows listening to the {% url "`before:run`" before-run-api %}, {% url "`before:spec`" before-spec-api %}, and {% url "`after:spec`" after-spec-api %} events in the plugins file.
 `experimentalSourceRewriting` | `false` | Enables AST-based JS/HTML rewriting. This may fix issues caused by the existing regex-based JS/HTML replacement algorithm. See {% issue 5273 %} for details.
 
 {% history %}

--- a/source/guides/tooling/plugins-guide.md
+++ b/source/guides/tooling/plugins-guide.md
@@ -46,6 +46,23 @@ You can use the `file:preprocessor` event to do things like:
 
 Check out our {% url 'File Preprocessor API docs' preprocessors-api %} which describe how to use this event.
 
+## Spec Lifecycle
+
+The events {% url `before:spec` before-spec-api %} and {% url `after:spec` after-spec-api %} run before and after a single spec is run, respectively.
+
+You can use {% url `before:spec` before-spec-api %} to do things like:
+
+- Set up reporting on a spec running
+- Start a timer for the spec to time how long it takes
+
+You can use {% url `after:spec` after-spec-api %} to do things like:
+
+- Finish up reporting set up in `before:spec`
+- Stop the timer for the spec set up in `before:spec`
+- Delete the video recorded for the spec. This prevents it from taking time and computing resources for compressing and uploading the video. You can do this conditionally based on the results of the spec, such as if it passes (so videos for failing tests are preserved for debugging purposes).
+
+Check out the {% url 'Before Spec API doc' before-spec-api %} and {% url 'After Spec API doc' after-spec-api %} which describe how to use these events.
+
 ## Browser Launching
 
 The event `before:browser:launch` can be used to modify the launch arguments for each particular browser.

--- a/source/guides/tooling/plugins-guide.md
+++ b/source/guides/tooling/plugins-guide.md
@@ -48,12 +48,17 @@ Check out our {% url 'File Preprocessor API docs' preprocessors-api %} which des
 
 ## Run Lifecycle
 
-The event {% url `before:spec` before-spec-api %} occurs before a run starts.
+The events {% url `before:run` before-run-api %} and {% url `after:run` after-run-api %} occur before and after a run, respectively.
 
 You can use {% url `before:run` before-run-api %} to do things like:
 
 - Set up reporting on a run
 - Start a timer for the run to time how long it takes
+
+You can use {% url `after:run` after-run-api %} to do things like:
+
+- Finish up reporting on a run set up in `before:run`
+- Stop the timer for the run set up in `before:run`
 
 ## Spec Lifecycle
 

--- a/source/guides/tooling/plugins-guide.md
+++ b/source/guides/tooling/plugins-guide.md
@@ -46,6 +46,15 @@ You can use the `file:preprocessor` event to do things like:
 
 Check out our {% url 'File Preprocessor API docs' preprocessors-api %} which describe how to use this event.
 
+## Run Lifecycle
+
+The event {% url `before:spec` before-spec-api %} occurs before a run starts.
+
+You can use {% url `before:run` before-run-api %} to do things like:
+
+- Set up reporting on a run
+- Start a timer for the run to time how long it takes
+
 ## Spec Lifecycle
 
 The events {% url `before:spec` before-spec-api %} and {% url `after:spec` after-spec-api %} run before and after a single spec is run, respectively.

--- a/themes/cypress/languages/en.yml
+++ b/themes/cypress/languages/en.yml
@@ -199,6 +199,7 @@ sidebar:
     preprocessors-api: Preprocessors
     browser-launch-api: Browser Launching
     before-spec-api: Before Spec
+    after-spec-api: After Spec
     configuration-api: Configuration
     version: version
     arch: arch

--- a/themes/cypress/languages/en.yml
+++ b/themes/cypress/languages/en.yml
@@ -198,6 +198,7 @@ sidebar:
     writing-a-plugin: Writing a Plugin
     preprocessors-api: Preprocessors
     browser-launch-api: Browser Launching
+    before-spec-api: Before Spec
     configuration-api: Configuration
     version: version
     arch: arch

--- a/themes/cypress/languages/en.yml
+++ b/themes/cypress/languages/en.yml
@@ -200,6 +200,7 @@ sidebar:
     preprocessors-api: Preprocessors
     browser-launch-api: Browser Launching
     before-run-api: Before Run
+    after-run-api: After Run
     before-spec-api: Before Spec
     after-spec-api: After Spec
     configuration-api: Configuration

--- a/themes/cypress/languages/en.yml
+++ b/themes/cypress/languages/en.yml
@@ -199,6 +199,7 @@ sidebar:
     writing-a-plugin: Writing a Plugin
     preprocessors-api: Preprocessors
     browser-launch-api: Browser Launching
+    before-run-api: Before Run
     before-spec-api: Before Spec
     after-spec-api: After Spec
     configuration-api: Configuration


### PR DESCRIPTION
- [x] Changelog
- [x] cy.wait() for network errors in intercept https://github.com/cypress-io/cypress-documentation/pull/3389
- [x] before:spec event https://github.com/cypress-io/cypress-documentation/pull/3393
- [x] after:spec event https://github.com/cypress-io/cypress-documentation/pull/3400
- [x] before:run event https://github.com/cypress-io/cypress-documentation/pull/3425
- [x] after:run event https://github.com/cypress-io/cypress-documentation/pull/3428
- [x] on links for 'before:spec', 'after:spec', 'before:run' https://github.com/cypress-io/cypress-services/pull/3322
- [x] document `matchUrlAgainstPath` https://github.com/cypress-io/cypress-documentation/pull/3424