### PR TITLE
fix typo for cy.exec() example

### DIFF
--- a/content/api/commands/exec.md
+++ b/content/api/commands/exec.md
@@ -121,9 +121,9 @@ cy.exec('npm run build', { timeout: 20000 })
 #### Choose to not fail on non-zero exit and assert on code and stderr
 
 ```javascript
-cy.exec('man bear pig', { failOnNonZeroExit: false }).then((obj) => {
-  expect(obj.code).to.eq(1)
-  expect(obj.stderr).to.contain('No manual entry for bear')
+cy.exec('man bear pig', { failOnNonZeroExit: false }).then((result) => {
+  expect(result.code).to.eq(1)
+  expect(result.stderr).to.contain('No manual entry for bear')
 })
 ```
 

--- a/content/api/commands/exec.md
+++ b/content/api/commands/exec.md
@@ -124,6 +124,7 @@ cy.exec('npm run build', { timeout: 20000 })
 cy.exec('man bear pig', { failOnNonZeroExit: false }).then((obj) => {
   expect(obj.code).to.eq(1)
   expect(obj.stderr).to.contain('No manual entry for bear')
+})
 ```
 
 #### Specify environment variables


### PR DESCRIPTION
> <img width="713" alt="image" src="https://user-images.githubusercontent.com/12410942/125421918-8778e246-3b19-49b4-95b3-7bab82bef4bd.png">
>
> https://docs.cypress.io/api/commands/exec#Options
