### PR TITLE
Add doc for before:spec event

### DIFF
--- a/source/_data/sidebar.yml
+++ b/source/_data/sidebar.yml
@@ -181,6 +181,7 @@ api:
     writing-a-plugin: writing-a-plugin.html
     configuration-api: configuration-api.html
     preprocessors-api: preprocessors-api.html
+    before-spec-api: before-spec-api.html
     browser-launch-api: browser-launch-api.html
     after-screenshot-api: after-screenshot-api.html
 

--- a/source/api/plugins/before-spec-api.md
+++ b/source/api/plugins/before-spec-api.md
@@ -4,11 +4,10 @@ title: before:spec
 
 The `before:spec` event fires before a spec file is run.
 
-The event timing is different depending on if Cypress is run via `cypress run` (run mode) or `cypress open` (interactive mode).
+The event timing is different depending on if Cypress is run via `cypress run` or `cypress open`.
 
-In run mode, the event is fired as soon as possible when a spec is about to be run.
-
-In interactive mode, since there is not a discreet before or after to a spec running, the event is fired once before the browser is launched for a spec.
+- During `cypress run`, the event is fired as soon as possible when a spec is about to run.
+- During `cypress open`, since there is not a discreet before or after to a spec running, the event is fired once before the browser is launched for a spec.
 
 # Syntax
 
@@ -47,7 +46,7 @@ module.exports = (on, config) => {
 
 ## Log the absolute spec path, but only when in run mode
 
-You can utilize `config.isInteractive` flag to determine if currently running via `cypress run` (run mode) or `cypress open` (interactive mode).
+You can utilize the `config.isInteractive` flag to determine if the spec is currently running via `cypress run` (run mode) or `cypress open` (interactive mode).
 
 ```javascript
 module.exports = (on, config) => {
@@ -59,3 +58,8 @@ module.exports = (on, config) => {
   })
 }
 ```
+
+# See also
+
+- {% url "Plugins Guide" plugins-guide %}
+- {% url "Writing a Plugin" writing-a-plugin %}

--- a/source/api/plugins/before-spec-api.md
+++ b/source/api/plugins/before-spec-api.md
@@ -26,6 +26,8 @@ Property | Description
 
 # Usage
 
+You can return a promise from the `before:spec` event handler and it will be awaited before Cypress proceeds running the spec.
+
 ## Log the relative spec path to stdout before the spec is run
 
 ```javascript

--- a/source/api/plugins/before-spec-api.md
+++ b/source/api/plugins/before-spec-api.md
@@ -1,0 +1,61 @@
+---
+title: before:spec
+---
+
+The `before:spec` event fires before a spec file is run.
+
+The event timing is different depending on if Cypress is run via `cypress run` (run mode) or `cypress open` (interactive mode).
+
+In run mode, the event is fired as soon as possible when a spec is about to be run.
+
+In interactive mode, since there is not a discreet before or after to a spec running, the event is fired once before the browser is launched for a spec.
+
+# Syntax
+
+```js
+on('before:spec', (spec) => { /* ... */ })
+```
+
+**{% fa fa-angle-right %} spec** ***(Object)***
+
+Details of the spec file, including the following properties:
+
+Property | Description
+--- | ---
+`name` | The base name of the spec file (e.g. `login_spec.js`)
+`relative` | The path to the spec file, relative to the project root (e.g. `cypress/integration/login_spec.js`)
+`absolute` | The absolute path to the spec file (e.g. `/Users/janelane/my-app/cypress/integration/login_spec.js`)
+
+# Usage
+
+## Log the relative spec path to stdout before the spec is run
+
+```javascript
+module.exports = (on, config) => {
+  on('before:spec', (spec) => {
+    // spec will look something like this:
+    // {
+    //   name: 'login_spec.js',
+    //   relative: 'cypress/integration/login_spec.js',
+    //   absolute: '/Users/janelane/app/cypress/integration/login_spec.js',
+    // }
+
+    console.log('Running', spec.relative)
+  })
+}
+```
+
+## Log the absolute spec path, but only when in run mode
+
+You can utilize `config.isInteractive` flag to determine if currently running via `cypress run` (run mode) or `cypress open` (interactive mode).
+
+```javascript
+module.exports = (on, config) => {
+  on('before:spec', (spec) => {
+    // only log if in run mode
+    if (!config.isInteractive) {
+      console.log('Running', spec.relative)
+    }
+  })
+}
+```

--- a/source/api/plugins/before-spec-api.md
+++ b/source/api/plugins/before-spec-api.md
@@ -2,12 +2,11 @@
 title: before:spec
 ---
 
-The `before:spec` event fires before a spec file is run.
+The `before:spec` event fires before a spec file is run. The event only fires when running via `cypress run`.
 
-The event timing is different depending on if Cypress is run via `cypress run` or `cypress open`.
-
-- During `cypress run`, the event is fired as soon as possible when a spec is about to run.
-- During `cypress open`, since there is not a discreet before or after to a spec running, the event is fired once before the browser is launched for a spec.
+{% note warning %}
+{% fa fa-warning orange %} **This is an experimental feature. In order to use it, you must set the {% url "`experimentalRunEvents`" experiments %} configuration option to `true`.**
+{% endnote %}
 
 # Syntax
 
@@ -40,21 +39,6 @@ module.exports = (on, config) => {
     // }
 
     console.log('Running', spec.relative)
-  })
-}
-```
-
-## Log the absolute spec path, but only when in run mode
-
-You can utilize the `config.isInteractive` flag to determine if the spec is currently running via `cypress run` (run mode) or `cypress open` (interactive mode).
-
-```javascript
-module.exports = (on, config) => {
-  on('before:spec', (spec) => {
-    // only log if in run mode
-    if (!config.isInteractive) {
-      console.log('Running', spec.relative)
-    }
   })
 }
 ```

--- a/source/api/plugins/before-spec-api.md
+++ b/source/api/plugins/before-spec-api.md
@@ -1,5 +1,5 @@
 ---
-title: before:spec
+title: Before Spec API
 ---
 
 The `before:spec` event fires before a spec file is run. The event only fires when running via `cypress run`.

--- a/source/api/plugins/writing-a-plugin.md
+++ b/source/api/plugins/writing-a-plugin.md
@@ -79,10 +79,11 @@ The `config` object also includes the following extra values that are not part o
 
 Event | Description
 --- | ---
-{% url `file:preprocessor` preprocessors-api %} | Occurs when a spec or spec-related file needs to be transpiled for the browser.
-{% url `before:browser:launch` browser-launch-api %} | Occurs immediately before launching a browser.
-{% url `task` task %} | Occurs in conjunction with the `cy.task` command.
 {% url `after:screenshot` after-screenshot-api %} | Occurs after a screenshot is taken.
+{% url `before:browser:launch` browser-launch-api %} | Occurs immediately before launching a browser.
+{% url `before:spec` before-spec-api %} | Occurs when spec is about to be run.
+{% url `file:preprocessor` preprocessors-api %} | Occurs when a spec or spec-related file needs to be transpiled for the browser.
+{% url `task` task %} | Occurs in conjunction with the `cy.task` command.
 
 # Execution context
 

--- a/source/guides/references/experiments.md
+++ b/source/guides/references/experiments.md
@@ -5,7 +5,7 @@ title: Experiments
 If you'd like to try out what we're working on in the {% url "Test Runner" test-runner %}, you can enable beta features for your project by turning on the experimental features you'd like to try.
 
 {% note warning %}
-⚠️ The experimental features might change or ultimately be removed without making it into the core product. Our primary goal for experiments is to collect real-world feedback during the development.
+⚠️ The experimental features might change or ultimately be removed without making it into the core product. Our primary goal for experiments is to collect real-world feedback during their development.
 {% endnote %}
 
 # Configuration
@@ -16,6 +16,7 @@ Option | Default | Description
 ----- | ---- | ----
 `experimentalComponentTesting` | `false` | Enables component testing using framework-specific adaptors. See {% url "Component Testing" component-testing-introduction %} for more detail.
 `experimentalFetchPolyfill` | `false` | Automatically replaces `window.fetch` with a polyfill that Cypress can spy on and stub. Note: `experimentalFetchPolyfill` has been deprecated in Cypress 6.0.0 and will be removed in a future release. Consider using {% url "`cy.intercept()`" intercept %} to intercept `fetch` requests instead.
+`experimentalRunEvents` | `false` | Allows listening to the {% url "`before:spec` event" %} in the plugins file.
 `experimentalSourceRewriting` | `false` | Enables AST-based JS/HTML rewriting. This may fix issues caused by the existing regex-based JS/HTML replacement algorithm. See {% issue 5273 %} for details.
 
 {% history %}

--- a/themes/cypress/languages/en.yml
+++ b/themes/cypress/languages/en.yml
@@ -198,6 +198,7 @@ sidebar:
     writing-a-plugin: Writing a Plugin
     preprocessors-api: Preprocessors
     browser-launch-api: Browser Launching
+    before-spec-api: Before Spec
     configuration-api: Configuration
     version: version
     arch: arch


### PR DESCRIPTION
For https://github.com/cypress-io/cypress/pull/9646

When I implement the `after:spec` event and add a doc for that, I'll add a 'Spec Events' section to the [Plugins Guide](https://github.com/cypress-io/cypress-documentation/blob/develop/source/guides/tooling/plugins-guide.md).