### PR TITLE
Update browser launch options for env key

### DIFF
--- a/content/api/plugins/browser-launch-api.md
+++ b/content/api/plugins/browser-launch-api.md
@@ -48,10 +48,11 @@ following properties:
 | `preferences` | `object`   | An object describing browser preferences. Differs between browsers. See [Changing browser preferences](#Changing-browser-preferences) for details.                                                                                           |
 | `args`        | `string[]` | An array of strings that will be passed as command-line args when the browser is launched. Has no effect on Electron. See [Modify browser launch arguments](#Modify-browser-launch-arguments) for details.                                   |
 | `extensions`  | `string[]` | An array of paths to folders containing unpacked WebExtensions to be loaded before the browser starts. Note: Electron currently only supports Chrome DevTools extensions. See [Add browser extensions](#Add-browser-extensions) for details. |
+| `env`         | `object`   | An object of environment variables set before launching the browser. See [Configure browser environment](#Configure-browser-environment) for details.                                                                                        |
 
 ## Usage
 
-### Modify browser launch arguments, preferences, and extensions
+### Modify browser launch arguments, preferences, extensions, and environment
 
 Using the [setupNodeEvents](/guides/tooling/plugins-guide#Using-a-plugin)
 function you can tap into the `before:browser:launch` event and modify how
@@ -113,6 +114,24 @@ on('before:browser:launch', (browser, launchOptions) => {
   // supply the absolute path to an unpacked extension's folder
   // NOTE: extensions cannot be loaded in headless Chrome
   launchOptions.extensions.push('Users/jane/path/to/extension')
+
+  return launchOptions
+})
+```
+
+:::
+
+#### Configure browser environment:
+
+<Alert type="warning">
+This option is not supported when targeting electron
+</Alert>
+
+:::cypress-plugin-example
+
+```js
+on('before:browser:launch', (browser, launchOptions) => {
+  launchOptions.env.CUSTOM_ENV_VALUE = '1'
 
   return launchOptions
 })

--- a/content/api/plugins/browser-launch-api.md
+++ b/content/api/plugins/browser-launch-api.md
@@ -48,7 +48,7 @@ following properties:
 | `preferences` | `object`   | An object describing browser preferences. Differs between browsers. See [Changing browser preferences](#Changing-browser-preferences) for details.                                                                                           |
 | `args`        | `string[]` | An array of strings that will be passed as command-line args when the browser is launched. Has no effect on Electron. See [Modify browser launch arguments](#Modify-browser-launch-arguments) for details.                                   |
 | `extensions`  | `string[]` | An array of paths to folders containing unpacked WebExtensions to be loaded before the browser starts. Note: Electron currently only supports Chrome DevTools extensions. See [Add browser extensions](#Add-browser-extensions) for details. |
-| `env`         | `object`   | An object of environment variables set before launching the browser. See [Configure browser environment](#Configure-browser-environment) for details.                                                                                        |
+| `env`         | `object`   | An object of environment variables to pass to the launched browser. See [Configure browser environment](#Configure-browser-environment) for details.                                                                                        |
 
 ## Usage
 

--- a/content/api/plugins/browser-launch-api.md
+++ b/content/api/plugins/browser-launch-api.md
@@ -124,7 +124,7 @@ on('before:browser:launch', (browser, launchOptions) => {
 #### Configure browser environment:
 
 <Alert type="warning">
-This option is not supported when targeting electron
+This option is not supported when targeting Electron.
 </Alert>
 
 :::cypress-plugin-example


### PR DESCRIPTION
Docs for new `env` key added to `launchOptions` in https://github.com/cypress-io/cypress/pull/23624