### PR TITLE
Add community badge to cypress-tags plugin

### DIFF
--- a/content/_data/plugins.json
+++ b/content/_data/plugins.json
@@ -305,7 +305,8 @@
           "name": "cypress-tags",
           "description": "Use custom tags to slice up Cypress test runs",
           "link": "https://github.com/annaet/cypress-tags",
-          "keywords": ["test", "tag", "browserify"]
+          "keywords": ["test", "tag", "browserify"],
+          "badge": "community"
         },
         {
           "name": "@swimlane/cy-mockapi",


### PR DESCRIPTION
The `cypress-tags` repo does not have the `community` badge on the plugins page. This PR should add the badge back in.

![image](https://user-images.githubusercontent.com/4550863/138355590-0059d7e2-364a-4e75-aff7-1b8f2608164b.png)
