### PR TITLE
docs: Updating 10.2.0 changelog to include link to M1 blog post

### DIFF
--- a/content/_changelogs/10.2.0.md
+++ b/content/_changelogs/10.2.0.md
@@ -4,8 +4,10 @@ _Released 6/21/2022_
 
 **Features:**
 
-- Cypress is now available natively on Apple silicon (M1). Addresses
-  [#19908](https://github.com/cypress-io/cypress/issues/19908).
+- Cypress is now available natively on Apple silicon (M1). For more details,
+  read
+  [our blog post](https://www.cypress.io/blog/2022/06/21/cypress-10-2-0-run-tests-up-to-2x-faster-on-apple-silicon-m1/).
+  Addresses [#19908](https://github.com/cypress-io/cypress/issues/19908).
 - Cypress is now available natively on ARM64 and AArch64 systems running Linux.
   Addresses [#4478](https://github.com/cypress-io/cypress/issues/4478).
 - The file name input field within the Create Spec modal is now automatically

--- a/content/_changelogs/10.2.0.md
+++ b/content/_changelogs/10.2.0.md
@@ -4,8 +4,8 @@ _Released 6/21/2022_
 
 **Features:**
 
-- Cypress is now available natively on Apple silicon (M1). For more details,
-  read
+- Cypress is now available natively on Apple silicon, including the M1 and M2
+  processor families. For more details, read
   [our blog post](https://www.cypress.io/blog/2022/06/21/cypress-10-2-0-run-tests-up-to-2x-faster-on-apple-silicon-m1/).
   Addresses [#19908](https://github.com/cypress-io/cypress/issues/19908).
 - Cypress is now available natively on ARM64 and AArch64 systems running Linux.


### PR DESCRIPTION
This updates the 10.2.0 changelog to include a link to the great blog post we released alongside 10.2.0.