### PR TITLE
9.7.0 Release

### DIFF
--- a/content/_changelogs/9.6.2.md
+++ b/content/_changelogs/9.6.2.md
@@ -1,9 +1,22 @@
 ## 9.6.2
 
+_Released 5/23/2022_
+
 **Deprecations:**
 
-- `Cypress.Cookies.preserveOnce()` and `Cypress.Cookies.defaults()` are
-  deprecated. In a future release, support for `Cypress.Cookies.preserveOnce()`
-  and `Cypress.Cookies.defaults()` will be removed. Consider using
-  [`cy.session()`](/api/commands/session) instead. Fixed
-  [#21455](https://github.com/cypress-io/cypress/issues/21455).
+- The `Cypress.Cookies.preserveOnce()` and `Cypress.Cookies.defaults()` Cypress
+  APIs have been deprecated. In a future release, support for
+  `Cypress.Cookies.preserveOnce()` and `Cypress.Cookies.defaults()` will be
+  removed. Consider using the [`cy.session()`](/api/commands/session) command
+  instead to cache and restore cookies and other sessions details between tests.
+  Fixed [#21333](https://github.com/cypress-io/cypress/issues/21333).
+
+**Bugfixes:**
+
+- Updated the `cy.contains()` command to correctly error and retry if the
+  provided regex pattern begins with an equal sign and a match was not initially
+  found. Previously the command would incorrectly fail with a syntax error.
+  Fixed [#21108](https://github.com/cypress-io/cypress/issues/21108).
+- Removed `eventemitter2` third-party type definitions from `cy` and `Cypress`
+  that were unintentionally exposed. Fixed
+  [#20556](https://github.com/cypress-io/cypress/issues/20556).

--- a/content/_changelogs/9.6.2.md
+++ b/content/_changelogs/9.6.2.md
@@ -1,0 +1,9 @@
+## 9.6.2
+
+**Deprecations:**
+
+- `Cypress.Cookies.preserveOnce()` and `Cypress.Cookies.defaults()` are
+  deprecated. In a future release, support for `Cypress.Cookies.preserveOnce()`
+  and `Cypress.Cookies.defaults()` will be removed. Consider using
+  [`cy.session()`](/api/commands/session) instead. Fixed
+  [#21455](https://github.com/cypress-io/cypress/issues/21455).

--- a/content/_changelogs/9.6.2.md
+++ b/content/_changelogs/9.6.2.md
@@ -13,10 +13,14 @@ _Released 5/23/2022_
 
 **Bugfixes:**
 
-- Updated the `cy.contains()` command to correctly error and retry if the
-  provided regex pattern begins with an equal sign and a match was not initially
-  found. Previously the command would incorrectly fail with a syntax error.
-  Fixed [#21108](https://github.com/cypress-io/cypress/issues/21108).
+- Updated the [`cy.contains()`](/api/commands/contains) command to correctly
+  error and retry if the provided regex pattern begins with an equal sign and a
+  match was not initially found. Previously the command would incorrectly fail
+  with a syntax error. Fixed
+  [#21108](https://github.com/cypress-io/cypress/issues/21108).
+- Corrected the `cy.session()` command log grouping and validation verbiage.
+  This change provides better insights to logs associated with the command.
+  Fixed [#21377](https://github.com/cypress-io/cypress/issues/21377).
 - Removed `eventemitter2` third-party type definitions from `cy` and `Cypress`
   that were unintentionally exposed. Fixed
   [#20556](https://github.com/cypress-io/cypress/issues/20556).

--- a/content/_changelogs/9.7.0.md
+++ b/content/_changelogs/9.7.0.md
@@ -5,7 +5,7 @@ _Released 5/23/2022_
 **Features:**
 
 - The Electron version and shipped Chromium browser version has been updated.
-  Addressed in [#20270](https://github.com/cypress-io/cypress/issues/20270).
+  Addressed in [#21418](https://github.com/cypress-io/cypress/pull/21418).
 
 **Deprecations:**
 
@@ -35,10 +35,10 @@ _Released 5/23/2022_
 
 - Upgraded the bundled node version shipped with Cypress from `16.5.0` to
   `16.13.2`. Addressed in
-  [#20270](https://github.com/cypress-io/cypress/issues/20270).
+  [#21418](https://github.com/cypress-io/cypress/pull/21418).
 - Upgraded the Chromium browser version used during `cypress run` and when
   selecting Electron browser in `cypress open` from `94.0.4606.81` to
   `100.0.4896.75`. Addressed in
-  [#20270](https://github.com/cypress-io/cypress/issues/20270).
+  [#21418](https://github.com/cypress-io/cypress/pull/21418).
 - Upgraded `electron` dependency from `15.5.1` to `18.0.4`. Addressed in
-  [#20270](https://github.com/cypress-io/cypress/issues/20270).
+  [#21418](https://github.com/cypress-io/cypress/pull/21418).

--- a/content/_changelogs/9.7.0.md
+++ b/content/_changelogs/9.7.0.md
@@ -1,15 +1,21 @@
-## 9.6.2
+## 9.7.0
 
 _Released 5/23/2022_
+
+**Features:**
+
+- The Electron version and shipped Chromium browser version has been updated.
+  Addressed in [#20270](https://github.com/cypress-io/cypress/issues/20270).
 
 **Deprecations:**
 
 - The `Cypress.Cookies.preserveOnce()` and `Cypress.Cookies.defaults()` Cypress
   APIs have been deprecated. In a future release, support for
   `Cypress.Cookies.preserveOnce()` and `Cypress.Cookies.defaults()` will be
-  removed. Consider using the [`cy.session()`](/api/commands/session) command
-  instead to cache and restore cookies and other sessions details between tests.
-  Fixed [#21333](https://github.com/cypress-io/cypress/issues/21333).
+  removed. Consider using the experimental
+  [`cy.session()`](/api/commands/session) command instead to cache and restore
+  cookies and other sessions details between tests. Fixed
+  [#21333](https://github.com/cypress-io/cypress/issues/21333).
 
 **Bugfixes:**
 
@@ -24,3 +30,15 @@ _Released 5/23/2022_
 - Removed `eventemitter2` third-party type definitions from `cy` and `Cypress`
   that were unintentionally exposed. Fixed
   [#20556](https://github.com/cypress-io/cypress/issues/20556).
+
+**Dependency Updates:**
+
+- Upgraded the bundled node version shipped with Cypress from `16.5.0` to
+  `16.13.2`. Addressed in
+  [#20270](https://github.com/cypress-io/cypress/issues/20270).
+- Upgraded the Chromium browser version used during `cypress run` and when
+  selecting Electron browser in `cypress open` from `94.0.4606.81` to
+  `100.0.4896.75`. Addressed in
+  [#20270](https://github.com/cypress-io/cypress/issues/20270).
+- Upgraded `electron` dependency from `15.5.1` to `18.0.4`. Addressed in
+  [#20270](https://github.com/cypress-io/cypress/issues/20270).

--- a/content/api/cypress-api/cookies.md
+++ b/content/api/cypress-api/cookies.md
@@ -2,6 +2,15 @@
 title: Cypress.Cookies
 ---
 
+<Alert type="warning">
+
+⚠️ **`Cypress.Cookies.preserveOnce()` and `Cypress.Cookies.defaults()` are
+deprecated in Cypress 9.6.2**. In a future release, support for
+`Cypress.Cookies.preserveOnce()` and `Cypress.Cookies.defaults()` will be
+removed. Consider using [`cy.session()`](/api/commands/session) instead.
+
+</Alert>
+
 `Cookies.preserveOnce()` and `Cookies.defaults()` enable you to control Cypress'
 cookie behavior.
 
@@ -212,6 +221,7 @@ Cypress.Cookies.defaults({
 
 | Version                                       | Changes                                                                                       |
 | --------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| [9.6.2](/guides/references/changelog#9-6-2)   | Deprecated `preserveOnce` and `defaults`                                                      |
 | [5.0.0](/guides/references/changelog#5-0-0)   | Renamed `whitelist` option to `preserve`                                                      |
 | [0.16.1](/guides/references/changelog#0-16-1) | `{verbose: false}` option added                                                               |
 | [0.16.0](/guides/references/changelog#0-16-0) | Removed support for `Cypress.Cookies.get`, `Cypress.Cookies.set` and `Cypress.Cookies.remove` |

--- a/content/api/cypress-api/cookies.md
+++ b/content/api/cypress-api/cookies.md
@@ -5,9 +5,11 @@ title: Cypress.Cookies
 <Alert type="warning">
 
 ⚠️ **`Cypress.Cookies.preserveOnce()` and `Cypress.Cookies.defaults()` are
-deprecated in Cypress 9.6.2**. In a future release, support for
+deprecated in Cypress 9.7.0**. In a future release, support for
 `Cypress.Cookies.preserveOnce()` and `Cypress.Cookies.defaults()` will be
-removed. Consider using [`cy.session()`](/api/commands/session) instead.
+removed. Consider using the experimental [`cy.session()`](/api/commands/session)
+command instead to cache and restore cookies and other sessions details between
+tests.
 
 </Alert>
 
@@ -221,7 +223,7 @@ Cypress.Cookies.defaults({
 
 | Version                                       | Changes                                                                                       |
 | --------------------------------------------- | --------------------------------------------------------------------------------------------- |
-| [9.6.2](/guides/references/changelog#9-6-2)   | Deprecated `preserveOnce` and `defaults`                                                      |
+| [9.7.0](/guides/references/changelog#9-7-0)   | Deprecated `preserveOnce` and `defaults`                                                      |
 | [5.0.0](/guides/references/changelog#5-0-0)   | Renamed `whitelist` option to `preserve`                                                      |
 | [0.16.1](/guides/references/changelog#0-16-1) | `{verbose: false}` option added                                                               |
 | [0.16.0](/guides/references/changelog#0-16-0) | Removed support for `Cypress.Cookies.get`, `Cypress.Cookies.set` and `Cypress.Cookies.remove` |


### PR DESCRIPTION
Note: The Electron 18 dependency upgrade bumps this release version to 9.7.0. The git branch does not reflect the correct release version.