### PR TITLE
Update best-practices.md

### DIFF
--- a/content/guides/references/best-practices.md
+++ b/content/guides/references/best-practices.md
@@ -681,8 +681,10 @@ describe('my form', () => {
 </Alert>
 
 <Alert type="success">
+
 <Icon name="check-circle" color="green"></Icon> **Best Practice:** Clean up
 state **before** tests run.
+
 </Alert>
 
 We see many of our users adding code to an `after` or `afterEach` hook in order


### PR DESCRIPTION
Fix unbolded text under https://docs.cypress.io/guides/references/best-practices#Using-after-or-afterEach-hooks

Current view before fix:
![image](https://user-images.githubusercontent.com/33106214/185716706-92005a1f-8e65-4dbf-95af-95797635f53b.png)

