### PR TITLE
add cypress 10, remove cypress 9

### DIFF
--- a/content/_data/courses.json
+++ b/content/_data/courses.json
@@ -1,12 +1,13 @@
 {
   "courses": [
     {
-      "title": "Cypress 9 Fundamentals",
-      "url": "https://app.pluralsight.com/library/courses/cypress-9-fundamentals/",
-      "author": "Adhithi Ravichandran",
-      "authorTwitter": "AdhithiRavi",
-      "sourceName": "Pluralsight",
-      "sourceUrl": "https://www.pluralsight.com"
+      "title": "Cypress 10 Fundamentals",
+      "url": "https://university.blazemeter.com/users/sign_in?next=%2Fenrollments%2F130677466%2Fdetails",
+      "author": "Gleb Bahmutov",
+      "authorTwitter": "bahmutov",
+      "sourceName": "Blazemeter University",
+      "sourceUrl": "https://www.blazemeter.com/university",
+      "free":true
     },
     {
       "title": "Cypress Network Testing Exercises",


### PR DESCRIPTION
Request to add a new course here: https://cypressio.slack.com/archives/C7R5R7KBP/p1663681960598429

I removed the version 9 course, however, we can keep it if we see value in it. I am not familiar with the course.