### PR TITLE
Update cypress-vue-unit-test links to @cypress/vue

### DIFF
--- a/source/guides/component-testing/introduction.md
+++ b/source/guides/component-testing/introduction.md
@@ -62,12 +62,12 @@ We currently support Vue and React and intend to support other frameworks in the
 We highly suggest using Vue CLI for a quick start. For manual installation, please check the README in the {% url "GitHub repository" https://github.com/cypress-io/cypress/tree/master/npm/vue %}.
 
 ```sh
-vue add cypress-experimental
+vue add @cypress/vue
 ```
 
 Cypress component testing with Vue currently supports Vue 2.x. Support for Vue 3 is in progress.
 
-Examples for testing different Vue applications (containing {% url "Vuex" https://github.com/bahmutov/cypress-vue-unit-test/tree/master/cypress/component/counter-vuex %}, {% url "VueRouter" https://github.com/bahmutov/cypress-vue-unit-test/tree/master/cypress/component/router-example %}, {% url "VueI18n" https://github.com/bahmutov/cypress-vue-unit-test/tree/master/cypress/component/advanced/i18n %}) exist in the component testing directory for {% url "@cypress/vue" https://github.com/bahmutov/cypress-vue-unit-test/tree/master/cypress/component %}.
+Examples for testing different Vue applications (containing {% url "Vuex" https://github.com/cypress-io/cypress/tree/master/npm/vue/cypress/component/counter-vuex %}, {% url "VueRouter" https://github.com/cypress-io/cypress/tree/master/npm/vue/cypress/component/router-example %}, {% url "VueI18n" https://github.com/cypress-io/cypress/tree/master/npm/vue/cypress/component/advanced/i18n %}) exist in the component testing directory for {% url "@cypress/vue" https://github.com/cypress-io/cypress/tree/master/npm/vue/cypress/component %}.
 
 ## React
 


### PR DESCRIPTION
I've updated links to example folders in the component section of the documentation: https://docs.cypress.io/guides/component-testing/introduction.html#What-is-Cypress-Component-Testing

The examples still pointed to the old cypres-vue-unit-test package, while that package was adopted by the `@cypress` organization a short time ago.

The "install" command for `yarn add` was also outdated, so it points to `@cypess/vue` too.