### PR TITLE
fix: correct config argument and code block

### DIFF
--- a/docs/api/cypress-api/config.mdx
+++ b/docs/api/cypress-api/config.mdx
@@ -48,7 +48,7 @@ Cypress.config(object)
 
 The name of the configuration to get or set.
 
-**<Icon name="angle-right" /> value** **_(String)_**
+**<Icon name="angle-right" /> value** **_(Any)_**
 
 The value of the configuration to set.
 
@@ -187,7 +187,7 @@ your configuration mid-test, be sure to chain the
 it('using cy.then', () => {
   cy.visit('/my-test_page')
   cy.click('#download-html').then(() => {
-    Cypress.config('baseUrl', 'null')
+    Cypress.config('baseUrl', null)
   })
   cy.visit('/downloads/contents.html')
 })


### PR DESCRIPTION
The [`value` argument](https://docs.cypress.io/api/cypress-api/config#Arguments) for `Cypress.config(name, value)` is described to be a `String`, which is incorrect since it can also be `number`, `null`, `undefined`

Also, the [code block example](https://docs.cypress.io/api/cypress-api/config#Cypress-config-executes-Synchronously) set the value as `'null'` instead of `null`
