### PR TITLE
docs: fix typo on the testing types page

### DIFF
--- a/docs/guides/core-concepts/testing-types.mdx
+++ b/docs/guides/core-concepts/testing-types.mdx
@@ -149,7 +149,7 @@ To learn more about component testing in Cypress, visit our guide on
 |                        |                       E2E                        |                   Component                   |
 | ---------------------- | :----------------------------------------------: | :-------------------------------------------: |
 | What's Tested          |                  All app layers                  |             Individual component              |
-| Characteristics        | Comprehensive, slower, more suspectable to flake |         Specialized, quick, reliable          |
+| Characteristics        | Comprehensive, slower, more susceptible to flake |         Specialized, quick, reliable          |
 | Used For               |     Verifying app works as a cohesive whole      | Testing functionality of individual component |
 | Written By             |            Developers, QA Team, SDETs            |             Developers, Designers             |
 | CI Infrastructure      |           Often requires complex setup           |                  None needed                  |


### PR DESCRIPTION
Small documentation fix on the testing types page — more suspectable to flake -> more _susceptible_ to flake