### PR TITLE
feat: Add docs section about opting out of commercial messaging

### DIFF
--- a/content/guides/references/advanced-installation.md
+++ b/content/guides/references/advanced-installation.md
@@ -246,8 +246,8 @@ setx CYPRESS_CRASH_REPORTS 0
 
 ## Opt out of Cypress commercial messaging
 
-Cypress may occasionally display messages related to our commercial offerings
-and how they could benefit you during your workflows.
+Cypress may occasionally display messages in your CI logs related to our
+commercial offerings and how they could benefit you during your workflows.
 
 If you would like to opt out of all commercial messaging, you can do so by
 setting `CYPRESS_COMMERCIAL_RECOMMENDATIONS=0` in your system environment

--- a/content/guides/references/advanced-installation.md
+++ b/content/guides/references/advanced-installation.md
@@ -244,6 +244,15 @@ To save the `CYPRESS_CRASH_REPORTS` variable for use in all new shells, use
 setx CYPRESS_CRASH_REPORTS 0
 ```
 
+## Opt out of Cypress commercial messaging
+
+Cypress may occasionally display messages related to our commercial offerings
+and how they could benefit you during your workflows.
+
+If you would like to opt out of all commercial messaging, you can do so by
+setting `CYPRESS_COMMERCIAL_RECOMMENDATIONS=0` in your system environment
+variables.
+
 ## Install pre-release version
 
 If you would like to install a pre-release version of Cypress to test out


### PR DESCRIPTION
Related to https://github.com/cypress-io/cypress/pull/24680.

This PR adds a section to the Advanced Installation page about opting out of Cypress messaging around Cypress Cloud. If the user sets this property to `0` during a cypress run process, we won't show the new recommendation message that we are planning to show in CI after https://github.com/cypress-io/cypress/pull/24680.

One question that remains here is how this relates to ACI messages in app. The wording that I came up with here is broad enough to sound like it covers ACI banners and the like, but it doesn't. 