### PR TITLE
 docs: udemy class added to the courses list

### DIFF
--- a/content/_data/courses.json
+++ b/content/_data/courses.json
@@ -1,6 +1,14 @@
 {
   "courses": [
     {
+      "title": "Cypress: Web Automation Testing from Zero to Hero",
+      "url": "https://www.udemy.com/course/cypress-web-automation-testing-from-zero-to-hero/?couponCode=CYPRESSDOCS",
+      "author": "Artem Bondar",
+      "authorTwitter": "ArtemBondar",
+      "sourceName": "Udemy",
+      "sourceUrl": "https://udemy.com"
+    },
+    {
       "title": "Test network edge cases with .intercept() command in Cypress",
       "url": "https://egghead.io/courses/test-network-edge-cases-with-cy-intercept-command-in-cypress-0fd94c68?af=1mdhb0",
       "author": "Filip Hric",


### PR DESCRIPTION
I am the author of the cypress class on Udemy - Cypress: From Zero To Hero
Adding the reference to this class to the Courses page. For some reason didn't do it earlier.
Thank you