### PR TITLE
Large screen size styles

### DIFF
--- a/styles/content.css
+++ b/styles/content.css
@@ -64,6 +64,11 @@
     padding-left: 8rem;
     padding-right: 6rem;
   }
+
+  @screen 2xl {
+    padding-left: 4rem;
+    padding-right: 3rem;
+  }
 }
 
 .main-content-header {
@@ -159,7 +164,7 @@
 }
 
 /* vertical alignment for 'hint' badge beside h2
-   section titles using flexbox become 
+   section titles using flexbox become
    problematic on some pages, e.g FAQ's */
 .nuxt-content h2 > a > div,
 .nuxt-content h3 > a > div {
@@ -210,9 +215,9 @@
   @apply pointer-events-none;
 }
 
-/* We use :first-of-type because a title 
-   may contain an anchor tag that isn't  
-   the hidden link that is automagically 
+/* We use :first-of-type because a title
+   may contain an anchor tag that isn't
+   the hidden link that is automagically
    added by nuxt-content. */
 .nuxt-content h2 > a:first-of-type::before,
 .nuxt-content h3 > a:first-of-type::before,
@@ -255,7 +260,8 @@
   @apply mb-0;
 }
 
-.nuxt-content svg, .toc-content svg {
+.nuxt-content svg,
+.toc-content svg {
   height: 1em;
   width: 1em;
   @apply inline-block;
@@ -378,9 +384,9 @@ pre[class*='language-'] ::selection {
 
 /* #endregion Syntax highlighting selection override */
 
-/* #region Overriding syntax highlighting theme 
+/* #region Overriding syntax highlighting theme
 
-/* Prevent calls to .continue() from being italicized since 
+/* Prevent calls to .continue() from being italicized since
    syntax highlighter thinks .continue() is a `continue` keyword */
 span.token.keyword.control-flow {
   font-style: normal;
@@ -403,8 +409,8 @@ span.token.keyword.control-flow {
 
 /* This style seems to be stripped out of css in prod builds from FA, so adding it in manually */
 .svg-inline--fa {
-    display: inline-block;
-    font-size: inherit;
-    height: 1em;
-    vertical-align: -0.125em;
+  display: inline-block;
+  font-size: inherit;
+  height: 1em;
+  vertical-align: -0.125em;
 }


### PR DESCRIPTION
- decreased the left and right padding for the main content for `2xl` tailwind breakpoints which is `1536px`