### PR TITLE
Correct code coverage setup example

### DIFF
--- a/content/guides/tooling/code-coverage.md
+++ b/content/guides/tooling/code-coverage.md
@@ -299,13 +299,14 @@ Then add the code below to the
 
 ```js
 // cypress/support/e2e.js
-import '@cypress/code-coverage/support'
+import codeCoverageTask from '@cypress/code-coverage/task';
 ```
 
 :::cypress-plugin-example
 
 ```js
-require('@cypress/code-coverage/task')(on, config)
+
+codeCoverageTask(on, config);
 // include any other plugin code...
 
 // It's IMPORTANT to return the config object


### PR DESCRIPTION
Proposed configuration returns Cypress not defined in a real use case.

```js
const { defineConfig } = require('cypress')

module.exports = defineConfig({
  // setupNodeEvents can be defined in either
  // the e2e or component configuration
  e2e: {
    setupNodeEvents(on, config) {
      require('@cypress/code-coverage/task')(on, config)
      // include any other plugin code...
      
      // It's IMPORTANT to return the config object
      // with any changed environment variables
      return config
    }
  }
})
```

Using [existing configuration from the RealWorldApp](https://github.com/cypress-io/cypress-realworld-app/blob/develop/cypress.config.js#L100) seems working though.

```js
import codeCoverageTask from "@cypress/code-coverage/task";
const { defineConfig } = require('cypress')

module.exports = defineConfig({
  // setupNodeEvents can be defined in either
  // the e2e or component configuration
  e2e: {
    setupNodeEvents(on, config) {
      codeCoverageTask(on, config);
      return config;
    },
```
