### PR TITLE
feat(plugins): add cypress chrome recorder to plugins page

### DIFF
--- a/content/_data/plugins.json
+++ b/content/_data/plugins.json
@@ -928,6 +928,16 @@
             "testing service"
           ],
           "badge": "community"
+        },
+        {
+          "name": "Cypress Chrome Recorder",
+          "description": "Tool for exporting Cypress Tests from Google Chrome DevTools' Recordings",
+          "link": "https://github.com/cypress-io/cypress-chrome-recorder",
+          "keywords": [
+            "visual testing",
+            "recorder"
+          ],
+          "badge": "experimental"
         }
       ]
     },


### PR DESCRIPTION
This PR adds the Cypress Chrome Recorder that was released today to our plugins page