### PR TITLE
Fix: gh link with hash that has quotes around it.

### DIFF
--- a/content/faq/questions/using-cypress-faq.md
+++ b/content/faq/questions/using-cypress-faq.md
@@ -559,7 +559,7 @@ Cypress.Cookies.defaults({
 })
 ```
 
-You **cannot** currently preserve localStorage across tests and can read more [here](https://github.com/cypress-io/cypress/issues/'461#issuecomment-325402086').
+You **cannot** currently preserve localStorage across tests and can read more [here](https://github.com/cypress-io/cypress/issues/461#issuecomment-325402086).
 
 ## <Icon name="angle-right"></Icon> Some of my elements animate in; how do I work around that?
 


### PR DESCRIPTION
- Close #3879 

This is easily fixed but wondering how this happened to begin with and whether other links are affected.