### PR TITLE
[DOCS] Add missing comma in session example

### DIFF
--- a/content/api/commands/session.md
+++ b/content/api/commands/session.md
@@ -339,7 +339,7 @@ const login = (name = 'user1') => {
     validate() {
         cy.visit('/user_profile')
         cy.contains(`Hello ${name}`)
-    }
+    },
     cacheAcrossSpecs: true,
   })
 }

--- a/content/api/commands/session.md
+++ b/content/api/commands/session.md
@@ -346,12 +346,12 @@ const login = (name = 'user1') => {
 
 // profile.cy.js
 it('can view profile', () => {
-  cy.login()
+  login()
 })
 
 // add_blog.cy.js
 it('can create a blog post', () => {
-  cy.login()
+  login()
 })
 
 ```


### PR DESCRIPTION
When I copied this code to my editor, the linter expected a comma here.