### PR TITLE
Adding an existing command or reserved internal function with `Cypress.Commands.add()` will throw an error

### DIFF
--- a/content/api/cypress-api/custom-commands.md
+++ b/content/api/cypress-api/custom-commands.md
@@ -286,6 +286,12 @@ Log? Read more about [Command Logging](#Command-Logging).
 
 </Alert>
 
+<Alert type="warning">
+
+Note that `Cypress.Commands.add()` will throw an error when trying to add a custom command with the same name as an existing built-in Cypress command. In order to override the behavior of an existing command, `Cypress.Commands.overwrite()` should be used instead. For more information, read the section [Overwrite Existing Commands](#Overwrite-Existing-Commands).
+
+</Alert>
+
 ### Child Commands
 
 Child commands are always chained off of a **parent** command, or another

--- a/content/api/cypress-api/custom-commands.md
+++ b/content/api/cypress-api/custom-commands.md
@@ -288,7 +288,7 @@ Log? Read more about [Command Logging](#Command-Logging).
 
 <Alert type="warning">
 
-Note that `Cypress.Commands.add()` will throw an error when trying to add a custom command with the same name as an existing built-in Cypress command. In order to override the behavior of an existing command, `Cypress.Commands.overwrite()` should be used instead. For more information, read the section [Overwrite Existing Commands](#Overwrite-Existing-Commands).
+Note that `Cypress.Commands.add()` will throw an error when trying to add a custom command with the same name as an existing built-in Cypress command or reserved internal function. In order to override the behavior of an existing command, `Cypress.Commands.overwrite()` should be used instead. For more information, read the section [Overwrite Existing Commands](#Overwrite-Existing-Commands).
 
 </Alert>
 


### PR DESCRIPTION
Link to issue: https://github.com/cypress-io/cypress/issues/18572
Link to PR: https://github.com/cypress-io/cypress/pull/18587

Added a warning alert in Custom Commands doc to note that an error will be thrown if attempting to add an existing built-in Cypress command.