### PR TITLE
fix: move plugins section under proper sidebar node

### DIFF
--- a/content/_data/sidebar.json
+++ b/content/_data/sidebar.json
@@ -851,8 +851,8 @@
               "slug": "before-run-api"
             },
             {
-              "title": "after-run-api",
-              "slug": "After Run"
+              "title": "After Run",
+              "slug": "after-run-api"
             },
             {
               "title": "Before Spec",

--- a/content/_data/sidebar.json
+++ b/content/_data/sidebar.json
@@ -829,48 +829,48 @@
               "slug": "version"
             }
           ]
-        }
-      ]
-    },
-    {
-      "title": "Plugins",
-      "slug": "plugins",
-      "children": [
-        {
-          "title": "Writing a Plugin",
-          "slug": "writing-a-plugin"
         },
         {
-          "title": "Configuration",
-          "slug": "configuration-api"
-        },
-        {
-          "title": "Preprocessors",
-          "slug": "preprocessors-api"
-        },
-        {
-          "title": "Before Run",
-          "slug": "before-run-api"
-        },
-        {
-          "title": "after-run-api",
-          "slug": "After Run"
-        },
-        {
-          "title": "Before Spec",
-          "slug": "before-spec-api"
-        },
-        {
-          "title": "After Spec",
-          "slug": "after-spec-api"
-        },
-        {
-          "title": "Browser Launching",
-          "slug": "browser-launch-api"
-        },
-        {
-          "title": "After Screenshot",
-          "slug": "after-screenshot-api"
+          "title": "Plugins",
+          "slug": "plugins",
+          "children": [
+            {
+              "title": "Writing a Plugin",
+              "slug": "writing-a-plugin"
+            },
+            {
+              "title": "Configuration",
+              "slug": "configuration-api"
+            },
+            {
+              "title": "Preprocessors",
+              "slug": "preprocessors-api"
+            },
+            {
+              "title": "Before Run",
+              "slug": "before-run-api"
+            },
+            {
+              "title": "after-run-api",
+              "slug": "After Run"
+            },
+            {
+              "title": "Before Spec",
+              "slug": "before-spec-api"
+            },
+            {
+              "title": "After Spec",
+              "slug": "after-spec-api"
+            },
+            {
+              "title": "Browser Launching",
+              "slug": "browser-launch-api"
+            },
+            {
+              "title": "After Screenshot",
+              "slug": "after-screenshot-api"
+            }
+          ]
         }
       ]
     }


### PR DESCRIPTION
This PR fixes an issue where the `Plugins` category under the API docs was missing. This was due to a recent change to how the `sidebar.json` data was formatted.

Expected: 
![image](https://user-images.githubusercontent.com/11802078/121403806-e7cc6280-c920-11eb-9c8d-c577ca8bcc28.png)

Current:
![image](https://user-images.githubusercontent.com/11802078/121403828-ee5ada00-c920-11eb-970a-395e4399819d.png)

Fixed:
![image](https://user-images.githubusercontent.com/11802078/121403942-0f232f80-c921-11eb-8405-46a6693547b0.png)

