### PR TITLE
Fix icon render issue

### DIFF
--- a/docs/guides/references/best-practices.mdx
+++ b/docs/guides/references/best-practices.mdx
@@ -37,14 +37,16 @@ and start testing.
 
 :::danger
 
-&#8239;<Icon name="exclamation-triangle" color="red" /> **Anti-Pattern:** Sharing page objects, using your UI to log in, and not taking shortcuts.
+&#8239;<Icon name="exclamation-triangle" color="red" /> **Anti-Pattern:**
+Sharing page objects, using your UI to log in, and not taking shortcuts.
 
 :::
 
 :::tip
 
-&#8239;<Icon name="check-circle" color="green" /> **Best Practice:** Test specs in isolation, programmatically log into your
-application, and take control of your application's state.
+&#8239;<Icon name="check-circle" color="green" /> **Best Practice:** Test specs
+in isolation, programmatically log into your application, and take control of
+your application's state.
 
 :::
 
@@ -70,14 +72,16 @@ in our examples.
 
 :::danger
 
-&#8239;<Icon name="exclamation-triangle" color="red" /> **Anti-Pattern:** Using highly brittle selectors that are subject to change.
+&#8239;<Icon name="exclamation-triangle" color="red" /> **Anti-Pattern:** Using
+highly brittle selectors that are subject to change.
 
 :::
 
 :::tip
 
-&#8239;<Icon name="check-circle" color="green" /> **Best Practice:** Use `data-*` attributes to provide context to your
-selectors and isolate them from CSS or JS changes.
+&#8239;<Icon name="check-circle" color="green" /> **Best Practice:** Use
+`data-*` attributes to provide context to your selectors and isolate them from
+CSS or JS changes.
 
 :::
 
@@ -231,15 +235,16 @@ recommend you approach testing your components, look to:
 
 :::danger
 
-&#8239;<Icon name="exclamation-triangle" color="red" /> **Anti-Pattern:** Trying to assign the return value of Commands with `const`, `let`, or `var`.
+&#8239;<Icon name="exclamation-triangle" color="red" /> **Anti-Pattern:** Trying
+to assign the return value of Commands with `const`, `let`, or `var`.
 
 :::
 
 :::tip
 
-&#8239;<Icon name="check-circle" color="green" /> **Best Practice:** Use [aliases and
-closures to access and store](/guides/core-concepts/variables-and-aliases) what Commands
-yield you.
+&#8239;<Icon name="check-circle" color="green" /> **Best Practice:** Use
+[aliases and closures to access and store](/guides/core-concepts/variables-and-aliases)
+what Commands yield you.
 
 :::
 
@@ -289,17 +294,18 @@ For working with either of these patterns, please read our
 
 :::danger
 
-&#8239;<Icon name="exclamation-triangle" color="red" /> **Anti-Pattern:** Trying to visit or interact with sites or servers you do
-not control.
+&#8239;<Icon name="exclamation-triangle" color="red" /> **Anti-Pattern:** Trying
+to visit or interact with sites or servers you do not control.
 
 :::
 
 :::tip
 
-&#8239;<Icon name="check-circle" color="green" /> **Best Practice:** Only test what
-you control. Try to avoid requiring a 3rd party server. When necessary, use [`cy.request()`](/api/commands/request)
-to talk to 3rd party servers via their APIs. If possible, cache results via [`cy.session()`](/api/commands/session)
-to avoid repeat visits.
+&#8239;<Icon name="check-circle" color="green" /> **Best Practice:** Only test
+what you control. Try to avoid requiring a 3rd party server. When necessary, use
+[`cy.request()`](/api/commands/request) to talk to 3rd party servers via their
+APIs. If possible, cache results via [`cy.session()`](/api/commands/session) to
+avoid repeat visits.
 
 :::
 
@@ -445,14 +451,16 @@ email's functionality and visual style:
 
 :::danger
 
-&#8239;<Icon name="exclamation-triangle" color="red" /> **Anti-Pattern:** Coupling multiple tests together.
+&#8239;<Icon name="exclamation-triangle" color="red" /> **Anti-Pattern:**
+Coupling multiple tests together.
 
 :::
 
 :::tip
 
-&#8239;<Icon name="check-circle" color="green" /> **Best Practice:** Tests should always be able to be run independently from
-one another **and still pass**.
+&#8239;<Icon name="check-circle" color="green" /> **Best Practice:** Tests
+should always be able to be run independently from one another **and still
+pass**.
 
 :::
 
@@ -574,13 +582,15 @@ can be run independently and pass.
 
 :::danger
 
-&#8239;<Icon name="exclamation-triangle" color="red" /> **Anti-Pattern:** Acting like you're writing unit tests.
+&#8239;<Icon name="exclamation-triangle" color="red" /> **Anti-Pattern:** Acting
+like you're writing unit tests.
 
 :::
 
 :::tip
 
-&#8239;<Icon name="check-circle" color="green" /> **Best Practice:** Add multiple assertions and don't worry about it
+&#8239;<Icon name="check-circle" color="green" /> **Best Practice:** Add
+multiple assertions and don't worry about it
 
 :::
 
@@ -658,13 +668,15 @@ describe('my form', () => {
 
 :::danger
 
-&#8239;<Icon name="exclamation-triangle" color="red" /> **Anti-Pattern:** Using `after` or `afterEach` hooks to clean up state.
+&#8239;<Icon name="exclamation-triangle" color="red" /> **Anti-Pattern:** Using
+`after` or `afterEach` hooks to clean up state.
 
 :::
 
 :::tip
 
-&#8239;<Icon name="check-circle" color="green" /> **Best Practice:** Clean up state **before** tests run.
+&#8239;<Icon name="check-circle" color="green" /> **Best Practice:** Clean up
+state **before** tests run.
 
 :::
 
@@ -858,15 +870,17 @@ script.
 
 :::danger
 
-&#8239;<Icon name="exclamation-triangle" color="red" /> **Anti-Pattern:** Waiting for arbitrary time periods using
+&#8239;<Icon name="exclamation-triangle" color="red" /> **Anti-Pattern:**
+Waiting for arbitrary time periods using
 [`cy.wait(Number)`](/api/commands/wait#Time).
 
 :::
 
 :::tip
 
-&#8239;<Icon name="check-circle" color="green" /> **Best Practice:** Use route aliases or assertions to guard Cypress from
-proceeding until an explicit condition is met.
+&#8239;<Icon name="check-circle" color="green" /> **Best Practice:** Use route
+aliases or assertions to guard Cypress from proceeding until an explicit
+condition is met.
 
 :::
 
@@ -951,14 +965,16 @@ waste.
 
 :::danger
 
-&#8239;<Icon name="exclamation-triangle" color="red" /> **Anti-Pattern:** Trying to start a web server from within Cypress scripts
-with [`cy.exec()`](/api/commands/exec) or [`cy.task()`](/api/commands/task).
+&#8239;<Icon name="exclamation-triangle" color="red" /> **Anti-Pattern:** Trying
+to start a web server from within Cypress scripts with
+[`cy.exec()`](/api/commands/exec) or [`cy.task()`](/api/commands/task).
 
 :::
 
 :::tip
 
-&#8239;<Icon name="check-circle" color="green" /> **Best Practice:** Start a web server prior to running Cypress.
+&#8239;<Icon name="check-circle" color="green" /> **Best Practice:** Start a web
+server prior to running Cypress.
 
 :::
 
@@ -999,15 +1015,15 @@ We have
 
 :::danger
 
-&#8239;<Icon name="exclamation-triangle" color="red" /> **Anti-Pattern:** Using [cy.visit()](/api/commands/visit) without setting a
-`baseUrl`.
+&#8239;<Icon name="exclamation-triangle" color="red" /> **Anti-Pattern:** Using
+[cy.visit()](/api/commands/visit) without setting a `baseUrl`.
 
 :::
 
 :::tip
 
-&#8239;<Icon name="check-circle" color="green" /> **Best Practice:** Set a `baseUrl` in your
-[Cypress configuration](/guides/references/configuration).
+&#8239;<Icon name="check-circle" color="green" /> **Best Practice:** Set a
+`baseUrl` in your [Cypress configuration](/guides/references/configuration).
 
 :::
 

--- a/docs/guides/references/best-practices.mdx
+++ b/docs/guides/references/best-practices.mdx
@@ -37,14 +37,13 @@ and start testing.
 
 :::danger
 
-‼️ **Anti-Pattern:** Sharing page objects, using your UI to log in, and not
-taking shortcuts.
+&#8239;<Icon name="exclamation-triangle" color="red" /> **Anti-Pattern:** Sharing page objects, using your UI to log in, and not taking shortcuts.
 
 :::
 
 :::tip
 
-✅ **Best Practice:** Test specs in isolation, programmatically log into your
+&#8239;<Icon name="check-circle" color="green" /> **Best Practice:** Test specs in isolation, programmatically log into your
 application, and take control of your application's state.
 
 :::
@@ -71,13 +70,13 @@ in our examples.
 
 :::danger
 
-‼️ **Anti-Pattern:** Using highly brittle selectors that are subject to change.
+&#8239;<Icon name="exclamation-triangle" color="red" /> **Anti-Pattern:** Using highly brittle selectors that are subject to change.
 
 :::
 
 :::tip
 
-✅ **Best Practice:** Use `data-*` attributes to provide context to your
+&#8239;<Icon name="check-circle" color="green" /> **Best Practice:** Use `data-*` attributes to provide context to your
 selectors and isolate them from CSS or JS changes.
 
 :::
@@ -232,14 +231,13 @@ recommend you approach testing your components, look to:
 
 :::danger
 
-‼️ **Anti-Pattern:** Trying to assign the return value of Commands with `const`,
-`let`, or `var`.
+&#8239;<Icon name="exclamation-triangle" color="red" /> **Anti-Pattern:** Trying to assign the return value of Commands with `const`, `let`, or `var`.
 
 :::
 
 :::tip
 
-<Icon name="check-circle" color="green"></Icon> **Best Practice:** Use [aliases and
+&#8239;<Icon name="check-circle" color="green" /> **Best Practice:** Use [aliases and
 closures to access and store](/guides/core-concepts/variables-and-aliases) what Commands
 yield you.
 
@@ -291,14 +289,14 @@ For working with either of these patterns, please read our
 
 :::danger
 
-‼️ **Anti-Pattern:** Trying to visit or interact with sites or servers you do
+&#8239;<Icon name="exclamation-triangle" color="red" /> **Anti-Pattern:** Trying to visit or interact with sites or servers you do
 not control.
 
 :::
 
 :::tip
 
-<Icon name="check-circle" color="green"></Icon> **Best Practice:** Only test what
+&#8239;<Icon name="check-circle" color="green" /> **Best Practice:** Only test what
 you control. Try to avoid requiring a 3rd party server. When necessary, use [`cy.request()`](/api/commands/request)
 to talk to 3rd party servers via their APIs. If possible, cache results via [`cy.session()`](/api/commands/session)
 to avoid repeat visits.
@@ -447,13 +445,13 @@ email's functionality and visual style:
 
 :::danger
 
-‼️ **Anti-Pattern:** Coupling multiple tests together.
+&#8239;<Icon name="exclamation-triangle" color="red" /> **Anti-Pattern:** Coupling multiple tests together.
 
 :::
 
 :::tip
 
-✅ **Best Practice:** Tests should always be able to be run independently from
+&#8239;<Icon name="check-circle" color="green" /> **Best Practice:** Tests should always be able to be run independently from
 one another **and still pass**.
 
 :::
@@ -576,13 +574,13 @@ can be run independently and pass.
 
 :::danger
 
-‼️ **Anti-Pattern:** Acting like you're writing unit tests.
+&#8239;<Icon name="exclamation-triangle" color="red" /> **Anti-Pattern:** Acting like you're writing unit tests.
 
 :::
 
 :::tip
 
-✅ **Best Practice:** Add multiple assertions and don't worry about it
+&#8239;<Icon name="check-circle" color="green" /> **Best Practice:** Add multiple assertions and don't worry about it
 
 :::
 
@@ -660,13 +658,13 @@ describe('my form', () => {
 
 :::danger
 
-‼️ **Anti-Pattern:** Using `after` or `afterEach` hooks to clean up state.
+&#8239;<Icon name="exclamation-triangle" color="red" /> **Anti-Pattern:** Using `after` or `afterEach` hooks to clean up state.
 
 :::
 
 :::tip
 
-✅ **Best Practice:** Clean up state **before** tests run.
+&#8239;<Icon name="check-circle" color="green" /> **Best Practice:** Clean up state **before** tests run.
 
 :::
 
@@ -860,14 +858,14 @@ script.
 
 :::danger
 
-‼️ **Anti-Pattern:** Waiting for arbitrary time periods using
+&#8239;<Icon name="exclamation-triangle" color="red" /> **Anti-Pattern:** Waiting for arbitrary time periods using
 [`cy.wait(Number)`](/api/commands/wait#Time).
 
 :::
 
 :::tip
 
-✅ **Best Practice:** Use route aliases or assertions to guard Cypress from
+&#8239;<Icon name="check-circle" color="green" /> **Best Practice:** Use route aliases or assertions to guard Cypress from
 proceeding until an explicit condition is met.
 
 :::
@@ -953,14 +951,14 @@ waste.
 
 :::danger
 
-‼️ **Anti-Pattern:** Trying to start a web server from within Cypress scripts
+&#8239;<Icon name="exclamation-triangle" color="red" /> **Anti-Pattern:** Trying to start a web server from within Cypress scripts
 with [`cy.exec()`](/api/commands/exec) or [`cy.task()`](/api/commands/task).
 
 :::
 
 :::tip
 
-✅ **Best Practice:** Start a web server prior to running Cypress.
+&#8239;<Icon name="check-circle" color="green" /> **Best Practice:** Start a web server prior to running Cypress.
 
 :::
 
@@ -1001,14 +999,14 @@ We have
 
 :::danger
 
-‼️ **Anti-Pattern:** Using [cy.visit()](/api/commands/visit) without setting a
+&#8239;<Icon name="exclamation-triangle" color="red" /> **Anti-Pattern:** Using [cy.visit()](/api/commands/visit) without setting a
 `baseUrl`.
 
 :::
 
 :::tip
 
-✅ **Best Practice:** Set a `baseUrl` in your
+&#8239;<Icon name="check-circle" color="green" /> **Best Practice:** Set a `baseUrl` in your
 [Cypress configuration](/guides/references/configuration).
 
 :::


### PR DESCRIPTION
This was somewhere between using the icons from the previous site mixed with some emojis as a test but the markdown was still rendering incorrectly. I swapped out emojis for the icons with the mdx v1 workaround I discovered later. Now they render correctly. 