### PR TITLE
Fix typo in visual testing guide

### DIFF
--- a/content/guides/tooling/visual-testing.md
+++ b/content/guides/tooling/visual-testing.md
@@ -255,7 +255,7 @@ Below we stub network calls using [cy.intercept()](/api/commands/intercept) to r
 ```js
 cy.intercept('/api/items', { fixture: 'items' }).as('getItems')
 // ... action
-cy.wait('@getUsers')
+cy.wait('@getItems')
 cy.mySnapshotCommand()
 ```
 


### PR DESCRIPTION
Apologies if this is supposed to be reflected in the changelog. From what I interpreted since the change in documentation isn't due to a behavioural change this doesn't need to be in the changelog but let me know if that's wrong and I'll fix that!

While reading the docs on visual testing under this section: https://docs.cypress.io/guides/tooling/visual-testing#Application-state

I noticed this block of code:

```js
cy.intercept('/api/items', { fixture: 'items' }).as('getItems')
// ... action
cy.wait('@getUsers')
cy.mySnapshotCommand()
```

Almost certain the intention was to have `cy.wait('@getItems')`.