### PR TITLE
chore: call out mocha-junit-reporter upgrade in the 10.10.0 changelog

### DIFF
--- a/content/_changelogs/10.10.0.md
+++ b/content/_changelogs/10.10.0.md
@@ -47,4 +47,4 @@ _Released 10/11/2022_
 - Upgraded Electron from v19 to v21. Addressed in
   [#23843](https://github.com/cypress-io/cypress/issues/23843).
 - Upgraded `mocha-junit-reporter` from v2.0.0 to v2.1.0. Fixes
-  [#18970](https://github.com/cypress-io/cypress/issues/18970)
+  [#18970](https://github.com/cypress-io/cypress/issues/18970).

--- a/content/_changelogs/10.10.0.md
+++ b/content/_changelogs/10.10.0.md
@@ -46,3 +46,5 @@ _Released 10/11/2022_
 
 - Upgraded Electron from v19 to v21. Addressed in
   [#23843](https://github.com/cypress-io/cypress/issues/23843).
+- Upgraded `mocha-junit-reporter` from v2.0.0 to v2.1.0. Fixes
+  [#18970](https://github.com/cypress-io/cypress/issues/18970)


### PR DESCRIPTION
I missed this in my PR for the v10.10.0 changelog