### PR TITLE
Add doc for after:spec event

### DIFF
--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -241,6 +241,12 @@
       keywords: [commands, performance]
       badge: community
 
+    - name: cypress-fail-fast
+      description: Enables fail fast in Cypress, skipping the rest of tests on first failure.
+      link: https://github.com/javierbrea/cypress-fail-fast
+      keywords: [fail-fast, failure, skip, config]
+      badge: community
+
 - name: Custom Commands
   plugins:
     - name: cy-view

--- a/source/_data/sidebar.yml
+++ b/source/_data/sidebar.yml
@@ -181,6 +181,7 @@ api:
     writing-a-plugin: writing-a-plugin.html
     configuration-api: configuration-api.html
     preprocessors-api: preprocessors-api.html
+    before-spec-api: before-spec-api.html
     browser-launch-api: browser-launch-api.html
     after-screenshot-api: after-screenshot-api.html
 

--- a/source/_data/sidebar.yml
+++ b/source/_data/sidebar.yml
@@ -182,6 +182,7 @@ api:
     configuration-api: configuration-api.html
     preprocessors-api: preprocessors-api.html
     before-spec-api: before-spec-api.html
+    after-spec-api: after-spec-api.html
     browser-launch-api: browser-launch-api.html
     after-screenshot-api: after-screenshot-api.html
 

--- a/source/api/plugins/after-spec-api.md
+++ b/source/api/plugins/after-spec-api.md
@@ -1,0 +1,99 @@
+---
+title: After Spec API
+---
+
+The `after:spec` event fires after a spec file is run. The event only fires when running via `cypress run`.
+
+{% note warning %}
+{% fa fa-warning orange %} **This is an experimental feature. In order to use it, you must set the {% url "`experimentalRunEvents`" experiments %} configuration option to `true`.**
+{% endnote %}
+
+# Syntax
+
+```js
+on('after:spec', (spec, results) => { /* ... */ })
+```
+
+**{% fa fa-angle-right %} spec** ***(Object)***
+
+Details of the spec file, including the following properties:
+
+Property | Description
+--- | ---
+`name` | The base name of the spec file (e.g. `login_spec.js`)
+`relative` | The path to the spec file, relative to the project root (e.g. `cypress/integration/login_spec.js`)
+`absolute` | The absolute path to the spec file (e.g. `/Users/janelane/my-app/cypress/integration/login_spec.js`)
+
+**{% fa fa-angle-right %} results** ***(Object)***
+
+Details of the spec file's results, including numbers of passes/failures/etc and details on the tests themselves.
+
+# Usage
+
+You can return a promise from the `after:spec` event handler and it will be awaited before Cypress proceeds with processing the spec's video or moving on to further specs if there are any.
+
+## Log the relative spec path to stdout after the spec is run
+
+```javascript
+module.exports = (on, config) => {
+  on('after:spec', (spec, results) => {
+    // spec will look something like this:
+    // {
+    //   name: 'login_spec.js',
+    //   relative: 'cypress/integration/login_spec.js',
+    //   absolute: '/Users/janelane/my-app/cypress/integration/login_spec.js',
+    // }
+
+    // results will look something like this:
+    // {
+    //   stats: {
+    //     suites: 0,
+    //     tests: 1,
+    //     passes: 1,
+    //     pending: 0,
+    //     skipped: 0,
+    //     failures: 0,
+    //     // ...more properties
+    //   }
+    //   reporter: 'spec',
+    //   tests: [
+    //     {
+    //       title: ['login', 'logs user in'],
+    //       state: 'passed',
+    //       body: 'function () {}',
+    //       // ...more properties...
+    //     }
+    //   ],
+    //   error: null,
+    //   video: '/Users/janelane/my-app/cypress/videos/login_spec.js.mp4',
+    //   screenshots: [],
+    //   // ...more properties...
+    // }
+    console.log('Finished running', spec.relative)
+  })
+}
+```
+
+## Delete the recorded video after the spec is run if the spec passed
+
+You can delete the video created for the spec and it will not be compressed or uploaded (if recording). Using the spec results, you can choose to only do this when the tests passes, so that videos for failed specs will remain for debugging purposes.
+
+```javascript
+const del = require('del')
+
+module.exports = (on, config) => {
+  on('after:spec', (spec, results) => {
+    if (results.stats.failures === 0 && results.video) {
+      // `del()` returns a promise, so it's important to return it to ensure
+      // deleting the video is finished before moving on
+      return del(result.video)
+    }
+  })
+}
+```
+
+# See also
+
+- {% url "Before Spec API" before-spec-api %}
+- {% url "Plugins Guide" plugins-guide %}
+- {% url "Writing a Plugin" writing-a-plugin %}

--- a/source/api/plugins/after-spec-api.md
+++ b/source/api/plugins/after-spec-api.md
@@ -74,9 +74,13 @@ module.exports = (on, config) => {
 }
 ```
 
-## Delete the recorded video after the spec is run if the spec passed
+# Examples
 
-You can delete the video created for the spec and it will not be compressed or uploaded (if recording). Using the spec results, you can choose to only do this when the tests passes, so that videos for failed specs will remain for debugging purposes.
+## Delete the recorded video if the spec passed
+
+You can delete the recorded video for a spec. This will skip the compression and uploading of the video when recording to the Dashboard.
+
+The example below shows how to delete the recorded video for a spec with no failing tests.
 
 ```javascript
 const del = require('del')

--- a/source/api/plugins/before-spec-api.md
+++ b/source/api/plugins/before-spec-api.md
@@ -4,11 +4,10 @@ title: before:spec
 
 The `before:spec` event fires before a spec file is run.
 
-The event timing is different depending on if Cypress is run via `cypress run` (run mode) or `cypress open` (interactive mode).
+The event timing is different depending on if Cypress is run via `cypress run` or `cypress open`.
 
-In run mode, the event is fired as soon as possible when a spec is about to be run.
-
-In interactive mode, since there is not a discreet before or after to a spec running, the event is fired once before the browser is launched for a spec.
+- During `cypress run`, the event is fired as soon as possible when a spec is about to run.
+- During `cypress open`, since there is not a discreet before or after to a spec running, the event is fired once before the browser is launched for a spec.
 
 # Syntax
 
@@ -47,7 +46,7 @@ module.exports = (on, config) => {
 
 ## Log the absolute spec path, but only when in run mode
 
-You can utilize `config.isInteractive` flag to determine if currently running via `cypress run` (run mode) or `cypress open` (interactive mode).
+You can utilize the `config.isInteractive` flag to determine if the spec is currently running via `cypress run` (run mode) or `cypress open` (interactive mode).
 
 ```javascript
 module.exports = (on, config) => {
@@ -59,3 +58,8 @@ module.exports = (on, config) => {
   })
 }
 ```
+
+# See also
+
+- {% url "Plugins Guide" plugins-guide %}
+- {% url "Writing a Plugin" writing-a-plugin %}

--- a/source/api/plugins/before-spec-api.md
+++ b/source/api/plugins/before-spec-api.md
@@ -26,6 +26,8 @@ Property | Description
 
 # Usage
 
+You can return a promise from the `before:spec` event handler and it will be awaited before Cypress proceeds running the spec.
+
 ## Log the relative spec path to stdout before the spec is run
 
 ```javascript

--- a/source/api/plugins/before-spec-api.md
+++ b/source/api/plugins/before-spec-api.md
@@ -1,0 +1,61 @@
+---
+title: before:spec
+---
+
+The `before:spec` event fires before a spec file is run.
+
+The event timing is different depending on if Cypress is run via `cypress run` (run mode) or `cypress open` (interactive mode).
+
+In run mode, the event is fired as soon as possible when a spec is about to be run.
+
+In interactive mode, since there is not a discreet before or after to a spec running, the event is fired once before the browser is launched for a spec.
+
+# Syntax
+
+```js
+on('before:spec', (spec) => { /* ... */ })
+```
+
+**{% fa fa-angle-right %} spec** ***(Object)***
+
+Details of the spec file, including the following properties:
+
+Property | Description
+--- | ---
+`name` | The base name of the spec file (e.g. `login_spec.js`)
+`relative` | The path to the spec file, relative to the project root (e.g. `cypress/integration/login_spec.js`)
+`absolute` | The absolute path to the spec file (e.g. `/Users/janelane/my-app/cypress/integration/login_spec.js`)
+
+# Usage
+
+## Log the relative spec path to stdout before the spec is run
+
+```javascript
+module.exports = (on, config) => {
+  on('before:spec', (spec) => {
+    // spec will look something like this:
+    // {
+    //   name: 'login_spec.js',
+    //   relative: 'cypress/integration/login_spec.js',
+    //   absolute: '/Users/janelane/app/cypress/integration/login_spec.js',
+    // }
+
+    console.log('Running', spec.relative)
+  })
+}
+```
+
+## Log the absolute spec path, but only when in run mode
+
+You can utilize `config.isInteractive` flag to determine if currently running via `cypress run` (run mode) or `cypress open` (interactive mode).
+
+```javascript
+module.exports = (on, config) => {
+  on('before:spec', (spec) => {
+    // only log if in run mode
+    if (!config.isInteractive) {
+      console.log('Running', spec.relative)
+    }
+  })
+}
+```

--- a/source/api/plugins/before-spec-api.md
+++ b/source/api/plugins/before-spec-api.md
@@ -2,12 +2,11 @@
 title: before:spec
 ---
 
-The `before:spec` event fires before a spec file is run.
+The `before:spec` event fires before a spec file is run. The event only fires when running via `cypress run`.
 
-The event timing is different depending on if Cypress is run via `cypress run` or `cypress open`.
-
-- During `cypress run`, the event is fired as soon as possible when a spec is about to run.
-- During `cypress open`, since there is not a discreet before or after to a spec running, the event is fired once before the browser is launched for a spec.
+{% note warning %}
+{% fa fa-warning orange %} **This is an experimental feature. In order to use it, you must set the {% url "`experimentalRunEvents`" experiments %} configuration option to `true`.**
+{% endnote %}
 
 # Syntax
 
@@ -40,21 +39,6 @@ module.exports = (on, config) => {
     // }
 
     console.log('Running', spec.relative)
-  })
-}
-```
-
-## Log the absolute spec path, but only when in run mode
-
-You can utilize the `config.isInteractive` flag to determine if the spec is currently running via `cypress run` (run mode) or `cypress open` (interactive mode).
-
-```javascript
-module.exports = (on, config) => {
-  on('before:spec', (spec) => {
-    // only log if in run mode
-    if (!config.isInteractive) {
-      console.log('Running', spec.relative)
-    }
   })
 }
 ```

--- a/source/api/plugins/before-spec-api.md
+++ b/source/api/plugins/before-spec-api.md
@@ -1,5 +1,5 @@
 ---
-title: before:spec
+title: Before Spec API
 ---
 
 The `before:spec` event fires before a spec file is run. The event only fires when running via `cypress run`.

--- a/source/api/plugins/before-spec-api.md
+++ b/source/api/plugins/before-spec-api.md
@@ -45,5 +45,6 @@ module.exports = (on, config) => {
 
 # See also
 
+- {% url "After Spec API" after-spec-api %}
 - {% url "Plugins Guide" plugins-guide %}
 - {% url "Writing a Plugin" writing-a-plugin %}

--- a/source/api/plugins/writing-a-plugin.md
+++ b/source/api/plugins/writing-a-plugin.md
@@ -79,10 +79,11 @@ The `config` object also includes the following extra values that are not part o
 
 Event | Description
 --- | ---
-{% url `file:preprocessor` preprocessors-api %} | Occurs when a spec or spec-related file needs to be transpiled for the browser.
-{% url `before:browser:launch` browser-launch-api %} | Occurs immediately before launching a browser.
-{% url `task` task %} | Occurs in conjunction with the `cy.task` command.
 {% url `after:screenshot` after-screenshot-api %} | Occurs after a screenshot is taken.
+{% url `before:browser:launch` browser-launch-api %} | Occurs immediately before launching a browser.
+{% url `before:spec` before-spec-api %} | Occurs when spec is about to be run.
+{% url `file:preprocessor` preprocessors-api %} | Occurs when a spec or spec-related file needs to be transpiled for the browser.
+{% url `task` task %} | Occurs in conjunction with the `cy.task` command.
 
 # Execution context
 

--- a/source/api/plugins/writing-a-plugin.md
+++ b/source/api/plugins/writing-a-plugin.md
@@ -80,6 +80,7 @@ The `config` object also includes the following extra values that are not part o
 Event | Description
 --- | ---
 {% url `after:screenshot` after-screenshot-api %} | Occurs after a screenshot is taken.
+{% url `after:spec` after-spec-api %} | Occurs after spec is finished running.
 {% url `before:browser:launch` browser-launch-api %} | Occurs immediately before launching a browser.
 {% url `before:spec` before-spec-api %} | Occurs when spec is about to be run.
 {% url `file:preprocessor` preprocessors-api %} | Occurs when a spec or spec-related file needs to be transpiled for the browser.

--- a/source/guides/references/experiments.md
+++ b/source/guides/references/experiments.md
@@ -16,7 +16,7 @@ Option | Default | Description
 ----- | ---- | ----
 `experimentalComponentTesting` | `false` | Enables component testing using framework-specific adaptors. See {% url "Component Testing" component-testing-introduction %} for more detail.
 `experimentalFetchPolyfill` | `false` | Automatically replaces `window.fetch` with a polyfill that Cypress can spy on and stub. Note: `experimentalFetchPolyfill` has been deprecated in Cypress 6.0.0 and will be removed in a future release. Consider using {% url "`cy.intercept()`" intercept %} to intercept `fetch` requests instead.
-`experimentalRunEvents` | `false` | Allows listening to the {% url "`before:spec` event" %} in the plugins file.
+`experimentalRunEvents` | `false` | Allows listening to the {% url "`before:spec`" before-spec-api %} and {% url "`after:spec`" after-spec-api %} events in the plugins file.
 `experimentalSourceRewriting` | `false` | Enables AST-based JS/HTML rewriting. This may fix issues caused by the existing regex-based JS/HTML replacement algorithm. See {% issue 5273 %} for details.
 
 {% history %}

--- a/source/guides/references/experiments.md
+++ b/source/guides/references/experiments.md
@@ -5,7 +5,7 @@ title: Experiments
 If you'd like to try out what we're working on in the {% url "Test Runner" test-runner %}, you can enable beta features for your project by turning on the experimental features you'd like to try.
 
 {% note warning %}
-⚠️ The experimental features might change or ultimately be removed without making it into the core product. Our primary goal for experiments is to collect real-world feedback during the development.
+⚠️ The experimental features might change or ultimately be removed without making it into the core product. Our primary goal for experiments is to collect real-world feedback during their development.
 {% endnote %}
 
 # Configuration
@@ -16,6 +16,7 @@ Option | Default | Description
 ----- | ---- | ----
 `experimentalComponentTesting` | `false` | Enables component testing using framework-specific adaptors. See {% url "Component Testing" component-testing-introduction %} for more detail.
 `experimentalFetchPolyfill` | `false` | Automatically replaces `window.fetch` with a polyfill that Cypress can spy on and stub. Note: `experimentalFetchPolyfill` has been deprecated in Cypress 6.0.0 and will be removed in a future release. Consider using {% url "`cy.intercept()`" intercept %} to intercept `fetch` requests instead.
+`experimentalRunEvents` | `false` | Allows listening to the {% url "`before:spec` event" %} in the plugins file.
 `experimentalSourceRewriting` | `false` | Enables AST-based JS/HTML rewriting. This may fix issues caused by the existing regex-based JS/HTML replacement algorithm. See {% issue 5273 %} for details.
 
 {% history %}

--- a/source/guides/tooling/plugins-guide.md
+++ b/source/guides/tooling/plugins-guide.md
@@ -46,6 +46,23 @@ You can use the `file:preprocessor` event to do things like:
 
 Check out our {% url 'File Preprocessor API docs' preprocessors-api %} which describe how to use this event.
 
+## Spec Lifecycle
+
+The events `before:spec` and `after:spec` run before and after a single spec is run, respectively.
+
+You can use `before:spec` to do things like:
+
+- Set up reporting on a spec running
+- Start a timer for the spec to time how long it takes
+
+You can use `after:spec` to do things like:
+
+- Finish up reporting set up in `before:spec`
+- Stop the timer for the spec set up in `before:spec`
+- Delete the video recorded for the spec. This prevents it from taking time and computing resources for compressing and uploading the video. You can do this conditionally based on the results of the spec, such as if it passes (so videos for failing tests are preserved for debugging purposes).
+
+Check out the {% url 'Before Spec API doc' before-spec-api %} and {% url 'After Spec API doc' after-spec-api %}, which describe how to use these events.
+
 ## Browser Launching
 
 The event `before:browser:launch` can be used to modify the launch arguments for each particular browser.

--- a/source/guides/tooling/plugins-guide.md
+++ b/source/guides/tooling/plugins-guide.md
@@ -48,20 +48,20 @@ Check out our {% url 'File Preprocessor API docs' preprocessors-api %} which des
 
 ## Spec Lifecycle
 
-The events `before:spec` and `after:spec` run before and after a single spec is run, respectively.
+The events {% url `before:spec` before-spec-api %} and {% url `after:spec` after-spec-api %} run before and after a single spec is run, respectively.
 
-You can use `before:spec` to do things like:
+You can use {% url `before:spec` before-spec-api %} to do things like:
 
 - Set up reporting on a spec running
 - Start a timer for the spec to time how long it takes
 
-You can use `after:spec` to do things like:
+You can use {% url `after:spec` after-spec-api %} to do things like:
 
 - Finish up reporting set up in `before:spec`
 - Stop the timer for the spec set up in `before:spec`
 - Delete the video recorded for the spec. This prevents it from taking time and computing resources for compressing and uploading the video. You can do this conditionally based on the results of the spec, such as if it passes (so videos for failing tests are preserved for debugging purposes).
 
-Check out the {% url 'Before Spec API doc' before-spec-api %} and {% url 'After Spec API doc' after-spec-api %}, which describe how to use these events.
+Check out the {% url 'Before Spec API doc' before-spec-api %} and {% url 'After Spec API doc' after-spec-api %} which describe how to use these events.
 
 ## Browser Launching
 

--- a/themes/cypress/languages/en.yml
+++ b/themes/cypress/languages/en.yml
@@ -199,6 +199,7 @@ sidebar:
     preprocessors-api: Preprocessors
     browser-launch-api: Browser Launching
     before-spec-api: Before Spec
+    after-spec-api: After Spec
     configuration-api: Configuration
     version: version
     arch: arch

--- a/themes/cypress/languages/en.yml
+++ b/themes/cypress/languages/en.yml
@@ -198,6 +198,7 @@ sidebar:
     writing-a-plugin: Writing a Plugin
     preprocessors-api: Preprocessors
     browser-launch-api: Browser Launching
+    before-spec-api: Before Spec
     configuration-api: Configuration
     version: version
     arch: arch


### PR DESCRIPTION
For https://github.com/cypress-io/cypress/pull/14178

**Note**: Before merging this, wait for https://github.com/cypress-io/cypress-documentation/pull/3393 to be merged and change the base branch to `6.2.0-release`
