### PR TITLE
docs: explain user provided ci provider env vars

### DIFF
--- a/content/guides/continuous-integration/introduction.md
+++ b/content/guides/continuous-integration/introduction.md
@@ -444,7 +444,7 @@ DEBUG=commit-info,cypress:server:record
 
 #### CI Build Information
 
-In some newer CI providers, cypress can't map the environment variables required
+In some newer CI providers, Cypress can't map the environment variables required
 to link back to builds or pull requests. In this case we provided users some
 environment variables to help pass that information along.
 
@@ -452,7 +452,7 @@ environment variables to help pass that information along.
 - Pull Request URL: `CYPRESS_PULL_REQUEST_URL`
 - Build URL: `CYPRESS_CI_BUILD_URL`
 
-Setting these will allow links within the dashboard to take you to the
+Setting these will allow links within the Cloud run to take you to the
 appropriate place.
 
 #### Custom Environment Variables

--- a/content/guides/continuous-integration/introduction.md
+++ b/content/guides/continuous-integration/introduction.md
@@ -442,6 +442,19 @@ the commit information is unavailable.
 DEBUG=commit-info,cypress:server:record
 ```
 
+#### CI Build Information
+
+In some newer CI providers, cypress can't map the environment variables required
+to link back to builds or pull requests. In this case we provided users some
+environment variables to help pass that information along.
+
+- Pull Request Id: `CYPRESS_PULL_REQUEST_ID`
+- Pull Request URL: `CYPRESS_PULL_REQUEST_URL`
+- Build URL: `CYPRESS_CI_BUILD_URL`
+
+Setting these will allow links within the dashboard to take you to the
+appropriate place.
+
 #### Custom Environment Variables
 
 You can also set custom environment variables for use in your tests. These


### PR DESCRIPTION
Relates to: https://github.com/cypress-io/cypress/pull/25036

Add section explaining the new environment variables you can set to provide the cloud with context around pull request and builds.