### PR TITLE
docs: update plugins page with 10.0 changes

### DIFF
--- a/content/_data/plugins.json
+++ b/content/_data/plugins.json
@@ -4,13 +4,6 @@
       "name": "Preprocessors",
       "plugins": [
         {
-          "name": "Browserify",
-          "description": "Watches and bundles your spec files via browserify. This is the default preprocessor that's built into Cypress.",
-          "link": "https://github.com/cypress-io/cypress-browserify-preprocessor",
-          "keywords": ["browserify"],
-          "badge": "official"
-        },
-        {
           "name": "Cucumber",
           "description": "Run cucumber/gherkin-syntaxed specs with cypress.io",
           "link": "https://github.com/TheBrainFamily/cypress-cucumber-preprocessor",
@@ -199,10 +192,10 @@
         },
         {
           "name": "@cypress/fiddle",
-          "description": "Quickly generates Cypress tests from HTML and JS code",
+          "description": "Quickly generates Cypress E2E tests from HTML and JS code",
           "link": "https://github.com/cypress-io/cypress-fiddle",
           "keywords": ["prototype"],
-          "badge": "official"
+          "badge": "community"
         },
         {
           "name": "npm-cy",
@@ -512,7 +505,7 @@
           "description": "Simple commands to skip a test based on platform, browser or a url",
           "link": "https://github.com/cypress-io/cypress-skip-test",
           "keywords": ["commands"],
-          "badge": "official"
+          "badge": "community"
         },
         {
           "name": "cypress-websocket-testing",
@@ -1022,6 +1015,18 @@
           "link": "https://github.com/mailslurp/cypress-mailslurp",
           "keywords": ["email", "mailslurp", "test", "commands"],
           "badge": "community"
+        }
+      ]
+    },
+    {
+      "name": "Legacy",
+      "plugins": [
+        {
+          "name": "Browserify",
+          "description": "Watches and bundles your spec files via browserify.",
+          "link": "https://github.com/cypress-io/cypress-browserify-preprocessor",
+          "keywords": ["browserify"],
+          "badge": "official"
         }
       ]
     }


### PR DESCRIPTION
This PR updates the Plugins page with changes as a result of the `10.0` release and the overall Plugins audit.

Closes UDX-102