### PR TITLE
Remove `beforeinput` Firefox caveat

### DIFF
--- a/content/api/commands/type.md
+++ b/content/api/commands/type.md
@@ -410,13 +410,10 @@ the event spec:
 
 - `keydown`
 - `keypress`
-- `beforeinput`\*
+- `beforeinput`
 - `textInput`
 - `input`
 - `keyup`
-
-\* Firefox does not support the `beforeinput` event
-[MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/beforeinput_event)
 
 Additionally `change` events will be fired either when the `{enter}` key is
 pressed (and the value has changed since the last focus event), or whenever the


### PR DESCRIPTION
Removes `beforeinput` Firefox caveat now that Firefox supports `beforeinput`.

Related:
- https://github.com/cypress-io/cypress/pull/17820
- https://github.com/cypress-io/cypress/issues/17583