### PR TITLE
Add Cypress.Keyboard doc

### DIFF
--- a/content/_changelogs/7.6.0.md
+++ b/content/_changelogs/7.6.0.md
@@ -2,6 +2,10 @@
 
 _Released 06/21/2021_
 
+**Features:**
+
+- You can now override the default delay between characters for `cy.type()` with [`Cypress.Keyboard.defaults()`](https://on.cypress.io/keyboard-api) or via [test configuration](https://on.cypress.io/writing-and-organizing-tests#Allowed-config-values). Addresses [#566](https://github.com/cypress-io/cypress/issues/566).
+
 **Bugfixes:**
 
 - It is no longer necessary to return the config from the plugins function when using the `dev-server:start` event for component testing. Fixes [#16860](https://github.com/cypress-io/cypress/issues/16860).

--- a/content/_changelogs/7.6.0.md
+++ b/content/_changelogs/7.6.0.md
@@ -4,7 +4,7 @@ _Released 06/21/2021_
 
 **Features:**
 
-- You can now override the default delay between characters for `cy.type()` with [`Cypress.Keyboard.defaults()`](https://on.cypress.io/keyboard-api) or via [test configuration](https://on.cypress.io/writing-and-organizing-tests#Allowed-config-values). Addresses [#566](https://github.com/cypress-io/cypress/issues/566).
+- You can now override the default delay between typing characters for `.type()` with [`Cypress.Keyboard.defaults()`](https://on.cypress.io/keyboard-api) or via [test configuration](https://on.cypress.io/writing-and-organizing-tests#Allowed-config-values). Addresses [#566](https://github.com/cypress-io/cypress/issues/566).
 
 **Bugfixes:**
 

--- a/content/_data/en.json
+++ b/content/_data/en.json
@@ -233,7 +233,8 @@
       "selector-playground-api": "SelectorPlayground",
       "screenshot-api": "Screenshot",
       "after-screenshot-api": "After Screenshot",
-      "spec": "spec"
+      "spec": "spec",
+      "keyboard-api": "Keyboard"
     },
     "examples": {
       "examples": "Examples",

--- a/content/_data/sidebar.json
+++ b/content/_data/sidebar.json
@@ -769,6 +769,10 @@
               "slug": "cookies"
             },
             {
+              "title": "Keyboard",
+              "slug": "keyboard-api"
+            },
+            {
               "title": "Screenshot",
               "slug": "screenshot-api"
             },

--- a/content/api/commands/type.md
+++ b/content/api/commands/type.md
@@ -534,3 +534,4 @@ When clicking on `type` within the command log, the console outputs the followin
 - [`.click()`](/api/commands/click)
 - [`.focus()`](/api/commands/focus)
 - [`.submit()`](/api/commands/submit)
+- [`Cypress.Keyboard`](/api/cypress-api/keyboard-api)

--- a/content/api/cypress-api/keyboard-api.md
+++ b/content/api/cypress-api/keyboard-api.md
@@ -1,0 +1,70 @@
+---
+title: Cypress.Keyboard
+---
+
+The Keyboard API allows you set the default values for how the [.type()](/api/commands/type) command is executed.
+
+## Syntax
+
+```javascript
+Cypress.Keyboard.defaults(options)
+```
+
+### Arguments
+
+**<Icon name="angle-right"></Icon> options** **_(Object)_**
+
+An object containing the following:
+
+| Option           | Default | Description                                                                                                                                                    |
+| ---------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `keystrokeDelay` | `10`    | The delay, in milliseconds, between keystrokes while typing with [.type()](/api/commands/type). Set to `0` to remove the delay. Must be a non-negative number. |
+
+## Examples
+
+### Slow down typing by increasing the keystroke delay
+
+```javascript
+Cypress.Keyboard.defaults({
+  keystrokeDelay: 20,
+})
+```
+
+### Remove the keystroke delay
+
+```javascript
+Cypress.Keyboard.defaults({
+  keystrokeDelay: 0,
+})
+```
+
+## Notes
+
+### Where to put Keyboard configuration
+
+A great place to put this configuration is in your [`cypress/support/index.js` file](/guides/core-concepts/writing-and-organizing-tests#Support-file), since it is loaded before any test files are evaluated.
+
+### Set the keystroke delay in test configuration
+
+The keystroke delay can also be set via [test configuration](/guides/core-concepts/writing-and-organizing-tests#Test-Configuration), which can be useful when setting it for a single test or a subset of tests.
+
+```javascript
+it('removes keystroke delay for all typing in this test', { keystrokeDelay: 0 }, () => {
+  cy.get('input').eq(0).type('fast typing')
+  cy.get('input').eq(1).type('more fast typing')
+})
+
+describe('removes keystroke delay in all tests in this suite', { keystrokeDelay: 0 }, () => {
+  it('types fast in the first input', () => {
+    cy.get('input').eq(0).type('fast typing')
+  })
+
+  it('types fast in the second input', () => {
+    cy.get('input').eq(1).type('more fast typing')
+  })
+}))
+```
+
+## See also
+
+- [.type()](/api/commands/type)

--- a/content/guides/core-concepts/writing-and-organizing-tests.md
+++ b/content/guides/core-concepts/writing-and-organizing-tests.md
@@ -413,6 +413,7 @@ specify(name, config, fn)
 - `execTimeout`
 - `env` **note:** Provided environment variables will be merged with current environment variables.
 - `includeShadowDom`
+- `keystrokeDelay`
 - `requestTimeout`
 - `responseTimeout`
 - `retries`

--- a/cypress/integration/api.spec.js
+++ b/cypress/integration/api.spec.js
@@ -74,6 +74,7 @@ describe('APIs', () => {
             'custom-commands': 'Custom Commands',
             cookies: 'Cypress.Cookies',
             'screenshot-api': 'Cypress.Screenshot',
+            'keyboard-api': 'Cypress.Keyboard',
             'selector-playground-api': 'Cypress.SelectorPlayground',
             'cypress-server': 'Cypress.Server',
             arch: 'Cypress.arch',


### PR DESCRIPTION
For https://github.com/cypress-io/cypress/pull/15683. Requires changes for `on.cypress.io` in https://github.com/cypress-io/cypress-services/pull/3859 to be deployed.