### PR TITLE
Fix anchor

### DIFF
--- a/content/guides/guides/environment-variables.md
+++ b/content/guides/guides/environment-variables.md
@@ -10,7 +10,7 @@ variables</strong>
 In Cypress, "environment variables" are variables that are accessible via
 `Cypress.env`. These are not the same as OS-level environment variables.
 However,
-[it is possible to set Cypress environment variables from OS-level environment variables](/guides/guides/environment-variables#Option-3-CYPRESS).
+[it is possible to set Cypress environment variables from OS-level environment variables](/guides/guides/environment-variables#Option-3-CYPRESS_).
 
 </Alert>
 


### PR DESCRIPTION
There is a small bug in https://docs.cypress.io/guides/guides/environment-variables.

The link to "However, [it is possible to set Cypress environment variables from OS-level environment variables](https://docs.cypress.io/guides/guides/environment-variables#Option-3-CYPRESS)." is incorrect, and is missing a trailing `_`