### PR TITLE
docs: update how screenshots and videos are stripped of common ancestors

### DIFF
--- a/content/api/commands/screenshot.md
+++ b/content/api/commands/screenshot.md
@@ -167,7 +167,7 @@ cy.screenshot('my-screenshot', {
 Screenshot naming follows these rules:
 
 - Screenshots are saved inside the
-  [screenshots folder](guides/core-concepts/writing-and-organizing-tests#Asset-File-Paths).
+  [screenshots folder](/guides/core-concepts/writing-and-organizing-tests#Asset-File-Paths).
   Inside that folder, the screenshot is saved inside a folder structure relative
   to the path of the spec file, which is adjusted to remove any common ancestor
   paths shared with all other spec files. Inside this folder, the screenshot

--- a/content/api/commands/screenshot.md
+++ b/content/api/commands/screenshot.md
@@ -167,7 +167,7 @@ cy.screenshot('my-screenshot', {
 Screenshot naming follows these rules:
 
 - Screenshots are saved inside the
-  [screenshots folder](/guides/core-concepts/writing-and-organizing-tests#Asset-Saving-Structure).
+  [screenshots folder](/guides/references/configuration#Asset-Saving-Structure).
   Inside that folder, the screenshot is saved inside a folder structure relative
   to the path of the spec file, which is adjusted to remove any common ancestor
   paths shared with all other spec files. Inside this folder, the screenshot

--- a/content/api/commands/screenshot.md
+++ b/content/api/commands/screenshot.md
@@ -167,7 +167,7 @@ cy.screenshot('my-screenshot', {
 Screenshot naming follows these rules:
 
 - Screenshots are saved inside the
-  [screenshots folder](/guides/references/configuration#Asset-Saving-Structure).
+  [screenshots folder](guides/core-concepts/writing-and-organizing-tests#Asset-File-Paths).
   Inside that folder, the screenshot is saved inside a folder structure relative
   to the path of the spec file, which is adjusted to remove any common ancestor
   paths shared with all other spec files. Inside this folder, the screenshot

--- a/content/api/commands/screenshot.md
+++ b/content/api/commands/screenshot.md
@@ -167,10 +167,10 @@ cy.screenshot('my-screenshot', {
 Screenshot naming follows these rules:
 
 - By default, a screenshot is saved to a file with a path relative to the
-  [screenshots folder](/guides/references/configuration#Folders-Files), appended
-  by a path relating to where the spec file exists stripped of any common
-  acestor paths shared between all spec files found, with a name including the
-  current test's suites and test name:
+  [screenshots folder](/guides/core-concepts/writing-and-organizing-tests#Asset-Saving-Structure).
+  It is then appended by a path relative to where the spec file exists stripped
+  of any common acestor paths that are shared between all spec files found. It
+  will finally add a name for the current test's suites and test name:
   `{screenshotsFolder}/{adjustedSpecPath}/{testName}.png`
 - For a named screenshot, the name is used instead of the suites and test name:
   `{screenshotsFolder}/{adjustedSpecPath}/{name}.png`
@@ -197,14 +197,19 @@ describe('my tests', () => {
   it('takes a screenshot', () => {
     // NOTE: This file has multiple screenshots and each screenshot has a common ancestor path of `/users/`.
     // In this scenario `/users/` is stripped from the path.
-    cy.screenshot() // cypress/screenshots/login.cy.js/my tests -- takes a screenshot.png
-    cy.screenshot() // cypress/screenshots/login.cy.js/my tests -- takes a screenshot (1).png
-    cy.screenshot() // cypress/screenshots/login.cy.js/my tests -- takes a screenshot (2).png
+    // cypress/screenshots/login.cy.js/my tests -- takes a screenshot.png
+    cy.screenshot()
+    // cypress/screenshots/login.cy.js/my tests -- takes a screenshot (1).png
+    cy.screenshot()
+    // cypress/screenshots/login.cy.js/my tests -- takes a screenshot (2).png
+    cy.screenshot()
 
-    cy.screenshot('my-screenshot') // cypress/screenshots/login.cy.js/my-screenshot.png
-    cy.screenshot('my-screenshot') // cypress/screenshots/login.cy.js/my-screenshot (1).png
-
-    cy.screenshot('my/nested/screenshot') // cypress/screenshots/login.cy.js/my/nested/screenshot.png
+    // cypress/screenshots/login.cy.js/my-screenshot.png
+    cy.screenshot('my-screenshot')
+    // cypress/screenshots/login.cy.js/my-screenshot (1).png
+    cy.screenshot('my-screenshot')
+    // cypress/screenshots/login.cy.js/my/nested/screenshot.png
+    cy.screenshot('my/nested/screenshot')
 
     // if this test fails, the screenshot will be saved to cypress/screenshots/login.cy.js/my tests -- takes a screenshot (failed).png
   })

--- a/content/api/commands/screenshot.md
+++ b/content/api/commands/screenshot.md
@@ -171,12 +171,11 @@ Screenshot naming follows these rules:
   by a path relating to where the spec file exists stripped of any common
   acestor paths shared between all spec files found, with a name including the
   current test's suites and test name:
-  `{screenshotsFolder}/{specPathStrippedOfCommonAncestors}/{testName}.png`
+  `{screenshotsFolder}/{adjustedSpecPath}/{testName}.png`
 - For a named screenshot, the name is used instead of the suites and test name:
-  `{screenshotsFolder}/{specPathStrippedOfCommonAncestors}/{name}.png`
+  `{screenshotsFolder}/{adjustedSpecPath}/{name}.png`
 - For any duplicate screenshots (named or not), they will be appended with a
-  number:
-  `{screenshotsFolder}/{specPathStrippedOfCommonAncestors}/{testName} (1).png`.
+  number: `{screenshotsFolder}/{adjustedSpecPath}/{testName} (1).png`.
 
 <Alert type="info">
 
@@ -187,24 +186,27 @@ This behavior can be changed by passing the `{overwrite: true}` option to
 
 - For a failure screenshot, the default naming scheme is used and the name is
   appended with ` (failed)`:
-  `{screenshotsFolder}/{specPathStrippedOfCommonAncestors}/{testName} (failed).png`
+  ```javascript
+  {screenshotsFolder}/{adjustedSpecPath}/{testName} (failed).png
+  ```
 
 For example, given a spec file located at `cypress/e2e/users/login.cy.js`:
 
 ```javascript
 describe('my tests', () => {
   it('takes a screenshot', () => {
-    // NOTE: Because this file has multiple screenshots and therefore each screenshot has a common ancestor path of `/users/` and therefore stripped from the path.
-    cy.screenshot() // cypress/screenshots/login_spec.js/my tests -- takes a screenshot.png
-    cy.screenshot() // cypress/screenshots/login_spec.js/my tests -- takes a screenshot (1).png
-    cy.screenshot() // cypress/screenshots/login_spec.js/my tests -- takes a screenshot (2).png
+    // NOTE: This file has multiple screenshots and each screenshot has a common ancestor path of `/users/`.
+    // In this scenario `/users/` is stripped from the path.
+    cy.screenshot() // cypress/screenshots/login.cy.js/my tests -- takes a screenshot.png
+    cy.screenshot() // cypress/screenshots/login.cy.js/my tests -- takes a screenshot (1).png
+    cy.screenshot() // cypress/screenshots/login.cy.js/my tests -- takes a screenshot (2).png
 
-    cy.screenshot('my-screenshot') // cypress/screenshots/login_spec.js/my-screenshot.png
-    cy.screenshot('my-screenshot') // cypress/screenshots/login_spec.js/my-screenshot (1).png
+    cy.screenshot('my-screenshot') // cypress/screenshots/login.cy.js/my-screenshot.png
+    cy.screenshot('my-screenshot') // cypress/screenshots/login.cy.js/my-screenshot (1).png
 
-    cy.screenshot('my/nested/screenshot') // cypress/screenshots/login_spec.js/my/nested/screenshot.png
+    cy.screenshot('my/nested/screenshot') // cypress/screenshots/login.cy.js/my/nested/screenshot.png
 
-    // if this test fails, the screenshot will be saved to cypress/screenshots/login_spec.js/my tests -- takes a screenshot (failed).png
+    // if this test fails, the screenshot will be saved to cypress/screenshots/login.cy.js/my tests -- takes a screenshot (failed).png
   })
 })
 ```

--- a/content/api/commands/screenshot.md
+++ b/content/api/commands/screenshot.md
@@ -166,11 +166,12 @@ cy.screenshot('my-screenshot', {
 
 Screenshot naming follows these rules:
 
-- By default, a screenshot is saved to a file with a path relative to the
+- Screenshots are saved inside the
   [screenshots folder](/guides/core-concepts/writing-and-organizing-tests#Asset-Saving-Structure).
-  It is then appended by a path relative to where the spec file exists stripped
-  of any common acestor paths that are shared between all spec files found. It
-  will finally add a name for the current test's suites and test name:
+  Inside that folder, the screenshot is saved inside a folder structure relative
+  to the path of the spec file, which is adjusted to remove any common ancestor
+  paths shared with all other spec files. Inside this folder, the screenshot
+  will be saved with the test name:
   `{screenshotsFolder}/{adjustedSpecPath}/{testName}.png`
 - For a named screenshot, the name is used instead of the suites and test name:
   `{screenshotsFolder}/{adjustedSpecPath}/{name}.png`
@@ -195,7 +196,8 @@ For example, given a spec file located at `cypress/e2e/users/login.cy.js`:
 ```javascript
 describe('my tests', () => {
   it('takes a screenshot', () => {
-    // NOTE: This file has multiple screenshots and each screenshot has a common ancestor path of `/users/`.
+    // NOTE: This file has multiple screenshots
+    // each screenshot has a common ancestor path of `/users/`.
     // In this scenario `/users/` is stripped from the path.
     // cypress/screenshots/login.cy.js/my tests -- takes a screenshot.png
     cy.screenshot()
@@ -211,7 +213,8 @@ describe('my tests', () => {
     // cypress/screenshots/login.cy.js/my/nested/screenshot.png
     cy.screenshot('my/nested/screenshot')
 
-    // if this test fails, the screenshot will be saved to cypress/screenshots/login.cy.js/my tests -- takes a screenshot (failed).png
+    // if this test fails, the screenshot will be saved to
+    // cypress/screenshots/login.cy.js/my tests -- takes a screenshot (failed).png
   })
 })
 ```

--- a/content/api/commands/screenshot.md
+++ b/content/api/commands/screenshot.md
@@ -168,13 +168,15 @@ Screenshot naming follows these rules:
 
 - By default, a screenshot is saved to a file with a path relative to the
   [screenshots folder](/guides/references/configuration#Folders-Files), appended
-  by a path relating to where the spec file exists, with a name including the
+  by a path relating to where the spec file exists stripped of any common
+  acestor paths shared between all spec files found, with a name including the
   current test's suites and test name:
-  `{screenshotsFolder}/{specPath}/{testName}.png`
+  `{screenshotsFolder}/{specPathStrippedOfCommonAncestors}/{testName}.png`
 - For a named screenshot, the name is used instead of the suites and test name:
-  `{screenshotsFolder}/{specPath}/{name}.png`
+  `{screenshotsFolder}/{specPathStrippedOfCommonAncestors}/{name}.png`
 - For any duplicate screenshots (named or not), they will be appended with a
-  number: `{screenshotsFolder}/{specPath}/{testName} (1).png`.
+  number:
+  `{screenshotsFolder}/{specPathStrippedOfCommonAncestors}/{testName} (1).png`.
 
 <Alert type="info">
 
@@ -185,26 +187,35 @@ This behavior can be changed by passing the `{overwrite: true}` option to
 
 - For a failure screenshot, the default naming scheme is used and the name is
   appended with ` (failed)`:
-  `{screenshotsFolder}/{specPath}/{testName} (failed).png`
+  `{screenshotsFolder}/{specPathStrippedOfCommonAncestors}/{testName} (failed).png`
 
 For example, given a spec file located at `cypress/e2e/users/login.cy.js`:
 
 ```javascript
 describe('my tests', () => {
   it('takes a screenshot', () => {
-    cy.screenshot() // cypress/screenshots/users/login.cy.js/my tests -- takes a screenshot.png
-    cy.screenshot() // cypress/screenshots/users/login.cy.js/my tests -- takes a screenshot (1).png
-    cy.screenshot() // cypress/screenshots/users/login.cy.js/my tests -- takes a screenshot (2).png
+    // NOTE: Because this file has multiple screenshots and therefore each screenshot has a common ancestor path of `/users/` and therefore stripped from the path.
+    cy.screenshot() // cypress/screenshots/login_spec.js/my tests -- takes a screenshot.png
+    cy.screenshot() // cypress/screenshots/login_spec.js/my tests -- takes a screenshot (1).png
+    cy.screenshot() // cypress/screenshots/login_spec.js/my tests -- takes a screenshot (2).png
 
-    cy.screenshot('my-screenshot') // cypress/screenshots/users/login.cy.js/my-screenshot.png
-    cy.screenshot('my-screenshot') // cypress/screenshots/users/login.cy.js/my-screenshot (1).png
+    cy.screenshot('my-screenshot') // cypress/screenshots/login_spec.js/my-screenshot.png
+    cy.screenshot('my-screenshot') // cypress/screenshots/login_spec.js/my-screenshot (1).png
 
-    cy.screenshot('my/nested/screenshot') // cypress/screenshots/users/login.cy.js/my/nested/screenshot.png
+    cy.screenshot('my/nested/screenshot') // cypress/screenshots/login_spec.js/my/nested/screenshot.png
 
-    // if this test fails, the screenshot will be saved to cypress/screenshots/users/login.cy.js/my tests -- takes a screenshot (failed).png
+    // if this test fails, the screenshot will be saved to cypress/screenshots/login_spec.js/my tests -- takes a screenshot (failed).png
   })
 })
 ```
+
+<Alert type="info">
+
+To learn more about how to write and organize tests and how assets are saved,
+see
+[Writing And Organizing Tests](/guides/core-concepts/writing-and-organizing-tests#Asset-Files)
+
+</Alert>
 
 ### `after:screenshot` plugin event
 

--- a/content/guides/core-concepts/writing-and-organizing-tests.md
+++ b/content/guides/core-concepts/writing-and-organizing-tests.md
@@ -185,7 +185,7 @@ Any videos recorded of the run are stored in the
     - app.cy.js.mp4
 ```
 
-#### Asset Saving Structure
+#### Asset File Paths
 
 Generated screenshots and videos are saved inside their respective folders
 (`cypress/screenshots`, `cypress/videos`). The paths of the generated files will

--- a/content/guides/core-concepts/writing-and-organizing-tests.md
+++ b/content/guides/core-concepts/writing-and-organizing-tests.md
@@ -185,6 +185,39 @@ Any videos recorded of the run are stored in the
     - app.cy.js.mp4
 ```
 
+#### Asset Saving Structure
+
+Generated screenshots and videos are saved inside their respective folders
+(`cypress/screenshots`, `cypress/videos`). The paths of the generated files will
+be stripped of any common ancestor paths shared between all spec files found by
+the `specPattern` option (or via the `--spec` command line option or `spec`
+module API option, if specified)
+
+**Example 1:**
+
+- Spec file found
+  - `cypress/e2e/path/to/file/one.cy.js`
+- Common ancester paths (calculated at runtime)
+  - `cypress/e2e/path/to/file`
+- Generated screenshot file
+  - `cypress/screenshots/one.cy.js/your-screenshot.png`
+- Generated video file
+  - `cypress/videos/one.cy.js.mp4`
+
+**Example 2:**
+
+- Spec files found
+  - `cypress/e2e/path/to/file/one.cy.js`
+  - `cypress/e2e/path/to/two.cy.js`
+- Common ancester paths (calculated at runtime)
+  - `cypress/e2e/path/to/`
+- Generated screenshot files
+  - `cypress/screenshots/file/one.cy.js/your-screenshot.png`
+  - `cypress/screenshots/two.cy.js/your-screenshot.png`
+- Generated video files
+  - `cypress/videos/file/one.cy.js.mp4`
+  - `cypress/videos/two.cy.js.mp4`
+
 To learn more about videos and settings available, see
 [Screenshots and Videos](/guides/guides/screenshots-and-videos#Screenshots)
 


### PR DESCRIPTION
This PR updates the docs to reflect the new generated asset file saving behavior

Closes UDX-6