### PR TITLE
updates

### DIFF
--- a/content/api/plugins/configuration-api.md
+++ b/content/api/plugins/configuration-api.md
@@ -201,7 +201,7 @@ How you choose to edit the configuration is up to you. You don't have to read of
 
 ### Runner Specific Plugins
 
-As of Cypress 7.0, Cypress now includes a [Component Testing](/guides/component-testing/introduction/) specific runner. The exported function from the plugins file recevies three arugments; the third is `mode`, which is either `e2e` or `component` depending on which runner was launched. This allows you to configure runner specific plugins.
+The exported function from the plugins file receives three arguments. The third argument is `mode`, which is either `e2e` or `component` depending on if the E2E or [Component Testing](/guides/component-testing/introduction/) runner was launched. This allows you to configure runner specific plugins.
 
 #### Use Cypress React Plugin Conditionally
 
@@ -216,3 +216,9 @@ module.exports = (on, config, mode) => {
   return config
 }
 ```
+
+## History
+
+| Version                               | Changes                |
+| ------------------------------------- | ---------------------- |
+| [7.0.0](/guides/references/changelog) | Added `mode` argument. |

--- a/content/guides/references/configuration.md
+++ b/content/guides/references/configuration.md
@@ -180,11 +180,11 @@ cypress open --config '{"watchForFileChanges":false,"testFiles":["**/*.js","**/*
 
 ### Runner Specific Overrides
 
-As of Cypress 7.0, Cypress now includes a [Component Testing](/guides/component-testing/introduction/) specific runner. You can override configuration in `cypress.json` for either the E2E or Component Testing runner using the `e2e` and `component` options in `cypress.json`.
+You can override configuration for either the E2E or [Component Testing](/guides/component-testing/introduction/) runner using the `e2e` and `component` options.
 
 #### Examples
 
-Component Testing specific viewports:
+Component Testing specific viewports in configuration file (`cypress.json` by default):
 
 ```json
 {
@@ -197,7 +197,7 @@ Component Testing specific viewports:
 }
 ```
 
-E2E specific timeouts:
+E2E specific timeouts in configuration file (`cypress.json` by default):
 
 ```json
 {
@@ -547,6 +547,7 @@ DEBUG=cypress:cli,cypress:server:specs
 
 | Version                                      | Changes                                                 |
 | -------------------------------------------- | ------------------------------------------------------- |
+| [7.0.0](/guides/references/changelog)        | Added `e2e` and `component` options.                    |
 | [6.1.0](/guides/references/changelog#6-1-0)  | Added option `scrollBehavior`                           |
 | [5.2.0](/guides/references/changelog#5-2-0)  | Added `includeShadowDom` option.                        |
 | [5.0.0](/guides/references/changelog)        | Added `retries` configuration.                          |


### PR DESCRIPTION
- misspellings
- Configuration can be changed in many different ways, not just cypress.json, I assume that the e2e and component config is also accessible in all the other ways outside of just cypress.json? Updated to not be specific to cypress.json.
- Historically we have not mentioned version specific notes in docs - keeping everything current and mentioning in the History section for versioning. 
- Add History logs for 7.0 changes