### PR TITLE
chore(docs): update CT docs

### DIFF
--- a/content/guides/component-testing/getting-started.md
+++ b/content/guides/component-testing/getting-started.md
@@ -22,8 +22,8 @@ If you just want to see it working but don’t want to write code, follow these 
 
 <!-- FIXME: update the url of the example repo we choose -->
 
-- Clone the calc repo
-- Install depenedencies `yarn`
+- Clone the calculator repo
+- Install dependencies `yarn`
 - Open component testing runner `yarn cy:open`
 
 <DocsImage src="/img/guides/component-testing/first-open.png" alt="Splash Screen of Component Testing" ></DocsImage>
@@ -42,34 +42,32 @@ This section will show you how to set a project up from scratch that has compone
 Before we start testing components let's make sure we everything we need.
 
 <alert type="info">
-
-If you are using VueJs click on the Vue tab of the code examples.
-
+If you are using <a href="https://vuejs.org/">Vue.js</a> click on the Vue tab of the code examples.
 </alert>
 
 ### Prerequisites
 
-- An npm project with a `package.json` file at the root that runs on webpack 4 or 5. Create-react-app runs on webpack. It will work fine. So does Nextjs or Gatsby.
-- A `webpack.config.js` file or a way to access it. Refer to the docs tof your framework to access it.
-- A few components that have a visual part to them. It could be a Date Picker, tabs, responsive images, your imagination (and your time) is the limit.
-- A basic knowledge of how to write tests in cypress
+- An npm project with a `package.json` file at the root that runs on webpack 4 or 5. Create-react-app runs on webpack. It will work fine. So does [Next.js](https://nextjs.org/) or [Gatsby](https://www.gatsbyjs.com/).
+- A `webpack.config.js` file or a way to access it. Refer to your framework's documentation to find out how to access it.
+- A few components that have a visual part to them. It could be a date picker, tabs, responsive images - your imagination (and your time) is the limit.
+- A basic knowledge of how to write tests in Cypress
 
 ### Install
 
-First, run the following command. It will install both the latest version of cypress and the tooling you need to run component testing.
+Run the following command. It will install both the latest version of Cypress and the tooling you need to run component testing.
 
 <code-group>
   <code-block label="react" active>
 
 ```bash
-yarn add cypress @cypress/react @cypress/webpack-dev-server
+npm install cypress @cypress/react @cypress/webpack-dev-server --dev
 ```
 
   </code-block>
   <code-block label="vue">
 
 ```bash
-yarn add cypress @cypress/vue @cypress/webpack-dev-server
+npm install cypress @cypress/vue @cypress/webpack-dev-server --dev
 ```
 
   </code-block>
@@ -79,10 +77,14 @@ yarn add cypress @cypress/vue @cypress/webpack-dev-server
 
 Now that we have the necessary tools installed let's configure our tests.
 
-In the same folder as `package.json` create a `cypress.json` file and a `cypress` directory of it does not already exists. in this folder create a `support.js` file.
+In the same folder as `package.json` create a `cypress.json` file and a `cypress` directory of it does not already exists. In this folder create a plugins directory containing an `index.js` file.
 
-The `cypress.json` file will allow us to configure where the component test files are.
-In the following configuration all components test files are in the `src` directory and match the glob given in the `testFiles` key.
+<alert type="info">
+If it is your first time using Cypress, just run `npx cypress open` and Cypress will create the directories and files for you.
+</alert>
+
+The `cypress.json` file will allow us to configure how component tests are located.
+In the following configuration, all components test files are in the `src` directory and match the glob given in the `testFiles` key.
 
 ```json
 {
@@ -91,24 +93,23 @@ In the following configuration all components test files are in the `src` direct
 }
 ```
 
-Then it is time to fill in the `support.js` file to configure our component server.
+You also need to configure the component testing framework of your choice by adding the component testing plugin. Read more about plugins in general [here](/guides/tooling/plugins-guide).
 
 Since our project uses webpack, we will be using webpack-dev-server to facilitate the matching of the styling and display rules of component
 
 <alert type="info">
-
-If you have a dev and a production config, prefer the dev version for now, it will give you better location information using sourceMaps.
-
+If you have separate webpack configurations for development and production, use the development configuration. It will give you better location information using sourceMaps.
 </alert>
 
 ```js
 const { startDevServer } = require('@cypress/webpack-dev-server')
-const projectsWebpackConfig = require('../../webpack.config.js')
+// your project's webpack configuration
+const webpackConfig = require('../../webpack.config.js')
 
 module.exports = (on, config) => {
-  on('dev-server:start', (options) =>
-    startDevServer({ options, projectsWebpackConfig })
-  )
+  on('dev-server:start', (options) => {
+    return startDevServer({ options, webpackConfig })
+  })
   return config
 }
 ```
@@ -117,7 +118,7 @@ We are now ready to start testing our components.
 
 ### Writing Component Tests
 
-We assume a `button` component exists.
+This example assumes a `<Button />` component exists.
 
 - Navigate to where this component file is saved
 - Create a `Button.spec.jsx` file in the same folder
@@ -145,7 +146,16 @@ import { mount } from '@cypress/vue'
 import Button from './button'
 
 it('Button', () => {
+  // with JSX
   mount(() => <Button>Test button</Button>)
+
+  // ... or ...
+  mount(Button, {
+    slots: {
+      default: 'Test button',
+    },
+  })
+
   cy.get('button').contains('Test button').click()
 })
 ```
@@ -156,22 +166,22 @@ it('Button', () => {
 - Open Cypress Component Testing
 
 ```
-yarn cypress open-ct
+npx cypress open-ct
 ```
 
 - Select the spec in the sidebar. You should see the following:
 
 <DocsImage src="/img/guides/component-testing/one-spec.png" alt="Single Spec file with single test run" ></DocsImage>
 
-- Try modifying the spec, make the test fail, etc. the tests re-run instantly with visual feedback.
+- Try modifying the spec, make the test fail, etc. The tests re-run instantly with visual feedback.
 
 ### Setup CI
 
-Sometimes, we want to run tests without interactivity and see all results in the terminal.
-To run all tests in one command we use `cypress run-ct`.
+Sometimes we want to run tests without interactivity and see all results in the terminal.
+To run all tests in one command use `npx cypress run-ct`.
 
 In the project we just built, this command will yield the following results.
 
 <DocsImage src="/img/guides/component-testing/run-result.png" alt="Result of headless test run" ></DocsImage>
 
-To make the component tests part of your continuous integration pipeline, add a script running `cypress run-ct` to travis, circle or appveyor the same way you would add a `cypress run` script without needing to start your server first. We take care of that for you.
+To make the component tests part of your continuous integration pipeline, add a script running `npx cypress run-ct` to your CI configuration.


### PR DESCRIPTION
Some minor changes:

- the rest of the docs use npm, not yarn. I made this consistent in the CT guide.
- minor grammar improvements
- configuration for CT goes in `plugins/index.js` by default, not `support.js`.