### PR TITLE
docs: fix broken links caused by ts migration

### DIFF
--- a/content/api/cypress-api/dom.md
+++ b/content/api/cypress-api/dom.md
@@ -11,7 +11,7 @@ documented below. These methods are used internally by Cypress in nearly every
 single built in command.
 
 We suggest
-[reading through the source code here](https://github.com/cypress-io/cypress/blob/develop/packages/driver/src/dom/index.js)
+[reading through the source code here](https://github.com/cypress-io/cypress/blob/develop/packages/driver/src/dom/index.ts)
 to see all of the methods and what they do.
 
 </Alert>

--- a/content/api/plugins/writing-a-plugin.md
+++ b/content/api/plugins/writing-a-plugin.md
@@ -80,7 +80,7 @@ please [refer to the docs for each one](#List-of-events).
 This configuration contains all of the values that get passed into the browser
 for your project.
 
-[For a comprehensive list of all configuration values look here.](https://github.com/cypress-io/cypress/blob/master/packages/server/lib/config.js)
+[For a comprehensive list of all configuration values look here.](https://github.com/cypress-io/cypress/blob/master/packages/server/lib/config.ts)
 
 Some plugins may utilize or require these values, so they can take certain
 actions based on the configuration.


### PR DESCRIPTION
## Description

- This fixes a couple of broken links caused by the typescript migration

## Issues

closes #4232