### PR TITLE
Always wrap markdown prose

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
     "semi": false,
-    "singleQuote": true
+    "singleQuote": true,
+    "proseWrap": "always"
 }


### PR DESCRIPTION
By setting [`proseWrap`](https://prettier.io/docs/en/options.html#prose-wrap) to `always`, saving a file (with prettier formatting enabled) now results in a much easier to edit file if you use vim, because now you can actually use line-based commands!

Eg.

## Before

![image](https://user-images.githubusercontent.com/54051/125506109-f5152afa-a5c5-4b2b-8375-569bfae3253b.png)

## After

![image](https://user-images.githubusercontent.com/54051/125506017-a5955a99-2794-477b-bea0-365e8703faff.png)
