### PR TITLE
Adjust inverted description on custom queries docs

### DIFF
--- a/content/api/cypress-api/custom-queries.md
+++ b/content/api/cypress-api/custom-queries.md
@@ -321,11 +321,9 @@ Cypress has several builtin 'ensures' which can be helpful in this regard:
   implemented for commmands.
 - `cy.ensureElement(subject, queryName)`: Ensure that the passed in `subject` is
   one or more DOM elements.
-- `cy.ensureWindow(subject)`: Ensure that the passed in `subject` is a
-  `document`.
+- `cy.ensureWindow(subject)`: Ensure that the passed in `subject` is a `window`.
 - `cy.ensureDocument(subject)`: Ensure that the passed in `subject` is a
-  `window`.
-
+  `document`.
 - `cy.ensureAttached(subject, queryName)`: Ensure that DOM element(s) are
   attached to the page.
 - `cy.ensureNotDisabled(subject)`: Ensure that form elements aren't disabled.


### PR DESCRIPTION
By reading the [**Validation**](https://docs.cypress.io/api/cypress-api/custom-queries#Validation) section of the Custom Queries Docs, when it mentions the commands `cy.ensureDocument(subject)` and `cy.ensureWindow(subject)`, the descriptions seem to be inverted.

This PR fixes that.

Cc. @jaffrepaul