### PR TITLE
docs: add options API projectConfig to configuration

### DIFF
--- a/content/guides/references/configuration.md
+++ b/content/guides/references/configuration.md
@@ -594,6 +594,54 @@ See the
 [Custom Dev Server](/guides/component-testing/component-framework-configuration)
 guide for more info.
 
+### Options API
+
+You can also use the `options` API to provide your own project specific
+configuration to your `devServer` for frameworks like angular that do not have a
+`webpack.config` you can pass to cypress.
+
+The `devServer` function receives an `options` argument:
+
+<code-group>
+<code-block label="cypress.config.ts" active>
+
+```ts
+import { defineConfig } from 'cypress'
+
+export default {
+  component: {
+    framework: 'angular',
+    bundler: 'webpack',
+    options: {
+      projectConfig: {
+        root: '',
+        sourceRoot: 'apps/my-app',
+        buildOptions: {
+          outputPath: 'dist/my-app',
+          index: 'apps/my-app/src/index.html',
+          main: 'apps/my-app/src/main.ts',
+          polyfills: 'apps/my-app/src/polyfills.ts',
+          tsConfig: 'apps/my-app/tsconfig.app.json',
+          inlineStyleLanguage: 'scss',
+          assets: ['apps/my-app/src/favicon.ico', 'apps/my-app/src/assets'],
+          styles: ['apps/my-app/src/styles.scss'],
+          scripts: [],
+          buildOptimizer: false,
+          optimization: false,
+          vendorChunk: true,
+          extractLicenses: false,
+          sourceMap: true,
+          namedChunks: true,
+        },
+      },
+    },
+  },
+}
+```
+
+</code-block>
+</code-group>
+
 ### excludeSpecPattern
 
 Cypress uses `minimatch` with the options: `{dot: true, matchBase: true}`. We


### PR DESCRIPTION
This PR adds documentation around the new `options` API for our `@cypress/webpack-dev-server` config.

[See this PR](https://github.com/cypress-io/cypress/pull/23494)