### PR TITLE
Remove user links which no longer work from old contributing guides.

### DIFF
--- a/content/_changelogs/1.0.2.md
+++ b/content/_changelogs/1.0.2.md
@@ -8,22 +8,18 @@ _Released 10/13/2017_
   [#647](https://github.com/cypress-io/cypress/issues/647).
 - Fixed some problems serializing objects during domain change caused by
   circular references. In this case `zone.js` was the culprit. Fixes
-  [#741](https://github.com/cypress-io/cypress/issues/741). Contributed by
-  {% user MariMax %}.
+  [#741](https://github.com/cypress-io/cypress/issues/741).
 
 **Misc:**
 
 - `cy.scrollTo` now logs its coordinates when options are used. Fixes
-  [#725](https://github.com/cypress-io/cypress/issues/725). Contributed by
-  {% user sirugh %}.
+  [#725](https://github.com/cypress-io/cypress/issues/725).
 - You can now use environment variables that have a `=` character as values.
-  Fixes [#620](https://github.com/cypress-io/cypress/issues/620). Contributed by
-  {% user HugoGiraudel %}.
+  Fixes [#620](https://github.com/cypress-io/cypress/issues/620).
 - There is now a new `videoUploadOnPasses` configuration option in
   `cypress.json`. Turning this off will only compress and upload videos on
   failures. This only affects projects which are setup to record to the
   Dashboard. Fixes [#460](https://github.com/cypress-io/cypress/issues/460).
-  Contributed by {% user carlos-granados %}.
 
 **Documentation Changes:**
 

--- a/content/_changelogs/1.0.3.md
+++ b/content/_changelogs/1.0.3.md
@@ -6,7 +6,6 @@ _Released 10/29/2017_
 
 - The Test Runner now enables you to collapse folders when displaying a list of
   specs. Fixes [#760](https://github.com/cypress-io/cypress/issues/760).
-  Contributed by {% user metcorne %}.
 
 **Bugfixes**
 
@@ -18,11 +17,9 @@ _Released 10/29/2017_
   [#847](https://github.com/cypress-io/cypress/issues/847) and
   [#841](https://github.com/cypress-io/cypress/issues/841).
 - Using a single space on: `cy.type(' ')` now works. Fixes
-  [#807](https://github.com/cypress-io/cypress/issues/807). Contributed by
-  {% user tejasbubane %}.
+  [#807](https://github.com/cypress-io/cypress/issues/807).
 - `cy.spread()` can now be used on a collection of DOM elements. Fixes
-  [#735](https://github.com/cypress-io/cypress/issues/735). Contributed by
-  {% user verheyenkoen %}.
+  [#735](https://github.com/cypress-io/cypress/issues/735).
 - CLI shows help message when it is invoked with an unknown command like
   `$(npm bin)/cypress foo`. Fixes
   [#641](https://github.com/cypress-io/cypress/issues/641).

--- a/content/_changelogs/3.3.2.md
+++ b/content/_changelogs/3.3.2.md
@@ -14,8 +14,7 @@ _Released 6/27/2019_
   [#4313](https://github.com/cypress-io/cypress/issues/4313).
 - We reduced memory consumption and improved the performance of running tests
   anytime you're inside of `cypress open`. Fixes
-  [#2366](https://github.com/cypress-io/cypress/issues/2366). Thanks
-  {% user "CoryDanielson" %}!
+  [#2366](https://github.com/cypress-io/cypress/issues/2366).
 - We no longer delay proxied responses with no body with status codes 1xx,
   204, 304. This fixes a regression introduced in
   [3.2.0](/guides/references/changelog#3-2-0) where responses with these status


### PR DESCRIPTION
We use to attribute some users, but these generated links no longer work and we don’t do this anymore. 