### PR TITLE
Fix wrong command on retry-ability guide

### DIFF
--- a/content/guides/core-concepts/retry-ability.md
+++ b/content/guides/core-concepts/retry-ability.md
@@ -59,7 +59,7 @@ Let's look at the last chain of commands:
 
 ```javascript
 cy.get('.todoapp') // query
-  .children('.todo-list li') // query
+  .find('.todo-list li') // query
   .should('have.length', 1) // assertion
 ```
 


### PR DESCRIPTION
The code example is:

```js
it('creates an item', () => {
  cy.visit('/')

  cy.focused() // query
    .should('have.class', 'new-todo') // assertion

  cy.get('.new-todo') // query
    .type('todo A{enter}') // action

  cy.get('.todoapp') // query
    .find('.todo-list li') // query
    .should('have.length', 1) // assertion
})

```

But when explaining part of it, it mentions `.children`, instead of `.find`, as you can see below.

```js
cy.get('.todoapp') // query
  .children('.todo-list li') // query
  .should('have.length', 1) // assertion

```

This PR basically fixes that.