### PR TITLE
docs: correct Long Press example

### DIFF
--- a/source/api/commands/trigger.md
+++ b/source/api/commands/trigger.md
@@ -89,7 +89,7 @@ cy.get('button').trigger('mouseover') // yields 'button'
 ```javascript
 cy.get('.target').trigger('mousedown')
 cy.wait(1000)
-cy.get('.target').trigger('mouseleave')
+cy.get('.target').trigger('mouseup')
 ```
 
 ### Trigger a `mousedown` from a specific mouse button


### PR DESCRIPTION
The existing example says to simulate a "Long Press" by triggering `mousedown` followed by a `wait` and then `mouseleave`. It should be `mousedown`, the `wait`, then `mouseup`.