### PR TITLE
UDX-161-example-selector-updates

### DIFF
--- a/content/guides/core-concepts/cypress-app.md
+++ b/content/guides/core-concepts/cypress-app.md
@@ -436,7 +436,7 @@ describe('My First Test', () => {
     cy.url().should('include', '/commands/actions')
 
     // Get an input, type into it and verify that the value has been updated
-    cy.get('.action-email')
+    cy.get('[data-testid=action-email]')
       .type('fake@email.com')
       .should('have.value', 'fake@email.com')
   })

--- a/content/guides/core-concepts/retry-ability.md
+++ b/content/guides/core-concepts/retry-ability.md
@@ -39,11 +39,11 @@ it('creates 2 items', () => {
   cy.focused() // command
     .should('have.class', 'new-todo') // assertion
 
-  cy.get('.new-todo') // command
+  cy.get('[data-testid=new-todo]') // command
     .type('todo A{enter}') // command
     .type('todo B{enter}') // command
 
-  cy.get('.todo-list li') // command
+  cy.get('[data-testid=todo-list] li') // command
     .should('have.length', 2) // assertion
 })
 ```
@@ -56,7 +56,7 @@ commands and assertions with passing assertions showing in green.
 Let's look at the last command and assertion pair:
 
 ```javascript
-cy.get('.todo-list li') // command
+cy.get('[data-testid=todo-list] li') // command
   .should('have.length', 2) // assertion
 ```
 
@@ -107,9 +107,9 @@ app.TodoModel.prototype.addTodo = function (title) {
 }
 ```
 
-My test still passes! The last `cy.get('.todo-list')` and the assertion
-`should('have.length', 2)` are clearly showing the spinning indicators, meaning
-Cypress is requerying for them.
+My test still passes! The last `cy.get('[data-testid=todo-list]')` and the
+assertion `should('have.length', 2)` are clearly showing the spinning
+indicators, meaning Cypress is requerying for them.
 
 <DocsImage src="/img/guides/retry-ability/v10/retry-2-items.gif" alt="Retrying finding 2 items"></DocsImage>
 
@@ -131,7 +131,7 @@ function with 2 [`expect`](/guides/references/assertions#BDD-Assertions)
 assertions inside of it.
 
 ```javascript
-cy.get('.todo-list li') // command
+cy.get('[data-testid=todo-list] li') // command
   .should('have.length', 2) // assertion
   .and(($li) => {
     // 2 more assertions
@@ -192,7 +192,7 @@ even without any attached assertions until it finds an element with the given
 index in the previously yielded list of elements.
 
 ```javascript
-cy.get('.todo-list li') // command
+cy.get('[data-testid=todo-list] li') // command
   .should('have.length', 2) // assertion
   .eq(3) // command
 ```
@@ -238,7 +238,7 @@ time. For example:
 
 ```javascript
 // we've modified the timeout which affects default + added assertions
-cy.get('.mobile-nav', { timeout: 10000 })
+cy.get('[data-testid=mobile-nav]', { timeout: 10000 })
   .should('be.visible')
   .and('contain', 'Home')
 ```
@@ -256,7 +256,7 @@ since it will spend 0 milliseconds retrying.
 ```javascript
 // check synchronously that the element does not exist (no retry)
 // for example just after a server-side render
-cy.get('#ssr-error', { timeout: 0 }).should('not.exist')
+cy.get('[data-testid=ssr-error]', { timeout: 0 }).should('not.exist')
 ```
 
 ## Only the last command is retried
@@ -277,11 +277,11 @@ cy.mount(<Todos />)
 it('adds two items', () => {
   __VISIT_MOUNT_PLACEHOLDER__
 
-  cy.get('.new-todo').type('todo A{enter}')
-  cy.get('.todo-list li').find('label').should('contain', 'todo A')
+  cy.get('[data-testid=new-todo]').type('todo A{enter}')
+  cy.get('[data-testid=todo-list] li').find('label').should('contain', 'todo A')
 
-  cy.get('.new-todo').type('todo B{enter}')
-  cy.get('.todo-list li').find('label').should('contain', 'todo B')
+  cy.get('[data-testid=new-todo]').type('todo B{enter}')
+  cy.get('[data-testid=todo-list] li').find('label').should('contain', 'todo B')
 })
 ```
 
@@ -339,12 +339,13 @@ interesting - there was only one item at that moment.
 
 <DocsImage src="/img/guides/retry-ability/v10/second-get-li.png" alt="Second get li"></DocsImage>
 
-During the test, the `cy.get('.todo-list li')` command quickly found the
-rendered `<li>` item - and that item was the first and only "todo A" item. Our
-application was waiting 100ms before appending the second item "todo B" to the
-list. By the time the second item was added, Cypress had already "moved on",
-working only with the first `<li>` element. It only searched for `<label>`
-inside the first `<li>` element, completely ignoring the newly created 2nd item.
+During the test, the `cy.get('[data-testid=todo-list] li')` command quickly
+found the rendered `<li>` item - and that item was the first and only "todo A"
+item. Our application was waiting 100ms before appending the second item "todo
+B" to the list. By the time the second item was added, Cypress had already
+"moved on", working only with the first `<li>` element. It only searched for
+`<label>` inside the first `<li>` element, completely ignoring the newly created
+2nd item.
 
 To confirm this, let's remove the artificial delay to see what's happening in
 the passing test.
@@ -352,8 +353,9 @@ the passing test.
 <DocsImage src="/img/guides/retry-ability/v10/two-items.png" alt="Two items"></DocsImage>
 
 When the web application runs without the delay, it gets its items into the DOM
-before the Cypress command `cy.get('.todo-list li')` runs. After the `cy.get()`
-returns 2 items, the `.find()` command just has to find the right label. Great.
+before the Cypress command `cy.get('[data-testid=todo-list] li')` runs. After
+the `cy.get()` returns 2 items, the `.find()` command just has to find the right
+label. Great.
 
 Now that we understand the real reason behind the flaky test, we need to think
 about why the default retry-ability has not helped us in this situation. Why
@@ -363,8 +365,8 @@ For a variety of implementation reasons, Cypress commands **only** retry the
 **last command** before the assertion. In our test:
 
 ```javascript
-cy.get('.new-todo').type('todo B{enter}')
-cy.get('.todo-list li') // queries immediately, finds 1 <li>
+cy.get('[data-testid=new-todo]').type('todo B{enter}')
+cy.get('[data-testid=todo-list] li') // queries immediately, finds 1 <li>
   .find('label') // retried, retried, retried with 1 <li>
   .should('contain', 'todo B') // never succeeds with only 1st <li>
 ```
@@ -377,9 +379,9 @@ command is used for assertion retries, we can fix this test for good.
 ### Merging queries
 
 The first solution we recommend is to avoid unnecessarily splitting commands
-that query elements. Instead of `cy.get('.todo-list li').find('label')` we can
-combine two separate queries into one - forcing the combined query to be
-retried.
+that query elements. Instead of
+`cy.get('[data-testid=todo-list] li').find('label')` we can combine two separate
+queries into one - forcing the combined query to be retried.
 
 :::visit-mount-test-example
 
@@ -395,12 +397,12 @@ cy.mount(<Todos />)
 it('adds two items', () => {
   __VISIT_MOUNT_PLACEHOLDER__
 
-  cy.get('.new-todo').type('todo A{enter}')
-  cy.get('.todo-list li label') // 1 query command
+  cy.get('[data-testid=new-todo]').type('todo A{enter}')
+  cy.get('[data-testid=todo-list] li label') // 1 query command
     .should('contain', 'todo A') // assertion
 
-  cy.get('.new-todo').type('todo B{enter}')
-  cy.get('.todo-list li label') // 1 query command
+  cy.get('[data-testid=new-todo]').type('todo B{enter}')
+  cy.get('[data-testid=todo-list] li label') // 1 query command
     .should('contain', 'todo B') // assertion
 })
 ```
@@ -424,12 +426,12 @@ list elements when the second "todo B" is added to the DOM.
 command.
 
 ```javascript
-cy.get('.new-todo').type('todo A{enter}')
-cy.contains('.todo-list li', 'todo A')
-cy.get('.new-todo').type('todo B{enter}')
+cy.get('[data-testid=new-todo]').type('todo A{enter}')
+cy.contains('[data-testid=todo-list] li', 'todo A')
+cy.get('[data-testid=new-todo]').type('todo B{enter}')
 // you can use a regular expression
 // to match the text exactly
-cy.contains('.todo-list li', /^todo B$/)
+cy.contains('[data-testid=todo-list] li', /^todo B$/)
 ```
 
 </Alert>
@@ -478,14 +480,14 @@ cy.mount(<Todos />)
 it('adds two items', () => {
   __VISIT_MOUNT_PLACEHOLDER__
 
-  cy.get('.new-todo').type('todo A{enter}')
-  cy.get('.todo-list li') // command
+  cy.get('[data-testid=new-todo]').type('todo A{enter}')
+  cy.get('[data-testid=todo-list] li') // command
     .should('have.length', 1) // assertion
     .find('label') // command
     .should('contain', 'todo A') // assertion
 
-  cy.get('.new-todo').type('todo B{enter}')
-  cy.get('.todo-list li') // command
+  cy.get('[data-testid=new-todo]').type('todo B{enter}')
+  cy.get('[data-testid=todo-list] li') // command
     .should('have.length', 2) // assertion
     .find('label') // command
     .should('contain', 'todo B') // assertion
@@ -496,11 +498,11 @@ it('adds two items', () => {
 
 <DocsImage src="/img/guides/retry-ability/v10/alternating-commands-assertions.png" alt="Passing test"></DocsImage>
 
-The test passes, because the second `cy.get('.todo-list li')` is retried with
-its own assertion now `.should('have.length', 2)`. Only after successfully
-finding two `<li>` elements, the command `.find('label')` and its assertion
-starts, and by now, the item with the correct "todo B" label has been correctly
-queried.
+The test passes, because the second `cy.get('[data-testid=todo-list] li')` is
+retried with its own assertion now `.should('have.length', 2)`. Only after
+successfully finding two `<li>` elements, the command `.find('label')` and its
+assertion starts, and by now, the item with the correct "todo B" label has been
+correctly queried.
 
 ### Use `.should()` with a callback
 
@@ -533,7 +535,7 @@ following values, noted in the comments, before failing.
 
 ```javascript
 // WRONG: this test will not work as intended
-cy.get('#random-number') // <div>🎁</div>
+cy.get('[data-testid=random-number]') // <div>🎁</div>
   .invoke('text') // "🎁"
   .then(parseFloat) // NaN
   .should('be.gte', 1) // fails
@@ -552,7 +554,7 @@ We need to retry getting the element, invoking the `text()` method, calling the
 this using the `.should(callbackFn)`.
 
 ```javascript
-cy.get('#random-number').should(($div) => {
+cy.get('[data-testid=random-number]').should(($div) => {
   // all the code inside here will retry
   // until it passes or times out
   const n = parseFloat($div.text())

--- a/content/guides/core-concepts/variables-and-aliases.md
+++ b/content/guides/core-concepts/variables-and-aliases.md
@@ -123,7 +123,7 @@ cy.get('button').then(($btn) => {
   // inspect $btn <object>
   debugger
 
-  cy.get('#countries')
+  cy.get('[data-testid=countries]')
     .select('USA')
     .then(($select) => {
       // inspect $select <object>
@@ -155,7 +155,7 @@ Here's a great use case for a `const`.
 ```html
 <button>increment</button>
 
-you clicked button <span id="num">0</span> times
+you clicked button <span data-testid="num">0</span> times
 ```
 
 ```js
@@ -163,13 +163,13 @@ you clicked button <span id="num">0</span> times
 let count = 0
 
 $('button').on('click', () => {
-  $('#num').text((count += 1))
+  $('[data-testid=num]').text((count += 1))
 })
 ```
 
 ```js
 // cypress test code
-cy.get('#num').then(($span) => {
+cy.get('[data-testid=num]').then(($span) => {
   // capture what num is right now
   const num1 = parseFloat($span.text())
 
@@ -197,7 +197,7 @@ great&mdash;but what happens when you're running code in hooks like `before` or
 
 ```js
 beforeEach(() => {
-  cy.button().then(($btn) => {
+  cy.get('button').then(($btn) => {
     const text = $btn.text()
   })
 })
@@ -226,7 +226,7 @@ describe('a suite', () => {
   let text
 
   beforeEach(() => {
-    cy.button().then(($btn) => {
+    cy.get('button').then(($btn) => {
       // redefine text reference
       text = $btn.text()
     })
@@ -475,7 +475,7 @@ been _completely_ removed from the DOM and a new `<li>` is rendered in its
 place.
 
 ```javascript
-cy.get('#todos li').first().as('firstTodo')
+cy.get('#[data-testid=todos] li').first().as('firstTodo')
 cy.get('@firstTodo').find('.edit').click()
 cy.get('@firstTodo')
   .should('have.class', 'editing')
@@ -497,9 +497,9 @@ _Usually_, replaying previous commands will return what you expect, but not
 always. It is recommended that you **alias elements as soon as possible**
 instead of further down a chain of commands.
 
-- `cy.get('#nav header .user').as('user')`
+- `cy.get('nav header [data-testid=user]').as('user')`
   <Icon name="check-circle" color="green"></Icon> (good)
-- `cy.get('#nav').find('header').find('.user').as('user')`
+- `cy.get('nav').find('header').find('[data-testid=user]').as('user')`
   <Icon name="exclamation-triangle" color="red"></Icon> (bad)
 
 When in doubt, you can _always_ issue a regular [`cy.get()`](/api/commands/get)

--- a/content/guides/core-concepts/writing-and-organizing-tests.md
+++ b/content/guides/core-concepts/writing-and-organizing-tests.md
@@ -584,7 +584,7 @@ browsers.
 ```js
 describe('When NOT in Chrome', { browser: '!chrome' }, () => {
   it('Shows warning', () => {
-    cy.get('.browser-warning').should(
+    cy.get('[data-testid=browser-warning]').should(
       'contain',
       'For optimal viewing, use Chrome browser'
     )
@@ -668,7 +668,7 @@ describe('if your app uses jQuery', () => {
       // event that causes the event callback to fire
       cy.get('#with-jquery')
         .invoke('trigger', event)
-        .get('#messages')
+        .get('[data-testid=messages]')
         .should('contain', 'the event ' + event + 'was fired')
     })
   })
@@ -755,8 +755,10 @@ describe('TodoMVC', () => {
 
   it.skip('adds 2 todos', function () {
     cy.visit('/')
-    cy.get('.new-todo').type('learn testing{enter}').type('be cool{enter}')
-    cy.get('.todo-list li').should('have.length', 100)
+    cy.get('[data-testid=new-todo]')
+      .type('learn testing{enter}')
+      .type('be cool{enter}')
+    cy.get('[data-testid=todo-list] li').should('have.length', 100)
   })
 
   xit('another test', () => {
@@ -789,12 +791,14 @@ describe('TodoMVC', () => {
   })
 
   it('hides footer initially', () => {
-    cy.get('.filters').should('not.exist')
+    cy.get('[data-testid=filters]').should('not.exist')
   })
 
   it('adds 2 todos', () => {
-    cy.get('.new-todo').type('learn testing{enter}').type('be cool{enter}')
-    cy.get('.todo-list li').should('have.length', 2)
+    cy.get('[data-testid=new-todo]')
+      .type('learn testing{enter}')
+      .type('be cool{enter}')
+    cy.get('[data-testid=todo-list] li').should('have.length', 2)
   })
 })
 ```

--- a/content/guides/getting-started/writing-your-first-end-to-end-test.md
+++ b/content/guides/getting-started/writing-your-first-end-to-end-test.md
@@ -357,7 +357,8 @@ describe('My First Test', () => {
 
     cy.contains('type').click()
 
-    // Should be on a new URL which includes '/commands/actions'
+    // Should be on a new URL which
+    // includes '/commands/actions'
     cy.url().should('include', '/commands/actions')
   })
 })
@@ -372,10 +373,11 @@ likely to change your application state in more than one way.
 We can continue the interactions and assertions in this test by adding another
 chain to interact with and verify the behavior of elements on this new page.
 
-We can use [cy.get()](/api/commands/get) to select an element based on a CSS
-class. Then we can use the [.type()](/api/commands/type) command to enter text
-into the selected input. Finally, we can verify that the value of the input
-reflects the text that was typed with another [.should()](/api/commands/should).
+We can use [cy.get()](/api/commands/get) to select an element based on a
+`data-*` attribute. Then we can use the [.type()](/api/commands/type) command to
+enter text into the selected input. Finally, we can verify that the value of the
+input reflects the text that was typed with another
+[.should()](/api/commands/should).
 
 ```js
 describe('My First Test', () => {
@@ -384,11 +386,13 @@ describe('My First Test', () => {
 
     cy.contains('type').click()
 
-    // Should be on a new URL which includes '/commands/actions'
+    // Should be on a new URL which
+    // includes '/commands/actions'
     cy.url().should('include', '/commands/actions')
 
-    // Get an input, type into it and verify that the value has been updated
-    cy.get('.action-email')
+    // Get an input, type into it and verify
+    // that the value has been updated
+    cy.get('[data-testid=action-email]')
       .type('fake@email.com')
       .should('have.value', 'fake@email.com')
   })
@@ -404,7 +408,7 @@ the new page. If we read it out loud, it might sound like:
 > 3. Click on it
 > 4. Get the URL
 > 5. Assert it includes: `/commands/actions`
-> 6. Get the input with the `.action-email` class
+> 6. Get the input with the `action-email` data-testid
 > 7. Type `fake@email.com` into the input
 > 8. Assert the input reflects the new value
 
@@ -412,7 +416,7 @@ Or in the Given, When, Then syntax:
 
 > 1. Given a user visits `https://example.cypress.io`
 > 2. When they click the link labeled `type`
-> 3. And they type "fake@email.com" into the `.action-email` input
+> 3. And they type "fake@email.com" into the `[data-testid=action-email]` input
 > 4. Then the URL should include `/commands/actions`
 > 5. And the `.action-email` input has "fake@email.com" as its value
 

--- a/content/guides/overview/why-cypress.md
+++ b/content/guides/overview/why-cypress.md
@@ -161,9 +161,11 @@ performs actions via the UI just like a real user would.
 ```js
 it('adds todos', () => {
   cy.visit('https://todo.app.com')
-  cy.get('.new-input').type('write code{enter}').type('write tests{enter}')
+  cy.get('[data-testid=new-todo]')
+    .type('write code{enter}')
+    .type('write tests{enter}')
   // confirm the application is showing two items
-  cy.get('li.todo').should('have.length', 2)
+  cy.get('[data-testid=todos]').should('have.length', 2)
 })
 ```
 

--- a/content/guides/references/best-practices.md
+++ b/content/guides/references/best-practices.md
@@ -434,11 +434,11 @@ describe('my form', () => {
   __VISIT_MOUNT_PLACEHOLDER__
 
   it('requires first name', () => {
-    cy.get('#first').type('Johnny')
+    cy.get('[data-testid=first-name]').type('Johnny')
   })
 
   it('requires last name', () => {
-    cy.get('#last').type('Appleseed')
+    cy.get('[data-testid=last-name]').type('Appleseed')
   })
 
   it('can submit a valid form', () => {
@@ -477,10 +477,10 @@ describe('my form', () => {
     __VISIT_MOUNT_PLACEHOLDER__
 
     cy.log('filling out first name') // if you really need this
-    cy.get('#first').type('Johnny')
+    cy.get('[data-testid=first-name]').type('Johnny')
 
     cy.log('filling out last name') // if you really need this
-    cy.get('#last').type('Appleseed')
+    cy.get('[data-testid=last-name]').type('Appleseed')
 
     cy.log('submitting form') // if you really need this
     cy.get('form').submit()
@@ -510,14 +510,15 @@ cy.mount(<NewUser />)
 describe('my form', () => {
   beforeEach(() => {
     __VISIT_MOUNT_PLACEHOLDER__
-    cy.get('#first').type('Johnny')
-    cy.get('#last').type('Appleseed')
+    cy.get('[data-testid=first-name]').type('Johnny')
+    cy.get('[data-testid=last-name]').type('Appleseed')
   })
 
   it('displays form validation', () => {
-    cy.get('#first').clear() // clear out first name
+    // clear out first name
+    cy.get('[data-testid=first-name]').clear()
     cy.get('form').submit()
-    cy.get('#errors').should('contain', 'First name is required')
+    cy.get('[data-testid=errors]').should('contain', 'First name is required')
   })
 
   it('can submit a valid form', () => {
@@ -557,19 +558,25 @@ We've seen many users writing this kind of code:
 describe('my form', () => {
   beforeEach(() => {
     cy.visit('/users/new')
-    cy.get('#first').type('johnny')
+    cy.get('[data-testid=first-name]').type('johnny')
   })
 
   it('has validation attr', () => {
-    cy.get('#first').should('have.attr', 'data-validation', 'required')
+    cy.get('[data-testid=first-name]').should(
+      'have.attr',
+      'data-validation',
+      'required'
+    )
   })
 
   it('has active class', () => {
-    cy.get('#first').should('have.class', 'active')
+    cy.get('[data-testid=first-name]').should('have.class', 'active')
   })
 
   it('has formatted first name', () => {
-    cy.get('#first').should('have.value', 'Johnny') // capitalized first letter
+    cy.get('[data-testid=first-name]')
+      // capitalized first letter
+      .should('have.value', 'Johnny')
   })
 })
 ```
@@ -606,7 +613,7 @@ describe('my form', () => {
   })
 
   it('validates and formats first name', () => {
-    cy.get('#first')
+    cy.get('[data-testid=first-name]')
       .type('johnny')
       .should('have.attr', 'data-validation', 'required')
       .and('have.class', 'active')
@@ -879,7 +886,7 @@ aliased route.
 cy.intercept('GET', '/users', [{ name: 'Maggy' }, { name: 'Joan' }]).as(
   'getUsers'
 )
-cy.get('#fetch').click()
+cy.get('[data-testid=fetch-users]').click()
 cy.wait('@getUsers') // <--- wait explicitly for this route to finish
 cy.get('table tr').should('have.length', 2)
 ```


### PR DESCRIPTION
https://cypress-io.atlassian.net/browse/UDX-161

First pass at updating selectors in code examples to align with our best practices. Specifically, [this issue](https://github.com/cypress-io/cypress-documentation/issues/4227). 