### PR TITLE
docs: fix basUrl misspelling

### DIFF
--- a/content/api/commands/visit.md
+++ b/content/api/commands/visit.md
@@ -47,7 +47,7 @@ The URL to visit.
 Cypress will prefix the URL with the `baseUrl` configured in your
 [global configuration](/guides/references/configuration#Global) if set.
 
-If the the `baseUrl` has not been set, you will need to specify a fully qualified
+If the `baseUrl` has not been set, you will need to specify a fully qualified
 URL or Cypress will attempt to act as your web server. See the
 [prefixes notes](#prefixes) for more details.
 

--- a/content/api/commands/visit.md
+++ b/content/api/commands/visit.md
@@ -47,7 +47,7 @@ The URL to visit.
 Cypress will prefix the URL with the `baseUrl` configured in your
 [global configuration](/guides/references/configuration#Global) if set.
 
-If the the `basUrl` has not been set, you will need to specify a fully qualified
+If the the `baseUrl` has not been set, you will need to specify a fully qualified
 URL or Cypress will attempt to act as your web server. See the
 [prefixes notes](#prefixes) for more details.
 


### PR DESCRIPTION
basUrl should be changed to baseUrl

See https://github.com/cypress-io/cypress-documentation/issues/4290