### PR TITLE
GitHub Action Docs - Explicit version of Cypress GHA

### DIFF
--- a/content/guides/continuous-integration/github-actions.md
+++ b/content/guides/continuous-integration/github-actions.md
@@ -51,19 +51,12 @@ Cypress in the GitHub Actions platform.
 
 ### Explicit Version Number
 
-```yaml
-jobs:
-  cypress-run:
-    steps:
-      uses: cypress-io/github-action@v4.2.0
-```
-
 <Alert type="info">
 
 <strong class="alert-header">GitHub Action Version Number</strong>
 
 We recommend using the explicit version number of the Cypress GitHub Action to
-prevent accidnetally running tests with a new version of the action that may
+prevent accidentally running tests with a new version of the action that may
 have breaking changes.
 
 Read the
@@ -71,6 +64,15 @@ Read the
 for more information
 
 </Alert>
+
+For Example:
+
+```yaml
+jobs:
+  cypress-run:
+    steps:
+      uses: cypress-io/github-action@v4.2.0
+```
 
 ## Basic Setup
 

--- a/content/guides/continuous-integration/github-actions.md
+++ b/content/guides/continuous-integration/github-actions.md
@@ -49,6 +49,29 @@ running Cypress tests. This action provides npm installation, custom caching,
 additional configuration options and simplifies setup of advanced workflows with
 Cypress in the GitHub Actions platform.
 
+### Explicit Version Number
+
+```yaml
+jobs:
+  cypress-run:
+    steps:
+      uses: cypress-io/github-action@v4.2.0
+```
+
+<Alert type="info">
+
+<strong class="alert-header">GitHub Action Version Number</strong>
+
+We recommend using the explicit version number of the Cypress GitHub Action to
+prevent accidnetally running tests with a new version of the action that may
+have breaking changes.
+
+Read the
+[GitHub Action documentation](https://github.com/cypress-io/github-action#explicit-version)
+for more information
+
+</Alert>
+
 ## Basic Setup
 
 <DocsVideo src="https://youtube.com/embed/vVr7DXDdUks"></DocsVideo>
@@ -72,7 +95,7 @@ jobs:
       # Install NPM dependencies, cache them correctly
       # and run all Cypress tests
       - name: Cypress run
-        uses: cypress-io/github-action@v4
+        uses: cypress-io/github-action@v4.x.x # use the explicit version number
         with:
           build: npm run build
           start: npm start
@@ -131,7 +154,7 @@ jobs:
       # Install NPM dependencies, cache them correctly
       # and run all Cypress tests
       - name: Cypress run
-        uses: cypress-io/github-action@v4
+        uses: cypress-io/github-action@v4.x.x # use the explicit version number
         with:
           # Specify Browser since container image is compile with Firefox
           browser: firefox
@@ -178,7 +201,7 @@ jobs:
           path: build
 
       - name: Cypress install
-        uses: cypress-io/github-action@v4
+        uses: cypress-io/github-action@v4.x.x # use the explicit version number
         with:
           # Disable running of tests within install job
           runTests: false
@@ -214,7 +237,7 @@ jobs:
       # Install NPM dependencies, cache them correctly
       # and run all Cypress tests
       - name: Cypress run
-        uses: cypress-io/github-action@v4
+        uses: cypress-io/github-action@v4.x.x # use the explicit version number
         with:
           # Specify Browser since container image is compile with Firefox
           browser: firefox
@@ -275,7 +298,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Cypress install
-        uses: cypress-io/github-action@v4
+        uses: cypress-io/github-action@v4.x.x # use the explicit version number
         with:
           # Disable running of tests within install job
           runTests: false
@@ -338,7 +361,7 @@ jobs:
           path: build
 
       - name: 'UI Tests - Chrome'
-        uses: cypress-io/github-action@v4
+        uses: cypress-io/github-action@v4.x.x # use the explicit version number
         with:
           # we have already installed all dependencies above
           install: false
@@ -474,7 +497,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Cypress run
-        uses: cypress-io/github-action@v4
+        uses: cypress-io/github-action@v4.x.x # use the explicit version number
         with:
           record: true
         env:
@@ -501,7 +524,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Cypress run
-        uses: cypress-io/github-action@v4
+        uses: cypress-io/github-action@v4.x.x # use the explicit version number
         with:
           record: true
         env:


### PR DESCRIPTION
- updated the GitHub Actions docs to let users know that they should specifically reference the Cypress GitHub Action version number in the GHA config. 