### PR TITLE
7.3.0: add log source for ci info

### DIFF
--- a/content/guides/references/troubleshooting.md
+++ b/content/guides/references/troubleshooting.md
@@ -230,25 +230,26 @@ This allows you to isolate the problem a little better
 
 Cypress is built from multiple packages, each responsible for its own logging: server, reporter, driver, command line, etc. Each package writes debug logs under a different source. Here are a few common log sources and when you might want to enable them
 
-| Set `DEBUG` to value          | To enable debugging                         |
-| ----------------------------- | ------------------------------------------- |
-| `cypress:cli`                 | The top-level command line parsing problems |
-| `cypress:server:args`         | Incorrect parsed command line arguments     |
-| `cypress:server:specs`        | Not finding the expected specs              |
-| `cypress:server:project`      | Opening the project                         |
-| `cypress:server:browsers`     | Finding installed browsers                  |
-| `cypress:launcher`            | Launching the found browser                 |
-| `cypress:server:video`        | Video recording                             |
-| `cypress:network:*`           | Adding network interceptors                 |
-| `cypress:net-stubbing*`       | Network interception in the proxy layer     |
-| `cypress:server:reporter`     | Problems with test reporters                |
-| `cypress:server:preprocessor` | Processing specs                            |
-| `cypress:server:plugins`      | Running the plugins file and bundling specs  |
-| `cypress:server:socket-e2e`   | Watching spec files                         |
-| `cypress:server:task`         | Invoking the `cy.task` command              |
-| `cypress:server:socket-base`  | Debugging `cy.request` command              |
-| `cypress:webpack`             | Bundling specs using webpack                |
-| `cypress:server:fixture`      | Loading fixture files                       |
+| Set `DEBUG` to value            | To enable debugging                                                   |
+| ------------------------------- | --------------------------------------------------------------------- |
+| `cypress:cli`                   | The top-level command line parsing problems                           |
+| `cypress:server:args`           | Incorrect parsed command line arguments                               |
+| `cypress:server:specs`          | Not finding the expected specs                                        |
+| `cypress:server:project`        | Opening the project                                                   |
+| `cypress:server:browsers`       | Finding installed browsers                                            |
+| `cypress:launcher`              | Launching the found browser                                           |
+| `cypress:server:video`          | Video recording                                                       |
+| `cypress:network:*`             | Adding network interceptors                                           |
+| `cypress:net-stubbing*`         | Network interception in the proxy layer                               |
+| `cypress:server:reporter`       | Problems with test reporters                                          |
+| `cypress:server:preprocessor`   | Processing specs                                                      |
+| `cypress:server:plugins`        | Running the plugins file and bundling specs                           |
+| `cypress:server:socket-e2e`     | Watching spec files                                                   |
+| `cypress:server:task`           | Invoking the `cy.task` command                                        |
+| `cypress:server:socket-base`    | Debugging `cy.request` command                                        |
+| `cypress:webpack`               | Bundling specs using webpack                                          |
+| `cypress:server:fixture`        | Loading fixture files                                                 |
+| `cypress:server:record:ci-info` | Git commit and CI information when recording to the Cypress Dashboard |
 
 You can combine several areas together using the comma character. For example, to debug specs not being found, use:
 


### PR DESCRIPTION
After releasing v7.3.0 explains the new log source

https://github.com/cypress-io/cypress/pull/16238