### PR TITLE
Add cypress-plugin-stripe-elements to plugins list

### DIFF
--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -332,6 +332,12 @@
       link: https://github.com/kentcdodds/cypress-testing-library
       keywords: [testing-library, dom-testing-library, react-testing-library]
       badge: verified
+      
+    - name: cypress-plugin-stripe-elements
+      description: Simple commands that make it easy to target and fill in Stripe Elements input fields
+      link: https://github.com/dbalatero/cypress-plugin-stripe-elements
+      keywords: [stripe, commands, elements, inputs]
+      badge: community
 
     - name: cypress-xpath
       description: Adds XPath command. This repo is also a good example of using custom commands to do retries, provide TypeScript definitions, etc.


### PR DESCRIPTION
I created a new plugin to assist with filling Stripe Elements inputs, as this seemed to be a large-ish problem people were having!