### PR TITLE
add good result for cypress.json text search

### DIFF
--- a/content/faq/questions/using-cypress-faq.md
+++ b/content/faq/questions/using-cypress-faq.md
@@ -844,7 +844,7 @@ While there is no built-in `snapshot` command in Cypress, you can make your own 
 
 ## <Icon name="angle-right"></Icon> Can I use Testing Library?
 
-Absolutely! Feel free to add the [@testing-library/cypress](https://testing-library.com/docs/cypress-testing-library/intro/) to your setup and use its methods like `findByRole`, `findByLabelText`, `findByText`, and others to find the DOM elements.
+Absolutely! Feel free to add the [@testing-library/cypress](https://testing-library.com/docs/cypress-testing-library/intro/) to your setup and use its methods like `findByRole`, `findByLabelText`, `findByText`, `findByTestId`, and others to find the DOM elements.
 
 The following example comes from the Testing Library's documentation
 

--- a/content/guides/references/configuration.md
+++ b/content/guides/references/configuration.md
@@ -2,7 +2,9 @@
 title: Configuration
 ---
 
-When a project is added to Cypress, a `cypress.json` file is created in the project. This file is used to store the `projectId` ([after configuring your tests to record](/guides/dashboard/projects#Setup)) and any configuration values you supply.
+## cypress.json
+
+The first time you open Cypress Test Runner, it creates the `cypress.json` configuration file. This JSON file is used to store any configuration values you supply. If you [configure your tests to record](/guides/dashboard/projects#Setup) the results to the [Cypress Dashboard](https://on.cypress.io/dashboard-introduction) the `projectId` will be written in this file too.
 
 <Alert type="warning">
 


### PR DESCRIPTION
- added `cypress.json` section heading and rewrite that intro, since it was confusing
- added `findByTestId` to the answer
- partial solution to #3451
