### PR TITLE
Fix documentation issue with invalid regex example.

### DIFF
--- a/content/api/commands/intercept.md
+++ b/content/api/commands/intercept.md
@@ -277,7 +277,7 @@ cy.intercept({
 
 // same as above, but using regex
 cy.intercept({
-  method: '/PUT|PATCH/',
+  method: /PUT|PATCH/,
   url: '**/users/*',
 })
 ```


### PR DESCRIPTION
The example I modified in this PR does not work unless the quotes are removed. Ie. it needs to be a JavaScript regex, not a string of a regex.

If I'm misunderstanding this, my apologies.