### PR TITLE
Add experimentalStudio to experiments page

### DIFF
--- a/source/guides/references/experiments.md
+++ b/source/guides/references/experiments.md
@@ -18,8 +18,10 @@ Option | Default | Description
 `experimentalFetchPolyfill` | `false` | Automatically replaces `window.fetch` with a polyfill that Cypress can spy on and stub. Note: `experimentalFetchPolyfill` has been deprecated in Cypress 6.0.0 and will be removed in a future release. Consider using {% url "`cy.intercept()`" intercept %} to intercept `fetch` requests instead.
 `experimentalRunEvents` | `false` | Allows listening to the {% url "`before:run`" before-run-api %}, {% url "`after:run`" after-run-api %}, {% url "`before:spec`" before-spec-api %}, and {% url "`after:spec`" after-spec-api %} events in the plugins file.
 `experimentalSourceRewriting` | `false` | Enables AST-based JS/HTML rewriting. This may fix issues caused by the existing regex-based JS/HTML replacement algorithm. See {% issue 5273 %} for details.
+`experimentalStudio` | `false` | Generate and save commands directly to your test suite by interacting with your app as an end user would. See {% url "Cypress Studio" cypress-studio %} for more details.
 
 {% history %}
+{% url "6.3.0" changelog#6-3-0 %} | Added support for `experimentalStudio`.
 {% url "6.0.0" changelog#6-0-0 %} | Removed `experimentalNetworkStubbing` and made it the default behavior when using {% url "`cy.intercept()`" intercept %}.
 {% url "6.0.0" changelog#6-0-0 %} | Deprecated `experimentalFetchPolyfill`.
 {% url "5.2.0" changelog#5-2-0 %} | Removed `experimentalShadowDomSupport` and made it the default behavior.


### PR DESCRIPTION
Adds `experimentalStudio` option to experiments page since this was just released in 6.3.0