### PR TITLE
docs: remove unnecessary language

### DIFF
--- a/content/api/cypress-api/custom-commands.md
+++ b/content/api/cypress-api/custom-commands.md
@@ -71,9 +71,6 @@ declarative subject validations such as:
 - `document`: requires the previous subject be the document
 - `window`: requires the previous subject be the window
 
-Internally our built in commands make use of every single one of these
-combinations above.
-
 ## Examples
 
 ### Parent Commands


### PR DESCRIPTION
I don't see how this helps the user to know, can probably stand to be removed.