### PR TITLE
docs: change front matter header from Introduction to Dashboard

### DIFF
--- a/content/guides/dashboard/introduction.md
+++ b/content/guides/dashboard/introduction.md
@@ -1,5 +1,5 @@
 ---
-title: Introduction
+title: Dashboard
 ---
 
 The [Cypress Dashboard](https://on.cypress.io/dashboard) is a service that gives you access to recorded test results - typically when running Cypress tests from your [CI provider](/guides/continuous-integration/introduction). The Dashboard provides you insight into what happened when your tests ran.

--- a/cypress/integration/guides.spec.js
+++ b/cypress/integration/guides.spec.js
@@ -18,16 +18,31 @@ describe('Guides', () => {
           cy.get('.app-sidebar').contains(guides[category])
 
           cy.wrap(pages).each((page) => {
-            const pageTitle = guides[page]
+            /**
+             * The `title` in the front matter is _usually_ the same as the
+             * `en.json` data for that key. However, some exceptions exist
+             * which use a front matter `title` that does not match.
+             */
+            const titleMismatches = {
+              'dashboard-introduction': 'Dashboard',
+            }
+
+            const pageTitle = titleMismatches[page] || guides[page]
 
             if (page === 'component-testing-introduction') {
               // for now, bypass an error thrown on this page by vue-meta
               return
             }
 
+            // Title on /guides/dashboard/introduction is "Dashboard" whereas the sidebar
+            // item is "Introduction"
+            const sidebarItemMismatches = {
+              Dashboard: 'Introduction',
+            }
+
             cy.contains(
               `.app-sidebar [data-test="${category}"] a`,
-              pageTitle
+              sidebarItemMismatches[pageTitle] || pageTitle
             ).click({ force: true })
 
             const redirects = {
@@ -43,7 +58,7 @@ describe('Guides', () => {
 
             cy.contains(
               `.app-sidebar [data-test="${category}"] a`,
-              pageTitle
+              sidebarItemMismatches[pageTitle] || pageTitle
             ).should(
               'have.class',
               'nuxt-link-exact-active nuxt-link-active active-sidebar-link'


### PR DESCRIPTION
Changes front matter title from "Introduction" to "Dashboard" on the dashboard introduction doc so the `docsearch-scraper` can index this page better for when users search "Dashboard"