### PR TITLE
docs: Update Priorities Page to Point to Project Board

### DIFF
--- a/content/guides/references/roadmap.md
+++ b/content/guides/references/roadmap.md
@@ -2,18 +2,6 @@
 title: Roadmap
 ---
 
-## Upcoming features
+## The Cypress App Roadmap
 
-_Last updated May 25, 2022_
-
-Our team is always planning and working on really "big" upcoming features.
-Priorities can change as we move forward, but here is an outline of where
-Cypress is headed now.
-
-| Status             | Feature                    | Issue                                                      | PR                                                         | Released                                       |
-| ------------------ | -------------------------- | ---------------------------------------------------------- | ---------------------------------------------------------- | ---------------------------------------------- |
-| _Beta_             | **Component Testing**      | [#5922](https://github.com/cypress-io/cypress/issues/5922) | [#14479](https://github.com/cypress-io/cypress/pull/14479) | [v10.0.0](/guides/references/changelog#10-0-0) |
-| _Experimental_     | **Session API**            | [#8301](https://github.com/cypress-io/cypress/issues/8301) | [#8765](https://github.com/cypress-io/cypress/pull/8765)   | [v8.2.0](/guides/references/changelog#8-2-0)   |
-| _Experimental_     | **Visit Multiple Origins** | [#944](https://github.com/cypress-io/cypress/issues/944)   | [#21137](https://github.com/cypress-io/cypress/pull/21137) | [v9.6.0](/guides/references/changelog#9-6-0)   |
-| _Work in progress_ | **Iframe Support**         | [#136](https://github.com/cypress-io/cypress/issues/136)   |                                                            |                                                |
-| _Work in progress_ | **WebKit Support**         | [#6422](https://github.com/cypress-io/cypress/issues/6422) |                                                            |                                                |
+ At Cypress we love sharing what we are working on and are always striving to improve transparency and communication with our community.  If you are interested in learning more about what we have planned for the future of the Cypress app check out our Cypress app Roadmap Board [here](https://github.com/orgs/cypress-io/projects/13/views/1).

--- a/content/guides/references/roadmap.md
+++ b/content/guides/references/roadmap.md
@@ -2,6 +2,10 @@
 title: Roadmap
 ---
 
-## The Cypress App Roadmap
+## The Cypress App Priorities
 
- At Cypress we love sharing what we are working on and are always striving to improve transparency and communication with our community.  If you are interested in learning more about what we have planned for the future of the Cypress app check out our Cypress app Roadmap Board [here](https://github.com/orgs/cypress-io/projects/13/views/1).
+At Cypress we love sharing what we are working on and are always striving to
+improve transparency and communication with our community. If you are interested
+in learning more about what we have planned for the future of the Cypress app
+check out our Cypress app Priorities Board
+[here](https://github.com/orgs/cypress-io/projects/13/views/1).


### PR DESCRIPTION
For our transparency work we are opening up our github roadmap project board to the public.  I am updating our existing roadmap page to have links to this new resource.  I have removed the static resource from this page to keep the data better in sync.