### PR TITLE
feat: docsearch scraper running on next-docs branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,9 @@ jobs:
       - run:
           name: Netlify Deploy
           command: curl -X POST -d {} $NETLIFY_BUILD_HOOK_MASTER
+      - run:
+          name: Docsearch Scraper
+          command: node ./cy_scripts/scrape.js
 
 workflows:
   version: 2
@@ -85,4 +88,4 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - next-docs

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ support
 dist/
 static/sw.js
 .eslintcache
+.circle-credentials.json
 
 themes/cypress/source/css/vendor/
 themes/cypress/source/js/vendor/

--- a/cy_scripts/scrape.js
+++ b/cy_scripts/scrape.js
@@ -1,0 +1,94 @@
+/* eslint-disable no-console */
+
+const chalk = require('chalk')
+const Promise = require('bluebird')
+const request = require('request-promise')
+const {
+  configFromEnvOrJsonFile,
+  filenameToShellVariable,
+} = require('@cypress/env-or-json-file')
+const { stripIndent } = require('common-tags')
+
+const tap = (func) => {return (arg) => {
+  func(arg)
+
+  return arg
+}}
+
+function checkToken (token) {
+  if (!token) {
+    const example = JSON.stringify({
+      token: 'foobarbaz',
+    })
+
+    console.log(
+      chalk.red(
+        stripIndent`Cannot scrape docs.
+      You are missing your Circle CI API token.
+      It should look like this:
+
+        ${example}
+    `
+      )
+    )
+
+    throw new Error('missing token')
+  }
+}
+
+function getCircleCredentials () {
+  // the JSON file should have an object like
+  // { "token": "abc123..." }
+  // where the token is your personal API token from CircleCI
+  // alternatively, put the JSON object into environment variable
+  // with file shown by filenameToShellVariable(jsonFile) call
+  // which is something like _circle_credentials_json
+  // you can load such environment variable quickly from local terminal with
+  // https://github.com/bahmutov/as-a
+  const jsonFile = '.circle-credentials.json'
+  const config = configFromEnvOrJsonFile(jsonFile)
+
+  if (!config) {
+    console.error('⛔️  Cannot find CircleCI credentials')
+    console.error('Using @cypress/env-or-json-file module')
+    console.error('and key', filenameToShellVariable(jsonFile))
+    console.error('from file path', jsonFile)
+    throw new Error('Cannot load CircleCI credentials')
+  }
+
+  return config.token
+}
+
+function scrape () {
+  return Promise.resolve()
+  .then(getCircleCredentials)
+  .then(tap(checkToken))
+  .then((token) => {
+    // hmm, how do we trigger workflow?
+    // seems this is not supported yet as of July 10th 2017
+    // https://discuss.circleci.com/t/trigger-workflow-through-rest-api/13931
+    return request({
+      url: 'https://circleci.com/api/v1.1/project/github/cypress-io/docsearch-scraper/',
+      method: 'POST',
+      json: true,
+      auth: {
+        user: token,
+      },
+    }).then((body) => {
+      console.log(
+        '\n',
+        'Started Circle CI build:',
+        chalk.green(body.build_url),
+        '\n'
+      )
+    })
+  })
+}
+
+// if we're not being required
+// then kick off scraping
+if (!module.parent) {
+  scrape()
+}
+
+module.exports = scrape

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "*.{js,vue}": "eslint --cache --fix",
     "*.{css,vue}": "stylelint",
     "*.css": "stylelint --fix",
-    "*.md": "prettier --write" 
+    "*.md": "prettier --write"
   },
   "dependencies": {
     "@docsearch/css": "^1.0.0-alpha.28",
@@ -41,6 +41,7 @@
     "yamljs": "^0.3.0"
   },
   "devDependencies": {
+    "@cypress/env-or-json-file": "^2.0.0",
     "@cypress/eslint-plugin-dev": "^5.1.0",
     "@fortawesome/free-brands-svg-icons": "^5.14.0",
     "@fortawesome/free-solid-svg-icons": "^5.14.0",
@@ -51,6 +52,8 @@
     "autoprefixer": "^9",
     "babel-eslint": "^10.1.0",
     "bluebird": "^3.7.2",
+    "chalk": "^4.1.0",
+    "common-tags": "^1.8.0",
     "cross-env": "^7.0.3",
     "cypress": "^6.4.0",
     "eslint": "^7.2.0",
@@ -67,6 +70,7 @@
     "node-sass": "^4.14.1",
     "postcss": "^7",
     "prettier": "^2.0.5",
+    "request-promise": "^4.2.6",
     "sass-loader": "^9.0.3",
     "stylelint": "^13.6.1",
     "stylelint-config-prettier": "^8.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1710,6 +1710,15 @@
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
   integrity sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
 
+"@cypress/env-or-json-file@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@cypress/env-or-json-file/-/env-or-json-file-2.0.0.tgz#fb6479b8b379e05a5cd216d9ae89c049a7b3c444"
+  integrity sha1-+2R5uLN54Fpc0hbZronASaezxEQ=
+  dependencies:
+    check-more-types "2.24.0"
+    debug "3.1.0"
+    lazy-ass "1.6.0"
+
 "@cypress/eslint-plugin-dev@^5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@cypress/eslint-plugin-dev/-/eslint-plugin-dev-5.1.0.tgz#7c7b2e87d9f2e924f602c9f762d376359c12de8e"
@@ -5132,7 +5141,7 @@ chardet@^0.7.0:
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
-check-more-types@^2.24.0:
+check-more-types@2.24.0, check-more-types@^2.24.0:
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/check-more-types/-/check-more-types-2.24.0.tgz#1420ffb10fd444dcfc79b43891bbfffd32a84600"
   integrity sha1-FCD/sQ/URNz8ebQ4kbv//TKoRgA=
@@ -10387,7 +10396,7 @@ launch-editor@^2.2.1:
     chalk "^2.3.0"
     shell-quote "^1.6.1"
 
-lazy-ass@^1.6.0:
+lazy-ass@1.6.0, lazy-ass@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/lazy-ass/-/lazy-ass-1.6.0.tgz#7999655e8646c17f089fdd187d150d3324d54513"
   integrity sha1-eZllXoZGwX8In90YfRUNMyTVRRM=
@@ -14649,7 +14658,7 @@ request-promise-core@1.1.4:
   dependencies:
     lodash "^4.17.19"
 
-request-promise@^4.2.2:
+request-promise@^4.2.2, request-promise@^4.2.6:
   version "4.2.6"
   resolved "https://registry.yarnpkg.com/request-promise/-/request-promise-4.2.6.tgz#7e7e5b9578630e6f598e3813c0f8eb342a27f0a2"
   integrity sha512-HCHI3DJJUakkOr8fNoCc73E5nU5bqITjOYFMDrKHYOXWXrgD/SBaC7LjwuPymUprRyuF06UK7hd/lMHkmUXglQ==


### PR DESCRIPTION
This will trigger the docsearch-scraper to run on each deploy from the next-docs branch. We will need to change this to only run on `master` once the next-docs branch is merged.