### PR TITLE
Nuxt config example: Wait for getWebpackConfig() to resolve

### DIFF
--- a/content/guides/component-testing/framework-configuration.md
+++ b/content/guides/component-testing/framework-configuration.md
@@ -263,10 +263,11 @@ const { startDevServer } = require('@cypress/webpack-dev-server')
 const { getWebpackConfig } = require('nuxt')
 
 module.exports = (on, config) => {
-  on('dev-server:start', (options) => {
+  on('dev-server:start', async (options) => {
+    const webpackConfig = await getWebpackConfig()
     return startDevServer({
       options,
-      webpackConfig: getWebpackConfig(),
+      webpackConfig,
     })
   })
 


### PR DESCRIPTION
This PR updates the documentation that was originally resulting in the following error:

PS: It's also based on: https://github.com/cypress-io/cypress-component-examples/blob/main/nuxt-vue-2-cypress/cypress/plugins/index.js

```
Error [TypeError]: Promises are not supported
    at mergeWithOptions (/Users/jonathan/Documents/xxxx/node_modules/webpack-merge/dist/index.js:67:19)
    at Object.merge (/Users/jonathan/Documents/xxxx/node_modules/webpack-merge/dist/index.js:52:35)
    at Object.<anonymous> (/Users/jonathan/Documents/xxxx/node_modules/@cypress/webpack-dev-server/dist/makeWebpackConfig.js:89:46)
    at Generator.next (<anonymous>)
    at /Users/jonathan/Documents/xxxx/node_modules/@cypress/webpack-dev-server/dist/makeWebpackConfig.js:27:71
    at new Promise (<anonymous>)
    at __awaiter (/Users/jonathan/Documents/xxxx/node_modules/@cypress/webpack-dev-server/dist/makeWebpackConfig.js:23:12)
    at Object.makeWebpackConfig (/Users/jonathan/Documents/xxxx/node_modules/@cypress/webpack-dev-server/dist/makeWebpackConfig.js:45:12)
    at Object.<anonymous> (/Users/jonathan/Documents/xxxx/node_modules/@cypress/webpack-dev-server/dist/startServer.js:41:57)
    at Generator.next (<anonymous>)
    at /Users/jonathan/Documents/xxxx/node_modules/@cypress/webpack-dev-server/dist/startServer.js:8:71
    at new Promise (<anonymous>)
    at __awaiter (/Users/jonathan/Documents/xxxx/node_modules/@cypress/webpack-dev-server/dist/startServer.js:4:12)
    at Object.start (/Users/jonathan/Documents/xxxx/node_modules/@cypress/webpack-dev-server/dist/startServer.js:35:12)
    at /Users/jonathan/Documents/xxxx/node_modules/@cypress/webpack-dev-server/dist/index.js:18:54
    at Generator.next (<anonymous>)
TypeError: Promises are not supported
    at mergeWithOptions (/Users/jonathan/Documents/xxxx/node_modules/webpack-merge/dist/index.js:67:19)
    at Object.merge (/Users/jonathan/Documents/xxxx/node_modules/webpack-merge/dist/index.js:52:35)
    at Object.<anonymous> (/Users/jonathan/Documents/xxxx/node_modules/@cypress/webpack-dev-server/dist/makeWebpackConfig.js:89:46)
    at Generator.next (<anonymous>)
    at /Users/jonathan/Documents/xxxx/node_modules/@cypress/webpack-dev-server/dist/makeWebpackConfig.js:27:71
    at new Promise (<anonymous>)
    at __awaiter (/Users/jonathan/Documents/xxxx/node_modules/@cypress/webpack-dev-server/dist/makeWebpackConfig.js:23:12)
    at Object.makeWebpackConfig (/Users/jonathan/Documents/xxxx/node_modules/@cypress/webpack-dev-server/dist/makeWebpackConfig.js:45:12)
    at Object.<anonymous> (/Users/jonathan/Documents/xxxx/node_modules/@cypress/webpack-dev-server/dist/startServer.js:41:57)
    at Generator.next (<anonymous>)
    at /Users/jonathan/Documents/xxxx/node_modules/@cypress/webpack-dev-server/dist/startServer.js:8:71
    at new Promise (<anonymous>)
    at __awaiter (/Users/jonathan/Documents/xxxx/node_modules/@cypress/webpack-dev-server/dist/startServer.js:4:12)
    at Object.start (/Users/jonathan/Documents/xxxx/node_modules/@cypress/webpack-dev-server/dist/startServer.js:35:12)
    at /Users/jonathan/Documents/xxxx/node_modules/@cypress/webpack-dev-server/dist/index.js:18:54
    at Generator.next (<anonymous>)
jonathan@Jonathans-MBP admin % ℹ Merging Tailwind config from ~/tailwind.config.js   
```