### PR TITLE
Fix namespace example in typescript-support.md

### DIFF
--- a/content/guides/tooling/typescript-support.md
+++ b/content/guides/tooling/typescript-support.md
@@ -73,14 +73,17 @@ Then you can add the `dataCy` command to the global Cypress Chainable interface 
 // in cypress/support/index.ts
 // load type definitions that come with Cypress module
 /// <reference types="cypress" />
-
-declare namespace Cypress {
-  interface Chainable {
-    /**
-     * Custom command to select DOM element by data-cy attribute.
-     * @example cy.dataCy('greeting')
-     */
-    dataCy(value: string): Chainable<Element>
+// Must be declared global to be detected by typescript (allows import/export)
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace Cypress {
+    interface Chainable<Subject> {
+      /**
+       * Custom command to select DOM element by data-cy attribute.
+       * @example cy.dataCy('greeting')
+       */
+      dataCy(value: string): Chainable<Element>
+    }
   }
 }
 ```


### PR DESCRIPTION
The current version didn't work, I've updated it with the linked example code from:
https://github.com/omerose/cypress-support/blob/25acb5e92c1c88149b73418afd0aaa93710d2fee/cypress/support/commands.ts