### PR TITLE
Examples section visual adjustments 

### DIFF
--- a/src/components/blogs-list/index.tsx
+++ b/src/components/blogs-list/index.tsx
@@ -9,7 +9,7 @@ export default function blogsList(): BlogsProps {
       <div>
         <article>
           {blogsJSON.small &&
-          <div>
+          <div className="mediaListContainer">
             <ul>
               {blogsJSON.small.map((blog, index) => (
                 <li key={index}>

--- a/src/components/webinars-list/index.tsx
+++ b/src/components/webinars-list/index.tsx
@@ -9,7 +9,7 @@ export default function WebinarsList(): WebinarProps {
       <div>
         <article>
           {webinarsJSON.small &&
-          <div>
+          <div className="mediaListContainer">
             <ul>
               {webinarsJSON.small.map((webinar, index) => (
                 <li key={index}>

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -217,8 +217,12 @@ div[class^='announcementBar'] .close {
   gap: 30px 40px;
 }
 
+.mediaListContainer {
+  margin-bottom: 50px;
+}
+
 .mediaColumn {
-  max-width: 300px;
+  max-width: 350px;
 }
 
 .mediaTitleContainer {
@@ -228,6 +232,8 @@ div[class^='announcementBar'] .close {
 .mediaImage {
   width: 100%;
   height: auto;
+  border: 1px solid #ddd;
+  box-shadow: 0 1px 2px #ddd;
 }
 
 /* remove extra vertical space from tabs when it contains a code block */

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -227,6 +227,10 @@ div[class^='announcementBar'] .close {
 
 .mediaTitleContainer {
   height: 80px;
+
+  h3 {
+    font-size: 1.25rem;
+  }
 }
 
 .mediaImage {


### PR DESCRIPTION
Add space to list bottom, adjust grid width & add image border. 

We discussed that the whole _examples/media_ section needs to be revamped so we weren't investing a lot of time until there's a new content plan and accompanying layout. Until then, this makes it a little easier on the eyes and matches what's currently in production.