### PR TITLE
Update link checker

### DIFF
--- a/docs/guides/overview/why-cypress.mdx
+++ b/docs/guides/overview/why-cypress.mdx
@@ -45,7 +45,7 @@ using modern JavaScript frameworks.
 
 Cypress enables you to write all types of tests:
 
-- [End-to-end tests](/guides/end-to-end-testing/writing-your-first-end-to-end-test)
+- [End-to-end tests](/guides/end-to-end-testing/writing-your-first-end-to-end-testzz)
 - [Component tests](/guides/component-testing/overview)
 - Integration tests
 - Unit tests

--- a/docs/guides/overview/why-cypress.mdx
+++ b/docs/guides/overview/why-cypress.mdx
@@ -45,7 +45,7 @@ using modern JavaScript frameworks.
 
 Cypress enables you to write all types of tests:
 
-- [End-to-end tests](/guides/end-to-end-testing/writing-your-first-end-to-end-testzz)
+- [End-to-end tests](/guides/end-to-end-testing/writing-your-first-end-to-end-test)
 - [Component tests](/guides/component-testing/overview)
 - Integration tests
 - Unit tests

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -19,8 +19,8 @@ const config = {
     'Fast, easy and reliable testing for anything that runs in a browser.',
   url: 'https://docs.cypress.io',
   baseUrl: '/',
-  onBrokenLinks: 'warn', // TODO: update this to throw when we go live to production
-  onBrokenMarkdownLinks: 'warn',
+  onBrokenLinks: 'throw', // TODO: update this to throw when we go live to production
+  onBrokenMarkdownLinks: 'throw',
   favicon: undefined,
 
   // Even if you don't use internalization, you can use this field to set useful


### PR DESCRIPTION
Broken links will now error out & fail the deploy during the build instead of just warning.