### PR TITLE
Component Vue Typo

### DIFF
--- a/content/guides/component-testing/testing-vue.md
+++ b/content/guides/component-testing/testing-vue.md
@@ -58,14 +58,14 @@ it('stepper should default to 0', () => {
   // Arrange
   cy.mount(<Stepper />)
   // Assert
-  cy.get(counterSelector).should('have.text', 0)
+  cy.get(counterSelector).should('have.text', '0')
 })
 
 it('supports an "initial" prop to set the value', () => {
   // Arrange
   cy.mount(<Stepper initial={100} />)
   // Assert
-  cy.get(counterSelector).should('have.text', 100)
+  cy.get(counterSelector).should('have.text', '100')
 })
 ```
 


### PR DESCRIPTION
doesn't really matter but the JS version has quotes and the JSX version doesn't..