### PR TITLE
feat: add info about CAs to documentation

### DIFF
--- a/content/guides/references/advanced-installation.md
+++ b/content/guides/references/advanced-installation.md
@@ -199,9 +199,10 @@ Cypress, add the following to your `.npmrc`:
 cafile=/home/person/certs/ca.crt
 ```
 
-If neither `cafile` nor `ca` are set, Cypress looks at the system environment variable
-`NODE_EXTRA_CA_CERTS` and uses the corresponding certificate(s) as an extension 
-for the trusted certificate authority when downloading the Cypress binary. 
+If neither `cafile` nor `ca` are set, Cypress looks at the system environment
+variable `NODE_EXTRA_CA_CERTS` and uses the corresponding certificate(s) as an
+extension for the trusted certificate authority when downloading the Cypress
+binary.
 
 Note that the npm config is used as a replacement, and the node environment
 variable is used as an extension.

--- a/content/guides/references/advanced-installation.md
+++ b/content/guides/references/advanced-installation.md
@@ -182,13 +182,6 @@ Cypress will then attempt to download a binary with this format:
 
 ## Using a custom CA
 
-<Alert type="warning">
-
-Note that in versions prior to 11.0, the `CYPRESS_DOWNLOAD_USE_CA` environment
-variable needed to be set to honor the `ca` and `cafile` options
-
-</Alert>
-
 Cypress can be configured to use the `ca` and `cafile` options from your NPM
 config file to download the Cypress binary.
 

--- a/content/guides/references/advanced-installation.md
+++ b/content/guides/references/advanced-installation.md
@@ -180,7 +180,7 @@ CYPRESS_DOWNLOAD_MIRROR="https://www.example.com" cypress install
 Cypress will then attempt to download a binary with this format:
 `https://www.example.com/desktop/:version?platform=p`
 
-## Using a custom CA
+## Using a custom certificate authority (CA)
 
 Cypress can be configured to use the `ca` and `cafile` options from your NPM
 config file to download the Cypress binary.

--- a/content/guides/references/advanced-installation.md
+++ b/content/guides/references/advanced-installation.md
@@ -182,6 +182,13 @@ Cypress will then attempt to download a binary with this format:
 
 ## Using a custom CA
 
+<Alert type="warning">
+
+Note that in versions prior to 11.0, the `CYPRESS_DOWNLOAD_USE_CA` environment
+variable needed to be set to honor the `ca` and `cafile` options
+
+</Alert>
+
 Cypress can be configured to use the `ca` and `cafile` options from your NPM
 config file to download the Cypress binary.
 
@@ -191,18 +198,6 @@ Cypress, add the following to your `.npmrc`:
 ```shell
 cafile=/home/person/certs/ca.crt
 ```
-
-<Alert type="warning">
-
-Note that in versions prior to 11.0, the `CYPRESS_DOWNLOAD_USE_CA` environment
-variable needed to be set to honor the `ca` and `cafile` options
-
-```shell
-CYPRESS_DOWNLOAD_USE_CA=1
-cafile=/home/person/certs/ca.crt
-```
-
-</Alert>
 
 If neither `cafile` nor `ca` are set, Cypress looks at the system environment variable
 `NODE_EXTRA_CA_CERTS` and uses the corresponding certificate(s) as an extension 

--- a/content/guides/references/advanced-installation.md
+++ b/content/guides/references/advanced-installation.md
@@ -203,6 +203,9 @@ If neither `cafile` nor `ca` are set, Cypress looks at the system environment va
 `NODE_EXTRA_CA_CERTS` and uses the corresponding certificate(s) as an extension 
 for the trusted certificate authority when downloading the Cypress binary. 
 
+Note that the npm config is used as a replacement, and the node environment
+variable is used as an extension.
+
 ## Opt out of sending exception data to Cypress
 
 When an exception is thrown regarding Cypress, we send along the exception data

--- a/content/guides/references/advanced-installation.md
+++ b/content/guides/references/advanced-installation.md
@@ -189,9 +189,24 @@ For example, to use the CA at `/home/person/certs/ca.crt` when downloading
 Cypress, add the following to your `.npmrc`:
 
 ```shell
-CYPRESS_DOWNLOAD_USE_CA=1
-ca=/home/person/certs/ca.crt
+cafile=/home/person/certs/ca.crt
 ```
+
+<Alert type="warning">
+
+Note that in versions prior to 11.0, the `CYPRESS_DOWNLOAD_USE_CA` environment
+variable needed to be set to honor the `ca` and `cafile` options
+
+```shell
+CYPRESS_DOWNLOAD_USE_CA=1
+cafile=/home/person/certs/ca.crt
+```
+
+</Alert>
+
+If neither `cafile` nor `ca` are set, Cypress looks at the system environment variable
+`NODE_EXTRA_CA_CERTS` and uses the corresponding certificate(s) as an extension 
+for the trusted certificate authority when downloading the Cypress binary. 
 
 ## Opt out of sending exception data to Cypress
 

--- a/content/guides/references/proxy-configuration.md
+++ b/content/guides/references/proxy-configuration.md
@@ -117,7 +117,7 @@ If an uppercase and a lowercase version of the proxy settings are supplied (for
 example, `HTTP_PROXY` and `http_proxy` are both set), the lowercase variable
 will be preferred.
 
-## Using a custom CA
+## Using a custom certificate authority (CA)
 
 <Alert type="warning">
 

--- a/content/guides/references/proxy-configuration.md
+++ b/content/guides/references/proxy-configuration.md
@@ -133,7 +133,7 @@ this configuration, Cypress automatically reads from npm config's
 [`cafile`](https://docs.npmjs.com/cli/v8/using-npm/config#cafile) and 
 [`ca`](https://docs.npmjs.com/cli/v8/using-npm/config#ca) options and the
 [`NODE_EXTRA_CA_CERTS`](https://nodejs.org/api/cli.html#node_extra_ca_certsfile) 
-node environment variable to configure certificate authority signing certificates.
+node environment variable.
 
 To mimic the behavior of npm and node, Cypress looks at `cafile` first and then `ca`
 and uses the corresponding certificate(s) as a replacement for the trusted certificate

--- a/content/guides/references/proxy-configuration.md
+++ b/content/guides/references/proxy-configuration.md
@@ -121,31 +121,32 @@ will be preferred.
 
 <Alert type="warning">
 
-This section refers to npm config variables and node environment variables, _not_
-[Cypress environment variables](/guides/guides/environment-variables)
+This section refers to npm config variables and node environment variables,
+_not_ [Cypress environment variables](/guides/guides/environment-variables)
 
 </Alert>
 
-Cypress needs to be able to authenticate properly when communicating to
-the [Dashboard Service](/guides/dashboard/introduction). When connecting through a proxy,
-oftentimes a self signed certificate is used as a CA. In order to handle
-this configuration, Cypress automatically reads from npm config's 
-[`cafile`](https://docs.npmjs.com/cli/v8/using-npm/config#cafile) and 
+Cypress needs to be able to authenticate properly when communicating to the
+[Dashboard Service](/guides/dashboard/introduction). When connecting through a
+proxy, oftentimes a self signed certificate is used as a CA. In order to handle
+this configuration, Cypress automatically reads from npm config's
+[`cafile`](https://docs.npmjs.com/cli/v8/using-npm/config#cafile) and
 [`ca`](https://docs.npmjs.com/cli/v8/using-npm/config#ca) options and the
-[`NODE_EXTRA_CA_CERTS`](https://nodejs.org/api/cli.html#node_extra_ca_certsfile) 
+[`NODE_EXTRA_CA_CERTS`](https://nodejs.org/api/cli.html#node_extra_ca_certsfile)
 node environment variable.
 
-To mimic the behavior of npm and node, Cypress looks at `cafile` first and then `ca`
-and uses the corresponding certificate(s) as a replacement for the CA. 
-For example, to use the CA at `/home/person/certs/ca.crt`, add the following to your `.npmrc`:
+To mimic the behavior of npm and node, Cypress looks at `cafile` first and then
+`ca` and uses the corresponding certificate(s) as a replacement for the CA. For
+example, to use the CA at `/home/person/certs/ca.crt`, add the following to your
+`.npmrc`:
 
 ```shell
 cafile=/home/person/certs/ca.crt
 ```
 
-If neither `cafile` nor `ca` are set, Cypress looks at the system environment variable
-`NODE_EXTRA_CA_CERTS` and uses the corresponding certificate(s) as an extension 
-for the trusted CA. 
+If neither `cafile` nor `ca` are set, Cypress looks at the system environment
+variable `NODE_EXTRA_CA_CERTS` and uses the corresponding certificate(s) as an
+extension for the trusted CA.
 
 Note that the npm config is used as a replacement, and the node environment
 variable is used as an extension.

--- a/content/guides/references/proxy-configuration.md
+++ b/content/guides/references/proxy-configuration.md
@@ -117,7 +117,7 @@ If an uppercase and a lowercase version of the proxy settings are supplied (for
 example, `HTTP_PROXY` and `http_proxy` are both set), the lowercase variable
 will be preferred.
 
-## Certificate authority configuration
+## Using a custom CA
 
 <Alert type="warning">
 
@@ -128,7 +128,7 @@ This section refers to npm config variables and node environment variables, _not
 
 Cypress needs to be able to authenticate properly when communicating to
 the [Dashboard Service](/guides/dashboard/introduction). When connecting through a proxy,
-oftentimes a self signed certificate is used as a certificate authority. In order to handle
+oftentimes a self signed certificate is used as a CA. In order to handle
 this configuration, Cypress automatically reads from npm config's 
 [`cafile`](https://docs.npmjs.com/cli/v8/using-npm/config#cafile) and 
 [`ca`](https://docs.npmjs.com/cli/v8/using-npm/config#ca) options and the
@@ -136,8 +136,8 @@ this configuration, Cypress automatically reads from npm config's
 node environment variable.
 
 To mimic the behavior of npm and node, Cypress looks at `cafile` first and then `ca`
-and uses the corresponding certificate(s) as a replacement for the trusted certificate
-authority. For example, to use the CA at `/home/person/certs/ca.crt`, add the following to your `.npmrc`:
+and uses the corresponding certificate(s) as a replacement for the CA. 
+For example, to use the CA at `/home/person/certs/ca.crt`, add the following to your `.npmrc`:
 
 ```shell
 cafile=/home/person/certs/ca.crt
@@ -145,7 +145,7 @@ cafile=/home/person/certs/ca.crt
 
 If neither `cafile` nor `ca` are set, Cypress looks at the system environment variable
 `NODE_EXTRA_CA_CERTS` and uses the corresponding certificate(s) as an extension 
-for the trusted certificate authority. 
+for the trusted CA. 
 
 Note that the npm config is used as a replacement, and the node environment
 variable is used as an extension.

--- a/content/guides/references/proxy-configuration.md
+++ b/content/guides/references/proxy-configuration.md
@@ -126,7 +126,10 @@ This section refers to npm config variables and node environment variables, _not
 
 </Alert>
 
-Cypress automatically reads from npm config's 
+Cypress needs to be able to authenticate properly when communicating to
+the [Dashboard Service](/guides/dashboard/introduction). When connecting through a proxy,
+oftentimes a self signed certificate is used as a certificate authority. In order to handle
+this configuration, Cypress automatically reads from npm config's 
 [`cafile`](https://docs.npmjs.com/cli/v8/using-npm/config#cafile) and 
 [`ca`](https://docs.npmjs.com/cli/v8/using-npm/config#ca) options and the
 [`NODE_EXTRA_CA_CERTS`](https://nodejs.org/api/cli.html#node_extra_ca_certsfile) 

--- a/content/guides/references/proxy-configuration.md
+++ b/content/guides/references/proxy-configuration.md
@@ -117,6 +117,36 @@ If an uppercase and a lowercase version of the proxy settings are supplied (for
 example, `HTTP_PROXY` and `http_proxy` are both set), the lowercase variable
 will be preferred.
 
+## Certificate authority configuration
+
+<Alert type="warning">
+
+This section refers to npm config variables and node environment variables, _not_
+[Cypress environment variables](/guides/guides/environment-variables)
+
+</Alert>
+
+Cypress automatically reads from npm config's 
+[`cafile`](https://docs.npmjs.com/cli/v8/using-npm/config#cafile) and 
+[`ca`](https://docs.npmjs.com/cli/v8/using-npm/config#ca) options and the
+[`NODE_EXTRA_CA_CERTS`](https://nodejs.org/api/cli.html#node_extra_ca_certsfile) 
+node environment variable to configure certificate authority signing certificates.
+
+To mimic the behavior of npm and node, Cypress looks at `cafile` first and then `ca`
+and uses the corresponding certificate(s) as a replacement for the trusted certificate
+authority. For example, to use the CA at `/home/person/certs/ca.crt`, add the following to your `.npmrc`:
+
+```shell
+cafile=/home/person/certs/ca.crt
+```
+
+If neither `cafile` nor `ca` are set, Cypress looks at the system environment variable
+`NODE_EXTRA_CA_CERTS` and uses the corresponding certificate(s) as an extension 
+for the trusted certificate authority. 
+
+Note that the npm config is used as a replacement, and the node environment
+variable is used as an extension.
+
 ## View, unset, and set environment variables
 
 In order to properly configure your proxy configuration, it can be helpful to


### PR DESCRIPTION
Add info about certificate authorities for cypress binary downloads and calls to the dashboard service to documentation