### PR TITLE
Updates to cy studio docs

### DIFF
--- a/source/_changelogs/6.3.0.md
+++ b/source/_changelogs/6.3.0.md
@@ -4,7 +4,7 @@
 
 **Features:**
 
-- **Cypress Studio** provides a visual way to generate tests within the Test Runner, by *recording interactions* against the application under test. Cypress Studio is an experimental feature that can be enabled by adding the {% url "`experimentalStudio`" experiments %} attribute to your configuration, `cypress.json` by default. Address {% issue 73 %}.
+- {% url "**Cypress Studio**" cypress-studio %} provides a visual way to generate tests within the Test Runner, by *recording interactions* against the application under test. Cypress Studio is an experimental feature that can be enabled by adding the {% url "`experimentalStudio`" experiments %} attribute to your configuration, `cypress.json` by default. Address {% issue 73 %}.
 - **You can now test file downloads in Cypress** without the download prompt displaying. Any files downloaded while testing file downloads will be stored in the {% url "`downloadsFolder`" configuration#Downloads %} which is set to `cypress/downloads` by default. The `downloadsFolder` will be deleted before each run unless {% url "`trashAssetsBeforeRuns`" configuration#Downloads %} is set to `false`. Addresses {% issue 949 %}.
 
 **Bugfixes:**

--- a/source/api/commands/route.md
+++ b/source/api/commands/route.md
@@ -496,6 +496,10 @@ When clicking on `XHR Stub` within the Command Log, the console outputs the foll
 
 {% imgTag /img/api/route/console-log-shows-status-duration-response-request-and-other-data-for-routing.png "Console Log XHR alias route" %}
 
+{% history %}
+{% url "6.0.0" changelog#6-0-0 %} | Deprecated `cy.route()` command
+{% endhistory %}
+
 # See also
 
 - {% url "Migrating `cy.route()` to `cy.intercept()`" migration-guide#Migrating-cy-route-to-cy-intercept %}

--- a/source/api/commands/server.md
+++ b/source/api/commands/server.md
@@ -268,6 +268,7 @@ The intention of {% url "`cy.request()`" request %} is to be used for checking e
 - `cy.server()` does *not* log in the Command Log
 
 {% history %}
+{% url "6.0.0" changelog#6-0-0 %} | Deprecated `cy.server()` command
 {% url "5.0.0" changelog#5-0-0 %} | Renamed `whitelist` option to `ignore`
 {% url "0.13.6" changelog#0-13-6 %} | Added `onAbort` callback option
 {% url "0.5.10" changelog#0-5-10 %} | Added `delay` option

--- a/source/guides/core-concepts/cypress-studio.md
+++ b/source/guides/core-concepts/cypress-studio.md
@@ -14,29 +14,30 @@ title: Cypress Studio
 
 Cypress Studio provides a visual way to generate tests within the Test Runner, by *recording interactions* against the application under test.
 
-The {% url `.click()` click %}, {% url `.type()` type %}, {% url `.check()` check %}{% url `.uncheck()` uncheck %} and {% url `.select()` select %} Cypress commands are supported and will generate test code when interacting with the DOM inside of the Cypress Studio.
+The {% url `.click()` click %}, {% url `.type()` type %}, {% url `.check()` check %}, {% url `.uncheck()` uncheck %}, and {% url `.select()` select %} Cypress commands are supported and will generate test code when interacting with the DOM inside of the Cypress Studio.
 
-## Using Cypress Studio
+# Using Cypress Studio
 
 {% note info %}
-Cypress Studio is an experimental feature and can be enabled by adding the `experimentalStudio` attribute to your `cypress.json`.
+Cypress Studio is an experimental feature and can be enabled by adding the {% url "`experimentalStudio`" experiments %} attribute to your configuration file (`cypress.json` by default).
 {% endnote %}
 
 ```json
 {
-  "experimentalStudio": true,
+  "experimentalStudio": true
 }
 ```
 
-The Cypress {% fa fa-github %} {% url "Real World App (RWA)" https://github.com/cypress-io/cypress-realworld-app %} is an open source project implementing a payment application to demonstrate real-world usage of Cypress testing methods, patterns, and workflows. It will be used to demonstrate the functionality of Cypress Studio.
+The Cypress {% fa fa-github %} {% url "Real World App (RWA)" https://github.com/cypress-io/cypress-realworld-app %} is an open source project implementing a payment application to demonstrate real-world usage of Cypress testing methods, patterns, and workflows. It will be used to demonstrate the functionality of Cypress Studio below.
 
-### Extending a Test
+## Extending a Test
 
-You can extend any preexisting test or start by creating a new test under `cypress/integration` with the following test scaffolding.
+You can extend any preexisting test or start by creating a new test in your {% url "`integrationFolder`" configuration#Folders-Files %} (`cypress/integration` by default) with the following test scaffolding.
 
 ```js
-describe('Cypress Studio Demo', function () {
-  beforeEach(function () {
+// Code from Real World App (RWA)
+describe('Cypress Studio Demo', () => {
+  beforeEach(() => {
     // Seed database with test data
     cy.task('db:seed')
 
@@ -46,7 +47,7 @@ describe('Cypress Studio Demo', function () {
     })
   })
 
-  it('create new transaction', function () {
+  it('create new transaction', () => {
     // Extend test with Cypress Studio
   })
 })
@@ -57,12 +58,13 @@ describe('Cypress Studio Demo', function () {
 Clone the {% fa fa-github %} {% url "Real World App (RWA)" https://github.com/cypress-io/cypress-realworld-app %} and refer to the {% url "cypress/tests/demo/cypress-studio.spec.ts" https://github.com/cypress-io/cypress-realworld-app/cypress/tests/demo/cypress-studio.spec.ts %} file.
 {% endnote %}
 
-#### Step 1 - Run the spec
+### Step 1 - Run the spec
+
 We will use Cypress Studio to perform a "New Transaction" user journey. First, launch the Test Runner and run the spec created in the previous step.
 
 {% imgTag /img/guides/cypress-studio/run-spec-1.png "Cypress Studio" "no-border" %}
 
-Once the tests complete their run, hover over a test in the Command Log to reveal a "Add Commands to Test" button.
+Once the tests complete their run, hover over a test in the Command Log to reveal an "Add Commands to Test" button.
 
 Clicking on "Add Commands to Test" will launch the Cypress Studio.
 
@@ -72,18 +74,19 @@ Cypress Studio is directly integrated with the {% url 'Command Log' test-runner#
 
 {% imgTag /img/guides/cypress-studio/run-spec-2.png "Cypress Studio" "no-border" %}
 
-#### Step 2 - Launch Cypress Studio
+### Step 2 - Launch Cypress Studio
 
 {% note success %}
 Cypress will automatically execute all hooks and currently present test code, and then the test can be extended from that point on (e.g. We are logged into the application inside the `beforeEach` block).
 {% endnote %}
 
 Next, the Test Runner will execute the test in isolation and pause after the last command in the test.
+
 {% imgTag /img/guides/cypress-studio/extend-new-transaction-ready.png "Cypress Studio Ready" "no-border" %}
 
 Now, we can begin updating the test to create a new transaction between users.
 
-#### Step 3 - Interact with the Application
+### Step 3 - Interact with the Application
 
 To record actions, begin interacting with the application.  Here we will click on the first name input and as a result we will see the click recorded in the Command Log.
 
@@ -93,28 +96,32 @@ Next, we can type the name of a user to pay and click on the user in the results
 
 {% imgTag /img/guides/cypress-studio/extend-new-transaction-click-user.png "Cypress Studio Extend Test" "no-border" %}
 
-We will complete the transaction form by clicking on and typing in the amount and description inputs.  
+We will complete the transaction form by clicking on and typing in the amount and description inputs.
+
 {% imgTag /img/guides/cypress-studio/extend-new-transaction-form.png "Cypress Studio Extend Test" "no-border" %}
 
 {% note success %}
-Notice the commands generated in the command log.
+Notice the commands generated in the Command Log.
 {% endnote %}
 
 Finally, we will click the "Pay" button.
+
 {% imgTag /img/guides/cypress-studio/extend-new-transaction-pay.png "Cypress Studio Extend Test" "no-border" %}
 
 We are presented with a confirmation page of our new transaction.
+
 {% imgTag /img/guides/cypress-studio/extend-new-transaction-confirmation.png "Cypress Studio Extend Test Confirmation" "no-border" %}
 
-To discard the interactions, click the "Cancel" button to exit Cypress Studio. If satisfied with the interactions with the application, click "Save Commands" and the test code will be saved to the file.
+To discard the interactions, click the "Cancel" button to exit Cypress Studio. If satisfied with the interactions with the application, click "Save Commands" and the test code will be saved to your spec file.
 
-#### Generated Test Code
+### Generated Test Code
 
 Viewing our test code, we can see that the test is updated after clicking "Save Commands" with the actions we recorded in Cypress Studio.
 
 ```js
-describe('Cypress Studio Demo', function () {
-  beforeEach(function () {
+// Code from Real World App (RWA)
+describe('Cypress Studio Demo', () => {
+  beforeEach(() => {
     // Seed database with test data
     cy.task('db:seed')
 
@@ -124,7 +131,7 @@ describe('Cypress Studio Demo', function () {
     })
   })
 
-  it('create new transaction', function () {
+  it('create new transaction', () => {
     /* ==== Generated with Cypress Studio ==== */
     cy.get('[data-test=nav-top-new-transaction]').click()
     cy.get('[data-test=user-list-search-input]').click()
@@ -139,9 +146,10 @@ describe('Cypress Studio Demo', function () {
 })
 ```
 
-### Adding a New Test
+## Adding a New Test
 
-Next, we can add a new test, by clicking "Add New Test" beside the test file header.
+You can add a new test to any existing `describe` or `context` block. Next, we can add a new test, by clicking "Add New Test" our defined `describe` block.
+
 {% imgTag /img/guides/cypress-studio/add-test-1.png "Cypress Studio Add Test" "no-border" %}
 
 We are launched into Cypress Studio and can begin interacting with our application to generate the test.
@@ -170,10 +178,11 @@ Once saved, the file will be run again in Cypress.
 Finally, viewing our test code, we can see that the test is updated after clicking "Save Commands" with the actions we recorded in Cypress Studio.
 
 ```js
+// Code from Real World App (RWA)
 import { User } from "models";
 
-describe("Cypress Studio Demo", function () {
-  beforeEach(function () {
+describe("Cypress Studio Demo", () => {
+  beforeEach(() => {
     cy.task("db:seed");
 
     cy.database("find", "users").then((user: User) => {
@@ -181,7 +190,7 @@ describe("Cypress Studio Demo", function () {
     });
   });
 
-  it("create new transaction", function () {
+  it("create new transaction", () => {
     // Extend test with Cypress Studio
   });
 
@@ -206,3 +215,7 @@ describe("Cypress Studio Demo", function () {
 #### {% fa fa-graduation-cap %} Real World Example
 Clone the {% fa fa-github %} {% url "Real World App (RWA)" https://github.com/cypress-io/cypress-realworld-app %} and refer to the {% url "cypress/tests/demo/cypress-studio.spec.ts" https://github.com/cypress-io/cypress-realworld-app/cypress/tests/demo/cypress-studio.spec.ts %} file.
 {% endnote %}
+
+{% history %}
+{% url "6.3.0" changelog#6-3-0 %} | Added Cypress Studio as experimental
+{% endhistory %}

--- a/source/guides/references/roadmap.md
+++ b/source/guides/references/roadmap.md
@@ -13,6 +13,7 @@ Our team is always planning and working on really "big" upcoming features. Prior
 Status               | Feature                            |  Issue            | PR           | Released
 ---------------------| -----------------------------------|-------------------|--------------|------------
 *Experimental*       | **Component Testing**              |  {% issue 5922 %} | {% PR 5923 %}| {% url "v4.5.0" changelog#4-5-0 %}
+*Experimental*       | **Cypress Studio**              |  {% issue 73 %} | {% PR 9542 %}| {% url "v6.3.0" changelog#6-3-0 %}
 *Released*   | **File download support**                  |  {% issue 949 %}  | {% PR 14431 %} | {% url "v6.3.0" changelog#6-3-0 %}
 *Work in progress*   | **Session API**                    |  {% issue 8301 %} | {% PR 8765 %}|
 *Work in progress*   | **New plugin events**              |  {% issue 6665 %} |              |


### PR DESCRIPTION
- add deprecated history to route and server (just noticed it)
- clarifying that ‘describe’ and ‘context’ blocks are required to
create a test
- linking to other docs
- being more specific about configurable files
- Add history table