### PR TITLE
Fix markup errors on `best-practices.md`

### DIFF
--- a/content/guides/references/best-practices.md
+++ b/content/guides/references/best-practices.md
@@ -767,8 +767,8 @@ The same practice above can be used for any type of database (PostgreSQL,
 MongoDB, etc.). In this example, a request is sent to a back end API, but you
 could also interact directly with your database with direct queries, custom
 libraries, etc. If you already have non-JavaScript methods of handling or
-interacting with your database, you can use `[cy.exec](/api/commands/exec)`,
-instead of `[cy.task](/api/commands/task)`, to execute any system command or
+interacting with your database, you can use [`cy.exec`](/api/commands/exec),
+instead of [`cy.task`](/api/commands/task), to execute any system command or
 script.
 
 ## Unnecessary Waiting


### PR DESCRIPTION
Hello, I found Markdown markup errors on [Best Practices | Cypress Documentation](https://docs.cypress.io/guides/references/best-practices#Real-World-Example-1).

## Screenshot

### Before changing

<img width="795" alt="Screen Shot 2021-09-17 at 20 32 28" src="https://user-images.githubusercontent.com/1425259/133918181-e791286a-b425-4c44-b802-845135d1f825.png">

### After changing

<img width="631" alt="Screen Shot 2021-09-19 at 15 40 49" src="https://user-images.githubusercontent.com/1425259/133918177-48174634-fde8-4452-8b9d-82227e0002b7.png">
