### PR TITLE
chore: remove misleading Microsoft Edge changelog entry

### DIFF
--- a/docs/guides/references/changelog.mdx
+++ b/docs/guides/references/changelog.mdx
@@ -12,9 +12,6 @@ _Released 01/27/2023_
   exiting properly when running multiple Component Testing specs in `electron`
   in `run` mode. Fixes
   [#25568](https://github.com/cypress-io/cypress/issues/25568).
-- Fixed an issue where alternative Microsoft Edge Beta and Canary binary names
-  were not being discovered by Cypress. Fixes
-  [#25455](https://github.com/cypress-io/cypress/issues/25455).
 
 **Dependency Updates:**
 


### PR DESCRIPTION
The Microsoft Edge Binary detection addressing https://github.com/cypress-io/cypress/issues/25455 has only been partially solved, so we'll add this entry back in once the second PR has landed.