### PR TITLE
Remove cypress-plugin-retries from plugins

### DIFF
--- a/content/_data/plugins.json
+++ b/content/_data/plugins.json
@@ -135,13 +135,6 @@
           "badge": "official"
         },
         {
-          "name": "cypress-plugin-retries",
-          "description": "A Cypress plugin to retry failed tests.",
-          "link": "https://github.com/Bkucera/cypress-plugin-retries",
-          "keywords": ["cypress-plugin-retries"],
-          "badge": "verified"
-        },
-        {
           "name": "cly",
           "description": "A prototype of generating quicker project scaffolding for Cypress.",
           "link": "https://github.com/bahmutov/cly",


### PR DESCRIPTION
I don’t think the `cypress-plugins-retries` should be listed in our plugins as a verified plugin anymore. 

- The plugin is archived and no longer maintained.
- We have test retries built in and recommend people migrate off of this plugin from our migration guide.