### PR TITLE
Fix missing underscore from URL hashes and remove some .html suffixes

### DIFF
--- a/content/api/cypress-api/env.md
+++ b/content/api/cypress-api/env.md
@@ -32,7 +32,7 @@ variables</strong>
 In Cypress, "environment variables" are variables that are accessible via
 `Cypress.env`. These are not the same as OS-level environment variables.
 However,
-[it is possible to set Cypress environment variables from OS-level environment variables](/guides/guides/environment-variables.html#Option-3-CYPRESS).
+[it is possible to set Cypress environment variables from OS-level environment variables](/guides/guides/environment-variables#Option-3-CYPRESS_).
 
 </Alert>
 

--- a/content/guides/guides/environment-variables.md
+++ b/content/guides/guides/environment-variables.md
@@ -10,7 +10,7 @@ variables</strong>
 In Cypress, "environment variables" are variables that are accessible via
 `Cypress.env`. These are not the same as OS-level environment variables.
 However,
-[it is possible to set Cypress environment variables from OS-level environment variables](/guides/guides/environment-variables#Option-3-CYPRESS).
+[it is possible to set Cypress environment variables from OS-level environment variables](/guides/guides/environment-variables#Option-3-CYPRESS_).
 
 </Alert>
 

--- a/content/guides/references/configuration.md
+++ b/content/guides/references/configuration.md
@@ -441,7 +441,7 @@ value has been set via the following ways:
 - The
   [Cypress environment file](/guides/guides/environment-variables#Option-2-cypress-env-json)
 - System
-  [environment variables](/guides/guides/environment-variables#Option-3-CYPRESS)
+  [environment variables](/guides/guides/environment-variables#Option-3-CYPRESS_)
 - [Command Line arguments](/guides/guides/command-line)
 - [Plugins file](/api/plugins/configuration-api)
 

--- a/scripts/partials.js
+++ b/scripts/partials.js
@@ -22,7 +22,7 @@ The Chrome browser is evergreen - meaning it will automatically update itself, s
 `
 
 module.exports.CYPRESS_ENV_VAR_WARNING = `{% note warning "Difference between OS-level and Cypress environment variables" %}
-In Cypress, "environment variables" are variables that are accessible via \`Cypress.env\`. These are not the same as OS-level environment variables. However, [it is possible to set Cypress environment variables from OS-level environment variables](/guides/guides/environment-variables.html#Option-3-CYPRESS).
+In Cypress, "environment variables" are variables that are accessible via \`Cypress.env\`. These are not the same as OS-level environment variables. However, [it is possible to set Cypress environment variables from OS-level environment variables](/guides/guides/environment-variables#Option-3-CYPRESS_).
 {% endnote %}
 `
 


### PR DESCRIPTION
There were several broken links to the `Option #3: CYPRESS_*` section of the Environment Variables documentation page due to a missing underscore. This PR fixes that, and removes a few more `.html`-suffixes in the process, continuing the work in 486ed9ecf7d272394e30d80ee6d1f37dcc3ba8e2

(Force push because this PR initially only fixed one broken link and I discovered a few others a bit over an hour later 😇)