### PR TITLE
Update test case for action-email input

### DIFF
--- a/content/guides/end-to-end-testing/writing-your-first-end-to-end-test.md
+++ b/content/guides/end-to-end-testing/writing-your-first-end-to-end-test.md
@@ -365,7 +365,7 @@ describe('My First Test', () => {
 
     // Get an input, type into it and verify
     // that the value has been updated
-    cy.get('[data-testid="action-email"]')
+    cy.get('.action-email')
       .type('fake@email.com')
       .should('have.value', 'fake@email.com')
   })


### PR DESCRIPTION
As I understand, there is no more data-testid="action-email" for the input on example page. Somewhere in the repository I found another example with similar input which is queried by classname.