### PR TITLE
Add cypress-msteams-reporter to plugin.yml

### DIFF
--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -730,3 +730,9 @@
       link: https://github.com/LironEr/cypress-mochawesome-reporter
       keywords: [reporter, mochawesome, screenshot]
       badge: community
+
+    - name: cypress-msteams-reporter
+      description: A Microsoft Teams reporting tool which provides a fast feedback of the latest cypress test execution.
+      link: https://github.com/maritome/cypress-msteams-reporter
+      keywords: [reporter, ms-teams, allure report]
+      badge: community

--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -734,5 +734,5 @@
     - name: cypress-msteams-reporter
       description: A reporting tool which sends a message to Microsoft Teams with information about the latest cypress test execution results.
       link: https://github.com/maritome/cypress-msteams-reporter
-      keywords: [reporter, ms-teams, allure report]
+      keywords: [reporter, ms-teams, allure-report]
       badge: community

--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -732,7 +732,7 @@
       badge: community
 
     - name: cypress-msteams-reporter
-      description: A Microsoft Teams reporting tool which provides a fast feedback of the latest cypress test execution.
+      description: A reporting tool which sends a message to Microsoft Teams with information about the latest cypress test execution results.
       link: https://github.com/maritome/cypress-msteams-reporter
       keywords: [reporter, ms-teams, allure report]
       badge: community


### PR DESCRIPTION
Add cypress-msteams-reporter plugin to Cypress documentation.

- [x] 🚀 Works with the latest major version of Cypress
- [x]  🛠 Plugin purpose is clearly documented (in a README or docs website)
- [x] 📝 Well-written documentation - A great example (link)
- [x] 🔬 Tested using Cypress - tests using Cypress can act as both example usage and test coverage
- [x] 👷‍♀️ CI pipeline that's passing (CircleCI and Github Actions are both free for Open Source)