### PR TITLE
Updating CI Integrations in docs - LayerCI is now webapp.io :)

### DIFF
--- a/content/guides/continuous-integration/ci-provider-examples.md
+++ b/content/guides/continuous-integration/ci-provider-examples.md
@@ -192,6 +192,7 @@ and
 
 - [Basic Example (amplify.yml)](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/amplify.yml)
 
-### LayerCI
+### webapp.io
 
 - [cypress-example-layerci](https://github.com/bahmutov/cypress-example-layerci)
+- [Using cypress with webapp.io](https://webapp.io/docs/integrations/cypress)


### PR DESCRIPTION
LayerCI is now webapp.io, changing the reference in the docs here & adding some more documentation on how to use webapp.io with cypress.