### PR TITLE
Fix nesting in cy.session example with validate

### DIFF
--- a/content/api/commands/session.md
+++ b/content/api/commands/session.md
@@ -191,12 +191,11 @@ Cypress.Commands.add(
       }).then(({ body }) => {
         window.localStorage.setItem('authToken', body.token)
       })
+    }, {
+      validate() {
+        cy.request('/whoami').its('statusCode').should('eq', 200)
+      },
     })
-  },
-  {
-    validate() {
-      cy.request('/whoami').its('statusCode').should('eq', 200)
-    },
   }
 )
 ```


### PR DESCRIPTION
Hi there, first of all, thanks for the continued work on Cypress, really amazing to be able to use this tool!

A quick fix for the incorrect nesting of the options object using the `validate` option of the `cy.session` method