### PR TITLE
docs: fix the GitLab CI configuration link

### DIFF
--- a/content/guides/continuous-integration/ci-provider-examples.md
+++ b/content/guides/continuous-integration/ci-provider-examples.md
@@ -103,7 +103,7 @@ The Cypress
 [Cypress Dashboard recording](https://dashboard.cypress.io/projects/woih1m).
 
 Check out the full <Icon name="github"></Icon>
-[RWA GitLab CI configuration](https://github.com/cypress-io/cypress-realworld-app/blob/develop/gitlab-ci.yml).
+[RWA GitLab CI configuration](https://github.com/cypress-io/cypress-realworld-app/blob/develop/.gitlab-ci.yml).
 
 </Alert>
 


### PR DESCRIPTION
Fixes the link of the GitLab CI configuration file, in CI Provider Examples. Missing dot.
Thanks :slightly_smiling_face: 