### PR TITLE
UDX-201: Restore studio to sidebar & add removal notice

### DIFF
--- a/content/_data/sidebar.json
+++ b/content/_data/sidebar.json
@@ -189,6 +189,10 @@
             {
               "title": "Cypress App",
               "slug": "cypress-app"
+            },
+            {
+              "title": "Cypress Studio",
+              "slug": "cypress-studio"
             }
           ]
         },

--- a/content/guides/core-concepts/cypress-studio.md
+++ b/content/guides/core-concepts/cypress-studio.md
@@ -2,6 +2,16 @@
 title: Cypress Studio
 ---
 
+<Alert type="warning">
+
+<strong class="alert-header"><Icon name="exclamation-triangle"></Icon>
+Removed</strong>
+
+Cypress Studio has been removed in Cypress v10 and will be rethought/revisited
+in a later release. This page is for reference only.
+
+</Alert>
+
 <Alert type="info">
 
 ## <Icon name="graduation-cap"></Icon> What you'll learn


### PR DESCRIPTION
It's been decided to put Cypress Studio back in the sidebar & add a warning alert to the top of the page noting its removal.