### PR TITLE
fix: references pages sidebar

### DIFF
--- a/pages/guides/references/best-practices.vue
+++ b/pages/guides/references/best-practices.vue
@@ -3,6 +3,9 @@ import AppSidebar from '@/components/AppSidebar'
 import AppHeader from '@/components/AppHeader'
 import TableOfContentsList from '@/components/TableOfContentsList'
 import Footer from '@/components/Footer'
+import { getMetaData } from '../../../utils/getMetaData'
+import { getMetaDescription } from '../../../utils/getMetaDescription'
+
 
 export default {
   components: {
@@ -47,20 +50,42 @@ export default {
       return error({ statusCode: 404, message: 'Guide not found' })
     }
 
-    const slug = 'best-practices'
-
     const toc = guide.toc.filter((item) => item.depth === 2)
+
+    const [rawContent] = await $content({ deep: true, text: true }).where({ path }).fetch()
+    const metaDescription = await getMetaDescription(rawContent.text)
 
     return {
       algoliaSettings,
       guide: { ...guide, toc },
       guideSidebar: items,
-      path: slug,
+      path: 'references/best-practices',
+      metaDescription,
     }
   },
   head() {
     return {
       title: this.guide.title,
+      meta: this.meta,
+      link: [
+        {
+          hid: 'canonical',
+          rel: 'canonical',
+          href: `https://docs.cypress.io/guides/${this.path}`
+        }
+      ]
+    }
+  },
+  computed: {
+    meta() {
+      const metaData = {
+        type: 'article',
+        title: this.guide.title,
+        description: this.metaDescription,
+        url: `https://docs.cypress.io/guides/${this.path}`,
+      }
+
+      return getMetaData(metaData)
     }
   },
 }

--- a/pages/guides/references/error-messages.vue
+++ b/pages/guides/references/error-messages.vue
@@ -3,6 +3,8 @@ import AppSidebar from '@/components/AppSidebar'
 import AppHeader from '@/components/AppHeader'
 import TableOfContentsList from '@/components/TableOfContentsList'
 import Footer from '@/components/Footer'
+import { getMetaData } from '../../../utils/getMetaData'
+import { getMetaDescription } from '../../../utils/getMetaDescription'
 
 export default {
   components: {
@@ -47,18 +49,40 @@ export default {
       return error({ statusCode: 404, message: 'Guide not found' })
     }
 
-    const slug = 'error-messages'
+    const [rawContent] = await $content({ deep: true, text: true }).where({ path }).fetch()
+    const metaDescription = await getMetaDescription(rawContent.text)
 
     return {
       algoliaSettings,
       guide,
       guideSidebar: items,
-      path: slug,
+      path: 'references/error-messages',
+      metaDescription
     }
   },
   head() {
     return {
       title: this.guide.title,
+      meta: this.meta,
+      link: [
+        {
+          hid: 'canonical',
+          rel: 'canonical',
+          href: `https://docs.cypress.io/guides/${this.path}`
+        }
+      ]
+    }
+  },
+  computed: {
+    meta() {
+      const metaData = {
+        type: 'article',
+        title: this.guide.title,
+        description: this.metaDescription,
+        url: `https://docs.cypress.io/guides/${this.path}`,
+      }
+
+      return getMetaData(metaData)
     }
   },
 }


### PR DESCRIPTION
Fixed:

`/guides/references/` pages now have appropriate meta tags
`/guides/references/` pages now appear selected in the sidebar when the user is currently on a references page