### PR TITLE
Add the known issue section for `cy.shadow()` and `cy.click()` problem.

### DIFF
--- a/content/api/commands/shadow.md
+++ b/content/api/commands/shadow.md
@@ -73,6 +73,16 @@ can time out waiting for the element(s) to host a shadow
 root.</li><li>`.shadow()` can time out waiting for assertions you've added to
 pass.</li></List>
 
+## Known Issue
+
+When working with `cy.click()`, it sometimes won't click the right element in Chrome. It's happening because of [the ambiguity in spec](https://bugs.chromium.org/p/chromium/issues/detail?id=1188919&q=shadowRoot%20elementFromPoint&can=2).
+
+In this case, pass `{ position: 'top' }` to `cy.click()` like below:
+
+```js
+cy.get('#element').shadow().find('[data-test-id="my-button"]').click({ position: 'top' })
+```
+
 ## Command Log
 
 **_Traverse into the shadow DOM of an element_**


### PR DESCRIPTION
Related with cypress-io/cypress#19260. 

It's an `awaiting external fix` problem that won't be fixed soon. So, I added this known issue section. 