### PR TITLE
docs: fix broken link

### DIFF
--- a/content/guides/references/migration-guide.md
+++ b/content/guides/references/migration-guide.md
@@ -98,7 +98,7 @@ This guide details the changes and how to change your code to migrate to Cypress
 
 ### [`cy.intercept()`][intercept] changes
 
-[Cypress 7.0](<(/guides/references/changelog#7-0-0)>) comes with some breaking
+[Cypress 7.0](/guides/references/changelog#7-0-0) comes with some breaking
 changes to [`cy.intercept()`][intercept]:
 
 #### Handler ordering is reversed


### PR DESCRIPTION
Modify to correct link
https://docs.cypress.io/guides/references/migration-guide#Migrating-to-Cypress-7-0
![image](https://user-images.githubusercontent.com/22230889/138716991-c49044cc-72d1-4fb0-9270-5f2878ee207f.png)
