### PR TITLE
docs(guides): add experimental alert for autoSpyOutputs

### DIFF
--- a/content/guides/component-testing/events-angular.md
+++ b/content/guides/component-testing/events-angular.md
@@ -294,6 +294,13 @@ function. It currently does not work with the template syntax.
 
 </Alert>
 
+<Alert type="warning">
+
+`autoSpyOutput` is an **experimental feature** and could be removed or changed
+in the future
+
+</Alert>
+
 ## Learn More
 
 Spying is a powerful technique for observing behavior in Cypress. Learn more


### PR DESCRIPTION
Based upon feedback brought up by @brian-mann during yesterday's app demo, this PR adds a warning to the angular getting start guide that the `autoSpyOutputs` flag is an experimental feature.