### PR TITLE
Remove statement about multiple browser synchronization

### DIFF
--- a/docs/guides/references/trade-offs.mdx
+++ b/docs/guides/references/trade-offs.mdx
@@ -129,10 +129,6 @@ thing that causes the behavior you care about testing.
 Just like with multiple tabs - Cypress does not support controlling more than 1
 open browser at a time.
 
-However it **is possible** to synchronize Cypress with another back end
-process - whether it is Selenium or Puppeteer to drive a 2nd open browser. We
-have actually seen this work together quite nicely!
-
 With that said, except in the most unusual and rare circumstances, you can still
 test most application behavior without opening multiple browsers at the same
 time.


### PR DESCRIPTION
Removing this statement as it is confusing taken alone and without proof of concepts to back up how to achieve this it's not helpful. 

For context, this was written in the early days of Cypress in the tone of 'this is something we experimented with and we saw it is possible' because we experimented with many things in the early days of Cypress. So there were some statements in the docs that were more experimental in nature and not actually recommended practice. With the maturity that Cypress is at, I think it's best to not make a statement in this way without a clear recommendation on how to utilize it to show our users. 