### PR TITLE
Update web-security.md

### DIFF
--- a/content/guides/guides/web-security.md
+++ b/content/guides/guides/web-security.md
@@ -465,7 +465,7 @@ flag also does the following:
 
 - Adjusts the User Agent in Electron to appear more chrome-like. This option can
   be overridden with the
-  [userAgent](http://localhost:3000/guides/references/configuration#Browser)
+  [userAgent](/guides/references/configuration#Browser)
   config option.
 - Removes
   [Subresource Integrity (SRI)](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity)

--- a/content/guides/guides/web-security.md
+++ b/content/guides/guides/web-security.md
@@ -464,8 +464,7 @@ either loaded or navigated to inside your application. In addition to this, this
 flag also does the following:
 
 - Adjusts the User Agent in Electron to appear more chrome-like. This option can
-  be overridden with the
-  [userAgent](/guides/references/configuration#Browser)
+  be overridden with the [userAgent](/guides/references/configuration#Browser)
   config option.
 - Removes
   [Subresource Integrity (SRI)](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity)


### PR DESCRIPTION
Fixed the link to [/guides/references/configuration#Browser](https://docs.cypress.io/guides/references/configuration#Browser) in the documentation. It was still set to "full" URI used for development.

Hope this helped :)