### PR TITLE
docs: remove productboard links

### DIFF
--- a/content/faq/questions/dashboard-faq.md
+++ b/content/faq/questions/dashboard-faq.md
@@ -57,7 +57,7 @@ When a run happens and a test fails - instead of going and inspecting your CI pr
 
 ## <Icon name="angle-right"></Icon> Can I host the Dashboard data myself?
 
-No, although we are looking to build an on-premise version of the Dashboard for use in private clouds. If you're interested in our on-premise version, please add your interest to our [Dashboard Product Board](https://portal.productboard.com/cypress-io/1-cypress-dashboard)!
+No, although we are looking to build an on-premise version of the Dashboard for use in private clouds.
 
 ## <Icon name="angle-right"></Icon> Can I choose not to use the Dashboard?
 

--- a/content/guides/dashboard/bitbucket-integration.md
+++ b/content/guides/dashboard/bitbucket-integration.md
@@ -50,7 +50,3 @@ You can manage this behavior in your project's **Project Settings** page.
 ## Uninstalling the Bitbucket integration
 
 You can remove this integration by visiting the **Integrations → Bitbucket** page of your organization. This will stop all status checks and PR comments from Cypress.
-
-## Feedback
-
-Have ideas for how we can improve our Bitbucket Integration? [Let us know!](https://portal.productboard.com/cypress-io/1-cypress-dashboard/c/49-bitbucket-integration?utm_medium=social&utm_source=portal_share)

--- a/content/guides/dashboard/github-integration.md
+++ b/content/guides/dashboard/github-integration.md
@@ -8,7 +8,7 @@ The [Cypress Dashboard](https://on.cypress.io/dashboard) can integrate your Cypr
 
 <Alert type="info">
 
-GitHub Enterprise's On-premise platform is currently not supported. If you're interested in an integration with GitHub Enterprise's On-premise platform, please add your interest to our [Dashboard Product Board](https://portal.productboard.com/cypress-io/1-cypress-dashboard).
+GitHub Enterprise's On-premise platform is currently not supported.
 
 </Alert>
 
@@ -143,10 +143,6 @@ You can uninstall the Cypress GitHub app from GitHub by performing the following
 2. Click on **Installed GitHub Apps**.
 3. Click **Configure** beside the Cypress app.
 4. Click **Uninstall** below the "Uninstall Cypress" section.
-
-## Got Feedback?
-
-If you have any insights or feedback on how to improve Cypress GitHub Integration, please reach out via our official [Dashboard Product Board](https://portal.productboard.com/cypress-io/1-cypress-dashboard/c/9-github-status-checks-and-pull-request-comments).
 
 ## See also
 

--- a/content/guides/dashboard/gitlab-integration.md
+++ b/content/guides/dashboard/gitlab-integration.md
@@ -43,7 +43,3 @@ You can manage this behavior in your project's **Project Settings** page.
 ## Uninstalling the GitLab integration
 
 You can remove this integration by visiting the **Integrations → GitLab** page of your organization. This will stop all commit checks and MR comments from Cypress.
-
-## Feedback
-
-Have ideas for how we can improve our GitLab Integration? [Let us know!](https://portal.productboard.com/cypress-io/1-cypress-dashboard/c/48-gitlab-integration?utm_medium=social&utm_source=portal_share)

--- a/content/guides/references/roadmap.md
+++ b/content/guides/references/roadmap.md
@@ -18,7 +18,3 @@ _Last updated Apr 28, 2021_
 | _Work in progress_ | **Visit multiple superdomains** | [#944](https://github.com/cypress-io/cypress/issues/944)   |                                                            |
 | _Work in progress_ | **Iframe Support**              | [#136](https://github.com/cypress-io/cypress/issues/136)   |                                                            |
 | _Work in progress_ | **WebKit Support**              | [#6422](https://github.com/cypress-io/cypress/issues/6422) |                                                            |
-
-### Dashboard Service
-
-Please see our official [Dashboard Product Board](https://portal.productboard.com/cypress-io/1-cypress-dashboard).


### PR DESCRIPTION
Our subscription to Product Board is ending soon, so we are removing references to Product Board from the docs.