### PR TITLE
Document information about proxy settings on cypress install

### DIFF
--- a/content/guides/getting-started/installing-cypress.md
+++ b/content/guides/getting-started/installing-cypress.md
@@ -98,6 +98,12 @@ The version of the `npm` package determines the version of the binary
 downloaded. As of version `3.0`, the binary is downloaded to a global cache
 directory to be used across projects.
 
+System proxy properties `http_proxy`, `https_proxy` and `no_proxy` are respected
+for the download of the Cypress binary. You can also use the npm properties 
+`npm_config_proxy` and `npm_config_https_proxy`. Those have lower priority, so 
+they will only be used if the system properties are being resolved to not use a 
+proxy.
+
 </Alert>
 
 <Alert type="success">
@@ -123,6 +129,9 @@ cd /your/project/path
 ```shell
 yarn add cypress --dev
 ```
+
+System proxy properties `http_proxy`, `https_proxy` and `no_proxy` are respected
+for the download of the Cypress binary.
 
 ### <Icon name="download"></Icon> Direct download
 


### PR DESCRIPTION
This adds documentation about the usage of proxy properties on cypress installation for npm and yarn. This links to https://github.com/cypress-io/cypress/pull/17702