### PR TITLE
feat: reusable partials for markdown files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,6 +125,10 @@ Assume you have a `<Partial>` Vue component. If you wanted to introduce a `<Part
 
 For most use cases, you should use the `::include{file=FILE_NAME}` directive when you want to inject reusable markdown into multiple files. A `<Partial>` Vue component may be a better fit if you wish to add custom interactivity to reusable strings of text.
 
+#### Limitations
+
+When including the `::include{file=FILE_NAME}` directive in another markdown file, Nuxt's hot module reloading will automatically trigger the partial's content to be inserted into the markdown file. However, if you wish to make changes to the partial file itself, you will need to stop and restart the development server with `yarn start` to see the changes. This is because the custom remark plugin that is enabling this partial system is only ran when the server is started and not on each hot module reload.
+
 ### Adding Examples
 
 To add a course, blog, talk, podcast, or screencast to our docs, submit a [pull request](#Pull-Requests) with your data added to the corresponding [courses.json](/content/_data/courses.json), [blogs.json](/content/_data/blogs.json), [talks.json](/content/_data/talks.json), [podcasts.json](/content/_data/podcasts.json) or [screencasts.json](/content/_data/screencasts.json) file.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,7 @@ Thanks for taking the time to contribute! :smile:
     - [Images](#images)
     - [Videos](#videos)
     - [Icons](#icons)
+  - [Partials](#using-snippets)
   - [Adding Examples](#adding-examples)
   - [Adding Plugins](#adding-plugins)
   - [Adding Pages](#adding-pages)
@@ -81,6 +82,48 @@ You can embed videos within the markdown with the [`<DocsVideo>`](/components/gl
 ```jsx
 <Icon name="question-circle"></Icon>
 ```
+
+### Partials
+
+Partials are snippets of reusable markdown that can be inserted into other markdown files. You may want to use a partial when you are writing the same content across multiple markdown files.
+
+#### Writing a Partial
+
+A partial is a markdown file that you want to import and inject into another markdown file. They can contain any content that you would otherwise want to write in other markdown files.
+
+```md
+## My First Partial
+
+<Alert type="info">
+
+This is my reusable partial.
+
+</Alert>
+```
+
+#### Using Partials
+
+Partials can be imported into other markdown files with the `::include{file=FILE_NAME}` directive.
+
+```md
+## My Favorite Food
+
+### Pizza
+
+::include{file=path/to/pizza-recipe.md}
+```
+
+When the page is generated, the content of `path/to/pizza-recipe.md` will be injected into the markdown file.
+
+The `::include{file=FILE_NAME}` directive assumes that the `FILE_NAME` exists within the `content` directory. You must provide the path relative to the `content` directory as the `file` property. For example, if the partial `pizza-recipe.md` was located at `/content/recipes/pizza-recipe.md`, the `::include` directive would be `::include{file=recipes/pizza-recipe.md}`.
+
+#### When to use Partials instead of Vue components
+
+It is possible to create partials using Vue components in the markdown instead of using the `::include{file=FILE_NAME}` directive. However, there are downsides to this approach.
+
+Assume you have a `<Partial>` Vue component. If you wanted to introduce a `<Partial>` to a markdown file and let that partial add a new header to the page, you would need to add a header element to the `<Partial>` component. Due to how each page's table of contents is generated, this new header would not appear in the "On This Page" section that appears on the right-hand side of most documentation pages. The header would also be missing the anchor tag that is otherwise automatically inserted into all headers.
+
+For most use cases, you should use the `::include{file=FILE_NAME}` directive when you want to inject reusable markdown into multiple files. A `<Partial>` Vue component may be a better fit if you wish to add custom interactivity to reusable strings of text.
 
 ### Adding Examples
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Thanks for taking the time to contribute! :smile:
     - [Images](#images)
     - [Videos](#videos)
     - [Icons](#icons)
-  - [Partials](#using-snippets)
+  - [Partials](#partials)
   - [Adding Examples](#adding-examples)
   - [Adding Plugins](#adding-plugins)
   - [Adding Pages](#adding-pages)

--- a/content/guides/overview/snippet.md
+++ b/content/guides/overview/snippet.md
@@ -1,0 +1,9 @@
+## Hello World
+
+This is my snippet.
+
+<Alert type="info">
+
+Hi from my snippet!
+
+</Alert>

--- a/content/guides/overview/snippet.md
+++ b/content/guides/overview/snippet.md
@@ -1,9 +1,0 @@
-## Hello World
-
-This is my snippet.
-
-<Alert type="info">
-
-Hi from my snippet!
-
-</Alert>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -81,6 +81,16 @@ export default {
    */
   content: {
     markdown: {
+      remarkPlugins: (_defaultPlugins) => {return [
+        'remark-directive',
+        '~/scripts/remarkPartialPlugin.js',
+        'remark-squeeze-paragraphs',
+        'remark-slug',
+        'remark-autolink-headings',
+        'remark-external-links',
+        'remark-footnotes',
+        'remark-gfm',
+      ]},
       prism: {
         theme: 'prism-themes/themes/prism-material-oceanic.css',
       },

--- a/package.json
+++ b/package.json
@@ -38,13 +38,11 @@
     "@nuxtjs/sentry": "^5.0.3",
     "@tailwindcss/forms": "^0.2.1",
     "deepdash": "^5.3.5",
-    "hastscript": "^6.0.0",
     "nuxt": "^2.13.0",
     "prism-themes": "^1.4.0",
     "remark-directive": "^1.0.1",
     "replace-in-file": "^6.2.0",
     "unist-util-visit": "^2.0.3",
-    "unist-util-visit-children": "^2.0.0",
     "vue-scrollactive": "^0.9.3",
     "yamljs": "^0.3.0"
   },

--- a/package.json
+++ b/package.json
@@ -38,9 +38,13 @@
     "@nuxtjs/sentry": "^5.0.3",
     "@tailwindcss/forms": "^0.2.1",
     "deepdash": "^5.3.5",
+    "hastscript": "^6.0.0",
     "nuxt": "^2.13.0",
     "prism-themes": "^1.4.0",
+    "remark-directive": "^1.0.1",
     "replace-in-file": "^6.2.0",
+    "unist-util-visit": "^2.0.3",
+    "unist-util-visit-children": "^2.0.0",
     "vue-scrollactive": "^0.9.3",
     "yamljs": "^0.3.0"
   },

--- a/scripts/remarkPartialPlugin.js
+++ b/scripts/remarkPartialPlugin.js
@@ -40,6 +40,11 @@ module.exports = function remarkPartialPlugin() {
     const { file } = attributes
 
     if (!file) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        'Found a "::include" directive without a "name" attribute. You might have intended to import a partial into a markdown file, but no partial can be found without the "file" attribute. The "::include" directive should look like "::include{file=path/to/file}".'
+      )
+
       return
     }
 

--- a/scripts/remarkPartialPlugin.js
+++ b/scripts/remarkPartialPlugin.js
@@ -69,7 +69,7 @@ function readFile(filepath) {
     console.error(
       `Failed to read file: ${filepath}`,
       error,
-      'This error is due to a problem with templating. Check your markdown files for the "::include{file=PATH_TO_FILE}" directive and make sure that PATH_TO_FILE exists. If this issue persists, please open a new issue with steps to reproduce.'
+      'This error is due to a problem with partials. Check your markdown files for the "::include{file=PATH_TO_FILE}" directive and make sure that PATH_TO_FILE exists. If this issue persists, please open a new issue with steps to reproduce.'
     )
   }
 }

--- a/scripts/remarkPartialPlugin.js
+++ b/scripts/remarkPartialPlugin.js
@@ -1,0 +1,70 @@
+const fs = require('fs')
+const path = require('path')
+const unified = require('unified')
+const visit = require('unist-util-visit')
+const markdown = require('remark-parse')
+const remark2rehype = require('remark-rehype')
+const squeezeParagraphs = require('remark-squeeze-paragraphs')
+const slug = require('remark-slug')
+const autolinkHeadings = require('remark-autolink-headings')
+const externalLinks = require('remark-external-links')
+const remarkFootnotes = require('remark-footnotes')
+const gfm = require('remark-gfm')
+
+const processor = unified()
+  .use(markdown)
+  .use(remark2rehype)
+  .use(squeezeParagraphs)
+  .use(slug)
+  .use(externalLinks)
+  .use(autolinkHeadings)
+  .use(remarkFootnotes)
+  .use(gfm)
+
+const INCLUDE_DIRECTIVE_NAME = 'include'
+
+module.exports = function remarkPartialPlugin() {
+  return transform
+
+  function transform(tree) {
+    visit(tree, ['leafDirective'], onDirective)
+  }
+
+  function onDirective(node, index, parent) {
+    const { name, attributes } = node
+
+    if (name !== INCLUDE_DIRECTIVE_NAME) {
+      return
+    }
+
+    const { file } = attributes
+
+    if (!file) {
+      return
+    }
+
+    const snippet = readFile(file)
+    const result = processor.parse(snippet)
+
+    parent.children.splice(index, 1, ...result.children)
+  }
+}
+
+function readFile(filepath) {
+  if (!filepath) {
+    return
+  }
+
+  try {
+    return fs.readFileSync(path.join(__dirname, '../content/', filepath), {
+      encoding: 'utf8',
+    })
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error(
+      `Failed to read file: ${filepath}`,
+      error,
+      'This error is due to a problem with templating. Check your markdown files for the "::include{file=PATH_TO_FILE}" directive and make sure that PATH_TO_FILE exists. If this issue persists, please open a new issue with steps to reproduce.'
+    )
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -11526,6 +11526,17 @@ mdast-util-definitions@^4.0.0:
   dependencies:
     unist-util-visit "^2.0.0"
 
+mdast-util-directive@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mdast-util-directive/-/mdast-util-directive-1.0.1.tgz#bc2aea94eee5b89f2d11bf4546d40453e0b34cc6"
+  integrity sha512-VuO1za7BMtWMg8KA8eZrTBorEnCOOW5CXfIuNzUXe7YPie/wLgmNk/jxLMY8m+mzuqnO5eN0JuvlgFtO9EJpbQ==
+  dependencies:
+    mdast-util-to-markdown "^0.6.0"
+    parse-entities "^2.0.0"
+    repeat-string "^1.0.0"
+    stringify-entities "^3.1.0"
+    unist-util-visit-parents "^3.0.0"
+
 mdast-util-find-and-replace@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/mdast-util-find-and-replace/-/mdast-util-find-and-replace-1.1.0.tgz#8b782285741b05310e3641196dfc4b17bc30d971"
@@ -11727,6 +11738,14 @@ micro-memoize@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/micro-memoize/-/micro-memoize-2.1.2.tgz#0787eeb1a12b4033a0fe162dfc9df4280291cee4"
   integrity sha512-COjNutiFgnDHXZEIM/jYuZPwq2h8zMUeScf6Sh6so98a+REqdlpaNS7Cb2ffGfK5I+xfgoA3Rx49NGuNJTJq3w==
+
+micromark-extension-directive@^1.0.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/micromark-extension-directive/-/micromark-extension-directive-1.3.0.tgz#8b9214d7bf9177f866214a6c745c27a0917503fd"
+  integrity sha512-sbIkwLU6Xj2p4l29PnsN6Jjj2L2bCo9urE3rgft4kK4s73WLbmvUVLUQej0TNK8RJGujzvKAAYeqfPYgaH69zA==
+  dependencies:
+    micromark "~2.11.0"
+    parse-entities "^2.0.0"
 
 micromark-extension-footnote@^0.3.0:
   version "0.3.2"
@@ -15004,6 +15023,14 @@ remark-autolink-headings@^6.0.1:
     extend "^3.0.0"
     unist-util-visit "^2.0.0"
 
+remark-directive@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/remark-directive/-/remark-directive-1.0.1.tgz#13356db9c893d16ad15406e4b77a389525c4bdf9"
+  integrity sha512-x6rZs0qa0zu9gW7Avd+rRxHJL2K9TGk+c51NaLfQgCNI7SxwBycRJ3w5mMkjkIjO6O9/qdx0ntu48byCSgF96Q==
+  dependencies:
+    mdast-util-directive "^1.0.0"
+    micromark-extension-directive "^1.0.0"
+
 remark-external-links@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/remark-external-links/-/remark-external-links-8.0.0.tgz#308de69482958b5d1cd3692bc9b725ce0240f345"
@@ -16261,7 +16288,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-stringify-entities@^3.0.1:
+stringify-entities@^3.0.1, stringify-entities@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/stringify-entities/-/stringify-entities-3.1.0.tgz#b8d3feac256d9ffcc9fa1fefdcf3ca70576ee903"
   integrity sha512-3FP+jGMmMV/ffZs86MoghGqAoqXAdxLrJP4GUdrDN1aIScYih5tuIO3eF4To5AJZ79KDZ8Fpdy7QJnK8SsL1Vg==
@@ -17294,6 +17321,13 @@ unist-util-stringify-position@^2.0.0:
   integrity sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==
   dependencies:
     "@types/unist" "^2.0.2"
+
+unist-util-visit-children@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/unist-util-visit-children/-/unist-util-visit-children-2.0.0.tgz#c853e309863d764e4aaf69795f999c4e1c94b44a"
+  integrity sha512-n8CvdoeexGn6EkAa865Wp9SFFuS1IKf1j0vMoEwHHfA5f48gJPK6rwS/s/P+ouRDfAklQaiBQtlloX3KadUrww==
+  dependencies:
+    "@types/unist" "^2.0.0"
 
 unist-util-visit-parents@^3.0.0:
   version "3.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -17322,13 +17322,6 @@ unist-util-stringify-position@^2.0.0:
   dependencies:
     "@types/unist" "^2.0.2"
 
-unist-util-visit-children@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/unist-util-visit-children/-/unist-util-visit-children-2.0.0.tgz#c853e309863d764e4aaf69795f999c4e1c94b44a"
-  integrity sha512-n8CvdoeexGn6EkAa865Wp9SFFuS1IKf1j0vMoEwHHfA5f48gJPK6rwS/s/P+ouRDfAklQaiBQtlloX3KadUrww==
-  dependencies:
-    "@types/unist" "^2.0.0"
-
 unist-util-visit-parents@^3.0.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-3.1.1.tgz#65a6ce698f78a6b0f56aa0e88f13801886cdaef6"


### PR DESCRIPTION
## Overview

This PR introduces the concept of ✨  **partials** :sparkles: to the docs.

## What is a partial?

Partials are reusable markdown files that can be injected into other markdown files!

```md
## Hello world

<Alert type="info">

This is my partial.

</Alert>
```

If you want to import this partial into another markdown file, you can use the following syntax:

```md
## My Other Markdown File

::include{file=path/to/partial.md}
```

This is similar to the custom Hexo tags that existed in the previous docs: `{% partial foo %}`

For more info, see the updates to `CONTRIBUTING.md`.

## Future improvements

The previous custom Hexo tags allowed users to pass arguments. The current partial system can be extended to allow users to pass arguments into the template. This could theoretically look like: `::include{file=path/to/file, $1=foo, $2=bar}` which can be handled inside `remarkPartialPlugin.js` when the partial's AST is spliced into the markdown file's AST.
