### PR TITLE
update docker usage notes

### DIFF
--- a/content/guides/getting-started/installing-cypress.md
+++ b/content/guides/getting-started/installing-cypress.md
@@ -48,7 +48,7 @@ yum install -y xorg-x11-server-Xvfb gtk2-devel gtk3-devel libnotify-devel GConf2
 
 Docker images with all of the required dependencies installed are available under [cypress/base](https://github.com/cypress-io/cypress-docker-images)
 
-If you're running your projects in containers, then you'll want cypress in the container with the node process.
+If you're running your projects in containers, then you'll want Cypress in the container with the Node.js process.
 
 ```
   ui:

--- a/content/guides/getting-started/installing-cypress.md
+++ b/content/guides/getting-started/installing-cypress.md
@@ -32,8 +32,6 @@ If you're using `npm` to install Cypress, we support:
 
 If you're using Linux, you'll want to have the required dependencies installed on your system.
 
-We also have an official [cypress/base](https://hub.docker.com/r/cypress/base/) Docker container with all of the required dependencies installed.
-
 #### Ubuntu/Debian
 
 ```shell
@@ -45,6 +43,22 @@ apt-get install libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 lib
 ```shell
 yum install -y xorg-x11-server-Xvfb gtk2-devel gtk3-devel libnotify-devel GConf2 nss libXScrnSaver alsa-lib
 ```
+
+#### Docker
+
+Docker images with all of the required dependencies installed are available under [cypress/base](https://github.com/cypress-io/cypress-docker-images)
+
+If you're running your projects in containers, then you'll want cypress in the container with the node process.
+
+```
+  ui:
+    image: cypress/base:latest
+    # if targeting a specific node version, use e.g.
+    # image: cypress/base:14
+```
+
+`cypress/base` is a drop-in replacement for [base docker node images](https://hub.docker.com/_/node/). 
+
 
 ## Installing
 


### PR DESCRIPTION
## I'm submitting a...

```
[ ] Bug report
[x] Content update
[ ] Process update (build, deployment, ... )
```

## Type of bug / changes

I was trying to get started with cypress (thanks for the great talk at VueConf2021!). 

https://docs.cypress.io/guides/getting-started/installing-cypress#System-requirements

I wanted to use docker, which took me to:

```
We also have an official cypress/base Docker container with all of the required dependencies installed.
```

Which goes to:
https://hub.docker.com/r/cypress/base/

![Screenshot from 2021-04-21 17-29-20-cypress-docker](https://user-images.githubusercontent.com/2225624/115624718-04f19700-a2c9-11eb-9f8f-2a3bad9d9052.png)


On that page in the Sample Dockerfile it shows:

```
cypress/base:10
```

Seems obvious now (rookie mistake!), but I didn't catch that the suffix corresponds to the version of node. Node 10 isn't compatible with the latest version of cypress, so when I tried to add cypress in the container with `yarn add cypress --dev`, it failed. 

changing to
```
    image: cypress/base:latest
```
fixed the issue

I would have found it more useful to link to [cypress-io/cypress-docker-images](https://github.com/cypress-io/cypress-docker-images)

Here's one possible update. 