### PR TITLE
Docs: remove duplicate <<Sign up with Google>> and replace with GitHub

### DIFF
--- a/content/guides/cloud/users.md
+++ b/content/guides/cloud/users.md
@@ -41,7 +41,7 @@ Cypress Cloud. From there, you will have the choice of authenitication type:
 #### **Sign Up with Social Authentication**
 
 1. Click **"Don't have an account? Sign Up"**
-2. Click **"Sign up with Google"** or **"Sign up with Google"**
+2. Click **"Sign up with Google"** or **"Sign up with GitHub"**
 3. You may need to verify via your Social provider depending on your personal
    settings
 


### PR DESCRIPTION
Fixed location in docs where verbiage was duplicated: "Click "Sign up with Google" or "Sign up with Google"