### PR TITLE
docs: Update plugins documentation for cypress-terminal-report plugin.

### DIFF
--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -1032,6 +1032,13 @@
       "name": "Reporting",
       "plugins": [
         {
+          "name": "cypress-terminal-report",
+          "description": "Logs to terminal and files mimicking cypress UI. Logs all cypress commands, request/response data and browser console logs.",
+          "link": "https://github.com/archfz/cypress-terminal-report",
+          "keywords": ["reporter", "logger", "terminal", "files", "CI", "CLI"],
+          "badge": "community"
+        },
+        {
           "name": "cypress-failed-log",
           "description": "Saves the Cypress test command log as a JSON file if a test fails.",
           "link": "https://github.com/bahmutov/cypress-failed-log",
@@ -1085,13 +1092,6 @@
           "description": "Slack reporting tool. Uses mochawesome json reports, provides links to VCS Provider (github/bitbucket) and CircleCI logs",
           "link": "https://github.com/you54f/cypress-slack-reporter",
           "keywords": ["reporter", "mochawesome", "slack"],
-          "badge": "community"
-        },
-        {
-          "name": "cypress-terminal-report",
-          "description": "Logs cypress commands, route request data and browser console errors and warnings to terminal when tests fail on CI.",
-          "link": "https://github.com/archfz/cypress-terminal-report",
-          "keywords": ["reporter", "logs", "terminal", "CI", "CLI"],
           "badge": "community"
         },
         {


### PR DESCRIPTION
This PR updates the description and keywords of [cypress-terminal-report](https://github.com/archfz/cypress-terminal-report) plugin. It also brings it forwards in the list, which I hope is allowed.

The reason for bring it forwards is to hopefully raise the awareness of the community of the plugin. And I believe it deserves a better place in the list over the other logging plugins [cypress-failed-log](https://github.com/bahmutov/cypress-failed-log) [cypress-log-to-output](https://github.com/flotwig/cypress-log-to-output), as it's better maintained, supports cypress 10 and basically includes all their features and more.