### PR TITLE
Fix bug in NavGuide bottom border styling

### DIFF
--- a/components/global/NavGuide.vue
+++ b/components/global/NavGuide.vue
@@ -1,7 +1,11 @@
 <template>
   <nav class="flow-root" aria-label="Docs Guide Navigation">
-    <router-link v-if="prev" class="nav-button float-left" :to="prev"> Prev </router-link>
-    <router-link v-if="next" class="nav-button float-right" :to="next"> Next </router-link>
+    <router-link v-if="prev" class="nav-button float-left" :to="prev">
+      Prev
+    </router-link>
+    <router-link v-if="next" class="nav-button float-right" :to="next">
+      Next
+    </router-link>
   </nav>
 </template>
 
@@ -24,6 +28,6 @@ export default {
 
 <style scoped>
 .nav-button {
-  @apply items-center rounded-md py-2 px-4 bg-white text-base font-medium text-blue shadow-sm hover:bg-indigo-500 hover:text-white border border-indigo-500 !important;
+  @apply items-center rounded-md py-2 px-4 bg-white text-base font-medium text-blue shadow-sm hover:bg-indigo-500 hover:text-white border border-indigo-500 border-solid !important;
 }
 </style>


### PR DESCRIPTION
This PR fixes a bug where the NavGuide buttons (e.g. at the bottom of the Vue Component Testing pages) had a dotted bottom border.