### PR TITLE
Bugfix: Position is not an option but an argument to click()

### DIFF
--- a/content/api/commands/shadow.md
+++ b/content/api/commands/shadow.md
@@ -79,13 +79,13 @@ When working with `cy.click()`, it sometimes won't click the right element in
 Chrome. It's happening because of
 [the ambiguity in spec](https://bugs.chromium.org/p/chromium/issues/detail?id=1188919&q=shadowRoot%20elementFromPoint&can=2).
 
-In this case, pass `{ position: 'top' }` to `cy.click()` like below:
+In this case, pass `'top'` to `cy.click()` like below:
 
 ```js
 cy.get('#element')
   .shadow()
   .find('[data-test-id="my-button"]')
-  .click({ position: 'top' })
+  .click('top')
 ```
 
 ## Command Log


### PR DESCRIPTION
In the [click-documentation](https://docs.cypress.io/api/commands/click#Arguments), `position` is listed as an argument, not a s an option. Unfortunately i can't judge whether one or the other works as this seems to be flaky in our case.
I just wanted to do a PR instead of an issue in order to be more constructive in the case that i'm right but maybe i'm wrong here for some reason?