### PR TITLE
UDX-111: Add info box about Angular support

### DIFF
--- a/content/guides/component-testing/component-framework-configuration.md
+++ b/content/guides/component-testing/component-framework-configuration.md
@@ -22,6 +22,17 @@ testing:
 | [Vue with Vite](#Vue-with-Vite)                          | Vue 2+     | Vite 2     |
 | [Vue with Webpack](#Vue-with-Webpack)                    | Vue 2+     | Webpack 4+ |
 
+<Alert type="info">
+
+Currently Cypress does not officially suppoort Component Testing with Angular,
+but this is planned for a future release. Until then, users may roll their own
+solution with a
+[custom `cy.mount()` command](/api/commands/mount#Creating-a-New-cy-mount-Command),
+or take as a starting point
+[this unofficial solution from one of our own developers](https://github.com/jordanpowell88/angular-ct).
+
+</Alert>
+
 ## Automatic Configuration (Recommended)
 
 When you launch Cypress for the first time in a project and select Component


### PR DESCRIPTION
This PR adds an info alert to the Component Testing Framework Configuration page noting that Angular support is in the works & pointing users to interim solutions in the meantime. The goal here is to reassure Angular users that Cypress will support their use case and/or encourage early buy-in with a custom solution.