### PR TITLE
fix tag typo

### DIFF
--- a/content/guides/guides/command-line.md
+++ b/content/guides/guides/command-line.md
@@ -408,7 +408,7 @@ cypress run --project tests/e2e --spec ./tests/e2e/cypress/e2e/spec.js
 #### `cypress run --tag <tag>`
 
 Add a tag or tags to the recorded run. This can be used to help identify
-separate run when displayed in the Dashboard.
+separate runs when displayed in the Dashboard.
 
 ```shell
 cypress run  --record --tag "staging"


### PR DESCRIPTION
change "run" to "runs" under the _cypress run --tag <tag>_ section