### PR TITLE
Fix accessibility issues flagged by axe

### DIFF
--- a/components/AppHeader.vue
+++ b/components/AppHeader.vue
@@ -76,6 +76,7 @@ export default {
     <nav
       :class="isMenuOpen ? 'h-full' : ''"
       class="w-full bg-gray-800 fixed top-0 left-0 overflow-y-auto z-20"
+      aria-label="Header"
     >
       <Banner v-if="Boolean(banner)" :banner="banner"></Banner>
       <div class="mx-auto px-2 sm:px-4 lg:px-8">

--- a/components/AppSidebar.vue
+++ b/components/AppSidebar.vue
@@ -52,9 +52,10 @@ export default {
 </script>
 
 <template>
-  <aside
+  <nav
     class="app-sidebar hide-scroll hidden lg:flex lg:w-sidebar lg:col-span-3 xl:col-span-2 top-0 left-0 bottom-0 flex-col border-r border-b border-gray-200 mt-16 bg-lightGray overflow-y-auto"
     role="navigation"
+    aria-label="Sidebar"
   >
     <div
       :class="hasBanner ? $style.bannerMargin : ''"
@@ -72,7 +73,7 @@ export default {
         :path="path"
       />
     </div>
-  </aside>
+  </nav>
 </template>
 
 <style module>

--- a/components/sidebar/CollapsibleSidebarSection.vue
+++ b/components/sidebar/CollapsibleSidebarSection.vue
@@ -133,7 +133,7 @@ export default {
       class="space-y-1 m-0"
       :data-test="`${label}-children`"
     >
-      <div
+      <li
         v-for="(child, index) in children"
         :key="`collapsible-sidebar-section-${index}`"
       >
@@ -151,16 +151,15 @@ export default {
           :name="child.slug"
           :depth="depth + 1"
         />
-        <li v-else>
-          <nuxt-link
-            :to="child.redirect || `/${section}/${folder}/${child.slug}`"
-            :class="getSidebarItemClass(folder, child)"
-            class="rounded-md group w-full flex items-center pl-4 pr-2 py-1 text-md font-medium hover:text-green transition-colors hover:bg-gray-50"
-          >
-            {{ child.title }}
-          </nuxt-link>
-        </li>
-      </div>
+        <nuxt-link
+          v-else
+          :to="child.redirect || `/${section}/${folder}/${child.slug}`"
+          :class="getSidebarItemClass(folder, child)"
+          class="rounded-md group w-full flex items-center pl-4 pr-2 py-1 text-md font-medium hover:text-green transition-colors hover:bg-gray-50"
+        >
+          {{ child.title }}
+        </nuxt-link>
+      </li>
     </ul>
   </div>
 </template>


### PR DESCRIPTION
I took a quick peak at the documentation site with an automated
accessibility tool and it flagged a few issues.

This commit fixes two of those:
1) An aside shouldn't use the aria-role navigation
2) An ul shouldn't contain anything except li elements