### PR TITLE
use ram disk on circleci

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -10,8 +10,12 @@ env_defaults: &env_defaults
   # need to set unsafe perm to be able to do `npm postinstall`
   npm_config_unsafe-perm: true
 
+  # set Cypress to cache its binary on RAM disk
+  CYPRESS_CACHE_FOLDER: /mnt/ramdisk/.cache/Cypress
+
 defaults: &defaults
-  working_directory: ~/cypress-documentation
+  # use CircleCI RAM disk
+  working_directory: /mnt/ramdisk
   docker:
     # the Docker image with Cypress dependencies
     # https://github.com/cypress-io/cypress-docker-images
@@ -42,8 +46,10 @@ jobs:
       # need to restore previously caches files, if any to speed up the build
       # we want to use new cache if package or circle files change
       - restore_cache:
-          key: v2-deps-{{ .Branch }}-{{ checksum "package.json" }}-{{ checksum "circle.yml" }}
+          key: v1-ram-disk-deps-{{ .Branch }}-{{ checksum "package.json" }}-{{ checksum "circle.yml" }}
 
+      # set NPM to cache its dependencies on RAM disk
+      - run: npm config --global set cache /mnt/ramdisk/.npm
       - run: npm ci
       # run Cypress verify command to cache its status
       - run: npm run cypress:verify
@@ -56,10 +62,10 @@ jobs:
       # https://on.cypress.io/continuous-integration
       # this ensures that this job can start quickly next time
       - save_cache:
-          key: v2-deps-{{ .Branch }}-{{ checksum "package.json" }}-{{ checksum "circle.yml" }}
+          key: v1-ram-disk-deps-{{ .Branch }}-{{ checksum "package.json" }}-{{ checksum "circle.yml" }}
           paths:
-            - /root/.npm
-            - /root/.cache
+            - /mnt/ramdisk/.npm
+            - /mnt/ramdisk/.cache
 
       #
       # build the static content
@@ -83,23 +89,24 @@ jobs:
               exit 1
             fi
 
+      # when passing files to run the app and the tests
+      # we do NOT need the NPM cache since everything has been installed already
+      - run: rm -rf .npm
       # see how large are the folders in the workspace
       - run: du -h -d 1
       ## save entire folder + Cypress binary as the workspace for other jobs to continue
       - persist_to_workspace:
-          root: ~/
+          root: /mnt
           paths:
-            - cypress-documentation
-            - .cache/Cypress
+            - ramdisk
 
-  "docs-tests":
+  docs-tests:
     <<: *defaults
     parallelism: 4
     steps:
       # restore application and Cypress binary before running the test command
       - attach_workspace:
-          at: ~/
-      - run: ls -Rl themes/cypress/source/js
+          at: /mnt
       - run:
           command: npm start
           background: true
@@ -121,59 +128,6 @@ jobs:
       - store_artifacts:
           path: npm-debug.log
 
-  # TODO: deploy in a single job and then trigger parallel jobs to test the deployed docs
-  "deploy-docs-staging":
-    <<: *defaults
-    steps:
-      # restore application and Cypress binary before running the test command
-      - attach_workspace:
-          at: ~/
-      - run: npm ls || true
-      # need to build the app for STAGING environment
-      - run: NODE_ENV=staging npm run build
-      - run: ls -Rl themes/cypress/source/js
-      - run: ls public
-      - run: DEBUG=ggit,deploy npm run deploy-prebuilt -- --environment staging --force
-      - run:
-          name: Print deployed version
-          command: cat public/build.json
-      - run:
-          name: Test deployed docs
-          command: |
-            export CYPRESS_baseUrl=https://docs-staging.cypress.io
-            if [ -n "$DOCS_RECORD_KEY" ]; then
-              $(npm bin)/cypress run --record --key $DOCS_RECORD_KEY --parallel --group "staging" --ci-build-id $CIRCLE_WORKFLOW_ID-$CIRCLE_BUILD_NUM
-            else
-              $(npm bin)/cypress run
-            fi
-      - store_artifacts:
-          path: cypress/videos
-      - store_artifacts:
-          path: cypress/screenshots
-      - store_artifacts:
-          path: npm-debug.log
-      # store NPM logs in case there was a problem
-      - store_artifacts:
-          path: ~/.npm/_logs
-
-  "deploy-docs-production":
-    <<: *defaults
-    steps:
-      # restore application and Cypress binary before running the test command
-      - attach_workspace:
-          at: ~/
-      # need to build the app for PRODUCTION environment
-      - run: NODE_ENV=production npm run build
-      # because we already built docs for production
-      # use script that just deploys without rebuilding the production docs
-      - run: npm run deploy-prebuilt -- --environment production --scrape
-      - run: cat public/build.json
-      - store_artifacts:
-          path: npm-debug.log
-      # store NPM logs in case there was a problem
-      - store_artifacts:
-          path: ~/.npm/_logs
-
 workflows:
   version: 2
   build_and_test:
@@ -182,21 +136,3 @@ workflows:
       - docs-tests:
           requires:
             - build
-      # we can deploy development docs in parallel
-      # with unit testing them.
-      - deploy-docs-staging:
-          filters:
-            branches:
-              only:
-                # allow deploying to staging from "develop"
-                # and branches starting with special prefix
-                - develop
-                - /docs-.*/
-          requires:
-            - docs-tests
-      - deploy-docs-production:
-          filters:
-            branches:
-              only: master
-          requires:
-            - docs-tests

--- a/circle.yml
+++ b/circle.yml
@@ -128,6 +128,59 @@ jobs:
       - store_artifacts:
           path: npm-debug.log
 
+  # TODO: deploy in a single job and then trigger parallel jobs to test the deployed docs
+  deploy-docs-staging:
+    <<: *defaults
+    steps:
+      # restore application and Cypress binary before running the test command
+      - attach_workspace:
+          at: ~/
+      - run: npm ls || true
+      # need to build the app for STAGING environment
+      - run: NODE_ENV=staging npm run build
+      - run: ls -Rl themes/cypress/source/js
+      - run: ls public
+      - run: DEBUG=ggit,deploy npm run deploy-prebuilt -- --environment staging --force
+      - run:
+          name: Print deployed version
+          command: cat public/build.json
+      - run:
+          name: Test deployed docs
+          command: |
+            export CYPRESS_baseUrl=https://docs-staging.cypress.io
+            if [ -n "$DOCS_RECORD_KEY" ]; then
+              $(npm bin)/cypress run --record --key $DOCS_RECORD_KEY --parallel --group "staging" --ci-build-id $CIRCLE_WORKFLOW_ID-$CIRCLE_BUILD_NUM
+            else
+              $(npm bin)/cypress run
+            fi
+      - store_artifacts:
+          path: cypress/videos
+      - store_artifacts:
+          path: cypress/screenshots
+      - store_artifacts:
+          path: npm-debug.log
+      # store NPM logs in case there was a problem
+      - store_artifacts:
+          path: ~/.npm/_logs
+
+  deploy-docs-production:
+    <<: *defaults
+    steps:
+      # restore application and Cypress binary before running the test command
+      - attach_workspace:
+          at: ~/
+      # need to build the app for PRODUCTION environment
+      - run: NODE_ENV=production npm run build
+      # because we already built docs for production
+      # use script that just deploys without rebuilding the production docs
+      - run: npm run deploy-prebuilt -- --environment production --scrape
+      - run: cat public/build.json
+      - store_artifacts:
+          path: npm-debug.log
+      # store NPM logs in case there was a problem
+      - store_artifacts:
+          path: ~/.npm/_logs
+
 workflows:
   version: 2
   build_and_test:
@@ -136,3 +189,21 @@ workflows:
       - docs-tests:
           requires:
             - build
+      # we can deploy development docs in parallel
+      # with unit testing them.
+      - deploy-docs-staging:
+          filters:
+            branches:
+              only:
+                # allow deploying to staging from "develop"
+                # and branches starting with special prefix
+                - develop
+                - /docs-.*/
+          requires:
+            - docs-tests
+      - deploy-docs-production:
+          filters:
+            branches:
+              only: master
+          requires:
+            - docs-tests

--- a/circle.yml
+++ b/circle.yml
@@ -56,7 +56,7 @@ jobs:
 
       # store NPM logs in case there was a problem
       - store_artifacts:
-          path: ~/.npm/_logs
+          path: .npm/_logs
 
       # cache NPM modules and folder with Cypress v3+ binary
       # https://on.cypress.io/continuous-integration
@@ -134,11 +134,10 @@ jobs:
     steps:
       # restore application and Cypress binary before running the test command
       - attach_workspace:
-          at: ~/
+          at: /mnt
       - run: npm ls || true
       # need to build the app for STAGING environment
       - run: NODE_ENV=staging npm run build
-      - run: ls -Rl themes/cypress/source/js
       - run: ls public
       - run: DEBUG=ggit,deploy npm run deploy-prebuilt -- --environment staging --force
       - run:
@@ -161,14 +160,14 @@ jobs:
           path: npm-debug.log
       # store NPM logs in case there was a problem
       - store_artifacts:
-          path: ~/.npm/_logs
+          path: .npm/_logs
 
   deploy-docs-production:
     <<: *defaults
     steps:
       # restore application and Cypress binary before running the test command
       - attach_workspace:
-          at: ~/
+          at: /mnt
       # need to build the app for PRODUCTION environment
       - run: NODE_ENV=production npm run build
       # because we already built docs for production
@@ -179,7 +178,7 @@ jobs:
           path: npm-debug.log
       # store NPM logs in case there was a problem
       - store_artifacts:
-          path: ~/.npm/_logs
+          path: .npm/_logs
 
 workflows:
   version: 2


### PR DESCRIPTION
- closes #3450 
- seems every machine during parallel testing spins faster and a lot closer together in time

Before
<img width="1101" alt="Screen Shot 2021-01-20 at 1 43 27 PM" src="https://user-images.githubusercontent.com/2212006/105224743-923b1900-5b2b-11eb-8523-8713812a98b1.png">

The difference _when_ the specs start on each machine is due to attaching the workspace (and how long it takes to spin the container at first). By default, it can be very very different to attach workspace, see the 4 machines below. 


https://user-images.githubusercontent.com/2212006/105229055-5acf6b00-5b31-11eb-8242-e766539026e3.mp4

From CircleCI reply, the difference is due to the disk IO on CI machines being busy

After
<img width="704" alt="Screen Shot 2021-01-20 at 2 27 57 PM" src="https://user-images.githubusercontent.com/2212006/105224821-b26ad800-5b2b-11eb-8952-b0fec1e29eda.png">

Look at the attached workspace difference - it is a lot more uniform (and shorter), because the workspace is stored and used in memory via RAM disk


https://user-images.githubusercontent.com/2212006/105229149-7dfa1a80-5b31-11eb-9d02-603345d745c2.mp4

The remaining variability comes from spinning the container and starting the server, not from the disk IO to attach the workspace