### PR TITLE
Update from CircleCI to circleci.md

### DIFF
--- a/content/guides/continuous-integration/circleci.md
+++ b/content/guides/continuous-integration/circleci.md
@@ -28,7 +28,7 @@ install, cache and run Cypress with very little effort.
 Full documentation can be found at the
 [`cypress-io/circleci-orb`](https://github.com/cypress-io/circleci-orb) repo.
 For the Orb Quick Start Guide and usage cases, view the CircleCI
-[Cypress orb documentation](https://github.com/cypress-io/circleci-orb).
+[Cypress orb documentation](https://circleci.com/developer/orbs/orb/cypress-io/cypress).
 
 A typical project can have:
 


### PR DESCRIPTION
Per a discussion with Leah Horgan, we would like to add the following text and link to the documentation file on CircleCI.

Proposed addition: “For the Orb Quick Start Guide and usage cases, view the `[CircleCI Cypress orb](https://circleci.com/developer/orbs/orb/cypress-io/cypress)` documentation.”



