### PR TITLE
fix: fix an example about asserting on network request body

### DIFF
--- a/content/guides/guides/network-requests.md
+++ b/content/guides/guides/network-requests.md
@@ -461,11 +461,11 @@ cy.get('@new-user') // yields the same interception object
   .its('request.body')
   .should(
     'deep.equal',
-    JSON.stringify({
+    {
       id: '101',
       firstName: 'Joe',
       lastName: 'Black',
-    })
+    }
   )
 
 // and we can place multiple assertions in a single "should" callback


### PR DESCRIPTION
There is no point in `JSON.stringify` when doing a deep equality check. In fact, it should make it fragile and depend on the order of fields, white spaces, etc.