### PR TITLE
Deprecation updates for the `nodeVersion` config option 

### DIFF
--- a/content/api/plugins/writing-a-plugin.md
+++ b/content/api/plugins/writing-a-plugin.md
@@ -141,19 +141,7 @@ Cypress.
 
 <strong class="alert-header">Node version</strong>
 
-As of version 9.0.0, Cypress will use the same version of node that was used to launch the cypress App via the CLI.
-
-Prior to version 9.0.0, Cypress would use the version of node bundled with Cypress itself.
-
-This version of Node has **nothing to do** with your locally installed versions.
-Therefore you may want to write Node code which is compatible with this version
-or document that the user of your plugin will need to set a specific
-[nodeVersion](/guides/references/configuration#Node-version) in their
-configuration.
-
-You can find the current Node version we use when the `nodeVersion` is set to
-the default `bundled`
-[here](https://github.com/cypress-io/cypress/blob/master/.node-version).
+As of version 9.0.0, Cypress will use the same Node version that launched Cypress to execute your plugins.
 
 </Alert>
 

--- a/content/api/plugins/writing-a-plugin.md
+++ b/content/api/plugins/writing-a-plugin.md
@@ -130,20 +130,8 @@ Cypress does this by spawning an independent `child_process` which then
 `requires` in your `pluginsFile`. This is similar to the way Visual Studio Code
 or Atom works.
 
-You will need to keep in mind it is **Cypress who is requiring your file** - not
-your local project, not your local Node version, and not anything else under
-your control.
-
-Because of this, this global context and the version of Node is controlled under
+The code in this file will be executed using the the Node version that launched
 Cypress.
-
-<Alert type="warning">
-
-<strong class="alert-header">Node version</strong>
-
-As of version 9.0.0, Cypress will use the same Node version that launched Cypress to execute your plugins.
-
-</Alert>
 
 ### npm modules
 

--- a/content/api/plugins/writing-a-plugin.md
+++ b/content/api/plugins/writing-a-plugin.md
@@ -141,8 +141,9 @@ Cypress.
 
 <strong class="alert-header">Node version</strong>
 
-Keep in mind - code executed in plugins **may** be executed by the Node version
-that comes bundled in Cypress itself.
+As of version 9.0.0, Cypress will use the same version of node that was used to launch the cypress App via the CLI.
+
+Prior to version 9.0.0, Cypress would use the version of node bundled with Cypress itself.
 
 This version of Node has **nothing to do** with your locally installed versions.
 Therefore you may want to write Node code which is compatible with this version

--- a/content/faq/questions/using-cypress-faq.md
+++ b/content/faq/questions/using-cypress-faq.md
@@ -811,9 +811,7 @@ You can `require` or `import` them as you're accustomed to. We preprocess your
 spec files with webpack and Babel.
 
 We recommend utilizing one of the following to execute code outside of the
-browser. Furthermore, you can use your own Node version during code excecution
-by setting the [nodeVersion](/guides/references/configuration#Node-version) in
-your configuration.
+browser.
 
 - [`cy.task()`](/api/commands/task) to run code in Node via the
   [pluginsFile](/guides/references/configuration#Folders-Files)

--- a/content/guides/references/configuration.md
+++ b/content/guides/references/configuration.md
@@ -137,13 +137,19 @@ For more information, see the docs on
 
 ### Node version
 
-The `nodeVersion` configuration option is deprecated and will be removed in a future version of Cypress. Please remove this option from your configuration file.
+<Alert type="warning">
 
-| Option        | Default   | Description                                                                                                                                                                                                         |
-| ------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+The `nodeVersion` configuration option is deprecated and will be removed in a
+future version of Cypress. Please remove this option from your configuration
+file.
+
+</Alert>
+
+| Option        | Default  | Description                                                                                                                                                                                                                                                                                                                                |
+| ------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `nodeVersion` | `system` | Can be `system` or `bundled`. If set to `system`, Cypress will try to use the same Node version that launched Cypress to execute your [plugins](/guides/tooling/plugins-guide). If that can't be determined, Cypress will use the Node version bundled with Cypress. If set to `bundled` Cypress will use the version bundled with Cypress |
 
-The Node version printed in the Node.js Version panel is used in Cypress to:
+The Node version is used in Cypress to:
 
 - Build files in the
   [integrationFolder](/guides/references/configuration#Folders-Files).

--- a/content/guides/references/configuration.md
+++ b/content/guides/references/configuration.md
@@ -137,9 +137,11 @@ For more information, see the docs on
 
 ### Node version
 
+The `nodeVersion` configuration option is deprecated and will be removed in the next major release of Cypress. Please remove this option from `cypress.json`.
+
 | Option        | Default   | Description                                                                                                                                                                                                         |
 | ------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `nodeVersion` | `bundled` | If set to `system`, Cypress will try to find a Node executable on your path to use when executing your [plugins](/guides/tooling/plugins-guide). Otherwise, Cypress will use the Node version bundled with Cypress. |
+| `nodeVersion` | `system` | Can be `system` or `bundled`. If set to `system`, Cypress will try to use the same node executable that launched the cli to execute your [plugins](/guides/tooling/plugins-guide). Otherwise, Cypress will use the Node version bundled with Cypress. If set to `bundled` Cypress will use the version bundled with Cypress |
 
 The Node version printed in the Node.js Version panel is used in Cypress to:
 
@@ -149,27 +151,6 @@ The Node version printed in the Node.js Version panel is used in Cypress to:
   [supportFile](/guides/references/configuration#Folders-Files).
 - Execute code in the
   [pluginsFile](/guides/references/configuration#Folders-Files).
-
-Cypress comes automatically bundled with a set Node version by default. You can
-see the bundled version by running the
-[`cypress version`](/guides/guides/command-line#cypress-version) command, for
-example:
-
-```shell
-npx cypress version
-Cypress package version: 6.2.1
-Cypress binary version: 6.2.1
-Electron version: 11.1.1
-Bundled Node version: 12.18.3
-```
-
-You may want to use a different Node version if the code executing from the
-plugins file requires features present in a different Node version from the Node
-version bundled with Cypress. You can use the Node version detected on your
-system by setting the
-[nodeVersion](/guides/references/configuration#Node-version) configuration to
-`system`. For example, you need to use the system Node if you want to load
-`node-sass` or `sqlite3` modules from your plugins file.
 
 <DocsImage src="/img/guides/test-runner-settings-nodejs-version.jpg" alt="Node version in Settings in Test Runner" ></DocsImage>
 

--- a/content/guides/references/configuration.md
+++ b/content/guides/references/configuration.md
@@ -137,11 +137,11 @@ For more information, see the docs on
 
 ### Node version
 
-The `nodeVersion` configuration option is deprecated and will be removed in the next major release of Cypress. Please remove this option from `cypress.json`.
+The `nodeVersion` configuration option is deprecated and will be removed in a future version of Cypress. Please remove this option from your configuration file.
 
 | Option        | Default   | Description                                                                                                                                                                                                         |
 | ------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `nodeVersion` | `system` | Can be `system` or `bundled`. If set to `system`, Cypress will try to use the same node executable that launched the cli to execute your [plugins](/guides/tooling/plugins-guide). Otherwise, Cypress will use the Node version bundled with Cypress. If set to `bundled` Cypress will use the version bundled with Cypress |
+| `nodeVersion` | `system` | Can be `system` or `bundled`. If set to `system`, Cypress will try to use the same Node version that launched Cypress to execute your [plugins](/guides/tooling/plugins-guide). If that can't be determined, Cypress will use the Node version bundled with Cypress. If set to `bundled` Cypress will use the version bundled with Cypress |
 
 The Node version printed in the Node.js Version panel is used in Cypress to:
 

--- a/content/guides/tooling/plugins-guide.md
+++ b/content/guides/tooling/plugins-guide.md
@@ -13,10 +13,7 @@ plugins can use.
 > browser.
 
 Plugins are a "seam" for you to write your own custom code that executes during
-particular stages of the Cypress lifecycle. It also allows you to execute code
-within your own Node version when the
-[nodeVersion](/guides/references/configuration#Node-version) is set in your
-configuration.
+particular stages of the Cypress lifecycle.
 
 <Alert type="info">
 
@@ -140,10 +137,7 @@ which describe how to use this event.
 
 The event `task` is used in conjunction with the
 [`cy.task()`](/api/commands/task) command. It allows you to write arbitrary code
-in Node to accomplish tasks that aren't possible in the browser. It also allows
-you to execute code within your own Node version when the
-[nodeVersion](/guides/references/configuration#Node-version) is set in your
-configuration.
+in Node to accomplish tasks that aren't possible in the browser.
 
 You can use the `task` event to do things like:
 


### PR DESCRIPTION
As a part of issue [#18684](https://github.com/cypress-io/cypress/issues/18684), This PR updates the documentation to declare the `nodeVersion` config as deprecated as well as explain the default `system` and behaviour, to use the same node binary that was used to launch cypress from the cli.