### PR TITLE
CLOUD-295: Add analytics aspect to "Why Cypress -> Our mission"

### DIFF
--- a/content/guides/overview/why-cypress.md
+++ b/content/guides/overview/why-cypress.md
@@ -77,7 +77,10 @@ We believe our documentation should be approachable. This means enabling our
 readers to understand fully not just the **what** but the **why** as well.
 
 We want to help developers build a new generation of modern applications faster,
-better, and without the stress and anxiety associated with managing tests.
+better, and without the stress and anxiety associated with managing tests. We
+want to elevate the art of software development by leveraging test results to
+generate actionable insights into long-term stability, and identify areas for
+improvement.
 
 We know that in order for us to be successful we must enable, nurture, and
 foster an ecosystem that thrives on open source. Every line of test code is an

--- a/content/guides/overview/why-cypress.md
+++ b/content/guides/overview/why-cypress.md
@@ -79,7 +79,7 @@ readers to understand fully not just the **what** but the **why** as well.
 We want to help developers build a new generation of modern applications faster,
 better, and without the stress and anxiety associated with managing tests. We
 want to elevate the art of software development by leveraging test results to
-generate actionable insights into long-term stability, and identify areas for
+generate actionable insights for long-term stability, and identify areas for
 improvement.
 
 We know that in order for us to be successful we must enable, nurture, and

--- a/content/guides/overview/why-cypress.md
+++ b/content/guides/overview/why-cypress.md
@@ -78,9 +78,9 @@ readers to understand fully not just the **what** but the **why** as well.
 
 We want to help developers build a new generation of modern applications faster,
 better, and without the stress and anxiety associated with managing tests. We
-want to elevate the art of software development by leveraging test results to
-generate actionable insights for long-term stability, and identify areas for
-improvement.
+aim to elevate the art of software development by leveraging test results to
+generate actionable insights for long-term stability by proactively identifying
+areas for improvement.
 
 We know that in order for us to be successful we must enable, nurture, and
 foster an ecosystem that thrives on open source. Every line of test code is an


### PR DESCRIPTION
This, possibly contentious, change adds language to the Our Mission section that emphasizes the analysis of test results as a key differentiator of Cypress in general, and by inference the dashboard specifically. I've tried to suggest a more general mission of leveraging test metadata to achieve a higher level of software refinement, hopefully it hasn't just degenerated into word salad.

Note also that I have added the new content to one of the existing paragraphs rather than create a new one. This is purely a subjective, aesthetic preference on my part. I felt that this content could be considered an addendum to or refinement of the language in that para.