### PR TITLE
CLOUD-295: Add Dashboard CTAs to "Why Cypress -> Features"

### DIFF
--- a/content/guides/overview/why-cypress.md
+++ b/content/guides/overview/why-cypress.md
@@ -115,14 +115,15 @@ do that no other testing framework can:
   Say hello to fast, consistent and reliable tests that are flake-free.
 - **Screenshots and Videos:** View screenshots taken automatically on failure,
   or videos of your entire test suite when run from the CLI. Record to the
-  Dashboard to store them with your test results for easy online browsing.
+  Dashboard to store them with your test results for zero-configuration
+  debugging.
 - **Cross browser Testing:** Run tests within Firefox and Chrome-family browsers
   (including Edge and Electron) locally and
   [optimally in a Continuous Integration pipeline](/guides/guides/cross-browser-testing).
-- **Test Orchestration:** Once you're set up to record to the Dashboard, easily
+- **Smart Orchestration:** Once you're set up to record to the Dashboard, easily
   [parallelize](/guides/guides/parallelization) your test suite and
-  [fail-fast](/guides/dashboard/smart-orchestration#Run-failed-specs-first) for
-  tight feedback loops.
+  [rerun failed specs first](/guides/dashboard/smart-orchestration#Run-failed-specs-first)
+  for tight feedback loops.
 - **Flake Detection:** Discover and diagnose unreliable tests with the
   Dashboard's [Flaky test management](/guides/dashboard/flaky-test-management).
 

--- a/content/guides/overview/why-cypress.md
+++ b/content/guides/overview/why-cypress.md
@@ -114,10 +114,18 @@ do that no other testing framework can:
 - **Consistent Results:** Our architecture doesn’t use Selenium or WebDriver.
   Say hello to fast, consistent and reliable tests that are flake-free.
 - **Screenshots and Videos:** View screenshots taken automatically on failure,
-  or videos of your entire test suite when run from the CLI.
+  or videos of your entire test suite when run from the CLI. Record to the
+  Dashboard to store them with your test results for easy online browsing.
 - **Cross browser Testing:** Run tests within Firefox and Chrome-family browsers
   (including Edge and Electron) locally and
   [optimally in a Continuous Integration pipeline](/guides/guides/cross-browser-testing).
+- **Test Orchestration:** Once you're set up to record to the Dashboard, easily
+  [parallelize](/guides/guides/parallelization) your test suite and
+  [fail-fast](/guides/dashboard/smart-orchestration#Run-failed-specs-first) for
+  tight feedback loops.
+- **Flake Detection:** Sometimes tests pass, sometimes they fail? Discover and
+  diagnose unreliable tests with the Dashboard's
+  [Flaky tests](/guides/dashboard/flaky-test-management) feature.
 
 ### <Icon name="cog"></Icon> Setting up tests
 

--- a/content/guides/overview/why-cypress.md
+++ b/content/guides/overview/why-cypress.md
@@ -123,9 +123,8 @@ do that no other testing framework can:
   [parallelize](/guides/guides/parallelization) your test suite and
   [fail-fast](/guides/dashboard/smart-orchestration#Run-failed-specs-first) for
   tight feedback loops.
-- **Flake Detection:** Sometimes tests pass, sometimes they fail? Discover and
-  diagnose unreliable tests with the Dashboard's
-  [Flaky tests](/guides/dashboard/flaky-test-management) feature.
+- **Flake Detection:** Discover and diagnose unreliable tests with the
+  Dashboard's [Flaky test management](/guides/dashboard/flaky-test-management).
 
 ### <Icon name="cog"></Icon> Setting up tests
 

--- a/content/guides/overview/why-cypress.md
+++ b/content/guides/overview/why-cypress.md
@@ -115,8 +115,8 @@ do that no other testing framework can:
   Say hello to fast, consistent and reliable tests that are flake-free.
 - **Screenshots and Videos:** View screenshots taken automatically on failure,
   or videos of your entire test suite when run from the CLI. Record to the
-  Dashboard to store them with your test results for zero-configuration
-  debugging.
+  [Dashboard](/guides/dashboard/introduction) to store them with your test
+  results for zero-configuration debugging.
 - **Cross browser Testing:** Run tests within Firefox and Chrome-family browsers
   (including Edge and Electron) locally and
   [optimally in a Continuous Integration pipeline](/guides/guides/cross-browser-testing).


### PR DESCRIPTION
One more update to add more Dashboard advocacy to the Why Cypress page. This adds extra copy to the Features section to better surface the unique benefits of Dashboard subscription.