### PR TITLE
Corrects return type of custom commands

### DIFF
--- a/content/guides/tooling/typescript-support.md
+++ b/content/guides/tooling/typescript-support.md
@@ -87,14 +87,10 @@ Cypress.Commands.add('dataCy', (value) => {
 ```
 
 Then you can add the `dataCy` command to the global Cypress Chainable interface
-(so called because commands are chained together) to your
-`cypress/support/index.ts` file.
+(so called because commands are chained together).
 
 ```typescript
-// in cypress/support/index.ts
-// load type definitions that come with Cypress module
-/// <reference types="cypress" />
-
+// cypress/support/index.ts
 declare global {
   namespace Cypress {
     interface Chainable {
@@ -102,7 +98,7 @@ declare global {
        * Custom command to select DOM element by data-cy attribute.
        * @example cy.dataCy('greeting')
        */
-      dataCy(value: string): Chainable<Element>
+      dataCy(value: string): Chainable<JQuery<HTMLElement>>
     }
   }
 }
@@ -160,10 +156,7 @@ When you add a custom command with `prevSubject`, Cypress will infer the subject
 type automatically based on the specified `prevSubject`.
 
 ```typescript
-// in cypress/support/index.ts
-// load type definitions that come with Cypress module
-/// <reference types="cypress" />
-
+// cypress/support/index.ts
 declare global {
   namespace Cypress {
     interface Chainable {
@@ -175,7 +168,7 @@ declare global {
       typeRandomWords(
         count?: number,
         options?: Partial<TypeOptions>
-      ): Chainable<Element>
+      ): Chainable<JQuery<HTMLElement>>
     }
   }
 }
@@ -263,8 +256,6 @@ following:
 
 ```javascript
 // cypress/plugins/index.ts
-
-/// <reference types="cypress" />
 
 /**
  * @type {Cypress.PluginConfig}


### PR DESCRIPTION
Changes: 
- Return type of custom commands:  `Chainable<Element>` => `Chainable<JQuery<HTMLElement>>`
- Removes `/// <reference types="cypress" />` as we already get these types from `tsconfig.json#compilerOptions.types`

closes cypress-io/cypress#24416