### PR TITLE
Add `overwrite` option for `Cypress.Screenshot.defaults`

### DIFF
--- a/content/api/cypress-api/screenshot-api.md
+++ b/content/api/cypress-api/screenshot-api.md
@@ -32,8 +32,9 @@ An object containing one or more of the following:
 | `blackout`                   | `[]`         | Array of string selectors used to match elements that should be blacked out when the screenshot is taken. Does not apply to `runner` captures.                                                                                                                                                                                                                                                                                                                                                                                 |
 | `capture`                    | `'fullPage'` | Which parts of the Test Runner to capture. This value is ignored for element screenshot captures. Valid values are `viewport`, `fullPage`, or `runner`. When `viewport`, your application under test is captured in the current viewport. When `fullPage`, your application under test is captured in its entirety from top to bottom. When `runner`, the entire browser viewport, including the Cypress Command Log, is captured. For screenshots automatically taken on test failure, capture is always coerced to `runner`. |
 | `disableTimersAndAnimations` | `true`       | When true, prevents JavaScript timers (`setTimeout`, `setInterval`, etc) and CSS animations from running while the screenshot is taken.                                                                                                                                                                                                                                                                                                                                                                                        |
-| `scale`                      | `false`      | Whether to scale the app to fit into the browser viewport. This is always coerced to `true` for `runner` captures.                                                                                                                                                                                                                                                                                                                                                                                                             |
-| `screenshotOnRunFailure`     | `true`       | When true, automatically takes a screenshot when there is a failure during `cypress run`.                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| `scale`                      | `false`      | Whether to scale the app to fit into the browser viewport. This is always coerced to `true` for `runner` captures.                                                                                                                                                                                                                                                                                                                                                                                                            |
+| `screenshotOnRunFailure`     | `true`       | When true, automatically takes a screenshot when there is a failure during `cypress run`.                                                                                                                                                                                    
+| `overwrite`                      | `false`                                                    | Whether to overwrite duplicate screenshot files with the same file name when saving.                                                                                                                                                                                                                                                     |
 | `onBeforeScreenshot`         | `null`       | A callback before a (non-failure) screenshot is taken. For an element capture, the argument is the element being captured. For other screenshots, the argument is the `$el`.                                                                                                                                                                                                                                                                                                                                                   |
 | `onAfterScreenshot`          | `null`       | A callback after a (non-failure) screenshot is taken. For an element capture, the first argument is the element being captured. For other screenshots, the first argument is the `$el`. The second argument is properties concerning the screenshot, including the path it was saved to and the dimensions of the saved screenshot.                                                                                                                                                                                            |
 
@@ -83,6 +84,17 @@ when running `cypress run`, but you can disable this.
 ```javascript
 Cypress.Screenshot.defaults({
   screenshotOnRunFailure: false,
+})
+```
+
+### Overwrite existing screenshots
+
+By default, Cypress saves unique screenshot files for every screenshot that is taken within the same test. You can
+choose to overwrite existing screenshots with the same file name using the `overwrite` option.
+
+```javascript
+Cypress.Screenshot.defaults({
+  overwrite: true,
 })
 ```
 


### PR DESCRIPTION
Link to related PR: https://github.com/cypress-io/cypress/pull/18457

Updates the `Cypress.Screenshot` docs to reflect support for passing `overwrite` option to defaults so it does not have to be set every time `cy.screenshot()` is called.