### PR TITLE
docs: add Cypress AG Grid plugin

### DIFF
--- a/content/_data/plugins.json
+++ b/content/_data/plugins.json
@@ -603,7 +603,15 @@
           "link": "https://github.com/elaichenkov/cy-verify-downloads",
           "keywords": ["commands", "assertions", "wait", "verify", "download"],
           "badge": "community"
+        },
+        {
+          "name": "cypress-ag-grid",
+          "description": "Cypress plugin for interacting with and validating against ag grid",
+          "link": "https://github.com/kpmck/cypress-ag-grid",
+          "keywords": ["aggrid", "ag-grid", "ag grid"],
+          "badge": "community"
         }
+
       ]
     },
     {

--- a/content/_data/plugins.json
+++ b/content/_data/plugins.json
@@ -606,7 +606,7 @@
         },
         {
           "name": "cypress-ag-grid",
-          "description": "Cypress plugin for interacting with and validating against ag grid",
+          "description": "Cypress plugin for interacting with and validating against AG Grid",
           "link": "https://github.com/kpmck/cypress-ag-grid",
           "keywords": ["aggrid", "ag-grid", "ag grid"],
           "badge": "community"


### PR DESCRIPTION
The added plugin contains:

- Example application
- Comprehensive, clear documentation
- Cypress tests against the example application
- CI pipeline tests against every branch
- Compatible with versions up to Cypress v10