### PR TITLE
docs: add usage of CYPRESS_DOWNLOAD_PATH_TEMPLATE in npmrc

### DIFF
--- a/content/guides/getting-started/installing-cypress.md
+++ b/content/guides/getting-started/installing-cypress.md
@@ -431,6 +431,13 @@ ${platform}, ${arch} are replaced with respective values.
 https://download.cypress.io/desktop/3.0.0/win32-x64/cypress.zip
 ```
 
+When used in `.npmrc`, you will need to escape each dollar sign with a backslash
+
+```ini
+CYPRESS_DOWNLOAD_PATH_TEMPLATE=\${endpoint}/v${platform}-\${arch}/cypress.zip
+```
+
+
 ### Mirroring
 
 If you choose to mirror the entire Cypress download site, you can specify


### PR DESCRIPTION
Add usage of CYPRESS_DOWNLOAD_PATH_TEMPLATE in npmrc.

This documentation PR should be merge once #19914 is addressed.
A PR addressing #19914 is available at #20698

Todo:
- [ ] Mention that npm@7 and npm@8  is compatible with setting CYPRESS_DOWNLOAD_PATH_TEMPLATE in npmrc
- [ ] Mention that npm@6 and yarn@1  is compatible with setting CYPRESS_DOWNLOAD_PATH_TEMPLATE in npmrc after cypress@x.y.z