### PR TITLE
fix(guides): fix typo in google auth testing strategy

### DIFF
--- a/content/guides/testing-strategies/google-authentication.md
+++ b/content/guides/testing-strategies/google-authentication.md
@@ -215,7 +215,7 @@ is in the
 
 </Alert>
 
-## Adapting an Google App for Testing
+## Adapting a Google App for Testing
 
 <Alert type="info">
 


### PR DESCRIPTION
This PR:
 - fixes a small typo in the google auth testing strategy guide