### PR TITLE
Remove duplicated alert message regarding cancel test run on first failure

### DIFF
--- a/content/guides/dashboard/smart-orchestration.md
+++ b/content/guides/dashboard/smart-orchestration.md
@@ -80,14 +80,6 @@ Canceling an **entire** test run, even if parallelized, upon the first test fail
 
 Controlling cancellation of test runs upon the first failed test is a _Smart Orchestration_ feature that is managed within a project's settings.
 
-<Alert type="warning">
-
-<strong class="alert-header">Consideration for Teams</strong>
-
-If your development, testing, or QA teams operate in a highly collaborative workflow where multiple people are working on various test failures at the same time, it may be helpful to disable run cancellation upon first failure, so **all failing tests can be surfaced for each test run**.
-
-</Alert>
-
 <Alert type="info">
 
 <strong class="alert-header">Consideration for Teams</strong>


### PR DESCRIPTION
Title says it all