### PR TITLE
Added extra comment to installing linux dependencies.

### DIFF
--- a/content/guides/guides/launching-browsers.md
+++ b/content/guides/guides/launching-browsers.md
@@ -192,7 +192,7 @@ GitHub repository.
 
 #### Linux Dependencies
 
-WebKit requires additional dependencies to run on Linux. To install the required
+WebKit requires additional dependencies to run on Linux (This will only work on Ubuntu/Debian based machines. For other linux distribution this command will not work). To install the required
 dependencies, run this:
 
 ```shell


### PR DESCRIPTION
We tried to use playwright a while back in our CI/CD and we also tried the same command.
The command to install deps will not work on other linux distros that are not debian based.

So I added a warning so that everyone that uses different linux distros dont run this command.

