### PR TITLE
UDX-225: Rename 'Testing Your Components with Cypress' to 'Writing Your First Component Test'

### DIFF
--- a/content/_data/sidebar.json
+++ b/content/_data/sidebar.json
@@ -80,8 +80,8 @@
               "title": "Introduction to Component Testing"
             },
             {
-              "title": "Testing Your Components with Cypress",
-              "slug": "testing-your-components-with-cypress"
+              "title": "Writing Your First Component Test",
+              "slug": "writing-your-first-component-test"
             },
             {
               "title": "Who Are You Testing For?",

--- a/content/guides/component-testing/writing-your-first-component-test.md
+++ b/content/guides/component-testing/writing-your-first-component-test.md
@@ -1,5 +1,5 @@
 ---
-title: Testing Your Components with Cypress
+title: Writing Your First Component Test
 ---
 
 <CtBetaAlert></CtBetaAlert>

--- a/content/guides/core-concepts/testing-types.md
+++ b/content/guides/core-concepts/testing-types.md
@@ -141,7 +141,7 @@ set of tests specializing in what they do best.
 </Alert>
 
 To learn more about component testing in Cypress, visit our guide on
-[Testing Your Components with Cypress](/guides/component-testing/testing-your-components-with-cypress).
+[Testing Your Components with Cypress](/guides/component-testing/writing-your-first-component-test).
 
 ## Test Type Comparison
 

--- a/content/guides/core-concepts/writing-and-organizing-tests.md
+++ b/content/guides/core-concepts/writing-and-organizing-tests.md
@@ -369,7 +369,7 @@ Cypress will be a breeze.
 <Alert type="info">
 
 To start writing tests for your app, follow our guides for writing your first
-[Component](/guides/component-testing/testing-your-components-with-cypress) or
+[Component](/guides/component-testing/writing-your-first-component-test) or
 [End-to-End](/guides/end-to-end-testing/writing-your-first-end-to-end-test)
 test.
 

--- a/content/guides/getting-started/opening-the-app.md
+++ b/content/guides/getting-started/opening-the-app.md
@@ -102,4 +102,4 @@ START BUTTON!</strong>
 Time to get testing! If you chose
 [to start with E2E testing, go here](/guides/end-to-end-testing/writing-your-first-end-to-end-test).
 Alternatively, if you decided
-[to try component testing, go here](/guides/component-testing/testing-your-components-with-cypress).
+[to try component testing, go here](/guides/component-testing/writing-your-first-component-test).

--- a/netlify.toml
+++ b/netlify.toml
@@ -55,13 +55,13 @@
 	
 [[redirects]]
   from = "/guides/component-testing/introduction"
-  to = "/guides/component-testing/testing-your-components-with-cypress"
+  to = "/guides/component-testing/writing-your-first-component-test"
   status = 301
   force = true
 
 [[redirects]]
   from = "/guides/component-testing"
-  to = "/guides/component-testing/testing-your-components-with-cypress"
+  to = "/guides/component-testing/writing-your-first-component-test"
   status = 301
   force = true
 

--- a/redirects.js
+++ b/redirects.js
@@ -25,7 +25,7 @@ export const redirects = [
   },
   {
     path: '/guides/component-testing',
-    redirect: '/guides/component-testing/testing-your-components-with-cypress',
+    redirect: '/guides/component-testing/writing-your-first-component-test',
   },
   {
     path: '/guides/dashboard/dashboard-introduction',


### PR DESCRIPTION
The purpose of this PR is to better align the intro pages for each testing flavor. The new title does not quite fit the content of the Component Testing intro but this will be addressed in a later pass.