### PR TITLE
fixed hydration errors

### DIFF
--- a/components/sidebar/CollapsibleSidebarSection.vue
+++ b/components/sidebar/CollapsibleSidebarSection.vue
@@ -104,12 +104,11 @@ export default {
 
 <template>
   <div
-    :class="
-      depth > 1
-        ? `ml-${depth + 3} pl-2 border-l-2 border-gray-200`
-        : 'px-4 pb-4'
-    "
-    class="space-y-1"
+    :class="[
+      'space-y-1', 
+      (depth > 1 ? `ml-${depth + 3} pl-2 border-l-2 border-gray-200` : 'px-4 pb-4'), 
+      (isOpen ? 'relative' : 'flex items-baseline')
+    ]"
     :data-test="folder"
   >
     <button
@@ -117,16 +116,20 @@ export default {
       @click="toggleSection"
     >
       {{ label }}
-      <!-- Expanded: "text-gray-400 rotate-90", Collapsed: "text-gray-300" -->
-      <svg
-        :class="isOpen ? 'text-gray-400 rotate-90' : 'text-gray-300'"
-        class="ml-auto h-5 w-5 transform group-hover:text-gray-400 transition-colors ease-in-out duration-150"
-        viewBox="0 0 20 20"
-        aria-hidden="true"
-      >
-        <path d="M6 6L14 10L6 14V6Z" fill="currentColor" />
-      </svg>
     </button>
+
+    <!-- Expanded: "text-gray-400 rotate-90", Collapsed: "text-gray-300" -->
+    <svg
+      :class="[
+        'ml-auto h-5 w-5 transform group-hover:text-gray-400 transition-colors ease-in-out duration-150', 
+        (isOpen ? 'text-gray-400 rotate-90 absolute top-0 right-4' : 'text-gray-300 relative')
+      ]"
+      viewBox="0 0 20 20"
+      aria-hidden="true"
+    >
+      <path d="M6 6L14 10L6 14V6Z" fill="currentColor" />
+    </svg>
+
     <!-- Expandable link section, show/hide based on state. -->
     <ul
       :class="isOpen ? '' : 'hidden'"


### PR DESCRIPTION
There were 3 `hydration` errors that were being thrown because a `<svg>` element was nested inside of a `<button>` element for each link in the sidebar. I managed to fix these errors by moving the `<svg>` element outside of the `<button>` and adding some additional tailwind classes to fix the styling. 

The elements which were causing this issue are in the sidebar. The arrow icon is the `<svg>` icon that was the issue. 
![Screen Shot 2021-07-15 at 1 56 36 PM](https://user-images.githubusercontent.com/5605310/125835114-b6267af8-98cf-4737-9102-bc9dd189511d.png)

You will not see the hydration errors in production, most likely. However, locally vue will output warnings to the console like so:
![Screen Shot 2021-07-15 at 1 58 46 PM](https://user-images.githubusercontent.com/5605310/125835313-02c47b5d-c9c8-4006-9b0b-99b57646c1c3.png)

If you pull down this branch locally, these errors are now gone. I share all of this as you most likely will not see these errors and issues on Prod or in the Netlify preview. 