### PR TITLE
Fixed typo in session.md

### DIFF
--- a/content/api/commands/session.md
+++ b/content/api/commands/session.md
@@ -453,7 +453,7 @@ const loginByApi = (name, password) => {
 
 ### Where to call `cy.visit()`
 
-If you call `cy.visit()` immediately after `cy.setup()` in your login function
+If you call `cy.visit()` immediately after `cy.session()` in your login function
 or custom command, it will effectively behave the same as a login function
 without any session caching.
 


### PR DESCRIPTION
Fixed what looks like a typo in the cy.session docs - as far as I can tell, `cy.setup()` is not a method that exists - I think the author meant `cy.session()`?