### PR TITLE
File change server

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -4,6 +4,18 @@
   </div>
 </template>
 
+<script>
+import { onFileChange } from '../utils/file-change-server/client'
+
+export default {
+  mounted() {
+    if (process.env.NODE_ENV === 'development') {
+      onFileChange({ onPath: (path) => this.$router.push(path) })
+    }
+  },
+}
+</script>
+
 <style>
 html {
   font-family: 'Source Sans Pro', -apple-system, BlinkMacSystemFont, 'Segoe UI',

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build": "nuxt generate && mv dist/404/index.html dist/404.html && rm -rf dist/404",
     "copy": "bash ./scripts/clone-current-docs.sh",
     "start": "cross-env NODE_ENV=development nuxt",
+    "start:file-change-server": "node ./utils/file-change-server/server",
     "start:ci": "cross-env NODE_ENV=test yarn build && cd dist/ && yarn serve:dist",
     "changed-files-broken-link-checker:ci": "node scripts/changedFilesBrokenLinkChecker.js",
     "broken-link-checker:prod": "node scripts/recursiveBrokenLinkChecker.js",
@@ -68,6 +69,7 @@
     "bluebird": "^3.7.2",
     "broken-link-checker": "^0.7.8",
     "chalk": "^4.1.0",
+    "chokidar": "^3.5.2",
     "common-tags": "^1.8.0",
     "cross-env": "^7.0.3",
     "cypress": "^8.3.0",
@@ -96,6 +98,7 @@
     "stylelint-config-css-modules": "^2.2.0",
     "stylelint-config-prettier": "^8.0.1",
     "stylelint-config-standard": "^20.0.0",
-    "tailwindcss": "npm:@tailwindcss/postcss7-compat"
+    "tailwindcss": "npm:@tailwindcss/postcss7-compat",
+    "ws": "^8.2.3"
   }
 }

--- a/utils/file-change-server/client.js
+++ b/utils/file-change-server/client.js
@@ -1,0 +1,63 @@
+const log = (...args) => {
+  /* eslint-disable no-console */
+  console.log('[file-change]', ...args)
+}
+
+const onFileChange = ({
+  port = 9999,
+  hostname = 'localhost',
+  pathRegex = /^content\/(.*?)\.md$/,
+  getPath = (filepath) => {
+    if (pathRegex.test(filepath)) {
+      return filepath.replace(pathRegex, '/$1')
+    }
+  },
+  onPath = (path) => log('You need to define an onPath handler!'),
+}) => {
+  let newPath
+
+  // Adapted from https://gist.github.com/paulirwin/0262cdede91793c2f6b9efab0b369d76
+  if (window.__whmEventSourceWrapper) {
+    for (let key of Object.keys(window.__whmEventSourceWrapper)) {
+      window.__whmEventSourceWrapper[key].addMessageListener((msg) => {
+        if (typeof msg.data === 'string' && msg.data.startsWith('{')) {
+          const data = JSON.parse(msg.data)
+
+          if (data.action === 'built' && newPath) {
+            log('Navigating to:', newPath)
+            onPath(newPath)
+            newPath = null
+          }
+        }
+      })
+    }
+  }
+
+  log(`Looking for WebSocket server on ${hostname}:${port}`)
+  const socket = new WebSocket(`ws://${hostname}:${port}`)
+  let open
+
+  socket.addEventListener('open', () => {
+    open = true
+    log('Connected to WebSocket server!')
+    socket.addEventListener('message', (event) => {
+      log('ws', event)
+      const { data } = event
+      const path = getPath(data)
+
+      if (path) {
+        log('File changed:', data)
+        log('New path:', path)
+        newPath = path
+      }
+    })
+  })
+
+  socket.addEventListener('close', () => {
+    if (open) {
+      log('Disconnected from WebSocket server!')
+    }
+  })
+}
+
+module.exports = { onFileChange }

--- a/utils/file-change-server/server.js
+++ b/utils/file-change-server/server.js
@@ -1,0 +1,35 @@
+/* eslint-disable no-console */
+
+const chokidar = require('chokidar')
+const { WebSocketServer } = require('ws')
+
+const host = 'localhost'
+const port = 9999
+const watchPattern = 'content/**/*.md'
+const wss = new WebSocketServer({ host, port })
+
+console.log(`Watching for changes to ${watchPattern}`)
+console.log(`WebSocket server started on ${host}:${port}`)
+console.log('Waiting for client...')
+
+let ws
+
+wss.on('connection', function connection(_ws) {
+  console.log('Client connected!')
+  ws = _ws
+})
+
+const notifyFile = (path) => {
+  if (ws) {
+    console.log('Path changed', path)
+    ws.send(path)
+  }
+}
+
+chokidar
+  .watch(watchPattern, {
+    ignored: /(^|[\/\\])\../, // ignore dotfiles
+    persistent: true,
+  })
+  .on('add', notifyFile)
+  .on('change', notifyFile)

--- a/yarn.lock
+++ b/yarn.lock
@@ -4811,7 +4811,7 @@ anymatch@^2.0.0:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
 
-anymatch@^3.0.0, anymatch@^3.0.3:
+anymatch@^3.0.0, anymatch@^3.0.3, anymatch@~3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.2.tgz#c0557c096af32f106198f4f4e2a383537e378716"
   integrity sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==
@@ -6138,6 +6138,21 @@ chokidar@^3.4.1, chokidar@^3.4.3, chokidar@^3.5.1:
     readdirp "~3.5.0"
   optionalDependencies:
     fsevents "~2.3.1"
+
+chokidar@^3.5.2:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.2.tgz#dba3976fcadb016f66fd365021d91600d01c1e75"
+  integrity sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==
+  dependencies:
+    anymatch "~3.1.2"
+    braces "~3.0.2"
+    glob-parent "~5.1.2"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.6.0"
+  optionalDependencies:
+    fsevents "~2.3.2"
 
 chownr@^1.1.1, chownr@^1.1.2:
   version "1.1.4"
@@ -9393,7 +9408,7 @@ fsevents@^1.2.7:
     bindings "^1.5.0"
     nan "^2.12.1"
 
-fsevents@^2.3.2, fsevents@~2.3.1:
+fsevents@^2.3.2, fsevents@~2.3.1, fsevents@~2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
@@ -9682,6 +9697,13 @@ glob-parent@^5.0.0, glob-parent@^5.1.0, glob-parent@~5.1.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.1.tgz#b6c1ef417c4e5663ea498f1c45afac6916bbc229"
   integrity sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==
+  dependencies:
+    is-glob "^4.0.1"
+
+glob-parent@~5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
+  integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
   dependencies:
     is-glob "^4.0.1"
 
@@ -16396,6 +16418,13 @@ readdirp@^3.4.0, readdirp@~3.5.0:
   dependencies:
     picomatch "^2.2.1"
 
+readdirp@~3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.6.0.tgz#74a370bd857116e245b29cc97340cd431a02a6c7"
+  integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
+  dependencies:
+    picomatch "^2.2.1"
+
 rechoir@^0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
@@ -19863,6 +19892,11 @@ ws@^7.4.3, ws@^7.4.6:
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.5.tgz#8b4bc4af518cfabd0473ae4f99144287b33eb881"
   integrity sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==
+
+ws@^8.2.3:
+  version "8.2.3"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.2.3.tgz#63a56456db1b04367d0b721a0b80cae6d8becbba"
+  integrity sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==
 
 x-is-array@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
The idea is to have the dev site automatically navigate to the content you just saved, so you can see the changes without having to navigate manually. It currently works, but needs to be vetted and refined a little bit

- [ ] it should only run in `yarn start` mode
- [ ] it should not run in `yarn build` mode
- [ ] the client should fail gracefully if the server is not running
- [ ] the server runs via `yarn start:file-change-server`
- [ ] it should navigate to the appropriate page when a content `.md` file is updated
- [ ]  should not be triggered by false positives
  - [ ] update the regex to not match any of the content subdirectories starting with `_`
  - [ ] rename the `partials` directory to `_partials` and update all content files (and docs) accordingly
