### PR TITLE
File download updates

### DIFF
--- a/source/_changelogs/6.3.0.md
+++ b/source/_changelogs/6.3.0.md
@@ -5,7 +5,7 @@
 **Features:**
 
 - Enabled testing file downloads by preventing the browser from displaying download prompts. Addressed in {% issue 14431 %}.
-- Added new {% url `downloadsFolder` configuration#Folders-Files %} configuration option with default of `cypress/downloads`.
+- Added new {% url `downloadsFolder` configuration#Downloads %} configuration option with default of `cypress/downloads`.
 
 **Bugfixes:**
 

--- a/source/_changelogs/6.3.0.md
+++ b/source/_changelogs/6.3.0.md
@@ -4,6 +4,9 @@
 
 **Features:**
 
+- Enabled testing file downloads by preventing the browser from displaying download prompts. Addressed in {% issue 14431 %}.
+- Added new {% url `downloadsFolder` configuration#Folders-Files %} configuration option with default of `cypress/downloads`.
+
 **Bugfixes:**
 
 **Misc:**

--- a/source/_changelogs/6.3.0.md
+++ b/source/_changelogs/6.3.0.md
@@ -4,8 +4,7 @@
 
 **Features:**
 
-- Enabled testing file downloads by preventing the browser from displaying download prompts. Addressed in {% issue 14431 %}.
-- Added new {% url `downloadsFolder` configuration#Downloads %} configuration option with default of `cypress/downloads`.
+- You can now test file downloads in Cypress without the download prompt displaying. Any files downloaded while testing file downloads will be stored in the {% url `downloadsFolder` configuration#Downloads %} which is set to `cypress/downloads` by default. The `downloadsFolder` will be deleted before each run unless `trashAssetsBeforeRuns` is set to `false`. Addresses {% issue 949 %}.
 
 **Bugfixes:**
 

--- a/source/api/plugins/browser-launch-api.md
+++ b/source/api/plugins/browser-launch-api.md
@@ -255,30 +255,20 @@ module.exports = (on, config) => {
 }
 ```
 
-## Change download directory
+## Support unique file download mime types
 
-Change the download directory of files downloaded during Cypress tests.
+Cypress supports a myriad of mime types when testing file downloads, but in case you have a unique one, you can add support for it.
 
 ```js
-// cypress/plugins/index.js
-const path = require('path')
-
 module.exports = (on) => {
   on('before:browser:launch', (browser, options) => {
-    const downloadDirectory = path.join(__dirname, '..', 'downloads')
-
-    if (browser.family === 'chromium' && browser.name !== 'electron') {
-      options.preferences.default['download'] = { default_directory: downloadDirectory }
-
-      return options
-    }
-
+    // only Firefox requires all mime types to be listed
     if (browser.family === 'firefox') {
-      options.preferences['browser.download.dir'] = downloadDirectory
-      options.preferences['browser.download.folderList'] = 2
+      const existingMimeTypes = options.preferences['browser.helperApps.neverAsk.saveToDisk']
+      const myMimeType = 'my/mimetype'
 
-      // needed to prevent download prompt for text/csv files.
-      options.preferences['browser.helperApps.neverAsk.saveToDisk'] = 'text/csv'
+      // prevents the browser download prompt
+      options.preferences['browser.helperApps.neverAsk.saveToDisk'] = `${existingMimeTypes},${myMimeType}`
 
       return options
     }

--- a/source/guides/core-concepts/writing-and-organizing-tests.md
+++ b/source/guides/core-concepts/writing-and-organizing-tests.md
@@ -66,12 +66,6 @@ You can modify the folder configuration in your configuration file. See {% url '
 Cypress will create a {% url `screenshotsFolder` configuration#Screenshots %} and a {% url `videosFolder` configuration#Videos %} to store the screenshots and videos taken during the testing of your application. Many users will opt to add these folders to their `.gitignore` file. Additionally, if you are storing sensitive environment variables in your configuration file (`cypress.json` by default) or {% url `cypress.env.json` environment-variables#Option-2-cypress-env-json %}, these should also be ignored when you check into source control.
 {% endnote %}
 
-## Fixture Files
-
-Fixtures are used as external pieces of static data that can be used by your tests. Fixture files are located in `cypress/fixtures` by default, but can be {% url 'configured' configuration#Folders-Files %} to another directory.
-
-You would typically use them with the {% url `cy.fixture()` fixture %} command and most often when you're stubbing {% url 'Network Requests' network-requests %}.
-
 ## Test files
 
 Test files are located in `cypress/integration` by default, but can be {% url 'configured' configuration#Folders-Files %} to another directory. Test files may be written as:
@@ -90,6 +84,53 @@ Check out our recipe using {% url 'ES2015 and CommonJS modules' recipes#Fundamen
 To see an example of every command used in Cypress, open the {% url "`example` folder" https://github.com/cypress-io/cypress-example-kitchensink/blob/master/cypress/integration/examples %} within your `cypress/integration` folder.
 
 To start writing tests for your app, create a new file like `app_spec.js` within your `cypress/integration` folder. Refresh your tests list in the Cypress Test Runner and your new file should have appeared in the list.
+
+## Fixture Files
+
+Fixtures are used as external pieces of static data that can be used by your tests. Fixture files are located in `cypress/fixtures` by default, but can be {% url 'configured' configuration#Folders-Files %} to another directory.
+
+You would typically use them with the {% url `cy.fixture()` fixture %} command and most often when you're stubbing {% url 'Network Requests' network-requests %}.
+
+## Asset Files
+
+There are some folders that may be generated after a test run, containing assets that were generated during the test run.
+
+You may consider adding these folders to your `.gitignore` file to ignore checking these files into source control.
+
+### Download Files
+
+Any files downloaded while testing an application's file download feature will be stored in `cypress/downloads`.
+
+```text
+/cypress
+  /downloads
+    - records.csv
+```
+
+### Screenshot Files
+
+If screenshots were taken via the {% url "`cy.screenshot()`" screenshot %} command or automatically when a test fails, the screenshots are stored in the {% url `screenshotsFolder` configuration#Screenshots %} which is set to `cypress/screenshots` by default.
+
+```text
+/cypress
+  /screenshots
+    /app_spec.js
+      - Navigates to main menu (failures).png
+```
+
+To learn more about screenshots and settings available, see {% url "Screenshots and Videos" screenshots-and-videos#Screenshots %}
+
+### Video Files
+
+Any videos recorded of the run are stored in the {% url `videosFolder` configuration#Videos %} which is set to `cypress/videos` by default.
+
+```text
+/cypress
+  /videos
+    - app_spec.js.mp4
+```
+
+To learn more about videos and settings available, see {% url "Screenshots and Videos" screenshots-and-videos#Screenshots %}
 
 ## Plugin files
 

--- a/source/guides/core-concepts/writing-and-organizing-tests.md
+++ b/source/guides/core-concepts/writing-and-organizing-tests.md
@@ -99,7 +99,7 @@ You may consider adding these folders to your `.gitignore` file to ignore checki
 
 ### Download Files
 
-Any files downloaded while testing an application's file download feature will be stored in the {% url `downloadsFolder` configuration#Folders-Files %} which is set to `cypress/downloads` by default.
+Any files downloaded while testing an application's file download feature will be stored in the {% url `downloadsFolder` configuration#Downloads %} which is set to `cypress/downloads` by default.
 
 ```text
 /cypress

--- a/source/guides/core-concepts/writing-and-organizing-tests.md
+++ b/source/guides/core-concepts/writing-and-organizing-tests.md
@@ -99,7 +99,7 @@ You may consider adding these folders to your `.gitignore` file to ignore checki
 
 ### Download Files
 
-Any files downloaded while testing an application's file download feature will be stored in `cypress/downloads`.
+Any files downloaded while testing an application's file download feature will be stored in the {% url `downloadsFolder` configuration#Folders-Files %} which is set to `cypress/downloads` by default.
 
 ```text
 /cypress

--- a/source/guides/references/configuration.md
+++ b/source/guides/references/configuration.md
@@ -45,6 +45,7 @@ Option | Default | Description
 
 Option | Default | Description
 ----- | ---- | ----
+`downloadsFolder`    | `cypress/downloads`    | Path to folder where files downloaded during a test are saved
 `fileServerFolder`    | root project folder    |Path to folder where application files will attempt to be served from
 `fixturesFolder`    | `cypress/fixtures`    | Path to folder containing fixture files (Pass `false` to disable)
 `ignoreTestFiles` | `*.hot-update.js` | A String or Array of glob patterns used to ignore test files that would otherwise be shown in your list of tests. Cypress uses `minimatch` with the options: `{dot: true, matchBase: true}`. We suggest using {% url "https://globster.xyz" https://globster.xyz %} to test what files would match.
@@ -61,7 +62,7 @@ Option | Default | Description
 ----- | ---- | ----
 `screenshotOnRunFailure` | `true` | Whether Cypress will take a screenshot when a test fails during `cypress run`.
 `screenshotsFolder`     | `cypress/screenshots`     | Path to folder where screenshots will be saved from {% url `cy.screenshot()` screenshot %} command or after a test fails during `cypress run`
-`trashAssetsBeforeRuns` | `true` | Whether Cypress will trash assets within the `screenshotsFolder` and `videosFolder` before tests run with `cypress run`.
+`trashAssetsBeforeRuns` | `true` | Whether Cypress will trash assets within the `downloadsFolder`, `screenshotsFolder`, and `videosFolder` before tests run with `cypress run`.
 
 For more options regarding screenshots, view the {% url 'Cypress.Screenshot API' screenshot-api %}.
 
@@ -69,7 +70,7 @@ For more options regarding screenshots, view the {% url 'Cypress.Screenshot API'
 
 Option | Default | Description
 ----- | ---- | ----
-`trashAssetsBeforeRuns` | `true` | Whether Cypress will trash assets within the `screenshotsFolder` and `videosFolder` before tests run with `cypress run`.
+`trashAssetsBeforeRuns` | `true` | Whether Cypress will trash assets within the `downloadsFolder`, `screenshotsFolder`, and `videosFolder` before tests run with `cypress run`.
 `videoCompression` | `32` | The quality setting for the video compression, in Constant Rate Factor (CRF). The value can be `false` to disable compression or a value between `0` and `51`, where a lower value results in better quality (at the expense of a higher file size).
 `videosFolder`     | `cypress/videos` | Where Cypress will automatically save the video of the test run when tests run with `cypress run`.
 `video`     | `true`     | Whether Cypress will capture a video of the tests run with `cypress run`.

--- a/source/guides/references/configuration.md
+++ b/source/guides/references/configuration.md
@@ -76,6 +76,13 @@ Option | Default | Description
 `video`     | `true`     | Whether Cypress will capture a video of the tests run with `cypress run`.
 `videoUploadOnPasses`     | `true`     | Whether Cypress will process, compress, and upload videos to the {% url "Dashboard" dashboard-introduction%} even when all tests in a spec file are passing. This only applies when recording your runs to the Dashboard. Turn this off if you'd like to only upload the spec file's video when there are failing tests.
 
+## Downloads
+
+Option | Default | Description
+----- | ---- | ----
+`downloadsFolder` | `cypress/downloads` | Path to folder where files downloaded during a test are saved
+`trashAssetsBeforeRuns` | `true` | Whether Cypress will trash assets within the `downloadsFolder`, `screenshotsFolder`, and `videosFolder` before tests run with `cypress run`.
+
 ## Browser
 
 Option | Default | Description

--- a/source/guides/references/roadmap.md
+++ b/source/guides/references/roadmap.md
@@ -13,9 +13,9 @@ Our team is always planning and working on really "big" upcoming features. Prior
 Status               | Feature                            |  Issue            | PR           | Released
 ---------------------| -----------------------------------|-------------------|--------------|------------
 *Experimental*       | **Component Testing**              |  {% issue 5922 %} | {% PR 5923 %}| {% url "v4.5.0" changelog#4-5-0 %}
+*Released*   | **File download support**                  |  {% issue 949 %}  | {% PR 14431 %} | {% url "v6.3.0" changelog#6-3-0 %}
 *Work in progress*   | **Session API**                    |  {% issue 8301 %} | {% PR 8765 %}|
 *Work in progress*   | **New plugin events**              |  {% issue 6665 %} |              |
-*Work in progress*   | **File download support**          |  {% issue 949 %}  |              |
 *Work in progress*   | **Visit multiple superdomains**    |  {% issue 944 %}  |              |
 *Upcoming*           | **Iframe Support**                 |  {% issue 136 %}  |              |
 


### PR DESCRIPTION
Initially addressing docs for https://github.com/cypress-io/cypress/pull/14431 but I think we can leave this open to see if more work will merge in for 6.3.0, to further update the download docs.

### What to update?

- I added a new section to 'writing and organizing tests' explaining 'Asset files'. 
- I wonder if the 'Screenshots and Videos' page should be repurposed to 'Asset Files' doc? I've always leaned against doing that because I felt people would search and understand screenshots/videos more easily.

### Some other sections of docs that require updating:

- Change download directory: https://docs.cypress.io/api/plugins/browser-launch-api.html#Change-download-directory @chrisbreiding is this still relevant? Will this example work?
- FAQ about file download: https://docs.cypress.io/faq/questions/using-cypress-faq.html#Is-there-a-way-to-test-that-a-file-got-downloaded-I-want-to-test-that-a-button-click-triggers-a-download