### PR TITLE
fix(guides): Add build and start at example of Cypress Docker Images

### DIFF
--- a/content/guides/continuous-integration/github-actions.md
+++ b/content/guides/continuous-integration/github-actions.md
@@ -133,6 +133,8 @@ jobs:
       - name: Cypress run
         uses: cypress-io/github-action@v2
         with:
+          build: npm run build
+          start: npm start
           # Specify Browser since container image is compile with Firefox
           browser: firefox
 ```


### PR DESCRIPTION
https://docs.cypress.io/guides/continuous-integration/github-actions#Testing-in-Chrome-and-Firefox-with-Cypress-Docker-Images

without build and start:

```zsh
...
Cypress could not verify that this server is running:

  > http://localhost:3000

We are verifying this server because it has been configured as your baseUrl.

Cypress automatically waits until your server is accessible before running tests.

We will try connecting to it 3 more times...
We will try connecting to it 2 more times...
We will try connecting to it 1 more time...

Cypress failed to verify that your server is running.

Please start this server and then run Cypress again.
Test run failed, code 1
More information might be available above
Cypress module has returned the following error message:
Could not find Cypress test run results
Error: Could not find Cypress test run results
```