### PR TITLE
Update more kitchensink links and folder structure example.

### DIFF
--- a/content/api/commands/intercept.md
+++ b/content/api/commands/intercept.md
@@ -1599,7 +1599,7 @@ information about the request and response to the console:
 - [`cy.wait()`](/api/commands/wait)
 - [Network Requests Guide](/guides/guides/network-requests)
 - [Cypress Example Recipes](https://github.com/cypress-io/cypress-example-recipes#stubbing-and-spying)
-- [Kitchen Sink Examples](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/cypress/integration/examples/network_requests.spec.js)
+- [Kitchen Sink Examples](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/cypress/integration/2-advanced-examples/network_requests.spec.js)
 - [Migrating `cy.route()` to `cy.intercept()`](/guides/references/migration-guide#Migrating-cy-route-to-cy-intercept)
 <!-- TODO add examples from the resources below to `cypress-example-recipes` repo -->
 - [Smart GraphQL Stubbing in Cypress](https://glebbahmutov.com/blog/smart-graphql-stubbing/)

--- a/content/guides/core-concepts/writing-and-organizing-tests.md
+++ b/content/guides/core-concepts/writing-and-organizing-tests.md
@@ -117,7 +117,7 @@ Check out our recipe using
 </Alert>
 
 To see an example of every command used in Cypress, open the
-[`example` folder](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/cypress/integration/examples)
+[`2-advanced-examples` folder](https://github.com/cypress-io/cypress-example-kitchensink/tree/master/cypress/integration/2-advanced-examples)
 within your `cypress/integration` folder.
 
 To start writing tests for your app, create a new file like `app_spec.js` within

--- a/content/guides/core-concepts/writing-and-organizing-tests.md
+++ b/content/guides/core-concepts/writing-and-organizing-tests.md
@@ -38,25 +38,28 @@ folder structure. By default it will create:
 
   /integration
     /examples
-      - actions.spec.js
-      - aliasing.spec.js
-      - assertions.spec.js
-      - connectors.spec.js
-      - cookies.spec.js
-      - cypress_api.spec.js
-      - files.spec.js
-      - local_storage.spec.js
-      - location.spec.js
-      - misc.spec.js
-      - navigation.spec.js
-      - network_requests.spec.js
-      - querying.spec.js
-      - spies_stubs_clocks.spec.js
-      - traversal.spec.js
-      - utilities.spec.js
-      - viewport.spec.js
-      - waiting.spec.js
-      - window.spec.js
+      /1-getting-started
+        - todo.spec.js
+      /2-advanced-examples
+        - actions.spec.js
+        - aliasing.spec.js
+        - assertions.spec.js
+        - connectors.spec.js
+        - cookies.spec.js
+        - cypress_api.spec.js
+        - files.spec.js
+        - local_storage.spec.js
+        - location.spec.js
+        - misc.spec.js
+        - navigation.spec.js
+        - network_requests.spec.js
+        - querying.spec.js
+        - spies_stubs_clocks.spec.js
+        - traversal.spec.js
+        - utilities.spec.js
+        - viewport.spec.js
+        - waiting.spec.js
+        - window.spec.js
 
   /plugins
     - index.js

--- a/content/guides/guides/network-requests.md
+++ b/content/guides/guides/network-requests.md
@@ -578,7 +578,7 @@ following:
 ## See also
 
 - [`cy.intercept()` docs](/api/commands/intercept)
-- [Network requests in Kitchen Sink example](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/cypress/integration/examples/network_requests.spec.js)
+- [Network requests in Kitchen Sink example](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/cypress/integration/2-advanced-examples/network_requests.spec.js)
 - [See how to make a request with `cy.request()`](/api/commands/request)
 - [Real World App (RWA)](https://github.com/cypress-io/cypress-realworld-app)
   test suites to see Cypress network handling in action.


### PR DESCRIPTION
After https://github.com/cypress-io/cypress-documentation/pull/4092 was merged it occurred to me that there might be more instances of that link needing updating. Found some with a quick search that I wish I'd performed sooner! 😄 Also noticed that some text and the example folder structure did not reflect the new ways.

Hopefully the rest of the wording on [Writing and Organizing Tests](https://github.com/cjbramble/cypress-documentation/blob/212f996ee194139d5d0708a6b39eda0bf02bfca7/content/guides/core-concepts/writing-and-organizing-tests.md) is still sound with the updates. Seemed fine to me from my skimming.