### PR TITLE
Fix broken link

### DIFF
--- a/source/_partial/cypress_env_var_warning.md
+++ b/source/_partial/cypress_env_var_warning.md
@@ -1,3 +1,3 @@
 {% note warning "Difference between OS-level and Cypress environment variables" %}
-In Cypress, "environment variables" are variables that are accessible via `Cypress.env`. These are not the same as OS-level environment variables. However, [it is possible to set Cypress environment variables from OS-level environment variables](/guides/guides/environment-variables.html#Option-3-CYPRESS).
+In Cypress, "environment variables" are variables that are accessible via `Cypress.env`. These are not the same as OS-level environment variables. However, [it is possible to set Cypress environment variables from OS-level environment variables](/guides/guides/environment-variables.html#Option-3-CYPRESS_).
 {% endnote %}


### PR DESCRIPTION
At https://docs.cypress.io/guides/guides/environment-variables, the "it is possible to set Cypress environment variables from OS-level environment variables" link is broken. This should fix it.