### PR TITLE
update CT mount docs

### DIFF
--- a/content/guides/component-testing/angular/api.md
+++ b/content/guides/component-testing/angular/api.md
@@ -154,7 +154,7 @@ providers, declarations, imports and even component @Inputs()
 
 ### MountResponse
 
-Type that the `mount` function returns
+Type that the `mount` function yields
 
 <table class="api-table">
   <caption>members</caption>

--- a/content/guides/component-testing/react/api.md
+++ b/content/guides/component-testing/react/api.md
@@ -123,7 +123,7 @@ it('mounts', () => {
 
 ### MountReturn
 
-Type that the `mount` function returns
+Type that the `mount` function yields
 
 <table class="api-table">
   <caption>members</caption>

--- a/content/guides/component-testing/react/api.md
+++ b/content/guides/component-testing/react/api.md
@@ -123,7 +123,10 @@ it('mounts', () => {
 
 ### MountReturn
 
+Type that the `mount` function returns
+
 <table class="api-table">
+  <caption>members</caption>
   <thead>
     <td>Name</td>
     <td>Type</td>

--- a/content/guides/component-testing/svelte/api.md
+++ b/content/guides/component-testing/svelte/api.md
@@ -104,7 +104,7 @@ it('should render', () => {
 
 ### MountReturn
 
-Type that the `mount` function returns
+Type that the `mount` function yields
 
 <table class="api-table">
   <caption>members</caption>

--- a/content/guides/component-testing/svelte/api.md
+++ b/content/guides/component-testing/svelte/api.md
@@ -104,6 +104,8 @@ it('should render', () => {
 
 ### MountReturn
 
+Type that the `mount` function returns
+
 <table class="api-table">
   <caption>members</caption>
     <thead>

--- a/content/guides/component-testing/vue/api.md
+++ b/content/guides/component-testing/vue/api.md
@@ -70,11 +70,11 @@ Type that the `mount` function returns
   <tr>
     <td>wrapper</td>
     <td>VueWrapper</td>
-    <td></td>
+    <td>The Vue Test Utils wrapper</td>
   </tr>
   <tr>
     <td>component</td>
-    <td>VueWrapper</td>
-    <td></td>
+    <td>VueComponent</td>
+    <td>The component instance</td>
   </tr>
 </table>

--- a/content/guides/component-testing/vue/api.md
+++ b/content/guides/component-testing/vue/api.md
@@ -70,7 +70,7 @@ Type that the `mount` function returns
   <tr>
     <td>wrapper</td>
     <td>VueWrapper</td>
-    <td>The Vue Test Utils wrapper</td>
+    <td>The Vue Test Utils `wrapper`</td>
   </tr>
   <tr>
     <td>component</td>

--- a/content/guides/component-testing/vue/api.md
+++ b/content/guides/component-testing/vue/api.md
@@ -58,7 +58,7 @@ import { mount } from 'cypress/vue2'
 
 ### MountReturn
 
-Type that the `mount` function returns
+Type that the `mount` function yields
 
 <table class="api-table">
   <caption>members</caption>

--- a/content/guides/component-testing/vue/api.md
+++ b/content/guides/component-testing/vue/api.md
@@ -58,7 +58,10 @@ import { mount } from 'cypress/vue2'
 
 ### MountReturn
 
+Type that the `mount` function returns
+
 <table class="api-table">
+  <caption>members</caption>
   <thead>
     <td>Name</td>
     <td>Type</td>

--- a/content/guides/component-testing/vue/examples.md
+++ b/content/guides/component-testing/vue/examples.md
@@ -208,8 +208,9 @@ In order to encourage interoperability between your existing component tests and
 Cypress, we support using Vue Test Utils' API.
 
 ```js
-cy.mount(Stepper).then((wrapper) => {
-  // this is the Vue Test Utils wrapper
+cy.mount(Stepper).then({ wrapper, component }) => {
+  // `wrapper` is the Vue Test Utils wrapper
+  // `component` is the component instance itself
 })
 ```
 
@@ -223,7 +224,7 @@ Cypress alias to get back at the `wrapper`.
 import { mount } from 'cypress/vue'
 
 Cypress.Commands.add('mount', (...args) => {
-  return mount(...args).then((wrapper) => {
+  return mount(...args).then(({ wrapper }) => {
     return cy.wrap(wrapper).as('vue')
   })
 })
@@ -260,7 +261,7 @@ in order to make sure the DOM has updated or any reactive events have fired.
 ```js
 cy.mount(Stepper, { props: { initial: 100 } })
 cy.get(incrementSelector).click()
-cy.get('@vue').should((wrapper) => {
+cy.get('@vue').should(({ wrapper }) => {
   expect(wrapper.emitted('change')).to.have.length
   expect(wrapper.emitted('change')[0][0]).to.equal('101')
 })


### PR DESCRIPTION
Small updates to fix some examples to match new mount API, standardized wording around `MountReturn`.