### PR TITLE
Add Migrating to v10 video to Migration Guide

### DIFF
--- a/content/guides/references/migration-guide.md
+++ b/content/guides/references/migration-guide.md
@@ -2,6 +2,8 @@
 title: Migration Guide
 ---
 
+<DocsVideo src="https://youtube.com/embed/mIqKNhLlPcU"></DocsVideo>
+
 ## Migrating to Cypress version 10.0
 
 This guide details the changes and how to change your code to migrate to Cypress


### PR DESCRIPTION
This PR adds the fantastic v10 migration walkthrough video by Jordan to the top of the Migration Guide page. This should be removed once the next guide is added to this page.