### PR TITLE
docs: fixed command line to run single test file using npm script

### DIFF
--- a/docs/guides/guides/command-line.mdx
+++ b/docs/guides/guides/command-line.mdx
@@ -77,7 +77,7 @@ your `package.json`
 Cypress Cloud, the command should be:
 
 ```shell
-npm run cy:run --record --spec "cypress/e2e/my-spec.cy.js"
+npm run cy:run -- --record --spec "cypress/e2e/my-spec.cy.js"
 ```
 
 If you are using the [npx](https://github.com/zkat/npx) tool, you can invoke the


### PR DESCRIPTION
Hi, this PR fix the command line documentation that shows how to test a single spec file. The `--` is needed to pass parameters to `npm run cy:run`.

Thanks!!!