### PR TITLE
fix: update broken blog post references in code coverage page

### DIFF
--- a/docs/guides/tooling/code-coverage.mdx
+++ b/docs/guides/tooling/code-coverage.mdx
@@ -130,9 +130,9 @@ reviews.
 
 If you are unfamiliar with code coverage or want to learn more, take a look at
 the "Understanding JavaScript Code Coverage" blog post
-[Part 1](https://www.semantics3.com/blog/understanding-code-coverage-1074e8fccce0/)
+[Part 1](https://medium.com/engineering-semantics3/understanding-code-coverage-1074e8fccce0)
 and
-[Part 2](https://www.semantics3.com/blog/understanding-javascript-code-coverage-part-2-9aedaa5119e5/).
+[Part 2](https://medium.com/engineering-semantics3/understanding-javascript-code-coverage-part-2-9aedaa5119e5).
 
 :::
 


### PR DESCRIPTION
handles https://github.com/cypress-io/cypress/discussions/22724