### PR TITLE
Replaced incorrect sample app link

### DIFF
--- a/docs/guides/component-testing/vue/overview.mdx
+++ b/docs/guides/component-testing/vue/overview.mdx
@@ -151,7 +151,7 @@ Cypress Component Testing works with Vue apps that use Vite 2+ as the bundler.
 
 #### Vue Vite Sample Apps
 
-- [Vue 3 Vite with TypeScript](https://github.com/cypress-io/cypress-component-testing-apps/tree/main/vue2-nuxt2-js)
+- [Vue 3 Vite with TypeScript](https://github.com/cypress-io/cypress-component-testing-apps/tree/main/vue3-vite-ts)
 
 ### Vue with Webpack
 


### PR DESCRIPTION
It was linking to the Vue 2 Nuxt sample app. Assumed that was a typo and should be linked to the Vue 3 (generic, not Nuxt) + Vite sample app, given the context.