### PR TITLE
fix: algolia search index name

### DIFF
--- a/content/settings.json
+++ b/content/settings.json
@@ -2,6 +2,6 @@
   "algolia": {
     "appId": "R9KDA5FMJB",
     "apiKey": "b4af59e23bc2fa05281af7dcf13fcae5",
-    "indexName": "dev_Docs_Next"
+    "indexName": "docs"
   }
 }


### PR DESCRIPTION
The previously used index name was meant for dev-only.

This uses the new index that the docsearch-scraper is updating.