### PR TITLE
Fix minor grammatical mistake in requirement

### DIFF
--- a/content/api/commands/request.md
+++ b/content/api/commands/request.md
@@ -329,7 +329,7 @@ The intention of `cy.request()` is to be used for checking endpoints on an actua
 
 ### Requirements [<Icon name="question-circle"/>](/guides/core-concepts/introduction-to-cypress#Chains-of-Commands)
 
-<List><li>`cy.request()` requires being chained off of `cy`.</li><li>`cy.request()` requires that the server send a response.</li><li>`cy.request()` requires that the response status code be `2xx` or `3xx` or `failOnStatusCode` is `true`.</li></List>
+<List><li>`cy.request()` requires being chained off of `cy`.</li><li>`cy.request()` requires that the server sends a response.</li><li>`cy.request()` requires that the response status code be `2xx` or `3xx` or `failOnStatusCode` is `true`.</li></List>
 
 ### Assertions [<Icon name="question-circle"/>](/guides/core-concepts/introduction-to-cypress#Assertions)
 

--- a/scripts/requirements.js
+++ b/scripts/requirements.js
@@ -95,7 +95,7 @@ const createReadFileListItems = (cmd) => {return [
 
 const createRequestListItems = (cmd) => {return [
   createParentCommandListItem(cmd),
-  `${codify(cmd)} requires that the server send a response.`,
+  `${codify(cmd)} requires that the server sends a response.`,
   `${codify(cmd)} requires that the response status code be ${codify(
     '2xx'
   )} or ${codify('3xx')} or ${codify('failOnStatusCode')} is ${codify(


### PR DESCRIPTION
This change fixes a minor grammatical mistake in the requirement when a response from the server is required.