### PR TITLE
[UNIFY-416] Update Component Testing docs

### DIFF
--- a/content/guides/component-testing/framework-configuration.md
+++ b/content/guides/component-testing/framework-configuration.md
@@ -547,7 +547,6 @@ extension.
 
 ```js
 const { startDevServer } = require('@cypress/vite-dev-server')
-const path = require('path')
 ```
 
 ```js
@@ -555,10 +554,7 @@ const path = require('path')
   component: {
     devServer(cypressDevServerConfig) {
       return startDevServer({
-        options: cypressDevServerConfig,
-        viteConfig: {
-          configFile: path.resolve(__dirname, './vite.config.js'),
-        },
+        options: cypressDevServerConfig
       })
     },
     componentFolder: 'src',
@@ -578,16 +574,10 @@ const path = require('path')
 
 ```js
 const { startDevServer } = require('@cypress/vite-dev-server')
-const path = require('path')
 
 module.exports = (on, config) => {
   on('dev-server:start', (options) => {
-    return startDevServer({
-      options,
-      viteConfig: {
-        configFile: path.resolve(__dirname, '../../vite.config.js'),
-      },
-    })
+    return startDevServer({ options })
   })
 }
 ```

--- a/content/guides/component-testing/framework-configuration.md
+++ b/content/guides/component-testing/framework-configuration.md
@@ -56,16 +56,12 @@ return config
 Lastly, tell Cypress where to find your test in the Cypress configuration. In
 this example all the tests are in `src` and named `test.js`:
 
-:::cypress-config-example
-
-```js
+```json
 {
-  testFiles: "**/*.test.{js,ts,jsx,tsx}",
-  componentFolder: "src"
+  "testFiles": "**/*.test.{js,ts,jsx,tsx}",
+  "componentFolder": "src"
 }
 ```
-
-:::
 
 Finally, add a test. We will replace the default test (using Testing Library)
 with one using Cypress:
@@ -151,16 +147,12 @@ for more information.
 Lastly, tell Cypress where to find your test in the Cypress configuration. In
 this example all the tests are in `src` and named `spec.js`:
 
-:::cypress-config-example
-
-```js
+```json
 {
-  testFiles: "**/*.spec.js",
-  componentFolder: "src"
+  "testFiles": "**/*.spec.js",
+  "componentFolder": "src"
 }
 ```
-
-:::
 
 Finally, add a test:
 
@@ -244,16 +236,12 @@ return config
 Lastly, tell Cypress where to find your test in the Cypress configuration. In
 this example all the tests are in `cypress/pages`:
 
-:::cypress-config-example
-
-```js
+```json
 {
-  testFiles: "*_/_.spec.{js,jsx}",
-  componentFolder: "cypress/pages"
+  "testFiles": "*_/_.spec.{js,jsx}",
+  "componentFolder": "cypress/pages"
 }
 ```
-
-:::
 
 Finally, add a test in `cypress/pages`:
 
@@ -360,16 +348,12 @@ implemented with Cypress e2e runner.
 In this example we specify the `componentFolder` as `components`, the default
 for Nuxt.
 
-:::cypress-config-example
-
-```js
+```json
 {
-  testFiles: "**/*.spec.js",
-  componentFolder: "components"
+  "testFiles": "**/*.spec.js",
+  "componentFolder": "components"
 }
 ```
-
-:::
 
 Finally, add a component and test:
 
@@ -496,16 +480,12 @@ on('dev-server:start', (options) => {
 Lastly, tell Cypress where to find your test in the Cypress configuration. In
 this example all the tests are in `src` and named `spec.jsx`:
 
-:::cypress-config-example
-
-```js
+```json
 {
-  testFiles: "**/*.spec.jsx",
-  componentFolder: "src"
+  "testFiles": "**/*.spec.jsx",
+  "componentFolder": "src"
 }
 ```
-
-:::
 
 Finally, add a test in `src/App.spec.jsx`:
 

--- a/content/guides/component-testing/framework-configuration.md
+++ b/content/guides/component-testing/framework-configuration.md
@@ -34,37 +34,53 @@ React App use Webpack v4.
 
 </Alert>
 
-Next configure the dev-server to use the same Webpack configuration used by
-Create React App. We can do this easily using the `react-scripts` plugin
-provided by Cypress. Place the following in `cypress/plugins/index.js`, creating
-the relevant directories.
+Configure the dev server to use the same Webpack configuration used by Create
+React App. You can do this using the `react-scripts` plugin provided by the
+`@cypress/react` module.
 
-:::cypress-plugin-example{configProp=component noComment}
+Also, you need to tell Cypress where to find your component tests. The following
+example configuration assumes that all the test files are somewhere in the `src`
+folder and end with a `.test.js`, `.test.jsx`, `.test.ts` or `.test.tsx`
+extension.
+
+:::cypress-config-plugin-example
 
 ```js
-const injectDevServer = require('@cypress/react/plugins/react-scripts')
+const { devServer } = require('@cypress/react/plugins/react-scripts')
 ```
 
 ```js
-injectDevServer(on, config)
+{
+  component: {
+    devServer,
+    componentFolder: 'src',
+    testFiles: '**/*.test.{js,ts,jsx,tsx}'
+  }
+}
+```
 
-return config
+```json
+{
+  "component": {
+    "componentFolder": "src",
+    "testFiles": "**/*.test.{js,ts,jsx,tsx}"
+  }
+}
+```
+
+```js
+const injectDevServer = require('@cypress/react/plugins/react-scripts')
+
+module.exports = (on, config) => {
+  injectDevServer(on, config)
+  return config
+}
 ```
 
 :::
 
-Lastly, tell Cypress where to find your test in the Cypress configuration. In
-this example all the tests are in `src` and named `test.js`:
-
-```json
-{
-  "testFiles": "**/*.test.{js,ts,jsx,tsx}",
-  "componentFolder": "src"
-}
-```
-
-Finally, add a test. We will replace the default test (using Testing Library)
-with one using Cypress:
+Now add a test. We will replace the default test (using Testing Library) with
+one using Cypress:
 
 ```jsx
 // src/App.test.js
@@ -111,11 +127,15 @@ need `html-webpack-plugin@5` instead.
 
 </Alert>
 
-Next configure the dev-server to use the same Webpack configuration used by Vue
-CLI. Place the following in `cypress/plugins/index.js`, creating the relevant
-directories.
+Configure the dev server to use the same Webpack configuration used by Vue CLI.
+You can do this using the plugin provided by the `@cypress/webpack-dev-server`
+module.
 
-:::cypress-plugin-example{configProp=component noComment}
+Also, you need to tell Cypress where to find your component tests. The following
+example configuration assumes that all the test files are somewhere in the `src`
+folder and end with the `.spec.js` extension.
+
+:::cypress-config-plugin-example
 
 ```js
 const { startDevServer } = require('@cypress/webpack-dev-server')
@@ -123,12 +143,41 @@ const webpackConfig = require('@vue/cli-service/webpack.config')
 ```
 
 ```js
-on('dev-server:start', (options) => {
-  return startDevServer({
-    options,
-    webpackConfig,
+{
+  component: {
+    devServer(cypressDevServerConfig) {
+      return startDevServer({
+        options: cypressDevServerConfig,
+        webpackConfig,
+      })
+    },
+    componentFolder: 'src',
+    testFiles: '**/*.spec.js'
+  }
+}
+```
+
+```json
+{
+  "component": {
+    "componentFolder": "src",
+    "testFiles": "**/*.spec.js"
+  }
+}
+```
+
+```js
+const { startDevServer } = require('@cypress/webpack-dev-server')
+const webpackConfig = require('@vue/cli-service/webpack.config')
+
+module.exports = (on, config) => {
+  on('dev-server:start', (options) => {
+    return startDevServer({
+      options,
+      webpackConfig,
+    })
   })
-})
+}
 ```
 
 :::
@@ -144,17 +193,7 @@ for more information.
 
 </Alert>
 
-Lastly, tell Cypress where to find your test in the Cypress configuration. In
-this example all the tests are in `src` and named `spec.js`:
-
-```json
-{
-  "testFiles": "**/*.spec.js",
-  "componentFolder": "src"
-}
-```
-
-Finally, add a test:
+Now add a test:
 
 ```jsx
 // src/components/HelloWorld.spec.js
@@ -215,37 +254,55 @@ versions that correspond to the current version of Next.js.
 
 </Alert>
 
-Next configure the dev-server using the Next.js adapter shipped with
-`@cypress/react` by adding the following code to `cypress/plugins/index.js`,
-creating the relevant directories:
+Configure the dev server to use the same Webpack configuration used by Next.js.
+You can do this using the `next` plugin provided by the `@cypress/react` module.
 
-:::cypress-plugin-example{configProp=component noComment}
+Also, you need to tell Cypress where to find your component tests. The following
+example configuration assumes that all the test files are somewhere in the
+`cypress/pages` folder and end with either the `.spec.js` or `.spec.jsx`
+extension.
+
+:::cypress-config-plugin-example
 
 ```js
-const injectDevServer = require('@cypress/react/plugins/next')
+const { devServer } = require('@cypress/react/plugins/next')
 ```
 
 ```js
-injectDevServer(on, config)
+{
+  component: {
+    devServer,
+    componentFolder: 'cypress/pages',
+    testFiles: '**/*.spec.{js,jsx}'
+  }
+}
+```
 
-return config
+```json
+{
+  "component": {
+    "componentFolder": "cypress/pages",
+    "testFiles": "**/*.spec.{js,jsx}"
+  }
+}
+```
+
+```js
+const injectDevServer = require('@cypress/react/plugins/next')
+
+module.exports = (on, config) => {
+  injectDevServer(on, config)
+  return config
+}
 ```
 
 :::
 
-Lastly, tell Cypress where to find your test in the Cypress configuration. In
-this example all the tests are in `cypress/pages`:
-
-```json
-{
-  "testFiles": "*_/_.spec.{js,jsx}",
-  "componentFolder": "cypress/pages"
-}
-```
-
-Finally, add a test in `cypress/pages`:
+Now add a test:
 
 ```jsx
+// cypress/pages/IndexPage.spec.jsx
+
 import React from 'react'
 import { mount } from '@cypress/react'
 import IndexPage from '../../pages/index'
@@ -317,11 +374,19 @@ CLI v4 use Webpack v4.
 
 </Alert>
 
-Next configure the dev-server to use the same Webpack configuration used by
-Nuxt. Place the following in `cypress/plugins/index.js`, creating the relevant
-directories.
+Configure the dev server to use the same Webpack configuration used by Nuxt. You
+can do this using the plugin provided by the `@cypress/webpack-dev-server`
+module.
 
-:::cypress-plugin-example{configProp=component noComment}
+Also, you need to tell Cypress where to find your component tests. While it's
+possible to mount components in the `pages` directory, generally you will want
+to be more granular with your component tests - full page tests are best
+implemented with Cypress e2e runner.
+
+The following example configuration assumes that all the test files are
+somewhere in the `components` folder, and end with the `.spec.js` extension.
+
+:::cypress-config-plugin-example
 
 ```js
 const { startDevServer } = require('@cypress/webpack-dev-server')
@@ -329,33 +394,48 @@ const { getWebpackConfig } = require('nuxt')
 ```
 
 ```js
-on('dev-server:start', async (options) => {
-  const webpackConfig = await getWebpackConfig()
-  return startDevServer({
-    options,
-    webpackConfig,
+{
+  component: {
+    async devServer(cypressDevServerConfig) {
+      const webpackConfig = await getWebpackConfig()
+      return startDevServer({
+        options: cypressDevServerConfig,
+        webpackConfig,
+      })
+    },
+    componentFolder: 'components',
+    testFiles: '**/*.spec.js'
+  }
+}
+```
+
+```json
+{
+  "component": {
+    "componentFolder": "components",
+    "testFiles": "**/*.spec.js"
+  }
+}
+```
+
+```js
+const { startDevServer } = require('@cypress/webpack-dev-server')
+const { getWebpackConfig } = require('nuxt')
+
+module.exports = (on, config) => {
+  on('dev-server:start', async (options) => {
+    const webpackConfig = await getWebpackConfig()
+    return startDevServer({
+      options,
+      webpackConfig,
+    })
   })
-})
+}
 ```
 
 :::
 
-Lastly, tell Cypress where to find your test in the Cypress configuration. While
-it's possible to mount components in the `pages` directory, generally you will
-want to be more granular with your component tests - full page tests are best
-implemented with Cypress e2e runner.
-
-In this example we specify the `componentFolder` as `components`, the default
-for Nuxt.
-
-```json
-{
-  "testFiles": "**/*.spec.js",
-  "componentFolder": "components"
-}
-```
-
-Finally, add a component and test:
+Now add a component:
 
 ```html
 <!-- components/mountains.vue -->
@@ -387,8 +467,11 @@ Finally, add a component and test:
 </script>
 ```
 
+And a test:
+
 ```js
 // components/mountains.spec.js
+
 import { mount } from '@cypress/vue'
 import Mountains from './mountains.vue'
 
@@ -454,42 +537,68 @@ project
 and a Vue project
 [here](https://github.com/cypress-io/cypress-component-examples/tree/main/vite-vue).
 
-Inside of `cypress/plugins/index.js`, configure Cypress to use the Vite dev
-server:
+Configure the dev server using the plugin provided by the
+`@cypress/vite-dev-server` module. Also, you need to tell Cypress where to find
+your component tests. The following example configuration assumes that all the
+test files are somewhere in the `src` folder and end with the `.spec.jsx`
+extension.
 
-:::cypress-plugin-example{configProp=component noComment}
+:::cypress-config-plugin-example
 
 ```js
-const path = require('path')
 const { startDevServer } = require('@cypress/vite-dev-server')
+const path = require('path')
 ```
 
 ```js
-on('dev-server:start', (options) => {
-  return startDevServer({
-    options,
-    viteConfig: {
-      configFile: path.resolve(__dirname, '..', '..', 'vite.config.js'),
+{
+  component: {
+    devServer(cypressDevServerConfig) {
+      return startDevServer({
+        options: cypressDevServerConfig,
+        viteConfig: {
+          configFile: path.resolve(__dirname, './vite.config.js'),
+        },
+      })
     },
+    componentFolder: 'src',
+    testFiles: '**/*.spec.jsx'
+  }
+}
+```
+
+```json
+{
+  "component": {
+    "componentFolder": "src",
+    "testFiles": "**/*.spec.jsx"
+  }
+}
+```
+
+```js
+const { startDevServer } = require('@cypress/vite-dev-server')
+const path = require('path')
+
+module.exports = (on, config) => {
+  on('dev-server:start', (options) => {
+    return startDevServer({
+      options,
+      viteConfig: {
+        configFile: path.resolve(__dirname, '../../vite.config.js'),
+      },
+    })
   })
-})
+}
 ```
 
 :::
 
-Lastly, tell Cypress where to find your test in the Cypress configuration. In
-this example all the tests are in `src` and named `spec.jsx`:
-
-```json
-{
-  "testFiles": "**/*.spec.jsx",
-  "componentFolder": "src"
-}
-```
-
-Finally, add a test in `src/App.spec.jsx`:
+Now add a test:
 
 ```jsx
+// src/App.spec.jsx
+
 import React from 'react'
 import { mount } from '@cypress/react'
 import App from './App'

--- a/scripts/directives/cypress-config-plugin-example.js
+++ b/scripts/directives/cypress-config-plugin-example.js
@@ -1,0 +1,77 @@
+const endent = require('endent').default
+
+const replacer = (key, value) => {
+  if (typeof value === 'function') {
+    throw new Error(`Function values not supported in json: ${key}`)
+  }
+
+  return value
+}
+
+function processNode(node, { _require, error, warn }) {
+  const helpers = _require(__dirname, './helpers/example-helpers')
+  const { children } = helpers.getNodeProperties(node)
+  const { errorArgs, parts } = helpers.getCodeBlocks(children, { count: 4 })
+
+  if (errorArgs) {
+    return error(...errorArgs)
+  }
+
+  const [header, body, cypressJson, pluginsFile] = parts
+
+  return helpers.getCodeGroup(
+    {
+      label: 'cypress.config.js',
+      language: 'js',
+      body: endent`
+        const { defineConfig } = require('cypress')
+        ${header}
+
+        module.exports = defineConfig(${body})
+      `,
+    },
+    {
+      label: 'cypress.config.ts',
+      language: 'ts',
+      body: endent`
+        import { defineConfig } from 'cypress'
+        ${header}
+
+        export default defineConfig(${body})
+      `,
+    },
+    {
+      label: 'cypress.json & plugins file',
+      language: 'js',
+      alert: endent`
+        <Alert type="warning">
+
+        <strong class="alert-header"><Icon name="exclamation-triangle"></Icon>
+        Deprecated</strong>
+
+        The \`cypress.json\` file and plugins file are deprecated as of Cypress
+        CFG_VERSION. We recommend that you update your configuration. Please see the
+        [new configuration guide](/guides/references/configuration),
+        [plugins guide](/guides/tooling/plugins-guide) and the
+        [migration guide](/guides/references/migration-guide) for more information.
+
+        </Alert>
+      `,
+      body: endent`
+        // cypress.json (deprecated)
+
+        WEIRD_WORKAROUND_SORRY${cypressJson}
+
+        // plugins file (deprecated)
+
+        WEIRD_WORKAROUND_SORRY${pluginsFile}
+      `,
+    }
+  )
+}
+
+module.exports = {
+  type: 'containerDirective',
+  name: 'cypress-config-plugin-example',
+  processNode,
+}

--- a/scripts/directives/helpers/example-helpers.js
+++ b/scripts/directives/helpers/example-helpers.js
@@ -57,6 +57,41 @@ exports.getHeaderAndBody = (children) => {
   return { header, body }
 }
 
+exports.getCodeBlocks = (children, { count, min, max } = {}) => {
+  const hasCount = typeof count === 'number'
+
+  if (!hasCount && (typeof min !== 'number' || typeof max !== 'number')) {
+    const errorArgs = [
+      `Expected either "count" or "min" + "max" options, instead got`,
+      { count, min, max },
+    ]
+
+    return { errorArgs }
+  }
+
+  if (hasCount) {
+    min = max = count
+  }
+
+  if (
+    children.length < min ||
+    children.length > max ||
+    !children.every(({ type }) => type === 'code')
+  ) {
+    const countText = hasCount ? count : `${min}-${max}`
+    const errorArgs = [
+      `Expected ${countText} code blocks inside directive, instead got`,
+      children.map((o) => o.type),
+    ]
+
+    return { errorArgs }
+  }
+
+  const parts = children.map(({ value }) => value.trim())
+
+  return { parts }
+}
+
 exports.getCodeGroup = (...blocks) => {
   const filterFn = (obj) => obj && obj.body
   const mapFn = ({ label, language, alert = '', body }, i) => {

--- a/scripts/remark-directives.js
+++ b/scripts/remark-directives.js
@@ -50,6 +50,7 @@ const getDisplay = (type, name) => {
 function loadDirectives() {
   loadDirective('./directives/include')
   loadDirective('./directives/cypress-config-example')
+  loadDirective('./directives/cypress-config-plugin-example')
   loadDirective('./directives/cypress-plugin-example')
 }
 


### PR DESCRIPTION
Update all Component Testing Framework Configuration examples to have **cypress.config.js** / **cypress.config.ts** / **cypress.json & plugins file** tabs via a new `:::cypress-config-plugin-example` directive, which will allow us to show _all_ CT configuration in a single tabbed example.

Note that this does not address any issues with or examples on the CT Introduction page. That will likely need a significant rewrite.

Preview
https://deploy-preview-4137--cypress-docs.netlify.app/guides/component-testing/framework-configuration