### PR TITLE
chore: lint 10.0 changelog

### DIFF
--- a/content/_changelogs/10.0.0.md
+++ b/content/_changelogs/10.0.0.md
@@ -75,8 +75,8 @@ breaking changes in more detail.**
     [#19319](https://github.com/cypress-io/cypress/pull/19319) and
     [#20565](https://github.com/cypress-io/cypress/pull/20565).
   - The `integrationFolder` and `componentFolder` options were removed. These
-    options were made obsolete by the new `specPattern` option. Addressed
-    in [#19319](https://github.com/cypress-io/cypress/pull/19319).
+    options were made obsolete by the new `specPattern` option. Addressed in
+    [#19319](https://github.com/cypress-io/cypress/pull/19319).
   - The `ignoreTestFiles` option was removed. This option was replaced with the
     new `excludeSpecPattern` option. Addressed in
     [#19319](https://github.com/cypress-io/cypress/pull/19319).
@@ -200,8 +200,8 @@ breaking changes in more detail.**
     [#20763](https://github.com/cypress-io/cypress/pull/20763),
     [#20853](https://github.com/cypress-io/cypress/pull/20853).
     - The [`e2e.excludeSpecPattern`](/guides/references/configuration#e2e)
-      default value is the same as the replaced `ignoreTestFiles` glob
-      pattern of `*.hot-update.js`.
+      default value is the same as the replaced `ignoreTestFiles` glob pattern
+      of `*.hot-update.js`.
     - The
       [`component.excludeSpecPattern`](/guides/references/configuration#component)
       default value is `['**/__snapshots__/*','**/__image_snapshots__/*']` plus
@@ -219,8 +219,8 @@ breaking changes in more detail.**
 - We've made some updates to **Cypress API commands** detailed below:
 
   - Enhancements were made to provide visual indication of nested commands and
-    logs. With this change, users are now able to click on log groups to
-    print additional log details to the dev tools console.
+    logs. With this change, users are now able to click on log groups to print
+    additional log details to the dev tools console.
   - The `.within()` command was updated to provide visual indication of logs and
     commands executed in the `.within` command context. Addresses
     [#20433](https://github.com/cypress-io/cypress/issues/20433).

--- a/content/_data/sidebar.json
+++ b/content/_data/sidebar.json
@@ -74,7 +74,7 @@
               "title": "Migrating from Other Frameworks"
             },
             {
-              "title": "Protractor to Cypress",
+              "title": "Migrating from Protractor to Cypress",
               "slug": "protractor-to-cypress"
             }
           ]
@@ -113,7 +113,7 @@
               "title": "Vue Component Testing"
             },
             {
-              "title": "Quickstart",
+              "title": "Quickstart: Vue",
               "slug": "quickstart-vue"
             },
             {
@@ -121,26 +121,26 @@
               "slug": "mounting-vue"
             },
             {
-              "title": "Testing Props",
+              "title": "Vue Components with Props",
               "slug": "props-vue"
             },
             {
-              "title": "Testing Emitted Events",
+              "title": "Testing Vue Components with Emitted Events",
               "slug": "events-vue"
             },
             {
-              "title": "Testing Slots",
+              "title": "Testing Vue Components with Slots",
               "slug": "slots-vue"
             },
             {
-              "title": "Custom Mount Commands",
+              "title": "Custom Mount Commands and Styles",
               "slug": "custom-mount-vue"
             },
             {
               "title": "React Component Testing"
             },
             {
-              "title": "Quickstart",
+              "title": "Quickstart: React",
               "slug": "quickstart-react"
             },
             {
@@ -148,15 +148,15 @@
               "slug": "mounting-react"
             },
             {
-              "title": "Testing Components",
+              "title": "Testing React Components",
               "slug": "testing-react"
             },
             {
-              "title": "Testing Events",
+              "title": "Testing React Components with Events",
               "slug": "events-react"
             },
             {
-              "title": "Custom Mount Commands",
+              "title": "Custom Mount Commands for React",
               "slug": "custom-mount-react"
             }
           ]


### PR DESCRIPTION
This PR lints the `10.0 changelog` as it is causing circle to fail.