### PR TITLE
add notes about contains and non-breaking space

### DIFF
--- a/source/api/commands/contains.md
+++ b/source/api/commands/contains.md
@@ -274,7 +274,7 @@ cy.get('pre').contains('                 Hello,           World      !') // pass
 
 ## Non-breaking space
 
-You can use a space character in `cy.contains()` to match text in the HTML that uses a non-braking space entity `&nbsp;`.
+You can use a space character in `cy.contains()` to match text in the HTML that uses a non-breaking space entity `&nbsp;`.
 
 ```html
 <span>Hello&nbsp;world</span>

--- a/source/api/commands/contains.md
+++ b/source/api/commands/contains.md
@@ -272,6 +272,21 @@ cy.get('pre').contains('Hello, World !') // fail
 cy.get('pre').contains('                 Hello,           World      !') // pass
 ```
 
+## Non-breaking space
+
+Non-breaking space entity `&nbsp;` in the HTML is considered a whitespace and `cy.contains` automatically handles it. Thus you can use space character in the test to match the text where the application might have used `&nbsp;`
+
+```html
+<div data-testid="testattr">
+  <div><span>GBP&nbsp;0.50</span></div>
+</div>
+```
+
+```javascript
+// finds the right element
+cy.contains('[data-testid=testattr]', 'GBP 0.50')
+```
+
 ## Single Element
 
 ### Only the *first* matched element will be returned

--- a/source/api/commands/contains.md
+++ b/source/api/commands/contains.md
@@ -274,18 +274,15 @@ cy.get('pre').contains('                 Hello,           World      !') // pass
 
 ## Non-breaking space
 
-Non-breaking space entity `&nbsp;` in the HTML is considered a whitespace and `cy.contains` automatically handles it. Thus you can use space character in the test to match the text where the application might have used `&nbsp;`
+You can use a space character in `cy.contains()` to match text in the HTML that uses a non-braking space entity `&nbsp;`.
 
 ```html
-<div data-testid="testattr">
-  <div><span>GBP&nbsp;0.50</span></div>
-</div>
+<span>Hello&nbsp;world</span>
 ```
 
 ```javascript
-// finds the right element
-cy.contains('[data-testid=testattr]', 'GBP 0.50')
-```
+// finds the span element
+cy.contains('Hello world')
 
 ## Single Element
 

--- a/source/api/commands/filter.md
+++ b/source/api/commands/filter.md
@@ -100,17 +100,17 @@ cy.get('li')
 
 ### Non-breaking space
 
-If the application HTML uses {% url "non-breaking space" https://en.wikipedia.org/wiki/Non-breaking_space %} entity, and the test wants to use {% url "jQuery :contains" https://api.jquery.com/contains-selector/ %} selector, then the test needs to use the Unicode value `\u00a0` instead of `&nbsp;`
+If the HTML contains a {% url "non-breaking space" https://en.wikipedia.org/wiki/Non-breaking_space %} entity `&nbsp;` and the test uses the {% url "jQuery :contains" https://api.jquery.com/contains-selector/ %} selector, then the test needs to use the Unicode value `\u00a0` instead of `&nbsp;`.
 
 ```html
 <div data-testid="testattr">
-  <div><span>GBP&nbsp;0.50</span></div>
+  <span>Hello&nbsp;world</span>
 </div>
 ```
 
 ```javascript
 cy.get('[data-testid=testattr]')
-  .filter(':contains("GBP\u00a00.50")')
+  .filter(':contains("Hello\u00a0world")')
 ```
 
 # Rules

--- a/source/api/commands/filter.md
+++ b/source/api/commands/filter.md
@@ -74,6 +74,45 @@ Option | Default | Description
 cy.get('ul').find('>li').filter('.active')
 ```
 
+## Contains
+
+### Filter by text
+
+You can use the {% url "jQuery :contains" https://api.jquery.com/contains-selector/ %} selector to perform a case-sensitive text substring match.
+
+```html
+<ul>
+  <li>Home</li>
+  <li>Services</li>
+  <li>Advanced Services</li>
+  <li>Pricing</li>
+  <li>Contact</li>
+</ul>
+```
+
+Let's find both list items that contain the work "Services"
+
+```javascript
+cy.get('li')
+  .filter(':contains("Services")')
+  .should('have.length', 2)
+```
+
+### Non-breaking space
+
+If the application HTML uses {% url "non-breaking space" https://en.wikipedia.org/wiki/Non-breaking_space %} entity, and the test wants to use {% url "jQuery :contains" https://api.jquery.com/contains-selector/ %} selector, then the test needs to use the Unicode value `\u00a0` instead of `&nbsp;`
+
+```html
+<div data-testid="testattr">
+  <div><span>GBP&nbsp;0.50</span></div>
+</div>
+```
+
+```javascript
+cy.get('[data-testid=testattr]')
+  .filter(':contains("GBP\u00a00.50")')
+```
+
 # Rules
 
 ## Requirements {% helper_icon requirements %}

--- a/source/faq/questions/using-cypress-faq.md
+++ b/source/faq/questions/using-cypress-faq.md
@@ -14,6 +14,16 @@ If you're trying to assert on an element's text content:
 cy.get('div').should('have.text', 'foobarbaz')
 ```
 
+If the text contains the {% url "non-breaking space" https://en.wikipedia.org/wiki/Non-breaking_space %} entity `&nbsp;` then use the Unicode character `\u00a0` instead of `&nbsp;`
+
+```html
+<div>GBP&nbsp;0.50</div>
+```
+
+```javascript
+cy.get('div').should('have.text', 'GBP\u00a00.50')
+```
+
 If you'd like to work with the text prior to an assertion:
 
 ```javascript

--- a/source/faq/questions/using-cypress-faq.md
+++ b/source/faq/questions/using-cypress-faq.md
@@ -14,14 +14,14 @@ If you're trying to assert on an element's text content:
 cy.get('div').should('have.text', 'foobarbaz')
 ```
 
-If the text contains the {% url "non-breaking space" https://en.wikipedia.org/wiki/Non-breaking_space %} entity `&nbsp;` then use the Unicode character `\u00a0` instead of `&nbsp;`
+If the text contains a {% url "non-breaking space" https://en.wikipedia.org/wiki/Non-breaking_space %} entity `&nbsp;` then use the Unicode character `\u00a0` instead of `&nbsp;`.
 
 ```html
-<div>GBP&nbsp;0.50</div>
+<div>Hello&nbsp;world</div>
 ```
 
 ```javascript
-cy.get('div').should('have.text', 'GBP\u00a00.50')
+cy.get('div').should('have.text', 'Hello\u00a0world')
 ```
 
 If you'd like to work with the text prior to an assertion:


### PR DESCRIPTION
verified by adding tests in https://github.com/cypress-io/cypress-fiddle/commit/9dec37dbbefa0572dcdb3c3b63bb1cfaab43eecd

answers questions like https://github.com/cypress-io/cypress/issues/9531 and https://github.com/cypress-io/cypress/issues/9530

- [x] `cy.contains` example with non-breaking space
- [x] `cy.filter` example with `:contains` and non-breaking space
- [x] `should('have.text')` example with non-breaking space