### PR TITLE
fix: prepend /api/ to beginning of links on TOC page

### DIFF
--- a/components/ApiTableOfContents.vue
+++ b/components/ApiTableOfContents.vue
@@ -32,7 +32,7 @@ export default {
             class="mb-4"
           >
             <NuxtLink
-              :to="item.redirect || `/${section.slug}/${item.slug}`"
+              :to="item.redirect || `/api/${section.slug}/${item.slug}`"
               class="text-blue border-b border-dotted hover:border-transparent"
             >
               {{ item.title }}


### PR DESCRIPTION
This was an issue caught by a user in our Cypress Community Discord (it looks like our nightly cron for broken link checking caught it too). The links on `https://docs.cypress.io/api/table-of-contents` for Commands, Utilities, and Cypress API don't have `/api/` prepending their paths, so they don't link to the correct page and subsequently 404. This PR fixes that. This was a regression introduced in https://github.com/cypress-io/cypress-documentation/pull/3967.