### PR TITLE
docs: Update client certificates docs

### DIFF
--- a/content/guides/guides/web-security.md
+++ b/content/guides/guides/web-security.md
@@ -27,8 +27,7 @@ Cypress does some pretty interesting things under the hood to make testing HTTPS
 
 You'll notice Chrome display a warning that the 'SSL certificate does not match'. This is normal and correct. Under the hood we act as our own CA authority and issue certificates dynamically in order to intercept requests otherwise impossible to access. We only do this for the superdomain currently under test, and bypass other traffic. That's why if you open a tab in Cypress to another host, the certificates match as expected.
 
-Note, that Cypress allows you to optionally specify CA / client certificate information for use with HTTPS sites. See [Configuring security certificates](/guides/references/certificates). If the remote server requests a client certificate for a configured URL, Cypress will supply it.
-
+Note, that Cypress allows you to optionally specify CA / client certificate information for use with HTTPS sites. See [Configuring client certificates](/guides/references/client-certificates). If the remote server requests a client certificate for a configured URL, Cypress will supply it.
 
 </Alert>
 

--- a/content/guides/references/client-certificates.md
+++ b/content/guides/references/client-certificates.md
@@ -31,7 +31,7 @@ Each object in the `certs` array can define either a **PEM format certificate/pr
 | Property     | Type     | Description                                                                           |
 | ------------ | -------- | ------------------------------------------------------------------------------------- |
 | `cert`       | `String` | Path to the certificate file, relative to project root.                               |
-| `key`        | `String` | _(Optional)_ Path to the private key file, relative to project root.                  |
+| `key`        | `String` | Path to the private key file, relative to project root.                               |
 | `passphrase` | `String` | _(Optional)_ Path to a text file containing the passphrase, relative to project root. |
 
 **A PFX certificate container can have the following properties:**

--- a/content/guides/references/client-certificates.md
+++ b/content/guides/references/client-certificates.md
@@ -12,9 +12,38 @@ This document merely offers guidance on how to specify certificate file paths fo
 
 </Alert>
 
-## Structure within JSON config file
+## Syntax
 
-To configure CA / client certificates within your [cypress.env.json](/guides/guides/environment-variables#Option-2-cypress-env-json), you should add a section at the top level something like:
+**<Icon name="angle-right"></Icon> clientCertificates** **_(Object[])_**
+
+An array of objects defining the certificates. Each object must have the following properties
+
+| Property | Type       | Description                                                                                                              |
+| -------- | ---------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `url`    | `String`   | URL to match requests against. Wildcards following [minimatch](https://github.com/isaacs/minimatch) rules are supported. |
+| `ca`     | `Array`    | _(Optional)_ Paths to one or more CA files to validate certs against, relative to project root.                          |
+| `certs`  | `Object[]` | A PEM format certificate/private key pair or PFX certificate container                                                   |
+
+Each object in the `certs` array can define either a **PEM format certificate/private key pair** or a **PFX certificate container**.
+
+**A PEM format certificate/private key pair can have the following properties:**
+
+| Property     | Type     | Description                                                                           |
+| ------------ | -------- | ------------------------------------------------------------------------------------- |
+| `cert`       | `String` | Path to the certificate file, relative to project root.                               |
+| `key`        | `String` | _(Optional)_ Path to the private key file, relative to project root.                  |
+| `passphrase` | `String` | _(Optional)_ Path to a text file containing the passphrase, relative to project root. |
+
+**A PFX certificate container can have the following properties:**
+
+| Property     | Type     | Description                                                                           |
+| ------------ | -------- | ------------------------------------------------------------------------------------- |
+| `pfx`        | `String` | Path to the certificate container, relative to project root.                          |
+| `passphrase` | `String` | _(Optional)_ Path to a text file containing the passphrase, relative to project root. |
+
+## Usage
+
+To configure CA / client certificates within your configuration file (`cypress.json` by default), you can add the `clientCertificates` key to define an array of client certificates as shown below:
 
 ```json
   "clientCertificates": [
@@ -54,17 +83,9 @@ To configure CA / client certificates within your [cypress.env.json](/guides/gui
   ]
 }
 ```
-## `clientCertificates` schema
 
-* The `clientCertificates` value is an **Array** of objects. Each object must have a `url` and `certs` property, and may have an optional `ca` property.
-  * `url` is a **String** used to match requests. Wildcards following [minimatch](https://github.com/isaacs/minimatch) rules are supported.
-  * `ca` is an optional **Array** of paths to one or more CA files to validate certs against, relative to project root.
-  * `certs` is an **Array** of objects.
-* Each object in the `certs` array can contain either
-  * a PEM format certificate/private key pair:
-    *  `cert` is a **String** path to the certificate file, relative to project root.
-    *  `key` is a **String** path to the private key file, relative to project root.
-    *  `passphrase` is an optional **String** path to a text file containing the passphrase, relative to project root.
-  * a PFX certificate container:
-    *  `pfx` is a **String** path to the certificate container, relative to project root.
-    *  `passphrase` is an optional **String** path to a text file containing the passphrase, relative to project root.
+## History
+
+| Version                                     | Changes                                         |
+| ------------------------------------------- | ----------------------------------------------- |
+| [8.0.0](/guides/references/changelog#8-0-0) | Added Client Certificates configuration options |

--- a/content/guides/references/configuration.md
+++ b/content/guides/references/configuration.md
@@ -23,7 +23,7 @@ The default behavior of Cypress can be modified by supplying any of the followin
 | Option                 | Default                           | Description                                                                                                                                                                                  |
 | ---------------------- | --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `baseUrl`              | `null`                            | URL used as prefix for [`cy.visit()`](/api/commands/visit) or [`cy.request()`](/api/commands/request) command's URL                                                                          |
-| `clientCertificates`   | `[]`                              | An optional array of [client certificates](/guides/references/client_certificates)                                                                                   |
+| `clientCertificates`   | `[]`                              | An optional array of [client certificates](/guides/references/client-certificates)                                                                                                           |
 | `env`                  | `{}`                              | Any values to be set as [environment variables](/guides/guides/environment-variables)                                                                                                        |
 | `includeShadowDom`     | `false`                           | Whether to traverse shadow DOM boundaries and include elements within the shadow DOM in the results of query commands (e.g. [`cy.get()`](/api/commands/get))                                 |
 | `numTestsKeptInMemory` | `50`                              | The number of tests for which snapshots and command data are kept in memory. Reduce this number if you are experiencing high memory consumption in your browser during a test run.           |
@@ -581,6 +581,7 @@ DEBUG=cypress:cli,cypress:server:specs
 
 | Version                                      | Changes                                                 |
 | -------------------------------------------- | ------------------------------------------------------- |
+| [8.0.0](/guides/references/changelog#8-0-0)  | Added `clientCertificates` option                       |
 | [7.0.0](/guides/references/changelog#7-0-0)  | Added `e2e` and `component` options.                    |
 | [7.0.0](/guides/references/changelog#7-0-0)  | Added `redirectionLimit` option.                        |
 | [6.1.0](/guides/references/changelog#6-1-0)  | Added `scrollBehavior` option.                          |


### PR DESCRIPTION
- Fix links that did not go to client-certificates doc
- Add History to client certs and config pages to specify when this feature is added
- Fix reference of where this should live (should be cypress.json, not cypress.env.json)
- Rearrange Syntax

I’m on the fence about my updates to the Syntax section. I like tables for the properties, but maybe this isn’t clearer than  the  list before? Thoughts?

### Before

<img width="733" alt="Screen Shot 2021-07-15 at 1 28 27 PM" src="https://user-images.githubusercontent.com/1271364/125839920-5ea6b385-06f4-4175-88e4-0549304ce877.png">


### After

![localhost_3000_guides_references_client-certificates (1)](https://user-images.githubusercontent.com/1271364/125839945-93a0c1cd-7c15-45d6-8141-1d22239f9c53.png)
