### PR TITLE
Remove CT adapter readme links

### DIFF
--- a/content/api/commands/mount.md
+++ b/content/api/commands/mount.md
@@ -35,6 +35,10 @@ to start with for your commands:
 <template #react>
 
 ```js
+// React 18
+import { mount } from 'cypress/react18'
+
+// React 16, 17
 import { mount } from 'cypress/react'
 
 Cypress.Commands.add('mount', (component, options) => {

--- a/content/partials/import-mount-functions.md
+++ b/content/partials/import-mount-functions.md
@@ -9,16 +9,17 @@ framework-specific `mount()` functions, which can be imported like so:
 
 The `mount()` command exported from the
 [cypress/react](https://github.com/cypress-io/cypress/tree/develop/npm/react)
-module supports standard JSX syntax for mounting components. If you have any
-questions about mount options that aren't covered in this guide, be sure to
-check out the module
-[documentation](https://github.com/cypress-io/cypress/tree/develop/npm/react#readme).
+module supports standard JSX syntax for mounting components.
 
 </Alert>
 </template>
 <template #react>
 
 ```js
+// React 18
+import { mount } from 'cypress/react18'
+
+// React 16, 17
 import { mount } from 'cypress/react'
 ```
 
@@ -32,9 +33,7 @@ The `mount()` command exported from the
 [cypress/vue](https://github.com/cypress-io/cypress/tree/develop/npm/vue)
 library uses [Vue Test Utils](https://vue-test-utils.vuejs.org/) internally, but
 instead of mounting your components in a virtual browser in node, it mounts them
-in your actual browser. If you have any questions about mount options that
-aren't covered in this guide, be sure to check out the library
-[documentation](https://github.com/cypress-io/cypress/tree/develop/npm/vue#readme).
+in your actual browser.
 
 </Alert>
 </template>
@@ -58,10 +57,7 @@ The `mount()` command exported from the
 [cypress/angular](https://github.com/cypress-io/cypress/tree/develop/npm/angular)
 library uses [Angular TestBed](https://angular.io/api/core/testing/TestBed)
 internally, but instead of mounting your components in a virtual browser in
-node, it mounts them in your actual browser. If you have any questions about
-mount options that aren't covered in this guide, be sure to check out the
-library
-[documentation](https://github.com/cypress-io/cypress/tree/develop/npm/angular#readme).
+node, it mounts them in your actual browser.
 
 </Alert>
 </template>


### PR DESCRIPTION
[We're removing a lot of info from the adapter readme documents](https://github.com/cypress-io/cypress/pull/24590), so we shouldn't link to them from our docs page anymore.