### PR TITLE
add example appending json files

### DIFF
--- a/source/api/commands/writefile.md
+++ b/source/api/commands/writefile.md
@@ -148,6 +148,30 @@ cy.writeFile('path/to/ascii.txt', 'Hello World', { encoding: 'ascii', flag: 'a+'
 cy.writeFile('path/to/message.txt', 'Hello World', { flag: 'a+' })
 ```
 
+Note that appending assumes plain text file. If you want to merge a JSON object for example, you need to read it first, add new properties, then write the combined result back.
+
+```javascript
+const filename = '/path/to/file.json'
+
+cy.readFile(filename).then((obj) => {
+  obj.id = '1234'
+  // write the merged object
+  cy.writeFile(filename, obj)
+})
+```
+
+Similarly, if you need to push new items to an array
+
+```javascript
+const filename = '/path/to/list.json'
+
+cy.readFile(filename).then((list) => {
+  list.push({ item: 'example' })
+  // write the merged array
+  cy.writeFile(filename, list)
+})
+```
+
 # Rules
 
 ## Requirements {% helper_icon requirements %}


### PR DESCRIPTION
we see this question periodically

<img width="905" alt="Screen Shot 2021-02-19 at 12 30 05 PM" src="https://user-images.githubusercontent.com/2212006/108539624-3db3c680-72ae-11eb-8dfc-e5417a2c20a6.png">

tested in https://glebbahmutov.com/cypress-examples/6.5.0/commands/files.html#writing-combined-json-object