### PR TITLE
feat: add prismjs to support line numbers, copy button, highlighting in code blocks

### DIFF
--- a/components/global/CodeBlock.vue
+++ b/components/global/CodeBlock.vue
@@ -14,9 +14,9 @@ export default {
 </script>
 
 <template>
-  <div :class="[active && 'active', $style.codeBlock]">
+  <prism :class="[active && 'active', $style.codeBlock]">
     <slot />
-  </div>
+  </prism>
 </template>
 
 <style module>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -152,7 +152,4 @@ export default {
       brands: ['faGithub', 'faTwitter', 'faYoutube'],
     },
   },
-  purgeCSS: {
-    whitelist: [/^token/, /^pre/, /^code/]
-  }
 }

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -49,7 +49,7 @@ export default {
    ** Plugins to load before mounting the App
    ** https://nuxtjs.org/guide/plugins
    */
-  plugins: ['@/plugins/vue-scrollactive', '@/plugins/sanity-client', {src: '@/plugins/fullstory', mode: 'client'}],
+  plugins: ['@/plugins/vue-scrollactive', '@/plugins/sanity-client', {src: '@/plugins/fullstory', mode: 'client'}, {src: '@/plugins/prism', mode: 'client'}],
   /*
    ** Auto import components
    ** See https://nuxtjs.org/api/configuration-components
@@ -100,7 +100,7 @@ export default {
         ]
       },
       prism: {
-        theme: 'prism-themes/themes/prism-material-oceanic.css',
+        theme: false,
       },
     },
   },

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -152,4 +152,7 @@ export default {
       brands: ['faGithub', 'faTwitter', 'faYoutube'],
     },
   },
+  purgeCSS: {
+    whitelist: [/^token/, /^pre/, /^code/]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "nuxt": "^2.13.0",
     "nuxt-build-optimisations": "^1.0.3",
     "prism-themes": "^1.4.0",
+    "prismjs": "^1.24.1",
     "remark-directive": "^1.0.1",
     "replace-in-file": "^6.2.0",
     "unist-util-visit": "^2.0.3",

--- a/plugins/prism.js
+++ b/plugins/prism.js
@@ -1,0 +1,44 @@
+/* eslint-disable no-template-curly-in-string */
+/* eslint-disable no-undef */
+import 'clipboard' // For the copy to clipboard plugin
+import Prism from 'prismjs'
+import Vue from 'vue'
+
+// Include theme
+import 'prism-themes/themes/prism-material-oceanic.css'
+
+// Include language support
+import 'prismjs/components/prism-markup'
+
+// Include the toolbar plugin
+import 'prismjs/plugins/toolbar/prism-toolbar'
+import 'prismjs/plugins/toolbar/prism-toolbar.css'
+
+// Include the autolinker plugin
+import 'prismjs/plugins/autolinker/prism-autolinker'
+import 'prismjs/plugins/autolinker/prism-autolinker.css'
+
+// Include the line numbers plugin
+import 'prismjs/plugins/line-numbers/prism-line-numbers'
+import 'prismjs/plugins/line-numbers/prism-line-numbers.css'
+
+// Include the line highlight plugin
+import 'prismjs/plugins/line-highlight/prism-line-highlight'
+import 'prismjs/plugins/line-highlight/prism-line-highlight.css'
+
+// Include some other plugins
+import 'prismjs/plugins/copy-to-clipboard/prism-copy-to-clipboard'
+
+// eslint-disable-next-line vue/component-definition-name-casing
+Vue.component('prism', {
+  props: {
+    lang: {
+      type: String,
+      default: 'js'
+    }
+  },
+  mounted () {
+    Prism.highlightAll()
+  },
+  template: '<div class="prism"><pre class="line-numbers" :class="`language-${lang}`"><code><slot></slot></code></pre></div>'
+})

--- a/plugins/prism.js
+++ b/plugins/prism.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-template-curly-in-string */
 /* eslint-disable no-undef */
-import 'clipboard' // For the copy to clipboard plugin
+import 'clipboard'
 import Prism from 'prismjs'
 import Vue from 'vue'
 
@@ -28,7 +28,7 @@ import 'prismjs/plugins/line-highlight/prism-line-highlight.css'
 import 'prismjs/plugins/line-numbers/prism-line-numbers'
 import 'prismjs/plugins/line-numbers/prism-line-numbers.css'
 
-// Include some other plugins
+// Include th copy to clipboard plugin
 import 'prismjs/plugins/copy-to-clipboard/prism-copy-to-clipboard'
 
 // eslint-disable-next-line vue/component-definition-name-casing

--- a/plugins/prism.js
+++ b/plugins/prism.js
@@ -9,6 +9,8 @@ import 'prism-themes/themes/prism-material-oceanic.css'
 
 // Include language support
 import 'prismjs/components/prism-markup'
+import 'prismjs/components/prism-javascript';
+import 'prismjs/components/prism-typescript';
 
 // Include the toolbar plugin
 import 'prismjs/plugins/toolbar/prism-toolbar'
@@ -18,13 +20,13 @@ import 'prismjs/plugins/toolbar/prism-toolbar.css'
 import 'prismjs/plugins/autolinker/prism-autolinker'
 import 'prismjs/plugins/autolinker/prism-autolinker.css'
 
-// Include the line numbers plugin
-import 'prismjs/plugins/line-numbers/prism-line-numbers'
-import 'prismjs/plugins/line-numbers/prism-line-numbers.css'
-
 // Include the line highlight plugin
 import 'prismjs/plugins/line-highlight/prism-line-highlight'
 import 'prismjs/plugins/line-highlight/prism-line-highlight.css'
+
+// Include the line numbers plugin
+import 'prismjs/plugins/line-numbers/prism-line-numbers'
+import 'prismjs/plugins/line-numbers/prism-line-numbers.css'
 
 // Include some other plugins
 import 'prismjs/plugins/copy-to-clipboard/prism-copy-to-clipboard'

--- a/styles/content.css
+++ b/styles/content.css
@@ -337,8 +337,16 @@ div.code-toolbar > .toolbar {
 }
 
 button.copy-to-clipboard-button {
-  padding: 0.2em 0.6em !important;
   color: white !important;
+  padding: 0.25rem 0.75rem !important;
+}
+
+button.copy-to-clipboard-button:hover {
+  border: 1px solid #ddd;
+}
+
+button.copy-to-clipboard-button:focus {
+  outline: none !important;
 }
 
 /* #region Syntax highlighting selection override */

--- a/styles/content.css
+++ b/styles/content.css
@@ -332,6 +332,15 @@
   border-radius: 6px;
 }
 
+div.code-toolbar > .toolbar {
+  right: 0.5em !important;
+}
+
+button.copy-to-clipboard-button {
+  padding: 0.2em 0.6em !important;
+  color: white !important;
+}
+
 /* #region Syntax highlighting selection override */
 code[class*='language-']::-moz-selection,
 pre[class*='language-']::-moz-selection,

--- a/yarn.lock
+++ b/yarn.lock
@@ -14525,6 +14525,11 @@ prismjs@^1.22.0:
   optionalDependencies:
     clipboard "^2.0.0"
 
+prismjs@^1.24.1:
+  version "1.24.1"
+  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.24.1.tgz#c4d7895c4d6500289482fa8936d9cdd192684036"
+  integrity sha512-mNPsedLuk90RVJioIky8ANZEwYm5w9LcvCXrxHlwf4fNVSn8jEipMybMkWUyyF0JhnC+C4VcOVSBuHRKs1L5Ow==
+
 process-es6@^0.11.2, process-es6@^0.11.6:
   version "0.11.6"
   resolved "https://registry.yarnpkg.com/process-es6/-/process-es6-0.11.6.tgz#c6bb389f9a951f82bd4eb169600105bd2ff9c778"


### PR DESCRIPTION
Added PrismJs plugins to support the following within code blocks:

- line numbers
- copy button 
- line highlighting (feature already there per https://content.nuxtjs.org/writing/#codeblocks, but this adds the actual style piece to display highlighted lines appropriately)


![](http://g.recordit.co/Hy0lHdMCYR.gif)

In light of this PR, I will close #3993 