### PR TITLE
UDX-120: update certain plugins to be community plugins

### DIFF
--- a/content/_data/plugins.json
+++ b/content/_data/plugins.json
@@ -202,7 +202,7 @@
           "description": "Quickly generates Cypress tests from HTML and JS code",
           "link": "https://github.com/cypress-io/cypress-fiddle",
           "keywords": ["prototype"],
-          "badge": "official"
+          "badge": "community"
         },
         {
           "name": "npm-cy",
@@ -512,7 +512,7 @@
           "description": "Simple commands to skip a test based on platform, browser or a url",
           "link": "https://github.com/cypress-io/cypress-skip-test",
           "keywords": ["commands"],
-          "badge": "official"
+          "badge": "community"
         },
         {
           "name": "cypress-websocket-testing",


### PR DESCRIPTION
This PR updates `cypress-fiddle` and `cypress-skip-test`. `cypress-grep` in the ticket is already listed as a community plugin.