### PR TITLE
Fix two jQuery code examples

### DIFF
--- a/content/api/commands/should.md
+++ b/content/api/commands/should.md
@@ -371,7 +371,7 @@ Cypress won't resolve your commands until all of its assertions pass.
 
 ```javascript
 // Application Code
-$('button').click(() => {
+$('button').click(function () {
   $button = $(this)
 
   setTimeout(() => {

--- a/content/guides/references/error-messages.md
+++ b/content/guides/references/error-messages.md
@@ -182,7 +182,7 @@ Let's take a look at an example below.
 #### Application JavaScript
 
 ```javascript
-$('button').click(() => {
+$('button').click(function () {
   // when the <button> is clicked
   // we remove the button from the DOM
   $(this).remove()


### PR DESCRIPTION
The fat arrow syntax was preventing a reference to `this` from working in two code examples.