### PR TITLE
UDX-201: Remove Studio from docs

### DIFF
--- a/content/_data/sidebar.json
+++ b/content/_data/sidebar.json
@@ -113,7 +113,7 @@
             {
               "title": "Custom Mount Commands",
               "slug": "custom-mount-react"
-            }            
+            }
           ]
         },
         {
@@ -147,10 +147,6 @@
             {
               "title": "Cypress App",
               "slug": "cypress-app"
-            },
-            {
-              "title": "Cypress Studio",
-              "slug": "cypress-studio"
             }
           ]
         },

--- a/content/guides/references/experiments.md
+++ b/content/guides/references/experiments.md
@@ -27,7 +27,6 @@ configuration to Cypress.
 | `experimentalInteractiveRunEvents` | `false` | Allows listening to the [`before:run`](/api/plugins/before-run-api), [`after:run`](/api/plugins/after-run-api), [`before:spec`](/api/plugins/before-spec-api), and [`after:spec`](/api/plugins/after-spec-api) events in the [setupNodeEvents](/guides/tooling/plugins-guide#Using-a-plugin) function during interactive mode. |
 | `experimentalSessionAndOrigin`     | `false` | Enables cross-origin and improved session support, including the [`cy.origin()`](/api/commands/origin) and [`cy.session()`](/api/commands/session) commands. Only available in end-to-end testing.                                                                                                                             |
 | `experimentalSourceRewriting`      | `false` | Enables AST-based JS/HTML rewriting. This may fix issues caused by the existing regex-based JS/HTML replacement algorithm. See [#5273](https://github.com/cypress-io/cypress/issues/5273) for details.                                                                                                                         |
-| `experimentalStudio`               | `false` | Generate and save commands directly to your test suite by interacting with your app as an end user would. See [Cypress Studio](/guides/core-concepts/cypress-studio) for more details.                                                                                                                                         |
 
 ## History
 


### PR DESCRIPTION
Note that this PR does not remove the `Cypress Studio` page itself, as specified by the referenced ticket.