### PR TITLE
fix: link format

### DIFF
--- a/content/_changelogs/12.0.0.md
+++ b/content/_changelogs/12.0.0.md
@@ -58,7 +58,7 @@ Read more about 12.0 in
   [#21472](https://github.com/cypress-io/cypress/issues/21472).
 - The `cy.server()` and `cy.route()` commands have been removed. Additionally,
   the corresponding `Cypress.Server.defaults` API has also been removed. Use the
-  [`cy.intercept()`(/api/commands/intercept) command to stub network responses
+  [`cy.intercept()`](/api/commands/intercept) command to stub network responses
   and requests. Addresses
   [#22126](https://github.com/cypress-io/cypress/issues/22126).
 - The Cookie commands now uses the `hostname` as the domain by default instead


### PR DESCRIPTION
**Fixes:** [issue-4936](https://github.com/cypress-io/cypress-documentation/issues/4936)

**Before changes:**

<img width="842" alt="Screenshot 2022-12-17 at 7 16 40 PM" src="https://user-images.githubusercontent.com/32891808/208301810-75e41c8c-ba84-48f0-9be2-87d03f3675ee.png">

**After changes:**

https://user-images.githubusercontent.com/32891808/208301795-02c1e0ef-5690-4280-97be-93e7431bfac4.mov
