### PR TITLE
Add Vulcan Next to list of plugins

### DIFF
--- a/content/_data/plugins.json
+++ b/content/_data/plugins.json
@@ -766,6 +766,13 @@
           "badge": "community"
         },
         {
+          "name": "Vulcan Next",
+          "description": "A model-driven Next.js and GraphQL boilerplate, with Storybook, Jest and Cypress all set up.",
+          "link": "https://github.com/VulcanJS/vulcan-next",
+          "keywords": ["next.js", "react", "graphql", "mongo", "vercel"],
+          "badge": "community"
+        },
+        {
           "name": "@cypress/schematic",
           "description": "Adds Cypress to your Angular project via the Angular CLI",
           "link": "https://github.com/cypress-io/cypress/tree/master/npm/cypress-schematic",


### PR DESCRIPTION
Hi,

I am the maintainer of [Vulcan Next](https://github.com/VulcanJS/vulcan-next), a React+GraphQL framework written on top of Next.js.

Vulcan Next is comparable to already listed plugins such as Next Right Now and Bison. However, Vulcan is backed by a more generic framework, [Vulcan NPM](https://github.com/VulcanJS/vulcan-npm), that itself is a port from our older MeteorJS version (Vulcan/Telescope), making it one of the oldest "meta-framework" around.

A huge part of the boilerplate is actually composed by the test tooling:

- we use Storybook and the "testing-react" in Jest to quickly write component unit and anti-regression tests
- we use Cypress for e2e testing, with demoes of advanced tests like testing a Next.js API or authentication-related mailing
- more broadly, we setup every little things you would expect when plugging Next.js and Cypress: automatically loading the right environment variable, enabling the "debug" package in the browser, being able to reuse your application logic and typings within the tests and so on
- we also try to have consistent experience with Jest: reusing the same test fixtures, using Testing Library to write the selectors for instance, so that testing logic is not duplicated

I hope you'll like the project enough to add it as a community plugin!


