### PR TITLE
Remove examples where returning config should no longer be necessary

### DIFF
--- a/content/guides/component-testing/framework-configuration.md
+++ b/content/guides/component-testing/framework-configuration.md
@@ -34,6 +34,7 @@ const injectDevServer = require('@cypress/react/plugins/react-scripts')
 
 module.exports = (on, config) => {
   injectDevServer(on, config)
+
   return config
 }
 ```
@@ -101,8 +102,6 @@ module.exports = (on, config) => {
       webpackConfig,
     })
   })
-
-  return config
 }
 ```
 
@@ -269,8 +268,6 @@ module.exports = (on, config) => {
       webpackConfig: getWebpackConfig(),
     })
   })
-
-  return config
 }
 ```
 
@@ -389,8 +386,6 @@ module.exports = (on, config) => {
       },
     })
   })
-
-  return config
 }
 ```
 

--- a/content/guides/component-testing/introduction.md
+++ b/content/guides/component-testing/introduction.md
@@ -168,8 +168,6 @@ module.exports = (on, config) => {
       startDevServer({ options, webpackConfig })
     )
   }
-
-  return config
 }
 ```
 
@@ -190,8 +188,6 @@ module.exports = (on, config) => {
       startDevServer({ options, webpackConfig })
     )
   }
-
-  return config
 }
 ```
 
@@ -324,7 +320,6 @@ export default function (on, config) {
     }
     return startDevServer({ options, viteConfig })
   })
-  return config
 }
 ```
 

--- a/content/guides/references/migration-guide.md
+++ b/content/guides/references/migration-guide.md
@@ -230,8 +230,6 @@ const webpackConfig = require('../webpack.config.js')
 
 module.exports = (on, config) => {
   on('file:preprocessor', webpackPreprocessor(options))
-
-  return config
 }
 ```
 
@@ -248,8 +246,6 @@ module.exports = (on, config) => {
   on('dev-server:start', (options) => {
     return startDevServer({ options, webpackConfig })
   })
-
-  return config
 }
 ```
 
@@ -293,8 +289,6 @@ module.exports = (on, config) => {
   on('dev-server:start', (options) => {
     return startDevServer({ options, webpackConfig })
   })
-
-  return config // you *must* return config
 }
 ```
 
@@ -312,8 +306,6 @@ module.exports = (on, config) => {
   on('dev-server:start', (options) => {
     return startDevServer({ options, webpackConfig })
   })
-
-  return config
 }
 ```
 


### PR DESCRIPTION
Due to changes in https://github.com/cypress-io/cypress/pull/16885