### PR TITLE
Add mimeType property and ArrayBuffer support

### DIFF
--- a/content/api/commands/selectfile.md
+++ b/content/api/commands/selectfile.md
@@ -55,7 +55,7 @@ Either a single file, or an array of files. A file can be:
   default Cypress configuration file). Eg: `'path/to/file.json'`
 - `@alias` - An alias of any type, previously stored using `.as()`. Eg:
   `'@alias'`
-- An
+- A
   [`TypedArray`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray)
   containing binary data, such as `Uint8Array.from('123')`.
   [`Cypress.Buffer`](/api/utilities/buffer) instances, such as those returned by
@@ -70,7 +70,7 @@ If an object is provided, it can have the following properties.
 | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `contents`     | The contents of the file. This can be a string shorthand as described above, a `TypedArray` instance containing binary data (such as a `Cypress.Buffer` instance) or a non-TypedArray object, which will be converted into a string with `JSON.stringify()` and `utf8` encoded. |
 | `fileName`     | The name of the file. If `contents` is a path on disk, this defaults to the actual filename. In any other case, this defaults to an empty string.                                                                                                                               |
-| `mimeType`     | The [mimeType](https://developer.mozilla.org/en-US/docs/Web/API/File/type) of the file. If omitted, it will be inferred from the file extension. If one cannot be inferred, it will default to an empty string.                                                                 |
+| `mimeType`     | The [mimeType](https://developer.mozilla.org/en-US/docs/Web/API/File/type) of the file. If omitted, it will be [inferred](https://github.com/jshttp/mime-types#mimelookuppath) from the file extension. If one cannot be inferred, it will default to an empty string.          |
 | `lastModified` | The file's last modified timestamp, in milliseconds elapsed since the UNIX epoch (eg. [`Date.prototype.getTime()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getTime)). This defaults to `Date.now()`.                              |
 
 **<Icon name="angle-right"></Icon> options** **_(Object)_**
@@ -192,7 +192,7 @@ This will fail unless the file input has the `multiple` property.
 cy.get('input[type=file]').selectFile({
   contents: 'path/to/file.json',
   fileName: 'custom-name.json',
-  mimeType: 'text/plain', // Overrides the 'application/json' mimeType detected from the .json extension
+  mimeType: 'text/plain',
   lastModified: new Date('Feb 18 1989').valueOf(),
 })
 ```
@@ -281,10 +281,10 @@ following:
 
 ## History
 
-| Version                                     | Changes                                                  |
-| ------------------------------------------- | -------------------------------------------------------- |
-| [9.3.0](/guides/references/changelog#9.3.0) | `.selectFile()` command added                            |
-| [9.4.0](/guides/references/changelog#9.4.0) | Support for `TypedArray`s and `mimeType` property added. |
+| Version                                     | Changes                                                 |
+| ------------------------------------------- | ------------------------------------------------------- |
+| [9.3.0](/guides/references/changelog#9.3.0) | `.selectFile()` command added                           |
+| [9.4.0](/guides/references/changelog#9.4.0) | Support for `TypedArray` and `mimeType` property added. |
 
 ### Community Recognition
 

--- a/content/api/commands/selectfile.md
+++ b/content/api/commands/selectfile.md
@@ -25,6 +25,7 @@ cy.get('input[type=file]').selectFile(['file.json', 'file2.json'])
 cy.get('input[type=file]').selectFile({
   contents: Cypress.Buffer.from('file contents'),
   fileName: 'file.txt',
+  mimeType: 'text/plain',
   lastModified: Date.now(),
 })
 
@@ -54,19 +55,23 @@ Either a single file, or an array of files. A file can be:
   default Cypress configuration file). Eg: `'path/to/file.json'`
 - `@alias` - An alias of any type, previously stored using `.as()`. Eg:
   `'@alias'`
-- A [`Cypress.Buffer`](/api/utilities/buffer) instance containing binary data,
-  such as that returned by `cy.readFile('file.json', { encoding: null })`. Eg:
-  `Cypress.Buffer.from('foo')`
+- An
+  [`TypedArray`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray)
+  containing binary data, such as `Uint8Array.from('123')`.
+  [`Cypress.Buffer`](/api/utilities/buffer) instances, such as those returned by
+  `cy.readFile('file.json', { encoding: null })` or created by
+  `Cypress.Buffer.from('foo')` are `TypedArray` instances.
 - An object with a non-null `contents` property, specifying details about the
   file. Eg: `{contents: '@alias', fileName: 'file.json'}`
 
 If an object is provided, it can have the following properties.
 
-| Option         | Description                                                                                                                                                                                                                                        |
-| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `contents`     | The contents of the file. This can be a string shorthand as described above, a `Cypress.Buffer` instance containing binary data or a non-Buffer object, which will be converted into a string with `JSON.stringify()` and `utf8` encoded.          |
-| `fileName`     | The name of the file. If `contents` is a path on disk, this defaults to the actual filename. In any other case, this defaults to an empty string.                                                                                                  |
-| `lastModified` | The file's last modified timestamp, in milliseconds elapsed since the UNIX epoch (eg. [`Date.prototype.getTime()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getTime)). This defaults to `Date.now()`. |
+| Option         | Description                                                                                                                                                                                                                                                                     |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `contents`     | The contents of the file. This can be a string shorthand as described above, a `TypedArray` instance containing binary data (such as a `Cypress.Buffer` instance) or a non-TypedArray object, which will be converted into a string with `JSON.stringify()` and `utf8` encoded. |
+| `fileName`     | The name of the file. If `contents` is a path on disk, this defaults to the actual filename. In any other case, this defaults to an empty string.                                                                                                                               |
+| `mimeType`     | The [mimeType](https://developer.mozilla.org/en-US/docs/Web/API/File/type) of the file. If omitted, it will be inferred from the file extension. If one cannot be inferred, it will default to an empty string.                                                                 |
+| `lastModified` | The file's last modified timestamp, in milliseconds elapsed since the UNIX epoch (eg. [`Date.prototype.getTime()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getTime)). This defaults to `Date.now()`.                              |
 
 **<Icon name="angle-right"></Icon> options** **_(Object)_**
 
@@ -181,12 +186,13 @@ This will fail unless the file input has the `multiple` property.
 
 </Alert>
 
-### Selecting a file with custom filename and lastModified
+### Selecting a file with custom filename, mimeType and lastModified
 
 ```javascript
 cy.get('input[type=file]').selectFile({
   contents: 'path/to/file.json',
   fileName: 'custom-name.json',
+  mimeType: 'text/plain', // Overrides the 'application/json' mimeType detected from the .json extension
   lastModified: new Date('Feb 18 1989').valueOf(),
 })
 ```
@@ -275,9 +281,10 @@ following:
 
 ## History
 
-| Version                                     | Changes                       |
-| ------------------------------------------- | ----------------------------- |
-| [9.3.0](/guides/references/changelog#9.3.0) | `.selectFile()` command added |
+| Version                                     | Changes                                                  |
+| ------------------------------------------- | -------------------------------------------------------- |
+| [9.3.0](/guides/references/changelog#9.3.0) | `.selectFile()` command added                            |
+| [9.4.0](/guides/references/changelog#9.4.0) | Support for `TypedArray`s and `mimeType` property added. |
 
 ### Community Recognition
 


### PR DESCRIPTION
Matching code PR: https://github.com/cypress-io/cypress/pull/19794

`.selectFile()` automatically infers the mime type of files based on their extension, and allows users to set it explicitly using the `mimeType` property on files.

In addition, users can specify the file contents with any `TypedArray` instance. Previously only instances of `Cypress.Buffer` were supported.

Example:
```
cy.get('input[type=file]').selectFile({
  contents: Uint8Array.from('567'),
  mimeType: 'text/plain',
})
```