### PR TITLE
Add explicit null as an option for encoding

### DIFF
--- a/content/api/commands/fixture.md
+++ b/content/api/commands/fixture.md
@@ -44,17 +44,20 @@ cy.fixture('users/admin.json') // Get data from {fixturesFolder}/users/admin.jso
 The encoding to be used when reading the file. The following encodings are
 supported:
 
-- `ascii`
-- `base64`
-- `binary`
-- `hex`
-- `latin1`
-- `utf8`
-- `utf-8`
-- `ucs2`
-- `ucs-2`
-- `utf16le`
-- `utf-16le`
+- `'ascii'`
+- `'base64'`
+- `'binary'`
+- `'hex'`
+- `'latin1'`
+- `'utf8'`
+- `'utf-8'`
+- `'ucs2'`
+- `'ucs-2'`
+- `'utf16le'`
+- `'utf-16le'`
+- `null`
+
+Using `null` explicitly will return the fixture as a `Buffer`, regardless of file extension.
 
 **<Icon name="angle-right"></Icon> options** **_(Object)_**
 
@@ -123,7 +126,7 @@ it('loads the same object', () => {
 
 ### Images
 
-#### Image fixtures are sent as `base64`
+#### Image fixtures are sent as `base64` by default
 
 ```javascript
 cy.fixture('images/logo.png').then((logo) => {
@@ -136,10 +139,10 @@ cy.fixture('images/logo.png').then((logo) => {
 #### Change encoding of Image fixture
 
 ```javascript
-cy.fixture('images/logo.png', 'binary').then((logo) => {
-  // logo will be encoded as binary
+cy.fixture('images/logo.png', null).then((logo) => {
+  // logo will be read as a buffer
   // and should look something like this:
-  // 000000000000000000000000000000000000000000...
+  // Buffer([0, 0, ...])
 })
 ```
 
@@ -230,7 +233,8 @@ Cypress automatically determines the encoding for the following file types:
 - `.zip`
 
 For other types of files, they will be read as `utf8` by default, unless
-specified in the second argument of `cy.fixture()`.
+specified in the second argument of `cy.fixture()`. You can specify `null`
+as the encoding in order to read the file as a `Buffer` instead.
 
 ### `this` context
 
@@ -261,6 +265,9 @@ describe('User page', () => {
 Please keep in mind that fixture files are assumed to be unchanged during the
 test, and thus the Test Runner loads them just once. Even if you overwrite the
 fixture file itself, the already loaded fixture data remains the same.
+
+If you wish to dynamically change the contents of a file during your tests,
+consider [`cy.readFile()`](/api/commands/readFile) instead.
 
 For example, if you want to reply to a network request with different object,
 the following **will not work**:
@@ -330,6 +337,7 @@ practical purposes it should never happen.
 - [Guide: Variables and Aliases](/guides/core-concepts/variables-and-aliases)
 - [`cy.intercept()`](/api/commands/intercept)
 - [`.then()`](/api/commands/then)
+- [`.readFile()`](/api/commands/readFile) for a similar command without caching and with builtin retryability
 - [Recipe: Bootstrapping App Test Data](/examples/examples/recipes#Server-Communication)
 - [Fixtures](https://github.com/cypress-io/testing-workshop-cypress#fixtures)
   section of the Cypress Testing Workshop

--- a/content/api/commands/readfile.md
+++ b/content/api/commands/readfile.md
@@ -33,17 +33,20 @@ default `cypress.json` configuration file).
 The encoding to be used when reading the file. The following encodings are
 supported:
 
-- `ascii`
-- `base64`
-- `binary`
-- `hex`
-- `latin1`
-- `utf8`
-- `utf-8`
-- `ucs2`
-- `ucs-2`
-- `utf16le`
-- `utf-16le`
+- `'ascii'`
+- `'base64'`
+- `'binary'`
+- `'hex'`
+- `'latin1'`
+- `'utf8'`
+- `'utf-8'`
+- `'ucs2'`
+- `'ucs-2'`
+- `'utf16le'`
+- `'utf-16le'`
+- `null`
+
+Using `null` explicitly will return the file as a `Buffer`, regardless of file extension.
 
 **<Icon name="angle-right"></Icon> options** **_(Object)_**
 
@@ -56,7 +59,7 @@ Pass in an options object to change the default behavior of `cy.readFile()`.
 
 ### Yields [<Icon name="question-circle"/>](/guides/core-concepts/introduction-to-cypress#Subject-Management)
 
-<List><li>`cy.readFile()` 'yields the contents of the file' </li></List>
+<List><li>`cy.readFile()` yields the contents of the file.</li></List>
 
 ## Examples
 
@@ -123,6 +126,16 @@ cy.readFile('path/to/logo.png', 'base64').then((logo) => {
   // logo will be encoded as base64
   // and should look something like this:
   // aIJKnwxydrB10NVWqhlmmC+ZiWs7otHotSAAAOw==...
+})
+```
+
+#### Read
+
+```javascript
+cy.fixture('path/to/logo.png', null).then((logo) => {
+  // logo will be read as a buffer
+  // and should look something like this:
+  // Buffer([0, 0, ...])
 })
 ```
 
@@ -218,6 +231,6 @@ outputs the following:
 ## See also
 
 - [`cy.exec()`](/api/commands/exec)
-- [`cy.fixture()`](/api/commands/fixture)
+- [`cy.fixture()`](/api/commands/fixture) for a similar command with caching
 - [`cy.task()`](/api/commands/task)
 - [`cy.writeFile()`](/api/commands/writefile)

--- a/content/api/commands/writefile.md
+++ b/content/api/commands/writefile.md
@@ -28,7 +28,7 @@ cy.writeFile('menu.json')
 A path to a file within the project root (the directory that contains the
 default `cypress.json`).
 
-**<Icon name="angle-right"></Icon> contents** **_(String, Array, or Object)_**
+**<Icon name="angle-right"></Icon> contents** **_(String, Array, Object or Buffer)_**
 
 The contents to be written to the file.
 
@@ -37,17 +37,21 @@ The contents to be written to the file.
 The encoding to be used when writing to the file. The following encodings are
 supported:
 
-- `ascii`
-- `base64`
-- `binary`
-- `hex`
-- `latin1`
-- `utf8`
-- `utf-8`
-- `ucs2`
-- `ucs-2`
-- `utf16le`
-- `utf-16le`
+- `'ascii'`
+- `'base64'`
+- `'binary'`
+- `'hex'`
+- `'latin1'`
+- `'utf8'`
+- `'utf-8'`
+- `'ucs2'`
+- `'ucs-2'`
+- `'utf16le'`
+- `'utf-16le'`
+- `null`
+
+Using `null` explicitly will allows you to write a `Buffer` directly, without
+first encoding it as a string.
 
 **<Icon name="angle-right"></Icon> options** **_(Object)_**
 
@@ -69,8 +73,8 @@ parameter and include encoding there. This is the same behavior as
 
 ### Yields [<Icon name="question-circle"/>](/guides/core-concepts/introduction-to-cypress#Subject-Management)
 
-<List><li>`cy.writeFile()` 'yields the value of the <code>contents</code>
-argument' </li></List>
+<List><li>`cy.writeFile()` yields the value of the <code>contents</code>
+argument.</li></List>
 
 ## Examples
 
@@ -183,6 +187,18 @@ cy.readFile(filename).then((list) => {
   list.push({ item: 'example' })
   // write the merged array
   cy.writeFile(filename, list)
+})
+```
+
+### Buffer
+
+#### Write a buffer directly without encoding as a string
+```javascript
+const filename = '/path/to/file.png'
+
+cy.readFile(filename, null).then((obj) => {
+  // <Buffer ef 3a bf ... >
+  cy.writeFile(filename, obj, null)
 })
 ```
 


### PR DESCRIPTION
Relates to https://github.com/cypress-io/cypress/pull/18534, which adds the changes mentioned here. See that PR for more details.