### PR TITLE
Fixes broken link on click.md

### DIFF
--- a/content/api/commands/click.md
+++ b/content/api/commands/click.md
@@ -246,7 +246,7 @@ following:
 ## See also
 
 - [`.check()`](/api/commands/check)
-- [`.click()` examples in kitchensink app](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/cypress/integration/examples/actions.spec.js#L66)
+- [`.click()` examples in kitchensink app](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/cypress/integration/2-advanced-examples/actions.spec.js#L67)
 - [`.dblclick()`](/api/commands/dblclick)
 - [`.rightclick()`](/api/commands/rightclick)
 - [`.select()`](/api/commands/select)


### PR DESCRIPTION
Looks like the folder structure changed at some point. This link points to the first of the `click()` examples.