### PR TITLE
Issue-19803: Use filename on disk when referring to fixtures

### DIFF
--- a/content/api/commands/selectfile.md
+++ b/content/api/commands/selectfile.md
@@ -216,7 +216,7 @@ cy.get('input[type=file][multiple]')
     expect(files[1].name).to.eq('file.png')
     expect(files[1].type).to.eq('image/png')
 
-    // But an explicitly specified MIME type is always used.:
+    // But an explicitly specified MIME type is always used.
     expect(files[2].name).to.eq('file.png')
     expect(files[2].type).to.eq('text/plain')
 

--- a/content/api/commands/selectfile.md
+++ b/content/api/commands/selectfile.md
@@ -186,15 +186,45 @@ This will fail unless the file input has the `multiple` property.
 
 </Alert>
 
-### Selecting a file with custom filename, mimeType and lastModified
+### Custom fileName, mimeType and lastModified
 
 ```javascript
-cy.get('input[type=file]').selectFile({
-  contents: 'path/to/file.yml',
-  fileName: 'custom-name.json',
-  mimeType: 'text/plain',
-  lastModified: new Date('Feb 18 1989').valueOf(),
-})
+cy.get('input[type=file][multiple]')
+  .selectFile([
+    {
+      contents: 'cypress/fixtures/example.json',
+    },
+    {
+      contents: 'cypress/fixtures/example.json',
+      fileName: 'file.png',
+    },
+    {
+      contents: 'cypress/fixtures/example.json',
+      fileName: 'file.png',
+      mimeType: 'text/plain',
+      lastModified: new Date('Feb 18 1989').valueOf(),
+    },
+  ])
+  .then(($input) => {
+    const files = $input[0].files
+
+    // If nothing is specified, the fileName and MIME type will be inferred from the path on disk.:
+    expect(files[0].name).to.eq('example.json')
+    expect(files[0].type).to.eq('application/json')
+
+    // If the fileName is given, the MIME type will be inferred based on that.
+    expect(files[1].name).to.eq('file.png')
+    expect(files[1].type).to.eq('image/png')
+
+    // But an explicitly specified MIME type is always used.:
+    expect(files[2].name).to.eq('file.png')
+    expect(files[2].type).to.eq('text/plain')
+
+    // lastModified defaults to the current time, but can be overridden.
+    expect(files[0].lastModified).to.be.closeTo(Date.now(), 1000)
+    expect(files[1].lastModified).to.be.closeTo(Date.now(), 1000)
+    expect(files[2].lastModified).to.eql(new Date('Feb 18 1989').valueOf())
+  })
 ```
 
 ### Dropping a file on the document

--- a/content/api/commands/selectfile.md
+++ b/content/api/commands/selectfile.md
@@ -69,7 +69,7 @@ If an object is provided, it can have the following properties.
 | Option         | Description                                                                                                                                                                                                                                                                     |
 | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `contents`     | The contents of the file. This can be a string shorthand as described above, a `TypedArray` instance containing binary data (such as a `Cypress.Buffer` instance) or a non-TypedArray object, which will be converted into a string with `JSON.stringify()` and `utf8` encoded. |
-| `fileName`     | The name of the file. If `contents` is a path on disk, this defaults to the actual filename. In any other case, this defaults to an empty string.                                                                                                                               |
+| `fileName`     | The name of the file. If `contents` is a path on disk or an alias from `cy.readFile()` or `cy.fixture()`, this defaults to the actual filename. In any other case, this defaults to an empty string.                                                                            |
 | `mimeType`     | The [mimeType](https://developer.mozilla.org/en-US/docs/Web/API/File/type) of the file. If omitted, it will be [inferred](https://github.com/jshttp/mime-types#mimelookuppath) from the file extension. If one cannot be inferred, it will default to an empty string.          |
 | `lastModified` | The file's last modified timestamp, in milliseconds elapsed since the UNIX epoch (eg. [`Date.prototype.getTime()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getTime)). This defaults to `Date.now()`.                              |
 
@@ -190,7 +190,7 @@ This will fail unless the file input has the `multiple` property.
 
 ```javascript
 cy.get('input[type=file]').selectFile({
-  contents: 'path/to/file.json',
+  contents: 'path/to/file.yml',
   fileName: 'custom-name.json',
   mimeType: 'text/plain',
   lastModified: new Date('Feb 18 1989').valueOf(),
@@ -281,10 +281,10 @@ following:
 
 ## History
 
-| Version                                     | Changes                                                 |
-| ------------------------------------------- | ------------------------------------------------------- |
-| [9.3.0](/guides/references/changelog#9.3.0) | `.selectFile()` command added                           |
-| [9.4.0](/guides/references/changelog#9.4.0) | Support for `TypedArray` and `mimeType` property added. |
+| Version                                     | Changes                                                                                                                      |
+| ------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| [9.3.0](/guides/references/changelog#9.3.0) | `.selectFile()` command added                                                                                                |
+| [9.4.0](/guides/references/changelog#9.4.0) | Support for `TypedArray` and `mimeType` property added. Default `fileName` name is no longer lost when working with aliases. |
 
 ### Community Recognition
 

--- a/content/api/commands/selectfile.md
+++ b/content/api/commands/selectfile.md
@@ -55,7 +55,7 @@ Either a single file, or an array of files. A file can be:
   default Cypress configuration file). Eg: `'path/to/file.json'`
 - `@alias` - An alias of any type, previously stored using `.as()`. Eg:
   `'@alias'`
-- An
+- A
   [`TypedArray`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray)
   containing binary data, such as `Uint8Array.from('123')`.
   [`Cypress.Buffer`](/api/utilities/buffer) instances, such as those returned by
@@ -70,7 +70,7 @@ If an object is provided, it can have the following properties.
 | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `contents`     | The contents of the file. This can be a string shorthand as described above, a `TypedArray` instance containing binary data (such as a `Cypress.Buffer` instance) or a non-TypedArray object, which will be converted into a string with `JSON.stringify()` and `utf8` encoded. |
 | `fileName`     | The name of the file. If `contents` is a path on disk, this defaults to the actual filename. In any other case, this defaults to an empty string.                                                                                                                               |
-| `mimeType`     | The [mimeType](https://developer.mozilla.org/en-US/docs/Web/API/File/type) of the file. If omitted, it will be inferred from the file extension. If one cannot be inferred, it will default to an empty string.                                                                 |
+| `mimeType`     | The [mimeType](https://developer.mozilla.org/en-US/docs/Web/API/File/type) of the file. If omitted, it will be [inferred](https://github.com/jshttp/mime-types#mimelookuppath) from the file extension. If one cannot be inferred, it will default to an empty string.          |
 | `lastModified` | The file's last modified timestamp, in milliseconds elapsed since the UNIX epoch (eg. [`Date.prototype.getTime()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getTime)). This defaults to `Date.now()`.                              |
 
 **<Icon name="angle-right"></Icon> options** **_(Object)_**
@@ -192,7 +192,7 @@ This will fail unless the file input has the `multiple` property.
 cy.get('input[type=file]').selectFile({
   contents: 'path/to/file.json',
   fileName: 'custom-name.json',
-  mimeType: 'text/plain', // Overrides the 'application/json' mimeType detected from the .json extension
+  mimeType: 'text/plain',
   lastModified: new Date('Feb 18 1989').valueOf(),
 })
 ```
@@ -281,10 +281,10 @@ following:
 
 ## History
 
-| Version                                     | Changes                                                  |
-| ------------------------------------------- | -------------------------------------------------------- |
-| [9.3.0](/guides/references/changelog#9.3.0) | `.selectFile()` command added                            |
-| [9.4.0](/guides/references/changelog#9.4.0) | Support for `TypedArray`s and `mimeType` property added. |
+| Version                                     | Changes                                                 |
+| ------------------------------------------- | ------------------------------------------------------- |
+| [9.3.0](/guides/references/changelog#9.3.0) | `.selectFile()` command added                           |
+| [9.4.0](/guides/references/changelog#9.4.0) | Support for `TypedArray` and `mimeType` property added. |
 
 ### Community Recognition
 

--- a/content/api/commands/selectfile.md
+++ b/content/api/commands/selectfile.md
@@ -25,6 +25,7 @@ cy.get('input[type=file]').selectFile(['file.json', 'file2.json'])
 cy.get('input[type=file]').selectFile({
   contents: Cypress.Buffer.from('file contents'),
   fileName: 'file.txt',
+  mimeType: 'text/plain',
   lastModified: Date.now(),
 })
 
@@ -54,19 +55,23 @@ Either a single file, or an array of files. A file can be:
   default Cypress configuration file). Eg: `'path/to/file.json'`
 - `@alias` - An alias of any type, previously stored using `.as()`. Eg:
   `'@alias'`
-- A [`Cypress.Buffer`](/api/utilities/buffer) instance containing binary data,
-  such as that returned by `cy.readFile('file.json', { encoding: null })`. Eg:
-  `Cypress.Buffer.from('foo')`
+- An
+  [`TypedArray`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray)
+  containing binary data, such as `Uint8Array.from('123')`.
+  [`Cypress.Buffer`](/api/utilities/buffer) instances, such as those returned by
+  `cy.readFile('file.json', { encoding: null })` or created by
+  `Cypress.Buffer.from('foo')` are `TypedArray` instances.
 - An object with a non-null `contents` property, specifying details about the
   file. Eg: `{contents: '@alias', fileName: 'file.json'}`
 
 If an object is provided, it can have the following properties.
 
-| Option         | Description                                                                                                                                                                                                                                        |
-| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `contents`     | The contents of the file. This can be a string shorthand as described above, a `Cypress.Buffer` instance containing binary data or a non-Buffer object, which will be converted into a string with `JSON.stringify()` and `utf8` encoded.          |
-| `fileName`     | The name of the file. If `contents` is a path on disk, this defaults to the actual filename. In any other case, this defaults to an empty string.                                                                                                  |
-| `lastModified` | The file's last modified timestamp, in milliseconds elapsed since the UNIX epoch (eg. [`Date.prototype.getTime()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getTime)). This defaults to `Date.now()`. |
+| Option         | Description                                                                                                                                                                                                                                                                     |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `contents`     | The contents of the file. This can be a string shorthand as described above, a `TypedArray` instance containing binary data (such as a `Cypress.Buffer` instance) or a non-TypedArray object, which will be converted into a string with `JSON.stringify()` and `utf8` encoded. |
+| `fileName`     | The name of the file. If `contents` is a path on disk, this defaults to the actual filename. In any other case, this defaults to an empty string.                                                                                                                               |
+| `mimeType`     | The [mimeType](https://developer.mozilla.org/en-US/docs/Web/API/File/type) of the file. If omitted, it will be inferred from the file extension. If one cannot be inferred, it will default to an empty string.                                                                 |
+| `lastModified` | The file's last modified timestamp, in milliseconds elapsed since the UNIX epoch (eg. [`Date.prototype.getTime()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getTime)). This defaults to `Date.now()`.                              |
 
 **<Icon name="angle-right"></Icon> options** **_(Object)_**
 
@@ -181,12 +186,13 @@ This will fail unless the file input has the `multiple` property.
 
 </Alert>
 
-### Selecting a file with custom filename and lastModified
+### Selecting a file with custom filename, mimeType and lastModified
 
 ```javascript
 cy.get('input[type=file]').selectFile({
   contents: 'path/to/file.json',
   fileName: 'custom-name.json',
+  mimeType: 'text/plain', // Overrides the 'application/json' mimeType detected from the .json extension
   lastModified: new Date('Feb 18 1989').valueOf(),
 })
 ```
@@ -275,9 +281,10 @@ following:
 
 ## History
 
-| Version                                     | Changes                       |
-| ------------------------------------------- | ----------------------------- |
-| [9.3.0](/guides/references/changelog#9.3.0) | `.selectFile()` command added |
+| Version                                     | Changes                                                  |
+| ------------------------------------------- | -------------------------------------------------------- |
+| [9.3.0](/guides/references/changelog#9.3.0) | `.selectFile()` command added                            |
+| [9.4.0](/guides/references/changelog#9.4.0) | Support for `TypedArray`s and `mimeType` property added. |
 
 ### Community Recognition
 

--- a/content/guides/references/migration-guide.md
+++ b/content/guides/references/migration-guide.md
@@ -30,9 +30,10 @@ When the first argument is an object:
   rather than `Cypress.Blob`.
 - `encoding`: Remove this property. It is no longer needed due to improved
   binary file handling in Cypress 9.0.
-- `mimeType`: This property is unsupported in Cypress 9.3.0. If you need
-  mimeType support, continue using cypress-file-upload until we add support for
-  this parameter. Support will be added in a future update.
+- `mimeType`: No change necessary. In most cases you do not need to give a
+  mimeType explicitly. Cypress will attempt to infer the MIME type
+  [based on the extension](https://github.com/jshttp/mime-types#mimelookuppath)
+  of the fileName if none is provided.
 
 In the second argument:
 
@@ -161,6 +162,27 @@ cy.fixture(special, { encoding: null })
   .as('special')
 
 cy.get('[data-cy="file-input"]').selectFile('@special')
+```
+
+#### Specifying a custom mimeType
+
+<Badge type="danger">Before</Badge> Specifying the MIME type with
+`cypress-file-upload`
+
+```js
+cy.get('[data-cy="dropzone"]').attachFile({
+  filePath: 'myfixture.json',
+  fileName: 'customFileName.json',
+})
+```
+
+<Badge type="success">After</Badge> Specifying a MIME type with `.selectFile()`.
+
+```js
+cy.get('[data-cy="dropzone"]').selectFile({
+  contents: 'fixtures/myfixture.json',
+  mimeType: 'text/plain',
+})
 ```
 
 ## Migrating to Cypress 8.0


### PR DESCRIPTION
Matching code PR: https://github.com/cypress-io/cypress/pull/19820

I struggled a bit to find a good way to document this change, mostly because it "just works" the way you expect, whereas the previous behavior was the surprising bit.