### PR TITLE
Add page for Cypress.currentTest

### DIFF
--- a/content/_data/en.json
+++ b/content/_data/en.json
@@ -211,6 +211,7 @@
       "env": "env",
       "isbrowser": "isBrowser",
       "iscy": "isCy",
+      "currenttest": "currentTest",
       "custom-commands": "Commands",
       "cookies": "Cookies",
       "dom": "dom",

--- a/content/_data/sidebar.json
+++ b/content/_data/sidebar.json
@@ -801,6 +801,10 @@
               "slug": "config"
             },
             {
+              "title": "currentTest",
+              "slug": "currenttest"
+            },
+            {
               "title": "dom",
               "slug": "dom"
             },

--- a/content/api/cypress-api/currenttest.md
+++ b/content/api/cypress-api/currenttest.md
@@ -1,0 +1,50 @@
+---
+title: Cypress.currentTest
+---
+
+`Cypress.currentTest` returns the currently executing test instance with
+properties to access the title of the test.
+
+## Syntax
+
+```javascript
+// returns object with title and titlePath properties
+Cypress.currentTest
+
+// returns title of current test
+Cypress.currentTest.title
+
+// returns array with current test title path
+Cypress.currentTest.titlePath
+```
+
+## Examples
+
+### Get current test title
+
+```javascript
+describe('app layout and responsiveness', () => {
+  it('toggles the nav', () => {
+    expect(Cypress.currentTest.title).to.eq('toggles the nav')
+  })
+})
+```
+
+### Get full path of current test title
+
+```javascript
+describe('app layout and responsiveness', () => {
+  it('toggles the nav', () => {
+    expect(Cypress.currentTest.titlePath).to.deep.eq([
+      'app layout and responsiveness',
+      'toggles the nav',
+    ])
+  })
+})
+```
+
+## History
+
+| Version                                     | Changes                     |
+| ------------------------------------------- | --------------------------- |
+| [8.2.0](/guides/references/changelog#8-2-0) | `Cypress.currentTest` added |

--- a/content/api/cypress-api/currenttest.md
+++ b/content/api/cypress-api/currenttest.md
@@ -5,6 +5,13 @@ title: Cypress.currentTest
 `Cypress.currentTest` is an object representing the currently executing test instance, with
 properties to access the title of the test.
 
+<Alert type="warning">
+
+Note that `Cypress.currentTest` may only be used inside tests and [test
+hooks](/guides/core-concepts/writing-and-organizing-tests#Hooks),
+and will be `null` outside of tests and test hooks.
+
+</Alert>
 ## Syntax
 
 ```javascript

--- a/content/api/cypress-api/currenttest.md
+++ b/content/api/cypress-api/currenttest.md
@@ -8,13 +8,13 @@ properties to access the title of the test.
 ## Syntax
 
 ```javascript
-// returns object with title and titlePath properties
+// an object with title and titlePath properties
 Cypress.currentTest
 
-// returns title of current test
+// the title of the current test
 Cypress.currentTest.title
 
-// returns array with current test title path
+// an array with the current test's title path
 Cypress.currentTest.titlePath
 ```
 

--- a/content/api/cypress-api/currenttest.md
+++ b/content/api/cypress-api/currenttest.md
@@ -12,6 +12,7 @@ hooks](/guides/core-concepts/writing-and-organizing-tests#Hooks),
 and will be `null` outside of tests and test hooks.
 
 </Alert>
+
 ## Syntax
 
 ```javascript

--- a/content/api/cypress-api/currenttest.md
+++ b/content/api/cypress-api/currenttest.md
@@ -2,7 +2,7 @@
 title: Cypress.currentTest
 ---
 
-`Cypress.currentTest` returns the currently executing test instance with
+`Cypress.currentTest` is an object representing the currently executing test instance, with
 properties to access the title of the test.
 
 ## Syntax

--- a/cypress/fixtures/sidebar-overrides.json
+++ b/cypress/fixtures/sidebar-overrides.json
@@ -24,6 +24,7 @@
     "/api/cypress-api/arch": "Cypress.arch",
     "/api/cypress-api/browser": "Cypress.browser",
     "/api/cypress-api/config": "Cypress.config",
+    "/api/cypress-api/currenttest": "Cypress.currentTest",
     "/api/cypress-api/dom": "Cypress.dom",
     "/api/cypress-api/env": "Cypress.env",
     "/api/cypress-api/isbrowser": "Cypress.isBrowser",


### PR DESCRIPTION
Add page to explain what Cypress.currentTest does technically. For https://github.com/cypress-io/cypress/pull/16652

I’d love this to have better examples of *why* someone would use this. Could likely look at https://github.com/cypress-io/cypress/issues/2972 for examples.