### PR TITLE
fix: Removed duplicate plugin warnings

### DIFF
--- a/content/api/plugins/browser-launch-api.md
+++ b/content/api/plugins/browser-launch-api.md
@@ -12,12 +12,6 @@ Before Cypress launches a browser, it gives you the opportunity to modify the br
 
 </Alert>
 
-<Alert type="warning">
-
-⚠️ This code is part of the [plugins file](/guides/core-concepts/writing-and-organizing-tests.html#Plugin-files) and thus executes in the Node environment. You cannot call `Cypress` or `cy` commands in this file, but you do have the direct access to the file system and the rest of the operating system.
-
-</Alert>
-
 ```js
 on('before:browser:launch', (browser = {}, launchOptions) => {
   /* ... */

--- a/content/api/plugins/configuration-api.md
+++ b/content/api/plugins/configuration-api.md
@@ -12,12 +12,6 @@ Cypress enables you to dynamically modify configuration values and environment v
 
 </Alert>
 
-<Alert type="warning">
-
-⚠️ This code is part of the [plugins file](/guides/core-concepts/writing-and-organizing-tests.html#Plugin-files) and thus executes in the Node environment. You cannot call `Cypress` or `cy` commands in this file, but you do have the direct access to the file system and the rest of the operating system.
-
-</Alert>
-
 To modify configuration, you return an object from your plugins file exported function.
 
 ```javascript

--- a/content/guides/tooling/plugins-guide.md
+++ b/content/guides/tooling/plugins-guide.md
@@ -126,12 +126,6 @@ The [Real World App (RWA)](https://github.com/cypress-io/cypress-realworld-app) 
 
 </Alert>
 
-<Alert type="warning">
-
-⚠️ This code is part of the [plugins file](/guides/core-concepts/writing-and-organizing-tests.html#Plugin-files) and thus executes in the Node environment. You cannot call `Cypress` or `cy` commands in this file, but you do have the direct access to the file system and the rest of the operating system.
-
-</Alert>
-
 ```ts
 // cypress/plugins/index.ts
 


### PR DESCRIPTION
Looks like a bad merge occurred, resulting in duplicated warnings on several pages.