### PR TITLE
docs: fix anchor for visual testing plugins link

### DIFF
--- a/content/guides/tooling/visual-testing.md
+++ b/content/guides/tooling/visual-testing.md
@@ -126,7 +126,7 @@ mouse hover:
 ## Tooling
 
 There are several published, open source plugins, listed in the
-[Visual Testing plugins](/plugins/directory#visual-testing) section, and several
+[Visual Testing plugins](/plugins/directory#Visual%20testing) section, and several
 commercial companies have developed visual testing solutions on top of Cypress
 listed below.
 


### PR DESCRIPTION
Fixes the anchor in the link from the ["Tooling" section of the Visual Testing page](https://docs.cypress.io/guides/tooling/visual-testing#Tooling) to the [relevant section on the Plugins page](https://docs.cypress.io/plugins/directory#visual-testing)

The link just below it in the "Open source" section has the right anchor, so looks like this was just missed when the anchor changed in the target page.