### PR TITLE
update experimental warning for session to reflect async/attach chang…

### DIFF
--- a/content/api/commands/session.md
+++ b/content/api/commands/session.md
@@ -29,11 +29,11 @@ Enabling this flag does the following:
     [`testIsolation=legacy`](/guides/core-concepts/writing-and-organizing-tests#Test-Isolation).
   - All active session data (cookies, `localStorage` and `sessionStorage`)
     across all domains are cleared.
-- It overrides the
-  [`Cypress.Cookies.preserveOnce()`](/api/cypress-api/cookies#Preserve-Once) and
-  [`Cypress.Cookies.defaults()`](/api/cypress-api/cookies#Defaults) methods.
-- Cross-origin navigation will no longer fail immediately, but instead, time out
-  based on [`pageLoadTimeout`](/guides/references/configuration#Timeouts).
+- It supersedes
+  the [`Cypress.Cookies.preserveOnce()`](/api/cypress-api/cookies#Preserve-Once) and
+  [`Cypress.Cookies.defaults()`](/api/cypress-api/cookies#Defaults) methods.
+- Cross-origin requests will now succeed, however, to interact with a
+  cross-origin page you must use a `cy.origin` block.
 - Tests will no longer wait on page loads before moving on to the next test.
 
 Because the page is cleared at the beginning of each test,

--- a/content/api/commands/session.md
+++ b/content/api/commands/session.md
@@ -34,7 +34,6 @@ Enabling this flag does the following:
   [`Cypress.Cookies.defaults()`](/api/cypress-api/cookies#Defaults) methods.
 - Cross-origin requests will now succeed, however, to interact with a
   cross-origin page you must use a `cy.origin` block.
-- Tests will no longer wait on page loads before moving on to the next test.
 
 Because the page is cleared at the beginning of each test,
 [`cy.visit()`](/api/commands/visit) must be explicitly called at the beginning


### PR DESCRIPTION
…es in 10.9.0

Stubbled into the `cy.session` docs and realized the cross-origin page loading docs in the experimental warning were out of date with cypress `10.9.0` with async/attach spec bridges. The changes here update this to be in parity with `cy.origin`.