### PR TITLE
clarify text to match the example that follows.

### DIFF
--- a/content/guides/core-concepts/retry-ability.md
+++ b/content/guides/core-concepts/retry-ability.md
@@ -365,9 +365,8 @@ command is used for assertion retries, we can fix this test for good.
 ### Merging queries
 
 The first solution we recommend is to avoid unnecessarily splitting commands
-that query elements. In our case we first query elements using `cy.get()` and
-then query from that list of elements using `.find()`. We can combine two
-separate queries into one - forcing the combined query to be retried.
+that query elements. Instead of `cy.get('.todo-list li').find('label')` we can
+combine two separate queries into one - forcing the combined query to be retried.
 
 ```javascript
 it('adds two items', () => {


### PR DESCRIPTION
This section (https://docs.cypress.io/guides/core-concepts/retry-ability#Merging-queries) mentions applying a `cy.get()` followed by a `.find()`. However, the code sample following that text doesn't use `.find()`.
So I updated the text to match the example.
