### PR TITLE
Specify line length in prettier config

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,6 @@
 {
-    "semi": false,
-    "singleQuote": true,
-    "proseWrap": "always"
+  "semi": false,
+  "singleQuote": true,
+  "printWidth": 80,
+  "proseWrap": "always"
 }


### PR DESCRIPTION
Not sure how config defaults work but maybe this is getting overridden by people's personal settings? Can't hurt anyway.