### PR TITLE
Add examples for how to upload videos for retried tests

### DIFF
--- a/content/guides/guides/screenshots-and-videos.md
+++ b/content/guides/guides/screenshots-and-videos.md
@@ -71,6 +71,42 @@ If you are an FFmpeg pro and want to see all the settings and debug messages dur
 
 </Alert>
 
+### Control which videos to keep and upload to Dashboard
+
+You may want to have more control over which videos you want to keep and upload to the Dashboard. Deleting videos after the run can save resource space on the machine as well as skip the time used to process, compress, and upload the video to the [Dashboard Service](/guides/dashboard/introduction).
+
+To only process videos in the case that a tests fail, you can set the [`videoUploadOnPasses`](/guides/references/configuration#Videos) configuration option to `false`.
+
+For more fine grained control, you can use Cypress's [`after:spec`](/api/plugins/after-spec-api) event listener that fires after each spec file is run and delete the video when certain conditions are met.
+
+#### Only upload videos for specs with failing or retried tests
+
+The example below shows how to delete the recorded video for specs that had no retry attempts or failures when using Cypress [test retries](/guides/guides/test-retries).
+
+```js
+// plugins/index.js
+
+// need to install these dependencies
+// npm i lodash del --save-dev
+const _ = require('lodash')
+const del = require('del')
+
+module.exports = (on, config) => {
+  on('after:spec', (spec, results) => {
+    if (results && results.video) {
+      // Do we have failures for any retry attempts?
+      const failures = _.some(results.tests, (test) => {
+        return _.some(test.attempts, { state: 'failed' })
+      })
+      if (!failures) {
+        // delete the video if the spec passed and no tests retried
+        return del(results.video)
+      }
+    }
+  })
+}
+```
+
 ## Now What?
 
 So you are capturing screenshots and recording videos of your test runs, now what?

--- a/content/guides/guides/screenshots-and-videos.md
+++ b/content/guides/guides/screenshots-and-videos.md
@@ -75,7 +75,7 @@ If you are an FFmpeg pro and want to see all the settings and debug messages dur
 
 You may want to have more control over which videos you want to keep and upload to the Dashboard. Deleting videos after the run can save resource space on the machine as well as skip the time used to process, compress, and upload the video to the [Dashboard Service](/guides/dashboard/introduction).
 
-To only process videos in the case that a tests fail, you can set the [`videoUploadOnPasses`](/guides/references/configuration#Videos) configuration option to `false`.
+To only process videos in the case that a test fails, you can set the [`videoUploadOnPasses`](/guides/references/configuration#Videos) configuration option to `false`.
 
 For more fine grained control, you can use Cypress's [`after:spec`](/api/plugins/after-spec-api) event listener that fires after each spec file is run and delete the video when certain conditions are met.
 

--- a/content/guides/guides/test-retries.md
+++ b/content/guides/guides/test-retries.md
@@ -189,6 +189,38 @@ describe('User Login', () => {
 
 ```
 
+## Videos
+
+You can use Cypress's [`after:spec`](/api/plugins/after-spec-api) event listener that fires after each spec file is run to delete the recorded video for specs that had no retry attempts or failures. Deleting passing and non-retried videos after the run can save resource space on the machine as well as skip the time used to process, compress, and upload the video to the [Dashboard Service](/guides/dashboard/introduction).
+
+### Only upload videos for specs with failing or retried tests
+
+The example below shows how to delete the recorded video for specs that had no retry attempts or failures when using Cypress test retries.
+
+```js
+// plugins/index.js
+
+// need to install these dependencies
+// npm i lodash del --save-dev
+const _ = require('lodash')
+const del = require('del')
+
+module.exports = (on, config) => {
+  on('after:spec', (spec, results) => {
+    if (results && results.video) {
+      // Do we have failures for any retry attempts?
+      const failures = _.some(results.tests, (test) => {
+        return _.some(test.attempts, { state: 'failed' })
+      })
+      if (!failures) {
+        // delete the video if the spec passed and no tests retried
+        return del(results.video)
+      }
+    }
+  })
+}
+```
+
 ## Dashboard
 
 If you are using the [Cypress Dashboard](/guides/dashboard/introduction), information related to test retries is displayed on the Test Results tab for a run. Selecting the Flaky filter will show tests that retried and then passed during the run.


### PR DESCRIPTION
I’ve had people open this issue a few times now, asking for a feature to also upload videos for retried tests:

- https://github.com/cypress-io/cypress/issues/16377
- https://github.com/cypress-io/cypress/issues/16672
- https://github.com/cypress-io/cypress/issues/16681

This is actually already possible, but I don’t think people are finding it since it’s in the [‘after:spec’ API page](https://docs.cypress.io/api/plugins/after-spec-api#Examples). Why would anyone look there?

- This adds the example to the ‘Screenshots & Videos’ page as well as ‘Test Retries’. 
- It also frames the example as ‘upload video on test retries’ instead of ‘delete videos that didn’t pass’, which is less direct on the intent. 
- **Question:** Is there a way to reuse snippets of the docs? We have this same exact code sample in the docs in 3 places now and I would prefer if it could be edited in one place.