### PR TITLE
Add history to cy.session and add new migration example to v12

### DIFF
--- a/content/api/commands/session.md
+++ b/content/api/commands/session.md
@@ -821,6 +821,15 @@ data, including cookies, `localStorage` and `sessionStorage`.
 
 <DocsImage src="/img/api/session/print-session-to-console.png" alt="Session console output"></DocsImage>
 
+## History
+
+| Version                                       | Changes                                                                                           |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| [12.0.0](/guides/references/changelog#12-0-0) | Removed `experimentalSessionAndOrigin` which allowed the use of the command available by default. |
+| [11.0.0](/guides/references/changelog#11-0-0) | The `setup` option is now required.                                                               |
+| [10.9.0](/guides/references/changelog#10-9-0) | Added `cacheAcrossSpecs` property.                                                                |
+| [8.2.0](/guides/references/changelog#8-2-0)   | `cy.session()` command added.                                                                     |
+
 ## See also
 
 - [Authenticate faster in tests with the cy.session command](https://cypress.io/blog/2021/08/04/authenticate-faster-in-tests-cy-session-command/)

--- a/content/guides/references/migration-guide.md
+++ b/content/guides/references/migration-guide.md
@@ -173,6 +173,39 @@ debugging errors since the errors are representative of the previous test.
 The best way to ensure your tests are independent is to add a `.only()` to your
 test and verify it can run successfully without the test before it.
 
+#### Simulating Pre-Test Isolation Behavior
+
+Test isolation did most truly exist pre-12. Pre-Cypress 12, the behavior was a
+hybrid of both `testIsolation` enabled and disabled. All local storage and
+cookies on the current domain were cleared, however, we did not clear session
+storage and the page always persisted.
+
+Now when `testIsolation` is enabled, local storage, session storage and cookies
+in **all** domains are cleared and the page is cleared. When `testIsolation`` is
+disabled, nothing is cleared before the next test so all local storage, session
+storage and cookies & the page persists.
+
+If you wanted to match pre-Cypress 12 behavior, you need to disable
+`testIsolation`, then run `cy.clearLocalStorage()` and `cy.clearCookies()` in a
+beforeEach hook to clear the local storage and cookies in the current domain.
+
+```js
+describe('match pre-12 behavior', { testIsolation: false }, () => {
+  beforeEach(() => {
+    cy.clearLocalStorage()
+    cy.clearCookies()
+    // other beforeEach logic to restore the expected local storage or cookies needed on the client.
+  })
+})
+```
+
+Many of the issues test isolation solved were around cookie management with
+people trying to save and persist cookies because the page was still available,
+but the cookies on the domain were unexpectedly cleared which broke interactions
+with their application. It wasn’t obvious Cypress was doing a partial browser
+clean up, which is why explicitly setting test isolation to enabled or disabled
+allows you to choose what is right for your tests.
+
 ### Behavior Changes in Alias Resolution
 
 Cypress always re-queries aliases when they are referenced. This can result in
@@ -211,15 +244,36 @@ cy.findByTestId('popover').findAllByRole('button').first().as('button')
 
 #### `Cypress.Cookies.defaults` and `Cypress.Cookies.preserveOnce`
 
-The `Cypress.Cookies.defaults` and `CypressCookies.preserveOnce` APIs been
+The `Cypress.Cookies.defaults` and `Cypress.Cookies.preserveOnce` APIs been
 removed. Use the [`cy.session()`](/api/commands/session) command to preserve
 cookies (and local and session storage) between tests.
+
+If you were using `Cypress.Cookies.preserveOnce` to preserve a specific cookie
+within a single spec, this might look like the following:
 
 ```diff
 describe('Dashboard', () => {
   beforeEach(() => {
 -    cy.login()
 -    Cypress.Cookies.preserveOnce('session_id', 'remember_token')
++    cy.session('unique_identifier', cy.login, {
++       validate () {
++        cy.getCookies().should('have.length', 2)
++       },
++    })
+  })
+```
+
+If you were using `Cypress.Cookies.defaults` to preserve a cookie or set of
+cookies across test, this might look like the following:
+
+```diff
+describe('Dashboard', () => {
+  beforeEach(() => {
+-    cy.login()
+-    Cypress.Cookies.defaults({
+-       preserve: ['session_id', 'remember_token']
+-    })
 +    cy.session('unique_identifier', cy.login, {
 +       validate () {
 +        cy.getCookies().should('have.length', 2)


### PR DESCRIPTION
Add history to `cy.session()` and add new migration example to v12

Closes #4820 