### PR TITLE
docs: add argos to plugin list

### DIFF
--- a/content/_data/plugins.json
+++ b/content/_data/plugins.json
@@ -869,6 +869,13 @@
       "description": "Visual testing is a great complement to functional testing",
       "plugins": [
         {
+          "name": "Argos",
+          "description": "Automate visual testing in your CI",
+          "link": "https://docs.argos-ci.com/cypress",
+          "keywords": ["devX", "screenshots"],
+          "badge": "verified"
+        },
+        {
           "name": "Applitools",
           "description": "Fast, easy and reliable visual UI testing with Cypress",
           "link": "https://applitools.com/tutorials/cypress.html",


### PR DESCRIPTION
This PR adds [Argos](https://www.argos-ci.com) to visual testing plugins list.

Here is the plugin GitHub's repo: [@argos-ci/cypress plugin](https://docs.argos-ci.com/cypress).

- [x] The repository has integration tests with cypress with a real-world like example
- [x] The test with this plugin is tested on a real-world like scenario
- [x] The test runs inside our CI pipeline
- [x] The plugin is compatible with the latest major version of Cypress