### PR TITLE
Updates to selectFile migration guide

### DIFF
--- a/content/guides/references/migration-guide.md
+++ b/content/guides/references/migration-guide.md
@@ -32,7 +32,7 @@ When the first argument is an object:
   binary file handling in Cypress 9.0.
 - `mimeType`: This property is unsupported in Cypress 9.3.0. If you need
   mimeType support, continue using cypress-file-upload until we add support for
-  this parameter.
+  this parameter. Support will be added in a future update.
 
 In the second argument:
 

--- a/content/guides/references/migration-guide.md
+++ b/content/guides/references/migration-guide.md
@@ -30,8 +30,9 @@ When the first argument is an object:
   rather than `Cypress.Blob`.
 - `encoding`: Remove this property. It is no longer needed due to improved
   binary file handling in Cypress 9.0.
-- `mimeType`: Remove this property. It is no longer needed due to improved
-  binary file handling in Cypress 9.0.
+- `mimeType`: This property is unsupported in Cypress 9.3.0. If you need
+  mimeType support, continue using cypress-file-upload until we add support for
+  this parameter.
 
 In the second argument:
 
@@ -39,6 +40,8 @@ In the second argument:
   `drag-n-drop` to `drag-drop` or from `input` to `select`.
 - `allowEmpty`: Remove this property. `.selectFile()` does not check the length
   of a file read from disk, only its existence.
+- `force`: Works the same with `.selectFile()` as it did in
+  `cypress-file-upload`. No change necessary.
 
 ### Examples
 


### PR DESCRIPTION
We've discovered an oversight with selectFIle(), and want to add the fact that it's not supported to the migration guide. For more details, see https://github.com/cypress-io/cypress/issues/19751.

This is a quick-fix while we work on an actual solution (supporting mimeType)