### PR TITLE
UNIFY-619 Remove E2EOnlyBadge and ComponentOnlyBadge from anchors

### DIFF
--- a/patches/github-slugger+1.3.0.patch
+++ b/patches/github-slugger+1.3.0.patch
@@ -1,8 +1,13 @@
 diff --git a/node_modules/github-slugger/index.js b/node_modules/github-slugger/index.js
-index 9d40bc2..21c4f6d 100644
+index 9d40bc2..ffe4026 100644
 --- a/node_modules/github-slugger/index.js
 +++ b/node_modules/github-slugger/index.js
-@@ -4,7 +4,14 @@ module.exports = BananaSlug
+@@ -1,10 +1,20 @@
++// Modified with patch-package
++
+ var emoji = require('emoji-regex')
+ 
+ module.exports = BananaSlug
  
  var own = Object.hasOwnProperty
  var whitespace = /\s/g
@@ -12,13 +17,14 @@ index 9d40bc2..21c4f6d 100644
 +// var shouldBecomeDash = /(?<!\.)\.{1,2}(?!\.)/g
 +var shouldBecomeDash = /\./g
 +var icons = /<[Ii]con.[^/]+\/*>(<\/[Ii]con>)*/
++var tagsToRemove = /<(?:E2EOnlyBadge|ComponentOnlyBadge)\s*\/?>/g
 +var lessThan = /</g
 +var greaterThan = />/g
 +var twoOrMoreDashes = /-{2,}/g
  
  function BananaSlug () {
    var self = this
-@@ -45,12 +52,28 @@ BananaSlug.prototype.reset = function () {
+@@ -45,12 +55,32 @@ BananaSlug.prototype.reset = function () {
  
  function slugger (string, maintainCase) {
    if (typeof string !== 'string') return ''
@@ -31,6 +37,7 @@ index 9d40bc2..21c4f6d 100644
 -    .replace(specials, '')
 +  var str = string.trim()
 +    .replace(icons, '')
++    .replace(tagsToRemove, '')
 +    .trim()
 +    .replace(periodAtEnd, '')
 +    .replace(shouldBecomeDash, '-')
@@ -44,6 +51,9 @@ index 9d40bc2..21c4f6d 100644
 +  if (str[str.length - 1] === '-') {
 +    str = str.slice(0, str.length - 1)
 +  }
++
++  // Used for debugging output
++  // console.log(`SLUG\t${str}\t${string}`)
 +
 +  return str
  }

--- a/patches/github-slugger.test.js
+++ b/patches/github-slugger.test.js
@@ -1,0 +1,29 @@
+const GithubSlugger = require('github-slugger')
+
+let slugger
+
+beforeEach(() => {
+  slugger = new GithubSlugger()
+})
+
+describe('tagsToRemove', () => {
+  it('should strip <E2EOnlyBadge/>', () => {
+    expect(slugger.slug('Sample Header <E2EOnlyBadge/>')).toBe('Sample-Header')
+  })
+
+  it('should strip <E2EOnlyBadge />', () => {
+    expect(slugger.slug('Sample Header <E2EOnlyBadge />')).toBe('Sample-Header')
+  })
+
+  it('should strip <ComponentOnlyBadge/>', () => {
+    expect(slugger.slug('Sample Header <ComponentOnlyBadge/>')).toBe(
+      'Sample-Header'
+    )
+  })
+
+  it('should strip <ComponentOnlyBadge />', () => {
+    expect(slugger.slug('Sample Header <ComponentOnlyBadge />')).toBe(
+      'Sample-Header'
+    )
+  })
+})


### PR DESCRIPTION
I was hoping for a more generic solution, but our patch to github-slugger is quite involved. I just added a few extra things to it to remove these anchors.

Examples:
- https://deploy-preview-4229--cypress-docs.netlify.app/api/commands/session#Where-to-call-cy-visit
- https://deploy-preview-4229--cypress-docs.netlify.app/api/commands/session#Where-to-call-cy-mount

TODO:

- [x] Add tests