### PR TITLE
Remove superfluous reference to .cache

### DIFF
--- a/content/guides/continuous-integration/gitlab-ci.md
+++ b/content/guides/continuous-integration/gitlab-ci.md
@@ -135,7 +135,6 @@ variables:
 cache:
   key: ${CI_COMMIT_REF_SLUG}
   paths:
-    - .cache/*
     - cache/Cypress
     - node_modules
     - build


### PR DESCRIPTION
Cypress by default caches its binaries to `~/.cache`, but since this can't be cached by GitLab CI the docs suggests to change the cache directory like this: `CYPRESS_CACHE_FOLDER: "$CI_PROJECT_DIR/cache/Cypress"`.

It then tells you to cache the new cache directory: `- cache/Cypress`. This means that caching `.cache/*` is superfluous.