### PR TITLE
add note about electron version

### DIFF
--- a/content/api/cypress-api/version.md
+++ b/content/api/cypress-api/version.md
@@ -25,3 +25,7 @@ if (semver.gte(Cypress.version, '1.1.3')) {
 ```
 
 **Hint:** you can use [semver](https://github.com/npm/node-semver#readme) library to work with semantic versions.
+
+## See also
+
+To find the version of the Electron component, or the bundled Node version, use the Cypress CLI command [cypress version](/guides/guides/command-line#cypress-version).


### PR DESCRIPTION
There was a question in the Gitter chat and I checked - our docs search returns nothing meaningful

<img width="584" alt="Screen Shot 2021-04-16 at 9 38 43 AM" src="https://user-images.githubusercontent.com/2212006/115033227-2d782c00-9e98-11eb-9c23-3c79fdc98b5c.png">
