### PR TITLE
Fix vue2 import example

### DIFF
--- a/content/api/commands/mount.md
+++ b/content/api/commands/mount.md
@@ -51,7 +51,7 @@ Cypress.Commands.add('mount', (component, options) => {
 <template #vue2>
 
 ```js
-import { mount } from 'cypress/vue-2'
+import { mount } from 'cypress/vue2'
 
 Cypress.Commands.add('mount', (component, options = {}) => {
   // Setup options object

--- a/content/partials/import-mount-functions.md
+++ b/content/partials/import-mount-functions.md
@@ -45,7 +45,7 @@ aren't covered in this guide, be sure to check out the library
 import { mount } from 'cypress/vue'
 
 // For Vue 2
-import { mount } from 'cypress/vue-2'
+import { mount } from 'cypress/vue2'
 ```
 
 </template>


### PR DESCRIPTION
I noticed this while reviewing https://github.com/cypress-io/cypress-documentation/pull/4759. The import should be `cypress/vue2` rather than `cypress/vue-2`