### PR TITLE
fix yarn command in command-line guide

### DIFF
--- a/content/guides/guides/command-line.md
+++ b/content/guides/guides/command-line.md
@@ -54,7 +54,7 @@ npx cypress run
 ...or by using Yarn...
 
 ```shell
-yarn open
+yarn cypress run
 ```
 
 You may find it easier to add the cypress command to the `scripts` object in


### PR DESCRIPTION
https://discord.com/channels/755913899261296641/763114122065739818/912481091582050354

```shell
$ yarn open
yarn run v1.22.10
error Command "open" not found.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

```shell
$ yarn cypress open
yarn run v1.22.10
$ ./node_modules/.bin/cypress open
# runs successfully
```