### PR TITLE
Change `run` to `open` Cypress command

### DIFF
--- a/content/guides/guides/command-line.md
+++ b/content/guides/guides/command-line.md
@@ -523,7 +523,7 @@ values with a comma. The values set here override any values set in your
 configuration file.
 
 ```shell
-cypress run --config pageLoadTimeout=100000,watchForFileChanges=false
+cypress open --config pageLoadTimeout=100000,watchForFileChanges=false
 ```
 
 #### `cypress open --config-file <config-file>`


### PR DESCRIPTION
Since it's section about `cypress open` the `open` command should be used instead of `run`. Related issue: https://github.com/cypress-io/cypress/issues/18712