### PR TITLE
Add signup link to top of dashboard introduction page

### DIFF
--- a/content/guides/dashboard/introduction.md
+++ b/content/guides/dashboard/introduction.md
@@ -2,6 +2,17 @@
 title: Dashboard
 ---
 
+<Alert type="success">
+
+<strong class="alert-header"><Icon name="star"></Icon> Get Started</strong>
+
+Whenever you're ready you can
+[sign up here](https://dashboard.cypress.io/signup) for our
+[free plan](https://www.cypress.io/pricing) which gives you up to 3 users and
+500 monthly test results.
+
+</Alert>
+
 The [Cypress Dashboard](https://on.cypress.io/dashboard) is our
 enterprise-ready, web-based companion to the Cypress app. It gives you online
 access to your recorded test results, orchestrates test runs across multiple
@@ -29,13 +40,6 @@ Check out the <Icon name="github"></Icon>
 [Real World App Dashboard](https://dashboard.cypress.io/projects/7s5okt).
 
 </Alert>
-
-## Getting Started
-
-Whenever you're ready you can
-[sign up here](https://dashboard.cypress.io/signup) for our
-[free plan](https://www.cypress.io/pricing) which gives you up to 3 users and
-500 monthly test results.
 
 ## Benefits
 

--- a/content/guides/dashboard/introduction.md
+++ b/content/guides/dashboard/introduction.md
@@ -30,6 +30,13 @@ Check out the <Icon name="github"></Icon>
 
 </Alert>
 
+## Getting Started
+
+Whenever you're ready you can
+[sign up here](https://dashboard.cypress.io/signup) for our
+[free plan](https://www.cypress.io/pricing) which gives you up to 3 users and
+500 monthly test results.
+
 ## Benefits
 
 ### Analyze and diagnose

--- a/content/guides/dashboard/introduction.md
+++ b/content/guides/dashboard/introduction.md
@@ -6,10 +6,10 @@ title: Dashboard
 
 <strong class="alert-header"><Icon name="star"></Icon> Get Started</strong>
 
-Whenever you're ready you can
+To get started with the Cypress Dashboard,
 [sign up here](https://dashboard.cypress.io/signup) for our
-[free plan](https://www.cypress.io/pricing) which gives you up to 3 users and
-500 monthly test results.
+[free plan](https://www.cypress.io/pricing) which comes with 3 users and 500
+monthly test results.
 
 </Alert>
 


### PR DESCRIPTION
Closes #4760 

What do we think of this? Questions:

- Do we want it before or after listing the benefits?
- Should we add some custom design element to make it pop more? I thought about putting it in a green "Premium" callout block but it's right underneath another callout (for the RWA) and I think it would be too busy