### PR TITLE
fix: Add doc for selecting an element with id that uses CSS characters.

### DIFF
--- a/content/api/commands/get.md
+++ b/content/api/commands/get.md
@@ -116,6 +116,12 @@ cy.get('[id$=-remote]')
 cy.get('[id^=local-][id$=-remote]')
 ```
 
+#### Find the element with id that has characters used in CSS like ".", ":".
+
+```javascript
+cy.get('#id\\.\\.\\.1234') // escape the character with \\
+```
+
 ### Get in `.within()`
 
 #### `cy.get()` in the [`.within()`](/api/commands/within) command


### PR DESCRIPTION
Related with cypress-io/cypress#15020