### PR TITLE
chore: fix firefox uncaught:exception sometimes failing test

### DIFF
--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -16,5 +16,10 @@
 // Import commands.js using ES2015 syntax:
 import './commands'
 
-// Alternatively you can use CommonJS syntax:
-// require('./commands')
+// in firefox, sometimes a page load will throw this uncaught exception
+// this has occured since docs moved to nuxt
+Cypress.on('uncaught:exception', (err) => {
+  if (err.message.includes('link.__prefetch')) {
+    return false
+  }
+})


### PR DESCRIPTION
ever since the move to `nuxt`, firefox tests (which run on TR CI on develop)have been failing:
![image](https://user-images.githubusercontent.com/14625260/114785866-44f5ce80-9d4b-11eb-8cb1-42bcb1e65b65.png)

looks like some uncaught exception that periodically gets thrown, but isn't under our control, so let's just ignore it