### PR TITLE
Docs: Remove broken link from React-Webpack documentation

### DIFF
--- a/content/guides/component-testing/component-framework-configuration.md
+++ b/content/guides/component-testing/component-framework-configuration.md
@@ -293,9 +293,6 @@ it via the `webpackConfig` option.
 
 - [React Webpack 5 with JavaScript](https://github.com/cypress-io/cypress-component-testing-apps/tree/main/react-webpack5-js)
 
-You can find an example React project that uses Webpack
-[here](https://github.com/cypress-io/cypress-component-examples/tree/main/setup-webpack-react-app).
-
 <!-- Couldn't simply call this next section "Vue" because using "## Vue" by itself killed the tabs in the code examples -->
 
 ## Vue 2 & Vue 3


### PR DESCRIPTION
Remove a dead link from the documentation for Creating a React App with Webpack