### PR TITLE
UDX-165: Correct usage of end-to-end vs E2E across docs

### DIFF
--- a/content/_data/sidebar.json
+++ b/content/_data/sidebar.json
@@ -37,7 +37,7 @@
           "slug": "end-to-end-testing",
           "children": [
             {
-              "title": "Introduction to End-to-End Testing"
+              "title": "Introduction to E2E Testing"
             },
             {
               "title": "Writing Your First End-to-End Test",

--- a/content/api/commands/session.md
+++ b/content/api/commands/session.md
@@ -53,7 +53,7 @@ cy.session(id, setup, options)
 
 ```javascript
 // Caching session when logging in via API
-// Used in both End-to-End and Component testing
+// Used in both E2E and Component Testing
 cy.session([username, password], () => {
   cy.request({
     method: 'POST',
@@ -65,7 +65,7 @@ cy.session([username, password], () => {
 })
 
 // Caching session when logging in via page visit
-// Used in End-to-End testing
+// Used in E2E Testing
 cy.session(name, () => {
   cy.visit('/login')
   cy.get('[data-test=name]').type(name)

--- a/content/api/commands/stub.md
+++ b/content/api/commands/stub.md
@@ -103,7 +103,7 @@ expect(removeStub).to.be.called
 
 #### Replace built-in window methods like prompt
 
-In End-to-End tests, replacing built-in `window` methods needs to happen _after_
+In end-to-end tests, replacing built-in `window` methods needs to happen _after_
 the page is visited, but _before_ the application under test is loaded. You can
 do this by stubbing functions inside the [`cy.visit()`](/api/commands/visit)
 command `onBeforeLoad` function.

--- a/content/api/cypress-api/testing-type.md
+++ b/content/api/cypress-api/testing-type.md
@@ -4,8 +4,8 @@ title: Cypress.testingType
 
 `Cypress.testingType` returns the current testing type, determined by your
 selection in the Cypress App. The `Cypress.testingType` returns `e2e` for
-[End-to-End Testing](/guides/core-concepts/testing-types#What-is-End-to-end-Testing)
-or `component` for
+[E2E Testing](/guides/core-concepts/testing-types#What-is-E2E-Testing) or
+`component` for
 [Component Testing](/guides/core-concepts/testing-types#What-is-Component-Testing).
 
 ## Syntax

--- a/content/api/plugins/configuration-api.md
+++ b/content/api/plugins/configuration-api.md
@@ -196,8 +196,7 @@ off of the file system - you could store them all in memory inside of
 
 You can access the type of tests running via the `config.testingType` property.
 The testing type is either `e2e` or `component` depending on if the
-[End-to-End Testing](/guides/core-concepts/testing-types#What-is-End-to-end-Testing)
-or
+[E2E Testing](/guides/core-concepts/testing-types#What-is-E2E-Testing) or
 [Component Testing](/guides/core-concepts/testing-types#What-is-Component-Testing)
 type was selected in the Cypress App. This allows you to configure test
 type-specific plugins.

--- a/content/guides/component-testing/component-framework-configuration.md
+++ b/content/guides/component-testing/component-framework-configuration.md
@@ -188,8 +188,8 @@ While you could pass in props directly to the page component in a component
 test, that would leave these server-side methods untested. However, an
 end-to-end test would execute and test a page entirely.
 
-Because of this, we recommend using E2E testing over component testing for
-Next.js pages and component testing for individual components in a Next.js app.
+Because of this, we recommend using E2E Testing over Component Testing for
+Next.js pages and Component Testing for individual components in a Next.js app.
 
 #### Sample Next.js Apps
 

--- a/content/guides/component-testing/component-framework-configuration.md
+++ b/content/guides/component-testing/component-framework-configuration.md
@@ -188,9 +188,8 @@ While you could pass in props directly to the page component in a component
 test, that would leave these server-side methods untested. However, an
 end-to-end test would execute and test a page entirely.
 
-Because of this, we recommend using end-to-end testing over component testing
-for Next.js pages and component testing for individual components in a Next.js
-app.
+Because of this, we recommend using E2E testing over component testing for
+Next.js pages and component testing for individual components in a Next.js app.
 
 #### Sample Next.js Apps
 

--- a/content/guides/component-testing/events-vue.md
+++ b/content/guides/component-testing/events-vue.md
@@ -280,7 +280,7 @@ test multiple things at once in a given scenario.
 
 This is up to the discretion of the developer. Combining tests will result in a
 faster overall test run, however it may be more difficult to isolate why a test
-failed in the first place. For End-to-end tests, because setup and visiting
+failed in the first place. For end-to-end tests, because setup and visiting
 pages is expensive, we recommend having longer tests. This is not necessarily a
 problem for Component tests because they are comparatively quick.
 

--- a/content/guides/component-testing/mounting-react.md
+++ b/content/guides/component-testing/mounting-react.md
@@ -130,8 +130,8 @@ you'll want to install `@testing-library/cypress` _instead_ of the
 npm i -D @testing-library/cypress
 ```
 
-The setup instructions are the same for end-to-end and component testing. Within
-your **component support file**, import the custom commands.
+The setup instructions are the same for E2E and Component Testing. Within your
+**component support file**, import the custom commands.
 
 ```js
 // cypress/support/component.js

--- a/content/guides/component-testing/mounting-vue.md
+++ b/content/guides/component-testing/mounting-vue.md
@@ -9,7 +9,7 @@ by Bill Wilke and is explained thoroughly in his blog post
 
 When it comes to component testing, mounting your component is where we
 **Arrange** our component under test. It is analogous to visiting a page in an
-End-to-End test.
+end-to-end test.
 
 This section covers how to mount **simple** Vue components in a Cypress test --
 like Buttons, SVGs, Icons, or a Stepper component.
@@ -136,8 +136,8 @@ you'll want to install `@testing-library/cypress` _instead_ of the
 npm i -D @testing-library/cypress
 ```
 
-The setup instructions are the same for End-to-end and Component testing. Within
-your **component support file**, import the custom commands.
+The setup instructions are the same for E2E and Component Testing. Within your
+**component support file**, import the custom commands.
 
 ```js
 // cypress/support/component.js

--- a/content/guides/continuous-integration/aws-codebuild.md
+++ b/content/guides/continuous-integration/aws-codebuild.md
@@ -153,7 +153,7 @@ The images are available in the following
 
 <strong class="alert-header">Choosing the right Docker Image</strong>
 
-For end-to-end tests on a CI provider like AWS CodeBuild, the
+For E2E Testing on a CI provider like AWS CodeBuild, the
 [Cypress 'browsers' Amazon ECR Public Gallery](https://gallery.ecr.aws/cypress-io/cypress/browsers)
 contains the images to use.
 

--- a/content/guides/core-concepts/cypress-app.md
+++ b/content/guides/core-concepts/cypress-app.md
@@ -164,7 +164,7 @@ Under Test is rendered.
 ### Application Under Test <E2EOnlyBadge />
 
 In
-[End-to-End testing](/guides/core-concepts/testing-types#What-is-End-to-end-Testing),
+[E2E Testing](/guides/core-concepts/testing-types#What-is-End-to-end-Testing),
 the righthand side of the Cypress App is used to display the Application Under
 Test (AUT): the application that was navigated to using a
 [`cy.visit()`](/api/commands/visit) or any subsequent routing calls made from

--- a/content/guides/core-concepts/testing-types.md
+++ b/content/guides/core-concepts/testing-types.md
@@ -6,13 +6,13 @@ title: 'Testing Types'
 
 ## <Icon name="graduation-cap"></Icon> What you'll learn
 
-- What is end-to-end testing and component testing
+- What is E2E Testing and Component Testing
 - Considerations for each testing type
 - How to choose which test type based on your scenario
 
 </Alert>
 
-## End-to-end or Component Tests?
+## End-to-End or Component Tests?
 
 One of the first decisions you will need to make on your testing journey is what
 type of test to create. Cypress offers two options: end-to-end and component
@@ -24,12 +24,12 @@ but how do you choose right now?
 Let's go over each of these test types, the benefits they bring, things to
 consider, and scenarios for each.
 
-## What is End-to-end Testing?
+## What is E2E Testing?
 
-End-to-end testing is a technique that tests your app from the web browser
-through to the back end of your application, as well as testing integrations
-with third-party APIs and services. These types of tests are great at making
-sure your entire app is functioning as a cohesive whole.
+E2E Testing is a technique that tests your app from the web browser through to
+the back end of your application, as well as testing integrations with
+third-party APIs and services. These types of tests are great at making sure
+your entire app is functioning as a cohesive whole.
 
 Cypress runs end-to-end tests the same way users interact with your app by using
 a real browser, visiting URLs, viewing content, clicking on links and buttons,
@@ -143,9 +143,9 @@ set of tests specializing in what they do best.
 To learn more about component testing in Cypress, visit our guide on
 [Testing Your Components with Cypress](/guides/component-testing/writing-your-first-component-test).
 
-## Test Type Comparison
+## Testing Type Comparison
 
-|                        |                    End-to-end                    |                   Component                   |
+|                        |                       E2E                        |                   Component                   |
 | ---------------------- | :----------------------------------------------: | :-------------------------------------------: |
 | What's Tested          |                  All app layers                  |             Individual component              |
 | Characteristics        | Comprehensive, slower, more suspectable to flake |         Specialized, quick, reliable          |

--- a/content/guides/core-concepts/writing-and-organizing-tests.md
+++ b/content/guides/core-concepts/writing-and-organizing-tests.md
@@ -274,7 +274,7 @@ is set to look for one of the following files:
 - `cypress/support/component.ts`
 - `cypress/support/component.tsx`
 
-**End-to-End:**
+**E2E:**
 
 - `cypress/support/e2e.js`
 - `cypress/support/e2e.jsx`

--- a/content/guides/getting-started/opening-the-app.md
+++ b/content/guides/getting-started/opening-the-app.md
@@ -67,15 +67,15 @@ steps in order.
 
 The Launchpad presents you with your biggest decision first: What type of
 testing shall I do?
-[End-to-End Testing](/guides/core-concepts/testing-types#What-is-End-to-end-Testing),
-where I run my whole application and visit pages to test them? Or
+[E2E Testing](/guides/core-concepts/testing-types#What-is-E2E-Testing), where I
+run my whole application and visit pages to test them? Or
 [Component Testing](/guides/core-concepts/testing-types#What-is-Component-Testing),
 where I mount individual components of my app and test them in isolation?
 
 For more background on this critical decision, read
 [Testing Types](/guides/core-concepts/testing-types). Alternatively, if you're
 not sure which type you want and just want to get on with your testing journey,
-just choose End-to-End for now - you can always change this later!
+just choose **E2E** for now - you can always change this later!
 
 ### Quick Configuration
 
@@ -100,6 +100,6 @@ START BUTTON!</strong>
 ## Next Steps
 
 Time to get testing! If you chose
-[to start with E2E testing, go here](/guides/end-to-end-testing/writing-your-first-end-to-end-test).
+[to start with E2E Testing, go here](/guides/end-to-end-testing/writing-your-first-end-to-end-test).
 Alternatively, if you decided
-[to try component testing, go here](/guides/component-testing/writing-your-first-component-test).
+[to try Component Testing, go here](/guides/component-testing/writing-your-first-component-test).

--- a/content/guides/guides/debugging.md
+++ b/content/guides/guides/debugging.md
@@ -96,7 +96,7 @@ the first time, (shown above with the [`cy.get()`](/api/commands/get)chain and
 its [`.then()`](/api/commands/then) attached) the commands are enqueued for
 Cypress to execute. The `it` block exits, and Cypress starts its work:
 
-1. In an End-to-End Test, the page is visited and Cypress waits for it to load.
+1. In an end-to-end test, the page is visited and Cypress waits for it to load.
    Alternatively, the component is mounted and rendered in a Component Test.
 2. The element is queried, and Cypress automatically waits and retries for a few
    moments if it isn't found immediately.

--- a/content/guides/references/best-practices.md
+++ b/content/guides/references/best-practices.md
@@ -591,7 +591,7 @@ Why you do this pattern in component and unit tests:
 - There was no performance penalty splitting up multiple tests because they run
   really fast
 
-Why you shouldn't do this in End-to-End tests:
+Why you shouldn't do this in end-to-end tests:
 
 - Writing integration tests is not the same as unit tests
 - You will always know (and can visually see) which assertion failed in a large

--- a/content/guides/references/configuration.md
+++ b/content/guides/references/configuration.md
@@ -285,8 +285,7 @@ See the [Command Line](/guides/guides/command-line) guide for more examples.
 In addition to setting
 [Testing Type-Specific options](#Testing-Type-Specific-Options), you can
 override other configuration options for either the
-[End-to-End Testing](/guides/core-concepts/testing-types#What-is-End-to-end-Testing)
-or
+[E2E Testing](/guides/core-concepts/testing-types#What-is-E2E-Testing) or
 [Component Testing](/guides/core-concepts/testing-types#What-is-Component-Testing).
 
 For example:


### PR DESCRIPTION
This PR attempts to regularize usage of the terms "end-to-end" and "E2E" across the docs. This required some subjective and possibly tendentious linguistic calls. My reasoning is as follows:

- The proper noun referring to the **practice** is "E2E Testing"
- The name of the Cypress **feature** is also "E2E Testing"
- The adjective used to denote the type of a test or tests is "end-to-end"
- "end-to-end" in title case is "End-to-End"
- When explaining the concept to people who may not have heard it, prefer "end-to-end", possibly with the acronym in brackets

Examples of correct usage:

- "Choose the E2E Testing option"
- "Writing your first end-to-end test"
- "What is End-to-End (E2E) Testing?"

There are some exceptions, but these are the principles I've tried to follow. I've also avoided changing any slugs because I'm already nervous about the amount of churn we're introducing to URLs.