### PR TITLE
error handling links and answers

### DIFF
--- a/source/api/events/catalog-of-events.md
+++ b/source/api/events/catalog-of-events.md
@@ -24,7 +24,7 @@ Event | Details
 --- | ---
 **Name:** | `uncaught:exception`
 **Yields:** | the error **(Object)**, Mocha runnable **(Object)**
-**Description:** | Fires when an uncaught exception occurs in your application. Cypress will fail the test when this fires. Return `false` from this event and Cypress will not fail the test. Also useful for debugging purposes because the actual `error` instance is provided to you.
+**Description:** | Fires when an uncaught exception occurs in your application. Cypress will fail the test when this fires. Return `false` from this event and Cypress will not fail the test. Also useful for debugging purposes because the actual `error` instance is provided to you. See our recipe {% url 'Handling errors' recipes#Fundamentals %}.
 
 Event | Details
 --- | ---
@@ -76,7 +76,7 @@ Event | Details
 --- | ---
 **Name:** | `fail`
 **Yields:** | the error **(Object)**, Mocha runnable **(Object)**
-**Description:** | Fires when the test has failed. It is technically possible to prevent the test from actually failing by binding to this event and invoking an async `done` callback. However this is **strongly discouraged**. Tests should never legitimately fail. This event exists because it's extremely useful for debugging purposes.
+**Description:** | Fires when the test has failed. It is technically possible to prevent the test from actually failing by binding to this event and invoking an async `done` callback. However this is **strongly discouraged**. Tests should never legitimately fail. This event exists because it's extremely useful for debugging purposes. See our recipe {% url 'Handling errors' recipes#Fundamentals %}.
 
 Event | Details
 --- | ---

--- a/source/examples/examples/recipes.md
+++ b/source/examples/examples/recipes.md
@@ -13,13 +13,18 @@ Recipe  | Description
 --- | ---
 {% url 'Node Modules' https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/fundamentals__node-modules %} | Import your own Node modules
 {% url 'Environment variables' https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/server-communication__env-variables %} | Passing environment variables to tests
+{% url 'Handling errors' https://github.com/cypress-io/cypress-example-recipes/blob/master/examples/fundamentals__errors %} | Handling thrown errors and unhandled promise rejections
 {% url 'Dynamic tests' https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/fundamentals__dynamic-tests %} | Create tests dynamically from data
 {% url 'Fixtures' https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/fundamentals__fixtures %} | Loading single or multiple fixtures
+{% url 'Adding Custom Commands' https://github.com/cypress-io/cypress-example-recipes/blob/master/examples/fundamentals__add-custom-command %} | Write your own custom commands using JavaScript with correct types for IntelliSense to work
+{% url 'Adding Custom Commands (TS)' https://github.com/cypress-io/cypress-example-recipes/blob/master/examples/fundamentals__add-custom-command-ts %} | Write your own custom commands using TypeScript
 {% url 'Adding Chai Assertions' https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/extending-cypress__chai-assertions %} | Add new or custom chai assertions
 {% url 'Cypress module API' https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/fundamentals__module-api %} | Run Cypress via its module API
+{% url 'Wrapping Cypress module API' https://github.com/cypress-io/cypress-example-recipes/blob/master/examples/fundamentals__module-api-wrap %} | Writing a wrapper around "cypress run" command line parsing
 {% url 'Custom browsers' https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/fundamentals__custom-browsers %} | Control which browsers the project can use, or even add a custom browser into the list
 {% url 'Use Chrome Remote Interface' https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/fundamentals__chrome-remote-debugging %} | Use Chrome debugger protocol to trigger hover state and print media style
-{% url 'File download' https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/testing-dom__download %} | Download and validate files
+{% url 'Out-of-the-box TypeScript' https://github.com/cypress-io/cypress-example-recipes/blob/master/examples/fundamentals__typescript %} | Write tests in TypeScript without setting up preprocessors
+{% url 'Per-test timeout' https://github.com/cypress-io/cypress-example-recipes/blob/master/examples/fundamentals__timeout %} | Fail a test if it runs longer than the specified time limit
 
 ## Testing the DOM
 
@@ -36,6 +41,7 @@ Recipe  | Description
 {% url 'Evaluate performance metrics' https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/testing-dom__performance-metrics %} | Utilize Cypress to monitor a website
 {% url 'Root style' https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/testing-dom__root-style %} | Trigger input color change that modifies CSS variable
 {% url 'Select widgets' https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/testing-dom__select2 %} | Working with `<select>` elements and [Select2](https://select2.org/) widgets
+{% url 'File download' https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/testing-dom__download %} | Download and validate files
 
 ## Logging In
 

--- a/source/faq/questions/using-cypress-faq.md
+++ b/source/faq/questions/using-cypress-faq.md
@@ -277,7 +277,57 @@ Cypress exposes an event for this (amongst many others) that you can listen for 
 - Debug the error instance itself
 - Prevent Cypress from failing the test
 
-This is documented in detail on the {% url "Catalog Of Events" catalog-of-events %} page.
+This is documented in detail on the {% url "Catalog Of Events" catalog-of-events %} page and the recipe {% url 'Handling errors' recipes#Fundamentals %}.
+
+## {% fa fa-angle-right %} Does Cypress test fail when an application has unhandled rejected promise?
+
+By default no, Cypress does not listen to the unhandled promise rejection event in your application, and thus does not fail the test. You can set up your own listener though and fail the test, see our recipe {% url 'Handling errors' recipes#Fundamentals %}:
+
+```js
+// register listener during cy.visit
+it('fails on unhandled rejection', () => {
+  cy.visit('/', {
+    onBeforeLoad (win) {
+      win.addEventListener('unhandledrejection', (event) => {
+        const msg = `UNHANDLED PROMISE REJECTION: ${event.reason}`
+
+        // fail the test
+        throw new Error(msg)
+      })
+    },
+  })
+})
+
+// ALTERNATIVE: register listener for this test
+it('fails on unhandled rejection', () => {
+  cy.on('window:before:load', (win) => {
+    win.addEventListener('unhandledrejection', (event) => {
+      const msg = `UNHANDLED PROMISE REJECTION: ${event.reason}`
+
+      // fail the test
+      throw new Error(msg)
+    })
+  })
+
+  cy.visit('/')
+})
+
+// ALTERNATIVE: register listener in every test
+before(() => {
+  Cypress.on('window:before:load', (win) => {
+    win.addEventListener('unhandledrejection', (event) => {
+      const msg = `UNHANDLED PROMISE REJECTION: ${event.reason}`
+
+      // fail the test
+      throw new Error(msg)
+    })
+  })
+})
+
+it('fails on unhandled rejection', () => {
+  cy.visit('/')
+})
+```
 
 ## {% fa fa-angle-right %} Can I override environment variables or create configuration for different environments?
 

--- a/source/faq/questions/using-cypress-faq.md
+++ b/source/faq/questions/using-cypress-faq.md
@@ -279,7 +279,7 @@ Cypress exposes an event for this (amongst many others) that you can listen for 
 
 This is documented in detail on the {% url "Catalog Of Events" catalog-of-events %} page and the recipe {% url 'Handling errors' recipes#Fundamentals %}.
 
-## {% fa fa-angle-right %} Does Cypress test fail when an application has unhandled rejected promise?
+## {% fa fa-angle-right %} Will Cypress fail the test when an application has unhandled rejected promise?
 
 By default no, Cypress does not listen to the unhandled promise rejection event in your application, and thus does not fail the test. You can set up your own listener though and fail the test, see our recipe {% url 'Handling errors' recipes#Fundamentals %}:
 


### PR DESCRIPTION
- add links to the fundamentals recipes
- add links to the errors recipe to the events
- explain the unhandled promise rejection