### PR TITLE
chore: add Svelte to Getting Started list of supported frameworks

### DIFF
--- a/content/guides/component-testing/writing-your-first-component-test.md
+++ b/content/guides/component-testing/writing-your-first-component-test.md
@@ -49,5 +49,6 @@ on the web. Therefore, many of your tests will appear framework-agnostic and
 
 Ready to get started? Check out our quickstart guides for
 [Vue](/guides/component-testing/quickstart-vue),
-[React](/guides/component-testing/quickstart-react) and
-[Angular](/guides/component-testing/quickstart-angular).
+[React](/guides/component-testing/quickstart-react),
+[Angular](/guides/component-testing/quickstart-angular) and
+[Svelte](/guides/component-testing/quickstart-svelte).


### PR DESCRIPTION
Missed the section for adding `Svelte` to the list of Getting started frameworks.