### PR TITLE
Fix example in the route -> intercept migration guide

### DIFF
--- a/source/guides/references/migration-guide.md
+++ b/source/guides/references/migration-guide.md
@@ -50,14 +50,14 @@ cy.route({
 
 ```js
 // Match HTTP requests with a path of /users
-cy.route({
+cy.intercept({
   method: 'POST',
   path: '/users'
 }).as('getUsers')
 
 // OR
 // Match HTTP requests with an exact url of https://example.cypress.io/users
-cy.route({
+cy.intercept({
   method: 'POST',
   url: 'https://example.cypress.io/users'
 }).as('getUsers')


### PR DESCRIPTION
There is a mistake in one of the examples (there should be `intercept` instead of `route` command)
