### PR TITLE
chore: remove windi vue-preprocessor

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -92,19 +92,6 @@ export default {
    */
   build: {
     loadingScreen: process.env.NODE_ENV === 'development',
-    extend(config) {
-      config.module.rules.push({
-        test: /\.vue$/,
-        loader: 'vue-windicss-preprocess',
-        options: {
-          config: "tailwind.config.js",  // tailwind config file path (optional)
-          compile: false,                // false: interpretation mode; true: compilation mode
-          globalPreflight: true,         // set preflight style is global or scoped
-          globalUtility: true,           // set utility style is global or scoped
-          prefix: 'windi-'               // set compilation mode style prefix
-        }
-      })
-    }
   },
   /*
    ** Font Awesome Configuration

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -38,7 +38,7 @@ export default {
   /*
    ** Global CSS
    */
-  css: [],
+  css: ['~/styles/content.scss'],
   /*
    ** Plugins to load before mounting the App
    ** https://nuxtjs.org/guide/plugins
@@ -52,7 +52,17 @@ export default {
   /*
    ** Nuxt.js dev-modules
    */
-  buildModules: ['nuxt-windicss', '@nuxtjs/fontawesome', '@nuxt/image'],
+  buildModules: [
+    'nuxt-windicss',
+    '@nuxtjs/fontawesome',
+    '@nuxt/image'
+  ],
+
+  windicss: {
+    scan: {
+      fileExtensions: ['vue', 'js', 'css', 'scss']
+    },
+  },
   /*
    ** Nuxt.js modules
    */

--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
     "strip-markdown": "^4.0.0",
     "stylelint": "^13.6.1",
     "stylelint-config-prettier": "^8.0.1",
-    "stylelint-config-standard": "^20.0.0",
-    "vue-windicss-preprocess": "^2.2.0"
+    "stylelint-config-standard": "^20.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "make-empty-github-commit": "^1.2.1",
     "netlify-cli": "^3.5.0",
     "node-sass": "^4.14.1",
-    "nuxt-windicss": "^0.5.4",
+    "nuxt-windicss": "^0.6.0",
     "patch-package": "^6.4.5",
     "postinstall-postinstall": "^2.1.0",
     "prettier": "^2.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3870,18 +3870,18 @@
     "@webassemblyjs/wast-parser" "1.9.0"
     "@xtuc/long" "4.2.2"
 
-"@windicss/plugin-utils@0.12.5":
-  version "0.12.5"
-  resolved "https://registry.yarnpkg.com/@windicss/plugin-utils/-/plugin-utils-0.12.5.tgz#d03517d1ae7a48b5b459e3d670e873d38b63e4a1"
-  integrity sha512-4ux2o4s6D/gRTD68os41oxs/0NFk/eSJxHhZL9nN2wy4RGt+pPMQJyOHV56l7zDh9B0ywU5+ZRxDjdw2cl5Yvg==
+"@windicss/plugin-utils@0.15.10":
+  version "0.15.10"
+  resolved "https://registry.yarnpkg.com/@windicss/plugin-utils/-/plugin-utils-0.15.10.tgz#93dde1823da8f89c660fba9467b61723bb2a836c"
+  integrity sha512-xhC/d2oqjN1XEjXzG1+8YLOXiktIq3kPXOH3Rv0XOGdmN27XV7eur5g/yXE0fQ8xGrrzOijUb3qAItTgCO1hFA==
   dependencies:
     debug "^4.3.2"
     fast-glob "^3.2.5"
     magic-string "^0.25.7"
-    micromatch "^4.0.2"
+    micromatch "^4.0.4"
     pirates "^4.0.1"
-    sucrase "^3.17.1"
-    windicss "^2.5.11"
+    sucrase "^3.18.1"
+    windicss "^2.5.14"
 
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
@@ -6755,6 +6755,11 @@ defu@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/defu/-/defu-3.2.2.tgz#be20f4cc49b9805d54ee6b610658d53894942e97"
   integrity sha512-8UWj5lNv7HD+kB0e9w77Z7TdQlbUYDVWqITLHNqFIn6khrNHv5WQo38Dcm1f6HeNyZf0U7UbPf6WeZDSdCzGDQ==
+
+defu@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/defu/-/defu-4.0.1.tgz#9d7d7a48f9295f08285d153dcff174c89b9bcb22"
+  integrity sha512-lC+G0KvvWRbisQa50+iFelm3/eMmwo4IlBmfASOVlw9MZpHHyQeVsZxc5j23+TQy5ydgEoTVSrWl7ptou1kzJQ==
 
 del@^5.1.0:
   version "5.1.0"
@@ -11764,6 +11769,14 @@ micromatch@^4.0.2:
     braces "^3.0.1"
     picomatch "^2.0.5"
 
+micromatch@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.4.tgz#896d519dfe9db25fce94ceb7a500919bf881ebf9"
+  integrity sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==
+  dependencies:
+    braces "^3.0.1"
+    picomatch "^2.2.3"
+
 miller-rabin@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/miller-rabin/-/miller-rabin-4.0.1.tgz#f080351c865b0dc562a8462966daa53543c78a4d"
@@ -12581,18 +12594,18 @@ number-is-nan@^1.0.0:
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
   integrity sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=
 
-nuxt-windicss@^0.5.4:
-  version "0.5.4"
-  resolved "https://registry.yarnpkg.com/nuxt-windicss/-/nuxt-windicss-0.5.4.tgz#f061a36827c221f521d463816d91489a09c7f827"
-  integrity sha512-I21jFQUfjrGKpfWOZmguCvjf6/be93gsqRUGvhys+IfaPKhmnFaua8lYPBUYOv3E5RFQV082kWL3UTLwFPBnEA==
+nuxt-windicss@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/nuxt-windicss/-/nuxt-windicss-0.6.0.tgz#393e40d6f0c791331a3595506bf6e3efddb61557"
+  integrity sha512-4nqETnZEUglEEznqyQucjwsiPV3Z4OVZQyLlYWF4wz/z7GCQBJFGOxyrrUChkqGy/ToF2DDyiWbzkTqFYr7+3Q==
   dependencies:
     clear-module "^4.1.1"
-    defu "^3.2.2"
+    defu "^4.0.1"
     rimraf "^3.0.2"
     semver "^7.3.5"
     upath "^2.0.1"
-    vite-plugin-windicss "^0.12.5"
-    windicss-webpack-plugin "^0.3.3"
+    vite-plugin-windicss "^0.15.10"
+    windicss-webpack-plugin "^0.4.1"
 
 nuxt@^2.13.0:
   version "2.14.12"
@@ -13413,6 +13426,11 @@ picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1, picomatch@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
   integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
+
+picomatch@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.3.tgz#465547f359ccc206d3c48e46a1bcb89bf7ee619d"
+  integrity sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg==
 
 pify@^2.0.0, pify@^2.2.0, pify@^2.3.0:
   version "2.3.0"
@@ -16468,7 +16486,7 @@ stylelint@^13.6.1:
     v8-compile-cache "^2.2.0"
     write-file-atomic "^3.0.3"
 
-sucrase@^3.17.1:
+sucrase@^3.18.1:
   version "3.18.1"
   resolved "https://registry.yarnpkg.com/sucrase/-/sucrase-3.18.1.tgz#7c699d5148734b1105542ca4ea2aa69bcab7f728"
   integrity sha512-TRyO38wwOPhLLlM8QLOG3TgMj0FKk+arlTrS9pRAanF8cAcHvgRPKIYWGO25mPSp/Rj87zMMTjFfkqIZGI6ZdA==
@@ -17581,15 +17599,15 @@ vfile@^4.0.0:
     unist-util-stringify-position "^2.0.0"
     vfile-message "^2.0.0"
 
-vite-plugin-windicss@^0.12.5:
-  version "0.12.5"
-  resolved "https://registry.yarnpkg.com/vite-plugin-windicss/-/vite-plugin-windicss-0.12.5.tgz#74a5043db3615fe432855f6ecff13be36f7a6843"
-  integrity sha512-M/eEA+x94kxZNpEEkJLdY7M6Lp3WFhN0Kb/a2zhdPxBviMwaHSA5A7fUqN1xTYMxlQe4xM7D7naxL7EpnSNlmg==
+vite-plugin-windicss@^0.15.10:
+  version "0.15.10"
+  resolved "https://registry.yarnpkg.com/vite-plugin-windicss/-/vite-plugin-windicss-0.15.10.tgz#903dd926acd210cd57de29f85daa33ff5555819f"
+  integrity sha512-6thupz/vOt6XTIHZGRd8vVwjmC+8/FNgdhZGfyp2gnkPxC4SKUa4wZFpLBhirw+ApP8vdm9oVpe2liBZdQIwIg==
   dependencies:
-    "@windicss/plugin-utils" "0.12.5"
+    "@windicss/plugin-utils" "0.15.10"
     chalk "^4.1.0"
     debug "^4.3.2"
-    windicss "^2.5.11"
+    windicss "^2.5.14"
 
 vm-browserify@^1.0.1:
   version "1.1.2"
@@ -17938,20 +17956,20 @@ win-release@^1.0.0:
   dependencies:
     semver "^5.0.1"
 
-windicss-webpack-plugin@^0.3.3:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/windicss-webpack-plugin/-/windicss-webpack-plugin-0.3.3.tgz#74addc441b3c9e20bb727598bcacb6c8903d67d8"
-  integrity sha512-XtV7cprqmWEglN6B3ALp09aGFIETnG3G3t762SROVbEgLsBq2Om8sB0MlCvdfBvq0jpIj/hPllApMSq5iVNcXg==
+windicss-webpack-plugin@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/windicss-webpack-plugin/-/windicss-webpack-plugin-0.4.1.tgz#8a782cceadfb3aa2992aebf993e8e805d025c2ce"
+  integrity sha512-KMVoxqJI+5OZBjs/+PY+A2lJul4EUrTLI/SR1VRdBbbpbOkVjKzTkJ/PpRcHUDHtzgAEg9a0CVGyE0CEtEJ7Cw==
   dependencies:
-    "@windicss/plugin-utils" "0.12.5"
+    "@windicss/plugin-utils" "0.15.10"
     debug "^4.3.1"
     loader-utils "^2.0.0"
     magic-string "^0.25.7"
     upath "^2.0.1"
     webpack-virtual-modules "^0.4.2"
-    windicss "^2.5.12"
+    windicss "^2.5.14"
 
-windicss@^2.5.11, windicss@^2.5.12:
+windicss@^2.5.14:
   version "2.5.14"
   resolved "https://registry.yarnpkg.com/windicss/-/windicss-2.5.14.tgz#41236ccc2517c0947e1adb69e0d5e8aa9bed9c1e"
   integrity sha512-8Lm7U1M5AzJPbiaVSVz7qWdETRzlkv//5LBMICBBAojos1jo09lUGhNZ5rBzHeldB9JmqYMDOGgrrXHExu0EAg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -17700,15 +17700,6 @@ vue-template-es2015-compiler@^1.9.0:
   resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz#1ee3bc9a16ecbf5118be334bb15f9c46f82f5825"
   integrity sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==
 
-vue-windicss-preprocess@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/vue-windicss-preprocess/-/vue-windicss-preprocess-2.2.0.tgz#a0bacf055c944e1c087333b7d1bdaefb1ef1e106"
-  integrity sha512-CKLD+OVqq1FD0vq8a7OC7UM1x18zF6NCZXUkYg0vBppH032mDnXg1iHEkrl1YLJaEKuOPZz4IvUO1O9VwOWEHw==
-  dependencies:
-    loader-utils "^2.0.0"
-    magic-string "^0.25.7"
-    windicss "^2.3.0"
-
 vue@^2.6.12:
   version "2.6.12"
   resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.12.tgz#f5ebd4fa6bd2869403e29a896aed4904456c9123"
@@ -17747,8 +17738,10 @@ watchpack@^1.7.4:
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.7.5.tgz#1267e6c55e0b9b5be44c2023aed5437a2c26c453"
   integrity sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==
   dependencies:
+    chokidar "^3.4.1"
     graceful-fs "^4.1.2"
     neo-async "^2.5.0"
+    watchpack-chokidar2 "^2.0.1"
   optionalDependencies:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.1"
@@ -17958,7 +17951,7 @@ windicss-webpack-plugin@^0.3.3:
     webpack-virtual-modules "^0.4.2"
     windicss "^2.5.12"
 
-windicss@^2.3.0, windicss@^2.5.11, windicss@^2.5.12:
+windicss@^2.5.11, windicss@^2.5.12:
   version "2.5.14"
   resolved "https://registry.yarnpkg.com/windicss/-/windicss-2.5.14.tgz#41236ccc2517c0947e1adb69e0d5e8aa9bed9c1e"
   integrity sha512-8Lm7U1M5AzJPbiaVSVz7qWdETRzlkv//5LBMICBBAojos1jo09lUGhNZ5rBzHeldB9JmqYMDOGgrrXHExu0EAg==


### PR DESCRIPTION
See: https://github.com/windicss/windicss-webpack-plugin/issues/42

There is an additional issue minus the vue-processor, windi does not have first-class support for scss files, when you import the content in your vue style blocks it doesn't allow the @apply's to be passed .

Not sure if there's a specific reason why the page layouts are setup the way they are, but I would recommend creating new layout file and have the windi classes used within the template, this would reduce a lot of boilerplate and simplify your styling.