### PR TITLE
fix: fix a typo in devServer for "React with Webpack"

### DIFF
--- a/content/guides/component-testing/component-framework-configuration.md
+++ b/content/guides/component-testing/component-framework-configuration.md
@@ -270,7 +270,7 @@ module.exports = {
       webpackConfig: require('./webpack.config'),
     },
   },
-})
+}
 ```
 
 </template>


### PR DESCRIPTION
Fix a typo in `cypress.config.js` on the page [Framework Configuration (React-with-Webpack)](https://docs.cypress.io/guides/component-testing/component-framework-configuration#React-with-Webpack)




