### PR TITLE
Update github-actions.mdx to match the example repo

### DIFF
--- a/docs/guides/continuous-integration/github-actions.mdx
+++ b/docs/guides/continuous-integration/github-actions.mdx
@@ -110,7 +110,7 @@ jobs:
 To try out the example above yourself, fork the
 [Cypress Kitchen Sink](https://github.com/cypress-io/cypress-example-kitchensink)
 example project and place the above GitHub Action configuration in
-`.github/workflows/main.yml`.
+[`.github/workflows/checks.yml`](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.github/workflows/checks.yml).
 
 :::
 


### PR DESCRIPTION
The example repo updated to `chrome.yml` instead of `main.yml`.
Also, having a link directly to the file itself might help.