### PR TITLE
fix: add `cy.wrap()` to commands sidebar

### DIFF
--- a/content/_data/sidebar.json
+++ b/content/_data/sidebar.json
@@ -725,6 +725,10 @@
               "slug": "within"
             },
             {
+              "title": "wrap",
+              "slug": "wrap"
+            },
+            {
               "title": "writeFile",
               "slug": "writefile"
             }


### PR DESCRIPTION
Can't forget about `cy.wrap()`!