### PR TITLE
docs: update pre-release expiry info

### DIFF
--- a/content/guides/getting-started/installing-cypress.md
+++ b/content/guides/getting-started/installing-cypress.md
@@ -518,8 +518,8 @@ out functionality that has not yet been released, here is how:
    operating system and CPU architecture, and follow the instructions there to
    install the pre-release.
 
-Cypress pre-releases are only available for 60 days after they are built.
-Do not rely on these being available past 60 days.
+Cypress pre-releases are only available for 60 days after they are built. Do not
+rely on these being available past 60 days.
 
 ### Windows Subsystem for Linux
 

--- a/content/guides/getting-started/installing-cypress.md
+++ b/content/guides/getting-started/installing-cypress.md
@@ -518,8 +518,8 @@ out functionality that has not yet been released, here is how:
    operating system and CPU architecture, and follow the instructions there to
    install the pre-release.
 
-Cypress pre-releases are only available for about a month after they are built.
-Do not rely on these being available past one month.
+Cypress pre-releases are only available for 60 days after they are built.
+Do not rely on these being available past 60 days.
 
 ### Windows Subsystem for Linux
 


### PR DESCRIPTION
This was recently changed to improve the experience for users trying out the 10.0-release pre-releases.