### PR TITLE
docs(support file): update support file docs to reflect changes in 10.0.0

### DIFF
--- a/content/guides/core-concepts/writing-and-organizing-tests.md
+++ b/content/guides/core-concepts/writing-and-organizing-tests.md
@@ -210,10 +210,17 @@ The initial imported plugins file can be
 
 ### Support file
 
-By default Cypress will automatically include the support file
-`cypress/support/index.js`. This file runs **before** every single spec file. We
-do this purely as a convenience mechanism so you don't have to import this file
-in every single one of your spec files.
+By default Cypress will automatically include type-specific support files. For
+E2E, the default is `cypress/support/e2e.{js,jsx,ts,tsx}`, and for Component
+Testing `cypress/support/e2e.{js,jsx,ts,tsx}`.
+
+The default support file can be configured to another file or turned off
+completely within each testing type's configuration object using the
+[supportFile](/guides/references/configuration#Folders-Files) configuration.
+
+This file runs **before** every single spec file. We do this purely as a
+convenience mechanism so you don't have to import this file in every single one
+of your spec files.
 
 <Alert type="danger">
 
@@ -224,10 +231,6 @@ before each spec file. See [Execution](#Execution) for more details.
 
 </Alert>
 
-The initial imported support file can be configured to another file or turned
-off completely using the
-[supportFile](/guides/references/configuration#Folders-Files) configuration.
-
 The support file is a great place to put reusable behavior such as
 [custom commands](/api/cypress-api/custom-commands) or global overrides that you
 want applied and available to all of your spec files.
@@ -235,8 +238,8 @@ want applied and available to all of your spec files.
 From your support file you can `import` or `require` other files to keep things
 organized.
 
-We automatically seed an example support file, which has several commented out
-examples.
+We automatically seed an example support file for each configured testing type,
+which has several commented out examples.
 
 You can define behaviors in a `before` or `beforeEach` within any of the
 `cypress/support` files:

--- a/content/guides/references/assertions.md
+++ b/content/guides/references/assertions.md
@@ -210,7 +210,7 @@ Cypress will "just work" with new assertions added to `chai`. You can:
 - Write your own `chai` assertions as
   [documented here](http://chaijs.com/api/plugins/).
 - npm install any existing `chai` library and import into your test file or
-  support file.
+  [support file](/guides/core-concepts/writing-and-organizing-tests#Support-file).
 
 <Alert type="info">
 

--- a/content/guides/references/configuration.md
+++ b/content/guides/references/configuration.md
@@ -207,7 +207,7 @@ object:
 | Option            | Default                               | Description                                                                                                                                                                                         |
 | ----------------- | ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `setupNodeEvents` | `null`                                | Function in which node events can be registered and config can be modified. Takes the place of the (deprecated) plugins file. [Please read the notes for examples on using this.](#setupNodeEvents) |
-| `supportFile`     | `cypress/support/index.js`            | Path to file to load before test files load. This file is compiled and bundled. (Pass `false` to disable)                                                                                           |
+| `supportFile`     | `cypress/support/e2e.{js,jsx,ts,tsx}` | Path to file to load before test files load. This file is compiled and bundled. (Pass `false` to disable)                                                                                           |
 | `specPattern`     | `cypress/e2e/**/*.cy.{js,jsx,ts,tsx}` | A String or Array of glob patterns of the test files to load                                                                                                                                        |
 
 :::cypress-config-example{noJson}
@@ -227,13 +227,13 @@ object:
 These options are available to be specified inside the `component` configuration
 object:
 
-| Option            | Default                    | Description                                                                                                                                                                                         |
-| ----------------- | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `devServer`       | `null`                     | Required function used to configure the component testing dev server. [Please read the notes for examples on using this.](#devServer-devServerConfig)                                               |
-| `devServerConfig` | `null`                     | Optional dev server configuration. Config options will be determined by the dev server. [Please read the notes for examples on using this.](#devServer-devServerConfig)                             |
-| `setupNodeEvents` | `null`                     | Function in which node events can be registered and config can be modified. Takes the place of the (deprecated) plugins file. [Please read the notes for examples on using this.](#setupNodeEvents) |
-| `supportFile`     | `cypress/support/index.js` | Path to file to load before test files load. This file is compiled and bundled. (Pass `false` to disable)                                                                                           |
-| `specPattern`     | `**/*.cy.{js,jsx,ts,tsx}`  | A String or Array of glob patterns of the test files to load. <br><br>Note that any files found matching the `e2e.specPattern` value will be automatically **excluded.**                            |
+| Option            | Default                                     | Description                                                                                                                                                                                         |
+| ----------------- | ------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `devServer`       | `null`                                      | Required function used to configure the component testing dev server. [Please read the notes for examples on using this.](#devServer-devServerConfig)                                               |
+| `devServerConfig` | `null`                                      | Optional dev server configuration. Config options will be determined by the dev server. [Please read the notes for examples on using this.](#devServer-devServerConfig)                             |
+| `setupNodeEvents` | `null`                                      | Function in which node events can be registered and config can be modified. Takes the place of the (deprecated) plugins file. [Please read the notes for examples on using this.](#setupNodeEvents) |
+| `supportFile`     | `cypress/support/component.{js,jsx,ts,tsx}` | Path to file to load before test files load. This file is compiled and bundled. (Pass `false` to disable)                                                                                           |
+| `specPattern`     | `**/*.cy.{js,jsx,ts,tsx}`                   | A String or Array of glob patterns of the test files to load. <br><br>Note that any files found matching the `e2e.specPattern` value will be automatically **excluded.**                            |
 
 :::cypress-config-example{noJson}
 

--- a/content/guides/references/error-messages.md
+++ b/content/guides/references/error-messages.md
@@ -41,6 +41,14 @@ your test files. However, automatically including all the files in a certain
 directory is somewhat magical and unintuitive, and requires creating globals for
 the purpose of utility functions.
 
+### <Icon name="exclamation-triangle" color="red"></Icon> Error Loading Config
+
+The `supportFile` configuration option was removed from the root configutation
+object in Cypress version `10.0.0`. Instead, it must be added within each
+testing type's configuration object as a separate property if you would like to
+use a file other than the default
+[supportFile](/guides/references/configuration#Folders-Files) configuration.
+
 #### Use modules for utility functions
 
 Cypress supports both ES2015 modules and CommonJS modules. You can
@@ -62,16 +70,7 @@ It's still useful to load a setup file before your test code. If you are setting
 Cypress defaults or utilizing custom Cypress commands, instead of needing to
 import/require those defaults/commands in every test file, you can use the
 [`supportFile`](/guides/references/configuration#Folders-Files) configuration
-option.
-
-To include code before your test files, set the
-[`supportFile`](/guides/references/configuration#Folders-Files) path. By
-default, [`supportFile`](/guides/references/configuration#Folders-Files) is set
-to look for one of the following files:
-
-- `cypress/support/index.js`
-- `cypress/support/index.ts`
-- `cypress/support/index.coffee`
+option within each testing type's configuration object.
 
 Just like with your test files, the
 [`supportFile`](/guides/references/configuration#Folders-Files) can use ES2015+,

--- a/content/guides/references/migration-guide.md
+++ b/content/guides/references/migration-guide.md
@@ -770,7 +770,9 @@ cypress run
 #### 5. Update the support file (optionally)
 
 Previously, a support file was required to set up the component testing target
-node. This is no longer necessary.
+node. This is no longer necessary. Instead, if a support file is needed, it
+should be set up according to the
+[support file documentation](/guides/core-concepts/writing-and-organizing-tests#Support-file).
 
 Specifically for React users, if the support file contains the following line,
 please remove it. The import will fail in the future. We have left it in to

--- a/content/guides/references/migration-guide.md
+++ b/content/guides/references/migration-guide.md
@@ -81,7 +81,12 @@ on('<event>', (arg1, arg2) => {
 
 ### Config option changes
 
-CONTENT_TBD
+#### `supportFile`
+
+The `supportFile` configuration option is no longer valid at the top-level.
+Instead, it must be configured within each testing type's configuration object.
+More information can be found in the
+[support file docs](/guides/core-concepts/writing-and-organizing-tests#Support-file).
 
 ## Migrating from `cypress-file-upload` to [`.selectFile()`](/api/commands/selectfile)
 
@@ -770,9 +775,7 @@ cypress run
 #### 5. Update the support file (optionally)
 
 Previously, a support file was required to set up the component testing target
-node. This is no longer necessary. Instead, if a support file is needed, it
-should be set up according to the
-[support file documentation](/guides/core-concepts/writing-and-organizing-tests#Support-file).
+node. This is no longer necessary.
 
 Specifically for React users, if the support file contains the following line,
 please remove it. The import will fail in the future. We have left it in to


### PR DESCRIPTION
Pages updated include:

`/guides/references/configuration#Testing-Type-Specific-Options`
`/guides/core-concepts/writing-and-organizing-tests#Support-file`
`/guides/references/migration-guide#Migrating-to-Cypress-version-10-0-0`