### PR TITLE
feat: add fullstory to documentation site

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -42,12 +42,13 @@ export default {
   env: {
     SANITY_PROJECT_ID: process.env.SANITY_PROJECT_ID,
     SANITY_AUTH_TOKEN: process.env.SANITY_AUTH_TOKEN,
+    FULLSTORY_ORG_ID: process.env.FULLSTORY_ORG_ID,
   },
   /*
    ** Plugins to load before mounting the App
    ** https://nuxtjs.org/guide/plugins
    */
-  plugins: ['@/plugins/vue-scrollactive', '@/plugins/sanity-client'],
+  plugins: ['@/plugins/vue-scrollactive', '@/plugins/sanity-client', '~/plugins/fullstory.client.js'],
   /*
    ** Auto import components
    ** See https://nuxtjs.org/api/configuration-components

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@docsearch/css": "^1.0.0-alpha.28",
     "@docsearch/js": "^1.0.0-alpha.28",
+    "@fullstory/browser": "^1.4.9",
     "@nuxt/content": "^1.3.2",
     "@nuxtjs/axios": "^5.11.0",
     "@nuxtjs/gtm": "^2.4.0",

--- a/plugins/fullstory.client.js
+++ b/plugins/fullstory.client.js
@@ -1,0 +1,3 @@
+import * as FullStory from '@fullstory/browser'
+
+FullStory.init({ orgId: process.env.FULLSTORY_ORG_ID })

--- a/plugins/fullstory.client.js
+++ b/plugins/fullstory.client.js
@@ -1,3 +1,5 @@
 import * as FullStory from '@fullstory/browser'
 
-FullStory.init({ orgId: process.env.FULLSTORY_ORG_ID })
+if (process.env.CONTEXT === 'production') {
+    FullStory.init({ orgId: process.env.FULLSTORY_ORG_ID })
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1878,6 +1878,11 @@
   dependencies:
     purgecss "^3.1.3"
 
+"@fullstory/browser@^1.4.9":
+  version "1.4.9"
+  resolved "https://registry.yarnpkg.com/@fullstory/browser/-/browser-1.4.9.tgz#e350d779caa1ba56bed22615d9b157efbefa7b47"
+  integrity sha512-h8ihrXT8pGemh5n7CKrukkEbbRIuCi0I/GJKI8DJpGyloI4WNTX5SC8Aihec7ScfK6Fi6ZpiLkGP3hogZqoNWw==
+
 "@jest/types@^24.9.0":
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/@jest/types/-/types-24.9.0.tgz#63cb26cb7500d069e5a389441a7c6ab5e909fc59"


### PR DESCRIPTION
Closes [DX-220](https://linear.app/cypress/issue/DX-220/add-fullstory-to-docs-site).

PR adds `@fullstory/browser` so that we can see user sessions in FS. Before merging, a new env variable will need to be added `FULLSTORY_ORG_ID=ZVWG5`