### PR TITLE
fix: incorrect link in changelog 9.0.0

### DIFF
--- a/content/_changelogs/9.0.0.md
+++ b/content/_changelogs/9.0.0.md
@@ -26,7 +26,7 @@ _Released 11/10/2021_
   [#18572](https://github.com/cypress-io/cypress/issues/18572).
 - Custom command implementations are now typed based on the declared custom
   chainables. Addresses
-  [#17496](https://github.com/cypress-io/cypress/issues/17496).
+  [#17496](https://github.com/cypress-io/cypress/pull/17496).
 - The bundled Node.js version was upgraded from `14.17.0` to `16.5.0`. This
   could change the behavior of code within the `pluginsFile` when using the
   bundled Node.js version of Cypress. Addressed in


### PR DESCRIPTION
Changes:
On changelog version 9.0.0, the link is incorrect when clicked from the changelog page (error 404 page not found). Corrected the link path link from `issues` to `pull`:
https://github.com/cypress-io/cypress/pull/17496