### PR TITLE
bug: fixed examples link to connect to the correct page

### DIFF
--- a/content/guides/continuous-integration/introduction.md
+++ b/content/guides/continuous-integration/introduction.md
@@ -46,7 +46,7 @@ cypress run
 Depending on which CI provider you use, you may need a config file. You'll want
 to refer to your CI provider's documentation to know where to add the commands
 to install and run Cypress. For more configuration examples check out our
-[examples](#Examples).
+[examples](/guides/continuous-integration/ci-provider-examples).
 
 ### Boot your server
 


### PR DESCRIPTION
Fixes a link in the end of https://docs.cypress.io/guides/continuous-integration/introduction#Basics - it is currently pointing to an Examples section, however these examples are available on another page.

