### PR TITLE
UNIFY-393 CT Getting Started Guide page 1: Framework Selection & Configuration

### DIFF
--- a/components/sidebar/CollapsibleSidebarSection.vue
+++ b/components/sidebar/CollapsibleSidebarSection.vue
@@ -151,7 +151,7 @@ export default {
           :name="child.slug"
           :depth="depth + 1"
         />
-        <li v-else-if="child.slug">
+        <li v-else-if="child.redirect || child.slug">
           <nuxt-link
             :to="child.redirect || `/${section}/${folder}/${child.slug}`"
             :class="getSidebarItemClass(folder, child)"

--- a/components/sidebar/CollapsibleSidebarSection.vue
+++ b/components/sidebar/CollapsibleSidebarSection.vue
@@ -151,7 +151,7 @@ export default {
           :name="child.slug"
           :depth="depth + 1"
         />
-        <li v-else>
+        <li v-else-if="child.slug">
           <nuxt-link
             :to="child.redirect || `/${section}/${folder}/${child.slug}`"
             :class="getSidebarItemClass(folder, child)"
@@ -159,6 +159,11 @@ export default {
           >
             {{ child.title }}
           </nuxt-link>
+        </li>
+        <li v-else>
+          <div class="pl-4 pr-2 py-0 text-md font-bold bg-gray-200">
+            {{ child.title }}
+          </div>
         </li>
       </div>
     </ul>

--- a/content/_data/sidebar.json
+++ b/content/_data/sidebar.json
@@ -27,12 +27,38 @@
               "slug": "installing-cypress"
             },
             {
+              "title": "End-to-End Testing"
+            },
+            {
               "title": "Writing Your First Test",
-              "slug": "writing-your-first-test"
+              "slug": "writing-your-first-end-to-end-test"
             },
             {
               "title": "Testing Your App",
               "slug": "testing-your-app"
+            },
+            {
+              "title": "Component Testing"
+            },
+            {
+              "title": "Framework Configuration",
+              "slug": "component-framework-configuration"
+            },
+            {
+              "title": "Writing Your First Test",
+              "slug": "writing-your-first-component-test"
+            },
+            {
+              "title": "Getting Components to Work",
+              "slug": "getting-components-to-work"
+            },
+            {
+              "title": "Rendering Components Correctly",
+              "slug": "rendering-components-correctly"
+            },
+            {
+              "title": "Creating a cy.mount Command",
+              "slug": "creating-a-cy-mount-command"
             }
           ]
         },
@@ -243,20 +269,6 @@
             {
               "title": "AWS CodeBuild",
               "slug": "aws-codebuild"
-            }
-          ]
-        },
-        {
-          "title": "Component Testing",
-          "slug": "component-testing",
-          "children": [
-            {
-              "title": "Introduction",
-              "slug": "introduction"
-            },
-            {
-              "title": "Framework Configuration",
-              "slug": "framework-configuration"
             }
           ]
         },

--- a/content/guides/getting-started/component-framework-configuration.md
+++ b/content/guides/getting-started/component-framework-configuration.md
@@ -1,6 +1,5 @@
 ---
 title: Framework Configuration
-containerClass: component-testing
 ---
 
 Recent years have seen an explosion in component based libraries (Vue, React)
@@ -95,9 +94,9 @@ it('renders learn react link', () => {
 })
 ```
 
-Start Cypress with `npx cypress open --component` - the test runner will open. Select
-your test to execute it and see the rendered output. You can also run the tests
-without opening a browser with `npx cypress run --component`.
+Start Cypress with `npx cypress open --component` - the test runner will open.
+Select your test to execute it and see the rendered output. You can also run the
+tests without opening a browser with `npx cypress run --component`.
 
 ## Vue (Vue CLI)
 
@@ -212,9 +211,9 @@ it('renders a message', () => {
 })
 ```
 
-Start Cypress with `npx cypress open --component` - the test runner will open. Select
-your test to execute it and see the rendered output. You can also run the tests
-without opening a browser with `npx cypress run --component`.
+Start Cypress with `npx cypress open --component` - the test runner will open.
+Select your test to execute it and see the rendered output. You can also run the
+tests without opening a browser with `npx cypress run --component`.
 
 ### Vue 3 (Vue CLI)
 
@@ -313,9 +312,9 @@ it('Renders page component', () => {
 })
 ```
 
-Start Cypress with `npx cypress open --component` - the test runner will open. Select
-your test to execute it and see the rendered output. You can also run the tests
-without opening a browser with `npx cypress run --component`.
+Start Cypress with `npx cypress open --component` - the test runner will open.
+Select your test to execute it and see the rendered output. You can also run the
+tests without opening a browser with `npx cypress run --component`.
 
 <Alert type="warning">
 
@@ -522,9 +521,9 @@ _not_ applied. In this example, the `fetch` hook is not automatically applied,
 so we used the `mocks` mounting option to specify the three component states
 (loading, error and success) and test each one in isolation.
 
-Start Cypress with `npx cypress open --component` - the test runner will open. Select
-your test to execute it and see the rendered output. You can also run the tests
-without opening a browser with `npx cypress run --component`.
+Start Cypress with `npx cypress open --component` - the test runner will open.
+Select your test to execute it and see the rendered output. You can also run the
+tests without opening a browser with `npx cypress run --component`.
 
 ## Vite Based Projects (Vue, React)
 
@@ -599,6 +598,6 @@ it('renders learn react link', () => {
 })
 ```
 
-Start Cypress with `npx cypress open --component` - the test runner will open. Select
-your test to execute it and see the rendered output. You can also run the tests
-without opening a browser with `npx cypress run --component`.
+Start Cypress with `npx cypress open --component` - the test runner will open.
+Select your test to execute it and see the rendered output. You can also run the
+tests without opening a browser with `npx cypress run --component`.

--- a/content/guides/getting-started/component-framework-configuration.md
+++ b/content/guides/getting-started/component-framework-configuration.md
@@ -2,10 +2,9 @@
 title: Framework Configuration
 ---
 
-Recent years have seen an explosion in component based libraries (Vue, React)
-and frameworks built on top of them (Nuxt, Next). Cypress tests are written and
-behave the same regardless. Some frameworks require some additional
-configuration to work correctly with Cypress component testing.
+Cypress component tests are written and behave the same regardless of framework
+choice (Vue, React, Nuxt, Next); however, some frameworks require additional
+configuration to work correctly.
 
 All the example projects described in this page can be found
 [here](https://github.com/cypress-io/cypress-component-examples).

--- a/content/guides/getting-started/creating-a-cy-mount-command.md
+++ b/content/guides/getting-started/creating-a-cy-mount-command.md
@@ -1,0 +1,5 @@
+---
+title: Creating a cy.mount Command
+---
+
+CONTENT TBD

--- a/content/guides/getting-started/getting-components-to-work.md
+++ b/content/guides/getting-started/getting-components-to-work.md
@@ -1,0 +1,5 @@
+---
+title: Getting Components to Work
+---
+
+CONTENT TBD

--- a/content/guides/getting-started/rendering-components-correctly.md
+++ b/content/guides/getting-started/rendering-components-correctly.md
@@ -1,0 +1,5 @@
+---
+title: Rendering Components Correctly
+---
+
+CONTENT TBD

--- a/content/guides/getting-started/writing-your-first-component-test.md
+++ b/content/guides/getting-started/writing-your-first-component-test.md
@@ -1,0 +1,5 @@
+---
+title: Writing Your First Component Test
+---
+
+CONTENT TBD

--- a/content/guides/getting-started/writing-your-first-end-to-end-test.md
+++ b/content/guides/getting-started/writing-your-first-end-to-end-test.md
@@ -1,5 +1,5 @@
 ---
-title: Writing Your First Test
+title: Writing Your First End-to-End Test
 ---
 
 <Alert type="info">

--- a/cypress/fixtures/sidebar-overrides.json
+++ b/cypress/fixtures/sidebar-overrides.json
@@ -8,6 +8,8 @@
   "PAGE_TITLE": {
     "/guides/dashboard/introduction": "Dashboard",
     "/guides/migrating-to-cypress/protractor": "Migrating from Protractor to Cypress",
+    "/guides/getting-started/writing-your-first-end-to-end-test": "Writing Your First End-to-End Test",
+    "/guides/getting-started/writing-your-first-component-test": "Writing Your First Component Test",
     "/guides/references/assertions": "Assertions",
     "/guides/references/legacy-configuration": "Configuration (Legacy)",
     "/api/utilities/_": "Cypress._",

--- a/cypress/integration/test-utils/index.js
+++ b/cypress/integration/test-utils/index.js
@@ -30,11 +30,7 @@ export const runSidebarTests = ([section]) => {
 
         category.children.forEach((page) => {
           it(page.title, () => {
-            // click the page link in the sidebar
-            cy.contains(
-              `.app-sidebar [data-test="${category.slug}"] a`,
-              page.title
-            ).click({ force: true })
+            const isLink = page.redirect || page.slug
 
             const constructedPath = `/${section.slug}/${category.slug}/${page.slug}`
             const pathname = page.redirect || constructedPath
@@ -43,12 +39,28 @@ export const runSidebarTests = ([section]) => {
             const sidebarText = OVERRIDES.SIDEBAR_TEXT[pathname] || page.title
             const pageTitle = OVERRIDES.PAGE_TITLE[pathname] || page.title
 
+            // If the item is not a link, simply verify that it has the correct text
+            if (!isLink) {
+              cy.contains(
+                `.app-sidebar [data-test="${categorySlug}"] div`,
+                sidebarText
+              )
+
+              return
+            }
+
+            // click the page link in the sidebar
+            cy.contains(
+              `.app-sidebar [data-test="${category.slug}"] a[href="${pathname}"]`,
+              page.title
+            ).click({ force: true })
+
             // ensure the correct page has been navigated to
             cy.location('pathname').should('equal', pathname)
 
             // ensure the current sidebar category contains an active link with the current page title
             cy.contains(
-              `.app-sidebar [data-test="${categorySlug}"] a`,
+              `.app-sidebar [data-test="${categorySlug}"] a[href="${pathname}"]`,
               sidebarText
             ).should(
               'have.class',


### PR DESCRIPTION
https://cypress-io.atlassian.net/browse/UNIFY-393

Preview:
https://deploy-preview-4193--cypress-docs.netlify.app/guides/getting-started/component-framework-configuration

Notes:

* Updated sidebar to render items without `slug` or `redirect` as subheaders (styling needed, we can also totally rework this, I just needed a starting point)
* Tweaked titles of the existing E2E Getting Started content
* Moved existing Component Testing > Framework Configuration content to the Getting Started section
* Created stub pages for other Getting Started pages
