### PR TITLE
chore(ci): add `yarn lint` to circle jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,7 @@ workflows:
             - build
 
       - lint:
-          name: 'Lint JS/CSS/Markdown'
+          name: "Lint JS/CSS/Markdown"
           requires:
             - build
 


### PR DESCRIPTION
* also mildly refactored the existing jobs to use a YAML partial to share config
* motivated by #4156 