### PR TITLE
Fix `toMatchImageSnapshot` example with image settings

### DIFF
--- a/source/guides/tooling/visual-testing.md
+++ b/source/guides/tooling/visual-testing.md
@@ -71,7 +71,9 @@ it('completes todo', () => {
   // capture the element screenshot and
   // compare to the baseline image
   cy.get('.todoapp').toMatchImageSnapshot({
-    threshold: 0.001,
+    imageConfig: {
+      threshold: 0.001,
+    },
   })
 })
 ```


### PR DESCRIPTION
On the `toMatchImageSnapshot` example for visual testing, the documentation places the image settings on the top level of the configuration, like this:

```
  cy.get('.todoapp').toMatchImageSnapshot({
    threshold: 0.001,
  })
```

The image settings must be inside the `imageConfig` object:

```
  cy.get('.todoapp').toMatchImageSnapshot({
    imageConfig: {
      threshold: 0.001,
    },
  })
```