### PR TITLE
Document issues pending release and missing from the changelog

### DIFF
--- a/content/_changelogs/5.5.0.md
+++ b/content/_changelogs/5.5.0.md
@@ -16,7 +16,7 @@ _Released 10/26/2020_
 - Headers field names passed to [`cy.route2()`](http) now case-insensitively match against the field names of incoming HTTP requests. Fixes [#8921](https://github.com/cypress-io/cypress/issues/8921).
 - Routes that stub fixtures for binary resources (including images) made with [`cy.route2()`](http) now serve the correct mime-type and content. Fixes [#8623](https://github.com/cypress-io/cypress/issues/8623).
 - When [experimentalNetworkStubbing](/guides/references/experiments) is enabled, using [cy.visit()](/api/commands/visit) to URLs that redirect and set Transfer-Encoding: chunked will no longer fail in Cypress with a "Parse Error". Fixes [#8497](https://github.com/cypress-io/cypress/issues/8497).
-- `cypress.run()` through the [Module API](/guides/guides/module-api) now has a `status` property in the results matching the correct CLI types (`"failed"` or `"finished"`). Addresses [#8799](https://github.com/cypress-io/cypress/issues/8799).
+- `cypress.run()` through the [Module API](/guides/guides/module-api) now has a `status` property in the results matching the correct CLI types (`"failed"` or `"finished"`). Addresses [#8798](https://github.com/cypress-io/cypress/issues/8798).
 - When a value containing an `e` character is passed to the `--ci-build-id` flag, Cypress now properly reads it as a string. Fixes [#8874](https://github.com/cypress-io/cypress/issues/8874).
 
 **Misc:**

--- a/content/_changelogs/6.1.0.md
+++ b/content/_changelogs/6.1.0.md
@@ -15,6 +15,7 @@ _Released 12/07/2020_
 - We fixed an issue where HTTP redirects could not be awaited using [cy.intercept()](/api/commands/intercept) unless dynamically intercepted. Addressed in [#9097](https://github.com/cypress-io/cypress/issues/9097).
 - Tests will no longer hang in certain situations when there's an error in a `before()` hook. Fixes [#9162](https://github.com/cypress-io/cypress/issues/9162).
 - We no longer strip `/` from URLs when they are explicitly passed with query paramaters. Fixes [#9360](https://github.com/cypress-io/cypress/issues/9360).
+- Fixed the regression [#8998](https://github.com/cypress-io/cypress/issues/8998) in `Cypress.dom.isVisible` behavior for elements with `position: fixed`
 
 **Deprecations:**
 

--- a/content/_changelogs/6.1.0.md
+++ b/content/_changelogs/6.1.0.md
@@ -15,7 +15,7 @@ _Released 12/07/2020_
 - We fixed an issue where HTTP redirects could not be awaited using [cy.intercept()](/api/commands/intercept) unless dynamically intercepted. Addressed in [#9097](https://github.com/cypress-io/cypress/issues/9097).
 - Tests will no longer hang in certain situations when there's an error in a `before()` hook. Fixes [#9162](https://github.com/cypress-io/cypress/issues/9162).
 - We no longer strip `/` from URLs when they are explicitly passed with query paramaters. Fixes [#9360](https://github.com/cypress-io/cypress/issues/9360).
-- Fixed the regression [#8998](https://github.com/cypress-io/cypress/issues/8998) in `Cypress.dom.isVisible` behavior for elements with `position: fixed`
+- Fixed the regression in `Cypress.dom.isVisible` behavior for elements with `position: fixed`, addresses [#8998](https://github.com/cypress-io/cypress/issues/8998) and [#9031](https://github.com/cypress-io/cypress/issues/9031).
 
 **Deprecations:**
 

--- a/content/_changelogs/6.2.0.md
+++ b/content/_changelogs/6.2.0.md
@@ -18,6 +18,7 @@ _Released 12/21/2020_
 - Using [Cypress.Commands.overwrite](/api/cypress-api/custom-commands#Overwrite-Existing-Commands) to overwrite [.then()](/api/commands/then) now preserves the proper `this` context and sets aliases correctly. Fixes [#5101](https://github.com/cypress-io/cypress/issues/5101).
 - Using [Cypress.Commands.overwrite](/api/cypress-api/custom-commands#Overwrite-Existing-Commands) to overwrite [cy.route()](/api/commands/route) or [cy.intercept()](/api/commands/intercept) and wait on its alias now properly works. Fixes [#3890](https://github.com/cypress-io/cypress/issues/3890) and [#9580](https://github.com/cypress-io/cypress/issues/9580).
 - Cypress no longer fails to find specs if you set the fixtures folder to be the same as the integration folder. Fixes [#14226](https://github.com/cypress-io/cypress/issues/14226).
+- Cypress no longer fails to show error code frames if the spec filename has a space in it, fixes [#7553](https://github.com/cypress-io/cypress/issues/7553).
 
 **Misc:**
 

--- a/content/_changelogs/6.4.0.md
+++ b/content/_changelogs/6.4.0.md
@@ -14,7 +14,7 @@ _Released 2/1/2021_
 
 - Fixed an issue causing a webpack compilation error when a `browserslist` is present in project root. Addresses [#8864](https://github.com/cypress-io/cypress/issues/8864).
 - Fixed an issue with [cy.intercept()](/api/commands/intercept) where aliases set via `req.alias` containing a period character would not work as expected. Addresses [#14444](https://github.com/cypress-io/cypress/issues/14444).
-- Fixed an issue where delays set using [cy.intercept()](/api/commands/intercept) would not work as expected. Addresses [#14446](https://github.com/cypress-io/cypress/issues/14446).
+- Fixed an issue where delays set using [cy.intercept()](/api/commands/intercept) would not work as expected. Addresses [#14446](https://github.com/cypress-io/cypress/issues/14446) and [#14511](https://github.com/cypress-io/cypress/issues/14511).
 - Reverted a change to how the Chrome DevTools Protocol is established. Instead of using stdio and then falling back to TCP, Cypress now only uses TCP to try to connect to Chrome DevTools Protocol. Addresses [#14819](https://github.com/cypress-io/cypress/issues/14819).
 - We now better handle spec paths containing special characters so they properly show in the code frame and work when interacting via your IDE. Addresses [#14659](https://github.com/cypress-io/cypress/issues/14659).
 - We addressed several issues with the experimental [Cypress Studio](/guides/core-concepts/cypress-studio). To enable the Cypress Studio you can set `experimentalStudio` to `true` in your Cypress configuration. Issues addressed:

--- a/content/_changelogs/6.5.0.md
+++ b/content/_changelogs/6.5.0.md
@@ -19,6 +19,7 @@ _Released 2/15/2021_
 
 - Expanded search bar in desktop GUI to fill the entire width. Addresses [#14830](https://github.com/cypress-io/cypress/issues/14830).
 - Added `autoEnd` to the types for `LogConfig`. Addresses [#9590](https://github.com/cypress-io/cypress/issues/9590).
+- We collect more variables from Bitbucket pipelines to correctly display the pull request information in the Dashboard. Addresses [#15081](https://github.com/cypress-io/cypress/issues/15081).
 
 **Dependency Updates:**
 

--- a/content/_changelogs/6.7.0.md
+++ b/content/_changelogs/6.7.0.md
@@ -19,6 +19,7 @@ _Released 3/15/2021_
 - When using `experimentalStudio`, [Cypress Studio](/guides/core-concepts/cypress-studio) now records typing by using the value of the input rather than the keys that were pressed. Studio also no longer records pressing special keys (such as arrows or ctrl) except for Enter. Fixes [#15023](https://github.com/cypress-io/cypress/issues/15023).
 - Empty jQuery objects are now properly shown in error messages in the Command Log. Fixes [#14279](https://github.com/cypress-io/cypress/issues/14279).
 - Length assertions on DOM elements now properly show the user-defined assertion message if specified. Fixes [#14484](https://github.com/cypress-io/cypress/issues/14484).
+- Cypress no longer scrolls on `mouse down` event, fixes [#8279](https://github.com/cypress-io/cypress/issues/8279).
 
 **Misc:**
 

--- a/content/_changelogs/7.0.0.md
+++ b/content/_changelogs/7.0.0.md
@@ -30,6 +30,7 @@ _Released 04/05/2021_
 - `Cypress.moment()` has been removed. Please migrate to a different datetime formatter. See [our recipe](https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/blogs__dayjs) for example replacements. Addresses [#8714](https://github.com/cypress-io/cypress/issues/8714).
 - The bundled Node.js version was upgraded from `12.18.3` to `14.16.0`. This could change the behavior of code within the `pluginsFile` when using the [bundled Node.js version](guides/references/configuration#Node-version) of Cypress. Addressed in [#15292](https://github.com/cypress-io/cypress/pull/15292).
 - Installing Cypress on your system now requires Node.js 12+. Addresses [#9545](https://github.com/cypress-io/cypress/issues/9545).
+- The default headless browser window size has been increased to 1920x1080 pixels to capture [High-definition videos and screenshots](https://www.cypress.io/blog/2021/03/01/generate-high-resolution-videos-and-screenshots/). Addresses [#15752](https://github.com/cypress-io/cypress/issues/15752), [#15730](https://github.com/cypress-io/cypress/issues/15730), and [#15481](https://github.com/cypress-io/cypress/issues/15481).
 
 **Features:**
 


### PR DESCRIPTION
Several issues that were closed without a release are missing from the changelog. After landing this change, I will go through the relevant releases in our GitHub repo and will update them