### PR TITLE
Rewrite that horrible CodeGroup component to actually work in dev

### DIFF
--- a/components/global/CodeBlock.vue
+++ b/components/global/CodeBlock.vue
@@ -10,11 +10,26 @@ export default {
       default: false,
     },
   },
+  data() {
+    return {
+      activeState: this.active,
+    }
+  },
+  beforeMount() {
+    if (this.$parent && this.$parent.registerCodeBlock) {
+      this.$parent.registerCodeBlock(this)
+    }
+  },
+  methods: {
+    setActiveState(state) {
+      this.activeState = state
+    },
+  },
 }
 </script>
 
 <template>
-  <div :class="[active && 'active', $style.codeBlock]">
+  <div :class="[activeState && $style.active, $style.codeBlock]">
     <div v-if="true" :class="['code-block', $style.alert]">
       <slot name="alert"></slot>
     </div>
@@ -27,11 +42,11 @@ export default {
   display: none;
 }
 
-:global(.active) {
+.active {
   display: block;
 }
 
-:global(.active .line-numbers) {
+.active .line-numbers {
   @apply mt-0;
 }
 

--- a/components/global/CodeGroup.vue
+++ b/components/global/CodeGroup.vue
@@ -14,8 +14,8 @@
         ) in codeBlocks"
         ref="tabs"
         :key="label"
-        class="px-4 py-3 text-gray-400 font-bold font-mono outline-none"
-        :class="[activeTabIndex === i && 'active']"
+        class="px-4 py-3 text-gray-400 font-bold font-mono"
+        :class="[$style.button, activeTabIndex === i && 'active']"
         @click="updateTabs(i)"
       >
         {{ label }}
@@ -85,8 +85,8 @@ export default {
 </script>
 
 <style module>
-button {
-  outline: none;
+.button {
+  outline: none !important;
 }
 
 .highlightUnderline {

--- a/components/global/CodeGroup.vue
+++ b/components/global/CodeGroup.vue
@@ -4,16 +4,29 @@
       class="rounded-t-md border-b-2 border-gray-700 px-2 bg-gray-800 text-sm text-white relative flex flex-row"
     >
       <button
-        v-for="({ label }, i) in tabs"
+        v-for="(
+          {
+            $vnode: {
+              componentInstance: { label },
+            },
+          },
+          i
+        ) in codeBlocks"
         ref="tabs"
         :key="label"
-        class="px-4 py-3 text-gray-400 font-bold font-mono"
+        class="px-4 py-3 text-gray-400 font-bold font-mono outline-none"
         :class="[activeTabIndex === i && 'active']"
         @click="updateTabs(i)"
       >
         {{ label }}
       </button>
-      <span ref="highlight-underline" :class="$style.highlightUnderline" />
+      <button
+        v-if="codeBlocks.length === 0"
+        class="px-4 py-3 text-gray-400 font-bold font-mono"
+      >
+        Loading...
+      </button>
+      <span ref="highlightUnderline" :class="$style.highlightUnderline" />
     </div>
     <slot />
   </div>
@@ -23,47 +36,46 @@
 export default {
   data() {
     return {
-      tabs: [],
+      codeBlocks: [],
       activeTabIndex: 0,
     }
   },
   watch: {
     activeTabIndex(newValue, oldValue) {
-      this.switchTab(newValue)
+      this.activateCodeBlock(newValue)
     },
   },
-  mounted() {
-    this.tabs = this.$slots.default
-      .filter((slot) => Boolean(slot.componentOptions))
-      .map((slot) => {
-        return {
-          label: slot.componentOptions.propsData.label,
-          elm: slot.elm,
-        }
-      })
-
-    this.$nextTick(this.updateHighlighteUnderlinePosition)
-  },
   methods: {
-    switchTab(i) {
-      this.tabs.forEach((tab) => {
-        tab.elm.classList.remove('active')
+    registerCodeBlock(codeBlock) {
+      const { length } = this.codeBlocks
+
+      if (length === 0) {
+        this.$nextTick(this.updateHighlighteUnderlinePosition)
+      }
+
+      if (codeBlock.$vnode.componentInstance.active) {
+        this.activeTabIndex = length
+      }
+
+      this.codeBlocks.push(codeBlock)
+    },
+    activateCodeBlock(index) {
+      this.codeBlocks.forEach((codeBlock, i) => {
+        codeBlock.setActiveState(i === index)
       })
 
-      this.tabs[i].elm.classList.add('active')
+      this.updateHighlighteUnderlinePosition()
     },
     updateTabs(i) {
       this.activeTabIndex = i
-      this.updateHighlighteUnderlinePosition()
     },
     updateHighlighteUnderlinePosition() {
-      const activeTab = this.$refs.tabs[this.activeTabIndex]
-
-      if (!activeTab) {
+      if (!this.$refs.tabs) {
         return
       }
 
-      const highlightUnderline = this.$refs['highlight-underline']
+      const activeTab = this.$refs.tabs[this.activeTabIndex]
+      const { highlightUnderline } = this.$refs
 
       highlightUnderline.style.left = `${activeTab.offsetLeft}px`
       highlightUnderline.style.width = `${activeTab.clientWidth}px`


### PR DESCRIPTION
Test locally with `yarn start`

And let's make sure it works in the build preview as well:
https://deploy-preview-4142--cypress-docs.netlify.app/

Notes:
- Should actually render tabs + code in both `yarn dev` and `yarn build`
- Should highlight the `active` tab and show the `active` code block by default
- Should highlight the correct tab and show the correct code block when tab clicked
- Should not break page scrolling when visiting a page with an anchor, eg. the **Argument should be serializable** heading should be at the top of the page and not jump around when visiting https://deploy-preview-4142--cypress-docs.netlify.app/api/commands/task#Argument-should-be-serializable