### PR TITLE
feat: Added explanations on objects as stub response body.

### DIFF
--- a/content/api/commands/intercept.md
+++ b/content/api/commands/intercept.md
@@ -342,6 +342,18 @@ Stub a response with a JSON body:
 cy.intercept('/projects', {
   body: [{ projectId: '1' }, { projectId: '2' }],
 })
+
+// If you want to stub only body, you can directly set it as an argument:
+cy.intercept(
+  '/projects', 
+  [{ projectId: '1' }, { projectId: '2' }]
+)
+
+// But empty object doesn't mean an empty JSON body, it's an empty StaticResponse:
+cy.intercept(
+  '/projects', 
+  {} // => StaticResponse
+)
 ```
 
 Stub headers, status code, and body all at once:


### PR DESCRIPTION
closes #3976

With the `cy.intercept` doc update on #3944, the explanation about passing an object as stub response body was removed entirely from the documentation. I kind of revived it with examples.

If you intentionally removed it and are planning to deprecate the feature in the future, just close this PR and #3976. 