### PR TITLE
docs(click): fix click assertions section

### DIFF
--- a/content/api/commands/click.md
+++ b/content/api/commands/click.md
@@ -210,7 +210,7 @@ element(s).</li></List>
 
 <List><li>`.click()` will automatically wait for the element to reach an
 [actionable state](/guides/core-concepts/interacting-with-elements)</li><li>`.click()`
-will automatically [retry](/guides/core-concepts/retry-ability) until all
+will **NOT** automatically [retry](/guides/core-concepts/retry-ability) until all
 chained assertions have passed</li></List>
 
 ### Timeouts [<Icon name="question-circle"/>](/guides/core-concepts/introduction-to-cypress#Timeouts)


### PR DESCRIPTION
click() will not retry but the assertions section says it will, so I fixed it to remove the confusion

fix #4056