### PR TITLE
docs: removing Cookies.defaults/preserveOnce

### DIFF
--- a/content/_changelogs/11.0.0.md
+++ b/content/_changelogs/11.0.0.md
@@ -1,0 +1,10 @@
+## 11.0.0
+
+_Released MM/DD/YYYY_
+
+**Breaking Changes:**
+
+- `Cookies.defaults` and `Cookies.preserveOnce` have been removed. Please update
+  to use [`cy.session()`](/api/commands/session) to preserve session details
+  between tests. Addresses
+  [#21472](https://github.com/cypress-io/cypress/issues/21472).

--- a/content/api/commands/origin.md
+++ b/content/api/commands/origin.md
@@ -30,9 +30,6 @@ Enabling this flag does the following:
   - The page is cleared (by setting it to `about:blank`).
   - All active session data (cookies, `localStorage` and `sessionStorage`)
     across all domains are cleared.
-- It supersedes
-  the [`Cypress.Cookies.preserveOnce()`](/api/cypress-api/cookies#Preserve-Once) and
-  [`Cypress.Cookies.defaults()`](/api/cypress-api/cookies#Defaults) methods.
 - Cross-origin requests will now succeed, however, to interact with a
   cross-origin page you must use a `cy.origin` block.
 
@@ -617,7 +614,6 @@ following Cypress commands will throw errors if used in the callback:
 - [`cy.session()`](/api/commands/session)
 - [`cy.server()`](/api/commands/server)
 - [`cy.route()`](/api/commands/route)
-- [`Cypress.Cookies.preserveOnce()`](/api/cypress-api/cookies)
 
 ### Other limitations
 

--- a/content/api/commands/session.md
+++ b/content/api/commands/session.md
@@ -29,9 +29,6 @@ Enabling this flag does the following:
     [`testIsolation=legacy`](/guides/core-concepts/writing-and-organizing-tests#Test-Isolation).
   - All active session data (cookies, `localStorage` and `sessionStorage`)
     across all domains are cleared.
-- It overrides the
-  [`Cypress.Cookies.preserveOnce()`](/api/cypress-api/cookies#Preserve-Once) and
-  [`Cypress.Cookies.defaults()`](/api/cypress-api/cookies#Defaults) methods.
 - Cross-origin navigation will no longer fail immediately, but instead, time out
   based on [`pageLoadTimeout`](/guides/references/configuration#Timeouts).
 - Tests will no longer wait on page loads before moving on to the next test.

--- a/content/api/cypress-api/cookies.md
+++ b/content/api/cypress-api/cookies.md
@@ -2,36 +2,13 @@
 title: Cypress.Cookies
 ---
 
-<Alert type="warning">
-
-⚠️ **`Cypress.Cookies.preserveOnce()` and `Cypress.Cookies.defaults()` are
-deprecated in Cypress 9.7.0**. In a future release, support for
-`Cypress.Cookies.preserveOnce()` and `Cypress.Cookies.defaults()` will be
-removed. Consider using the experimental [`cy.session()`](/api/commands/session)
-command instead to cache and restore cookies and other sessions details between
-tests.
-
-</Alert>
-
-`Cookies.preserveOnce()` and `Cookies.defaults()` enable you to control Cypress'
-cookie behavior.
-
 `Cookies.debug()` enables you to generate logs to the console whenever any
 cookies are modified.
-
-Cypress automatically clears all cookies **before** each test to prevent state
-from building up.
-
-You can take advantage of `Cypress.Cookies.preserveOnce()` or even preserve
-cookies by their name to preserve values across multiple tests. This enables you
-to preserve sessions through several tests.
 
 ## Syntax
 
 ```javascript
 Cypress.Cookies.debug(enable, options)
-Cypress.Cookies.preserveOnce(names...)
-Cypress.Cookies.defaults(options)
 ```
 
 ### Arguments
@@ -40,14 +17,13 @@ Cypress.Cookies.defaults(options)
 
 Whether cookie debugging should be enabled.
 
-**<Icon name="angle-right"></Icon> names**
-
-Names of cookies to be preserved. Pass an unlimited number of arguments.
-
 **<Icon name="angle-right"></Icon> options** **_(Object)_**
 
-Set defaults for all cookies, such as preserving a set of cookies to bypass
-being cleared before each test.
+Pass in an options object to control the behavior of `Cookies.debug()`.
+
+| option  | description                                         | default |
+| ------- | --------------------------------------------------- | ------- |
+| verbose | Whether or not to display the entire cookie object. | true    |
 
 ## Examples
 
@@ -89,139 +65,11 @@ Debugging will be turned on until you explicitly turn it off.
 Cypress.Cookies.debug(false) // now debugging is turned off
 ```
 
-### Preserve Once
-
-#### Preserve cookies through multiple tests
-
-Cypress gives you an interface to automatically preserve cookies for multiple
-tests. Cypress automatically clears all cookies before each new test starts by
-default.
-
-By clearing cookies before each test you are guaranteed to always start from a
-clean state. Starting from a clean state prevents coupling your tests to one
-another and prevents situations where mutating something in your application in
-one test affects another one downstream.
-
-<Alert type="info">
-
-The most common use case for preserving cookies is to prevent having to log in
-to your application before each individual test. This is a problem if the
-majority of each test is spent logging in a user.
-
-</Alert>
-
-You can use `Cypress.Cookies.preserveOnce()` to preserve cookies through
-multiple tests.
-
-There are _likely_ better ways to do this, but this isn't well documented at the
-moment. Every application is different and there is no one-size-fits-all
-solution. For the moment, if you're using session-based cookies, this method
-will work.
-
-```javascript
-describe('Dashboard', () => {
-  before(() => {
-    // log in only once before any of the tests run.
-    // your app will likely set some sort of session cookie.
-    // you'll need to know the name of the cookie(s), which you can find
-    // in your Resources -> Cookies panel in the Chrome Dev Tools.
-    cy.login()
-  })
-
-  beforeEach(() => {
-    // before each test, we can automatically preserve the
-    // 'session_id' and 'remember_token' cookies. this means they
-    // will not be cleared before the NEXT test starts.
-    //
-    // the name of your cookies will likely be different
-    // this is an example
-    Cypress.Cookies.preserveOnce('session_id', 'remember_token')
-  })
-
-  it('displays stats', () => {
-    // ...
-  })
-
-  it('can do something', () => {
-    // ...
-  })
-
-  it('opens a modal', () => {
-    // ...
-  })
-})
-```
-
-### Defaults
-
-#### Set global default cookies
-
-You can modify the global defaults and preserve a set of Cookies which will
-always be preserved across tests.
-
-Any change you make here will take effect immediately for the remainder of every
-single test.
-
-<Alert type="info">
-
-::include{file=partials/support-file-configuration.md}
-
-</Alert>
-
-#### `preserve` accepts:
-
-- String
-- Array
-- RegExp
-- Function
-
-#### Preserve String
-
-```javascript
-// now any cookie with the name 'session_id' will
-// not be cleared before each test runs
-Cypress.Cookies.defaults({
-  preserve: 'session_id',
-})
-```
-
-#### Preserve Array
-
-```javascript
-// now any cookie with the name 'session_id' or 'remember_token'
-// will not be cleared before each test runs
-Cypress.Cookies.defaults({
-  preserve: ['session_id', 'remember_token'],
-})
-```
-
-#### Preserve RegExp
-
-```javascript
-// now any cookie that matches this RegExp
-// will not be cleared before each test runs
-Cypress.Cookies.defaults({
-  preserve: /session|remember/,
-})
-```
-
-#### Preserve Function
-
-```javascript
-Cypress.Cookies.defaults({
-  preserve: (cookie) => {
-    // implement your own logic here
-    // if the function returns truthy
-    // then the cookie will not be cleared
-    // before each test runs
-  },
-})
-```
-
 ## History
 
 | Version                                       | Changes                                                                                       |
 | --------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| [11.0.0](/guides/references/changelog#11-0-0) | Removed `preserveOnce` and `defaults`                                                         |
 | [9.7.0](/guides/references/changelog#9-7-0)   | Deprecated `preserveOnce` and `defaults`                                                      |
 | [5.0.0](/guides/references/changelog#5-0-0)   | Renamed `whitelist` option to `preserve`                                                      |
 | [0.16.1](/guides/references/changelog#0-16-1) | `{verbose: false}` option added                                                               |

--- a/content/api/cypress-api/session.md
+++ b/content/api/cypress-api/session.md
@@ -24,9 +24,6 @@ Enabling this flag does the following:
   - The page is cleared (by setting it to `about:blank`).
   - All active session data (cookies, `localStorage` and `sessionStorage`)
     across all domains are cleared.
-- It overrides the
-  [`Cypress.Cookies.preserveOnce()`](/api/cypress-api/cookies#Preserve-Once) and
-  [`Cypress.Cookies.defaults()`](/api/cypress-api/cookies#Defaults) methods.
 
 Because the page is cleared before each test,
 [`cy.visit()`](/api/commands/visit) must be explicitly called in each test to

--- a/content/faq/questions/using-cypress-faq.md
+++ b/content/faq/questions/using-cypress-faq.md
@@ -723,19 +723,8 @@ By default, Cypress automatically
 [clears all cookies **before** each test](/api/commands/clearcookies) to prevent
 state from building up.
 
-You can preserve specific cookies across tests using the
-[Cypress.Cookies api](/api/cypress-api/cookies):
-
-```javascript
-// now any cookie with the name 'session_id' will
-// not be cleared before each test runs
-Cypress.Cookies.defaults({
-  preserve: 'session_id',
-})
-```
-
-You **cannot** currently preserve localStorage across tests and can read more in
-[this issue](https://github.com/cypress-io/cypress/issues/461#issuecomment-325402086).
+You can preserve session details across tests using the
+[`cy.session()`](/api/commands/session) command.
 
 ## <Icon name="angle-right"></Icon> Some of my elements animate in; how do I work around that?
 


### PR DESCRIPTION
Removing documentation for `Cookies.defaults` and `Cookies.preserveOnce` which is being replaced with `cy.session()`.