### PR TITLE
Devserver redirect

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -67,6 +67,7 @@ const config = {
 
   plugins: [
     './plugins/fav-icon',
+    './plugins/devserver-redirect',
   ],
 
   themeConfig:

--- a/plugins/devserver-redirect.js
+++ b/plugins/devserver-redirect.js
@@ -1,0 +1,12 @@
+module.exports = function (context, options) {
+    return {
+      name: 'devserver-redirect',
+      configureWebpack(config, isServer, utils) {
+        return {
+          devServer: {
+            open: '/guides/overview/why-cypress', // Opens localhost:3000/guides/overview/why-cypress instead of localhost:3000/
+          },
+        };
+      },
+    };
+  };


### PR DESCRIPTION
Add devserver redirect to load `localhost:3000/guides/overview/why-cypress` like production vs. `localhost:3000`