### PR TITLE
Remove duplicated sentence

### DIFF
--- a/source/_partial/errors_anatomy.md
+++ b/source/_partial/errors_anatomy.md
@@ -1,5 +1,5 @@
 1. **Error name**: This is the type of the error (e.g. AssertionError, CypressError)
-1. **Error message**: This generally tells you what went wrong. It can vary in length. Some are short like in the example, while some are long, and may tell you exactly how to fix the error. Some also contain a **Learn more** link that will take you to relevant Cypress documentation.
+1. **Error message**: This generally tells you what went wrong. It can vary in length. Some are short like in the example, while some are long, and may tell you exactly how to fix the error.
 1. **Learn more:** Some error messages contain a Learn more link that will take you to relevant Cypress documentation.
 1. **Code frame file**: This is usually the top line of the stack trace and it shows the file, line number, and column number that is highlighted in the code frame below. Clicking on this link will open the file in your  [preferred file opener](https://on.cypress.io/IDE-integration#File-Opener-Preference) and highlight the line and column in editors that support it.
 1. **Code frame**: This shows a snippet of code where the failure occurred, with the relevant line and column highlighted.


### PR DESCRIPTION
Removes a sentence that is repeated twice in the doc (see the line below).

ps: Congrats, your documentation is really good, it's such a pleasure to read and follow :tada: 