### PR TITLE
feat: add copy button to code blocks

### DIFF
--- a/components/AppCopyButton.vue
+++ b/components/AppCopyButton.vue
@@ -2,7 +2,7 @@
   <button
     ref="copy"
     :class="$style.copy"
-    class="copy rounded-t-md rounded-b-md text-sm text-white font-normal relative flex flex-row"
+    class="copy absolute rounded-md text-xs text-white font-normal flex flex-row self-end items-center"
     data-test="copy-button"
   >
     <Icon :name="state === 'copied' ? 'check-circle' : 'paste'" color="white" />
@@ -43,6 +43,8 @@ export default {
 
 <style module>
 .copy {
+  right: 0.25rem;
+  top: 0.25rem;
   border: 1px solid transparent;
   margin-left: 1rem;
   padding: 0.25rem 0.75rem;

--- a/components/AppCopyButton.vue
+++ b/components/AppCopyButton.vue
@@ -1,0 +1,36 @@
+<template>
+  <button ref="copy" class="copy" data-test="copy-button">
+    <Icon v-if="state === 'copied'" name="check-circle" color="green" data-test="copy-button-copied" />
+    <Icon v-else name="paste" color="inherit" data-test="copy-button-default" class="w-5 h-5" />
+  </button>
+</template>
+
+<script>
+import Icon from './global/Icon'
+import Clipboard from 'clipboard'
+
+export default {
+  components: {
+    Icon,
+  },
+  data () {
+    return {
+      state: 'init'
+    }
+  },
+  mounted () {
+    const copyCode = new Clipboard(this.$refs.copy, {
+      target (trigger) {
+        return trigger.parentElement
+      }    })
+
+    copyCode.on('success', (event) => {
+      event.clearSelection()
+      this.state = 'copied'
+      window.setTimeout(() => {
+        this.state = 'init'
+      }, 2000)
+    })
+  }
+}
+</script>

--- a/components/AppCopyButton.vue
+++ b/components/AppCopyButton.vue
@@ -1,7 +1,12 @@
 <template>
-  <button ref="copy" class="copy" data-test="copy-button">
-    <Icon v-if="state === 'copied'" name="check-circle" color="green" data-test="copy-button-copied" />
-    <Icon v-else name="paste" color="inherit" data-test="copy-button-default" class="w-5 h-5" />
+  <button
+    ref="copy"
+    :class="$style.copy"
+    class="copy rounded-t-md rounded-b-md text-sm text-white font-normal relative flex flex-row"
+    data-test="copy-button"
+  >
+    <Icon :name="state === 'copied' ? 'check-circle' : 'paste'" color="white" />
+    <span>{{ state === 'copied' ? 'Copied' : 'Copy' }}</span>
   </button>
 </template>
 
@@ -13,24 +18,42 @@ export default {
   components: {
     Icon,
   },
-  data () {
+  data() {
     return {
-      state: 'init'
+      state: 'init',
     }
   },
-  mounted () {
+  mounted() {
     const copyCode = new Clipboard(this.$refs.copy, {
-      target (trigger) {
+      target(trigger) {
         return trigger.parentElement
-      }    })
+      },
+    })
 
     copyCode.on('success', (event) => {
       event.clearSelection()
       this.state = 'copied'
       window.setTimeout(() => {
         this.state = 'init'
-      }, 2000)
+      }, 1500)
     })
-  }
+  },
 }
 </script>
+
+<style module>
+.copy {
+  border: 1px solid transparent;
+  margin-left: 1rem;
+  padding: 0.25rem 0.75rem;
+  align-items: center;
+}
+
+.copy svg {
+  margin-right: 0.5rem;
+}
+
+.copy:hover {
+  border: 1px solid #ddd;
+}
+</style>

--- a/cypress/integration/api.spec.js
+++ b/cypress/integration/api.spec.js
@@ -123,11 +123,11 @@ describe('APIs', () => {
     cy.visit('/api/commands/and')
 
     cy.get(':not(:contains("Incorrect Usage"))').next().within(()=> {
-      cy.get('[data-test="copy-button-default"]').should('be.visible')
+      cy.get('[data-test="copy-button"]').should('be.visible')
     })
 
     cy.get(':contains("Incorrect Usage")').next().within(() => {
-      cy.get('[data-test="copy-button-default"]').should('not.exist')
+      cy.get('[data-test="copy-button"]').should('not.exist')
     })
 
     cy.get('[data-test="copy-button"]').first().click({force: true});

--- a/cypress/integration/api.spec.js
+++ b/cypress/integration/api.spec.js
@@ -118,4 +118,20 @@ describe('APIs', () => {
       })
     })
   })
+
+  it('displays copy links in code blocks', () => {
+    cy.visit('/api/commands/and')
+
+    cy.get(':not(:contains("Incorrect Usage"))').next().within(()=> {
+      cy.get('[data-test="copy-button-default"]').should('be.visible')
+    })
+
+    cy.get(':contains("Incorrect Usage")').next().within(() => {
+      cy.get('[data-test="copy-button-default"]').should('not.exist')
+    })
+
+    cy.get('[data-test="copy-button"]').first().click({force: true});
+    cy.task('getClipboard').should('contain', '.and')
+  })
+
 })

--- a/cypress/integration/guides.spec.js
+++ b/cypress/integration/guides.spec.js
@@ -95,4 +95,13 @@ describe('Guides', () => {
       })
     })
   })
+
+  it('displays copy links in code blocks', () => {
+    cy.get('.nuxt-content-highlight').within(()=> {
+      cy.get('[data-test="copy-button-default"]').should('be.visible')
+    })
+
+    cy.get('[data-test="copy-button"]').first().click({force: true});
+    cy.task('getClipboard').should('contain', 'adds todos')
+  })
 })

--- a/cypress/integration/guides.spec.js
+++ b/cypress/integration/guides.spec.js
@@ -98,7 +98,7 @@ describe('Guides', () => {
 
   it('displays copy links in code blocks', () => {
     cy.get('.nuxt-content-highlight').within(()=> {
-      cy.get('[data-test="copy-button-default"]').should('be.visible')
+      cy.get('[data-test="copy-button"]').should('be.visible')
     })
 
     cy.get('[data-test="copy-button"]').first().click({force: true});

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -9,6 +9,7 @@
 // https://on.cypress.io/plugins-guide
 // ***********************************************************
 
+const clipboardy = require('clipboardy')
 let percyHealthCheck = require('@percy/cypress/task')
 
 // This function is called when a project is opened or re-opened (e.g. due to
@@ -21,4 +22,13 @@ module.exports = (on, config) => {
   // `on` is used to hook into various events Cypress emits
   // `config` is the resolved Cypress config
   on('task', percyHealthCheck)
+
+  on('task', {
+    // Clipboard test plugin
+    getClipboard: () => {
+      const clipboard = clipboardy.readSync()
+
+      return clipboard
+    },
+  })
 }

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -148,6 +148,7 @@ export default {
         'faStar',
         'faBook',
         'faExternalLinkAlt',
+        'faPaste',
       ],
       brands: ['faGithub', 'faTwitter', 'faYoutube'],
     },

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "bluebird": "^3.7.2",
     "broken-link-checker": "^0.7.8",
     "chalk": "^4.1.0",
+    "clipboardy": "^2.3.0",
     "common-tags": "^1.8.0",
     "cross-env": "^7.0.3",
     "cypress": "^7.0.0",

--- a/pages/api/_.vue
+++ b/pages/api/_.vue
@@ -1,8 +1,10 @@
 <script>
+import Vue from 'vue'
 import AppSidebar from '../../components/AppSidebar'
 import TableOfContents from '../../components/TableOfContents'
 import Footer from '../../components/Footer'
 import ApiTableOfContents from '../../components/ApiTableOfContents.vue'
+import AppCopyButton from '../../components/AppCopyButton'
 import { getMetaData, getMetaDescription, getTitle } from '../../utils'
 import { fetchBanner } from '../../utils/sanity'
 
@@ -80,6 +82,24 @@ export default {
 
       return getMetaData(metaData)
     },
+  },
+  mounted() {
+    setTimeout(() => {
+      const blocks = document.getElementsByTagName('pre')
+
+      for (const block of blocks) {
+        const textContent =
+          block.parentElement.previousElementSibling.textContent
+
+        // only append copy button if not a demo of incorrect usage
+        if (!textContent.toLowerCase().includes('incorrect usage')) {
+          const CopyButton = Vue.extend(AppCopyButton)
+          const component = new CopyButton().$mount()
+
+          block.append(component.$el)
+        }
+      }
+    }, 100)
   },
   methods: {
     onToggleMenu() {

--- a/pages/api/_.vue
+++ b/pages/api/_.vue
@@ -96,7 +96,7 @@ export default {
           const CopyButton = Vue.extend(AppCopyButton)
           const component = new CopyButton().$mount()
 
-          block.append(component.$el)
+          block.prepend(component.$el)
         }
       }
     }, 100)

--- a/pages/guides/_.vue
+++ b/pages/guides/_.vue
@@ -82,7 +82,7 @@ export default {
           const CopyButton = Vue.extend(AppCopyButton)
           const component = new CopyButton().$mount()
 
-          block.append(component.$el)
+          block.prepend(component.$el)
         }
       }
     }, 100)

--- a/pages/guides/_.vue
+++ b/pages/guides/_.vue
@@ -1,8 +1,10 @@
 <script>
+import Vue from 'vue'
 import AppSidebar from '../../components/AppSidebar'
 import AppHeader from '../../components/AppHeader'
 import TableOfContents from '../../components/TableOfContents'
 import Footer from '../../components/Footer'
+import AppCopyButton from '../../components/AppCopyButton'
 import { getMetaData, getMetaDescription, getTitle } from '../../utils'
 import { fetchBanner } from '../../utils/sanity'
 
@@ -66,6 +68,24 @@ export default {
 
       return getMetaData(metaData)
     },
+  },
+  mounted() {
+    setTimeout(() => {
+      const blocks = document.getElementsByTagName('pre')
+
+      for (const block of blocks) {
+        const textContent =
+          block.parentElement.previousElementSibling.textContent
+
+        // only append copy button if not a demo of incorrect usage
+        if (!textContent.toLowerCase().includes('incorrect usage')) {
+          const CopyButton = Vue.extend(AppCopyButton)
+          const component = new CopyButton().$mount()
+
+          block.append(component.$el)
+        }
+      }
+    }, 100)
   },
 }
 </script>

--- a/styles/content.css
+++ b/styles/content.css
@@ -303,6 +303,12 @@
 
 .nuxt-content pre {
   @apply mb-6;
+
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  justify-content: space-between;
+  align-items: flex-start;
 }
 
 /* #region Tables */
@@ -370,4 +376,8 @@ span.token.keyword.control-flow {
     height: 100%;
     background: rgb(252, 162, 162);
   }
+}
+
+.copy {
+  margin-left: 1rem;
 }

--- a/styles/content.css
+++ b/styles/content.css
@@ -301,16 +301,6 @@
 
 /* #endregion Lists */
 
-.nuxt-content pre {
-  @apply mb-6;
-
-  display: flex;
-  flex-direction: row;
-  flex-wrap: nowrap;
-  justify-content: space-between;
-  align-items: flex-start;
-}
-
 /* #region Tables */
 .nuxt-content table {
   @apply table-auto;
@@ -336,11 +326,7 @@
 
 .nuxt-content-highlight .line-numbers {
   border-radius: 6px;
-}
-
-.nuxt-content-highlight code {
-  flex: 85%;
-  overflow: auto;
+  padding: 1.5em 1em !important;
 }
 
 /* #region Syntax highlighting selection override */

--- a/styles/content.css
+++ b/styles/content.css
@@ -377,7 +377,3 @@ span.token.keyword.control-flow {
     background: rgb(252, 162, 162);
   }
 }
-
-.copy {
-  margin-left: 1rem;
-}

--- a/styles/content.css
+++ b/styles/content.css
@@ -338,6 +338,11 @@
   border-radius: 6px;
 }
 
+.nuxt-content-highlight code {
+  flex: 85%;
+  overflow: auto;
+}
+
 /* #region Syntax highlighting selection override */
 code[class*='language-']::-moz-selection,
 pre[class*='language-']::-moz-selection,


### PR DESCRIPTION
![copy-button](https://user-images.githubusercontent.com/2184114/123150197-b460fc00-d427-11eb-9cf6-7f669499ce34.gif)

This PR adds a copy button to code blocks within API and Guides pages. The button will not appear within API blocks that demonstrate incorrect usage.