### PR TITLE
Fix display of links in changelog

### DIFF
--- a/content/_changelogs/6.2.0.md
+++ b/content/_changelogs/6.2.0.md
@@ -7,11 +7,11 @@ _Released 12/21/2020_
 - You can now listen to `before:run`, `after:run`, `before:spec` and
   `after:spec` events in the plugins file when setting the
   [experimentalRunEvents](/guides/references/experiments) configuration option
-  to `true`. See the [before:run](/api/plugins/before-run-api),
-  [after:run](/api/plugins/after-run-api),
-  [before:spec](/api/plugins/before-spec-api) and
-  [after:spec](/api/plugins/after-spec-api) docs for more information. Addressed
-  in [#9646](https://github.com/cypress-io/cypress/issues/9646),
+  to `true`. See the [`before:run`](/api/plugins/before-run-api),
+  [`after:run`](/api/plugins/after-run-api),
+  [`before:spec`](/api/plugins/before-spec-api) and
+  [`after:spec`](/api/plugins/after-spec-api) docs for more information.
+  Addressed in [#9646](https://github.com/cypress-io/cypress/issues/9646),
   [#14178](https://github.com/cypress-io/cypress/issues/14178)
   [#14238](https://github.com/cypress-io/cypress/issues/14238) and
   [#14263](https://github.com/cypress-io/cypress/issues/14263).

--- a/content/_changelogs/6.7.0.md
+++ b/content/_changelogs/6.7.0.md
@@ -8,11 +8,11 @@ _Released 3/15/2021_
   listen to `before:run`, `after:run`, `before:spec` and `after:spec` events in
   the plugins file without needing the
   [experimentalRunEvents](/guides/references/experiments) configuration option.
-  See the [before:run](/api/plugins/before-run-api),
-  [after:run](/api/plugins/after-run-api),
-  [before:spec](/api/plugins/before-spec-api) and
-  [after:spec](/api/plugins/after-spec-api) docs for more information. Addressed
-  in [#15276](https://github.com/cypress-io/cypress/issues/15276).
+  See the [`before:run`](/api/plugins/before-run-api),
+  [`after:run`](/api/plugins/after-run-api),
+  [`before:spec`](/api/plugins/before-spec-api) and
+  [`after:spec`](/api/plugins/after-spec-api) docs for more information.
+  Addressed in [#15276](https://github.com/cypress-io/cypress/issues/15276).
 - When canceling a run from the Dashboard, previously only parallelized runs
   would cancel correctly. Now all recorded runs will respect cancelation and
   exit early. Addresses


### PR DESCRIPTION
This section was displaying weird in the changelog

<img width="714" alt="Screen Shot 2021-11-29 at 11 49 01 AM" src="https://user-images.githubusercontent.com/1271364/143917885-37444ac0-db92-4792-a0f4-bcf7cf0ad014.png">
