### PR TITLE
fixed broken links in mobile nav

### DIFF
--- a/components/AppHeaderMobileSection.vue
+++ b/components/AppHeaderMobileSection.vue
@@ -52,6 +52,14 @@ export default {
           :name="child.slug"
           :children="child.children"
         />
+        <div v-else-if="child.redirect">
+          <nuxt-link
+            :to="`${child.redirect}`"
+            class="text-gray-300 hover:bg-gray-700 hover:text-white block px-3 py-2 rounded-md text-base font-medium"
+          >
+            {{ child.title }}
+          </nuxt-link>
+        </div>
         <div v-else>
           <nuxt-link
             :to="`/${section}/${folder}/${child.slug}`"


### PR DESCRIPTION
The broken links in the mobile nav were caused by the link items in the `_data/sidebar.json` not having a slug property. I updated the `AppHeaderMobileSection.vue` component to also render items if they have a redirect property to fix the broken links.