### PR TITLE
UDX-132-fix-subheader-styles

### DIFF
--- a/styles/content.css
+++ b/styles/content.css
@@ -185,17 +185,11 @@
   @apply text-2xl;
   @apply font-bold;
   @apply mt-8;
-  @apply flex;
-  @apply flex-wrap;
-  @apply items-center;
 }
 
 .nuxt-content > h4 {
   @apply text-xl;
   @apply font-medium;
-  @apply flex;
-  @apply flex-wrap;
-  @apply items-center;
 }
 
 .nuxt-content h2 > em,


### PR DESCRIPTION
https://cypress-io.atlassian.net/browse/UDX-132

Reset CSS that is squishing h3 & h4 subheaders that include content wrapped in back ticks. 