### PR TITLE
change return type of dataCy() call in interface

### DIFF
--- a/content/guides/tooling/typescript-support.md
+++ b/content/guides/tooling/typescript-support.md
@@ -102,7 +102,7 @@ declare global {
        * Custom command to select DOM element by data-cy attribute.
        * @example cy.dataCy('greeting')
        */
-      dataCy(value: string): Chainable<Element>
+      dataCy(value: string): Chainable<JQuery<Element>>
     }
   }
 }


### PR DESCRIPTION
Currently the typing is wrong of the example dataCy() call.
It should be Chainable<JQuery<Element>> instead of Chainable<Element>.