### PR TITLE
docs: fix incorrect link for react with vite

### DIFF
--- a/content/guides/component-testing/component-framework-configuration.md
+++ b/content/guides/component-testing/component-framework-configuration.md
@@ -249,7 +249,7 @@ export default defineConfig({
 
 #### Sample React Vite Apps
 
-- [React Vite with TypeScript](https://github.com/cypress-io/cypress-component-testing-apps/tree/main/react-next12-ts)
+- [React Vite with TypeScript](https://github.com/cypress-io/cypress-component-testing-apps/tree/main/react-vite-ts)
 
 ### React with Webpack
 


### PR DESCRIPTION
Fixing an incorrect link. Previously it went to a Next app.