### PR TITLE
plugins: update Nx tagline and links

### DIFF
--- a/content/_data/plugins.json
+++ b/content/_data/plugins.json
@@ -690,9 +690,9 @@
         },
         {
           "name": "Nx",
-          "description": "Nrwl Extensions for Angular",
-          "link": "https://nrwl.io/nx/e2e-testing-with-cypress",
-          "keywords": ["angular", "cli"],
+          "description": "Smart, Fast and Extensible Build System",
+          "link": "https://nx.dev/cypress/overview",
+          "keywords": ["angular", "react", "cli", "monorepo"],
           "badge": "community"
         },
         {


### PR DESCRIPTION
Updates the Nx plugin, adjusting the tagline and links to the docs covering Cypress :)