### PR TITLE
Remove code cruft

### DIFF
--- a/docs/api/actions/check.mdx
+++ b/docs/api/actions/check.mdx
@@ -199,7 +199,7 @@ The commands above will display in the Command Log as:
 <DocsImage
   src="/img/api/check/check-checkbox-in-cypress.png"
   alt="Command log for check"
-></DocsImage>
+/>
 
 When clicking on `check` within the command log, the console outputs the
 following:
@@ -207,7 +207,7 @@ following:
 <DocsImage
   src="/img/api/check/console-showing-events-on-check.png"
   alt="console.log for check"
-></DocsImage>
+/>
 
 ## See also
 

--- a/docs/api/actions/clear.mdx
+++ b/docs/api/actions/clear.mdx
@@ -119,7 +119,7 @@ The commands above will display in the Command Log as:
 <DocsImage
   src="/img/api/clear/clear-input-in-cypress.png"
   alt="Command log for clear"
-></DocsImage>
+/>
 
 When clicking on `clear` within the command log, the console outputs the
 following:
@@ -127,7 +127,7 @@ following:
 <DocsImage
   src="/img/api/clear/one-input-cleared-in-tests.png"
   alt="console.log for clear"
-></DocsImage>
+/>
 
 ## See also
 

--- a/docs/api/actions/click.mdx
+++ b/docs/api/actions/click.mdx
@@ -47,7 +47,7 @@ default position. Valid positions are `topLeft`, `top`, `topRight`, `left`,
 <DocsImage
   src="/img/api/coordinates-diagram.jpg"
   alt="cypress-command-positions-diagram"
-></DocsImage>
+/>
 
 **<Icon name="angle-right" /> x** **_(Number)_**
 
@@ -239,7 +239,7 @@ The commands above will display in the Command Log as:
 <DocsImage
   src="/img/api/click/click-button-in-form-during-test.png"
   alt="Command log for click"
-></DocsImage>
+/>
 
 When clicking on `click` within the command log, the console outputs the
 following:
@@ -247,7 +247,7 @@ following:
 <DocsImage
   src="/img/api/click/click-coords-and-events-in-console.png"
   alt="console.log for click"
-></DocsImage>
+/>
 
 ## History
 

--- a/docs/api/actions/dblclick.mdx
+++ b/docs/api/actions/dblclick.mdx
@@ -47,7 +47,7 @@ the default position. Valid positions are `topLeft`, `top`, `topRight`, `left`,
 <DocsImage
   src="/img/api/coordinates-diagram.jpg"
   alt="cypress-command-positions-diagram"
-></DocsImage>
+/>
 
 **<Icon name="angle-right" /> x** **_(Number)_**
 
@@ -221,7 +221,7 @@ The commands above will display in the Command Log as:
 <DocsImage
   src="/img/api/dblclick/double-click-in-testing.png"
   alt="Command Log dblclick"
-></DocsImage>
+/>
 
 When clicking on `dblclick` within the command log, the console outputs the
 following:
@@ -229,7 +229,7 @@ following:
 <DocsImage
   src="/img/api/dblclick/element-double-clicked-on.png"
   alt="console.log dblclick"
-></DocsImage>
+/>
 
 ## History
 

--- a/docs/api/actions/rightclick.mdx
+++ b/docs/api/actions/rightclick.mdx
@@ -55,7 +55,7 @@ the default position. Valid positions are `topLeft`, `top`, `topRight`, `left`,
 <DocsImage
   src="/img/api/coordinates-diagram.jpg"
   alt="cypress-command-positions-diagram"
-></DocsImage>
+/>
 
 **<Icon name="angle-right" /> x** **_(Number)_**
 
@@ -230,7 +230,7 @@ The commands above will display in the Command Log as:
 <DocsImage
   src="/img/api/rightclick/rightclick-dom-element-in-command-log.png"
   alt="Command log for right click"
-></DocsImage>
+/>
 
 When clicking on `rightclick` within the command log, the console outputs the
 following:
@@ -238,7 +238,7 @@ following:
 <DocsImage
   src="/img/api/rightclick/rightclick-console-log-with-mouse-events.png"
   alt="console.log for right click"
-></DocsImage>
+/>
 
 ## History
 

--- a/docs/api/actions/select.mdx
+++ b/docs/api/actions/select.mdx
@@ -284,7 +284,7 @@ The commands above will display in the Command Log as:
 <DocsImage
   src="/img/api/select/select-homer-option-from-browser-dropdown.png"
   alt="Command Log select"
-></DocsImage>
+/>
 
 When clicking on `select` within the command log, the console outputs the
 following:
@@ -292,7 +292,7 @@ following:
 <DocsImage
   src="/img/api/select/console-log-for-select-shows-option-and-any-events-caused-from-clicking.png"
   alt="Console Log select"
-></DocsImage>
+/>
 
 ## See also
 

--- a/docs/api/actions/selectfile.mdx
+++ b/docs/api/actions/selectfile.mdx
@@ -310,7 +310,7 @@ The commands above will display in the Command Log as:
 <DocsImage
   src="/img/api/selectfile/selectfile-command-log.png"
   alt="Command log for selectFile"
-></DocsImage>
+/>
 
 When clicking on `selectFile` within the command log, the console outputs the
 following:
@@ -318,7 +318,7 @@ following:
 <DocsImage
   src="/img/api/selectfile/selectfile-console.png"
   alt="console.log for selectFile"
-></DocsImage>
+/>
 
 ## History
 

--- a/docs/api/actions/trigger.mdx
+++ b/docs/api/actions/trigger.mdx
@@ -49,7 +49,7 @@ default position. Valid positions are `topLeft`, `top`, `topRight`, `left`,
 <DocsImage
   src="/img/api/coordinates-diagram.jpg"
   alt="cypress-command-positions-diagram"
-></DocsImage>
+/>
 
 **<Icon name="angle-right" /> x** **_(Number)_**
 
@@ -292,7 +292,7 @@ The commands above will display in the Command Log as:
 <DocsImage
   src="/img/api/trigger/command-log-trigger.png"
   alt="command log trigger"
-></DocsImage>
+/>
 
 When clicking on `trigger` within the command log, the console outputs the
 following:
@@ -300,7 +300,7 @@ following:
 <DocsImage
   src="/img/api/trigger/console-log-trigger.png"
   alt="console log trigger"
-></DocsImage>
+/>
 
 ## History
 

--- a/docs/api/actions/type.mdx
+++ b/docs/api/actions/type.mdx
@@ -485,7 +485,7 @@ Any modifiers activated for the event are also listed in a `modifiers` column.
 <DocsImage
   src="/img/api/type/key-events-table-shown-in-console-for-testing-typing.png"
   alt="Cypress .type() key events table"
-></DocsImage>
+/>
 
 ### Tabbing
 
@@ -606,7 +606,7 @@ The commands above will display in the Command Log as:
 <DocsImage
   src="/img/api/type/type-in-input-shown-in-command-log.png"
   alt="Command Log type"
-></DocsImage>
+/>
 
 When clicking on `type` within the command log, the console outputs the
 following:
@@ -614,7 +614,7 @@ following:
 <DocsImage
   src="/img/api/type/console-log-of-typing-with-entire-key-events-table-for-each-character.png"
   alt="Console Log type"
-></DocsImage>
+/>
 
 ## History
 

--- a/docs/api/actions/uncheck.mdx
+++ b/docs/api/actions/uncheck.mdx
@@ -141,7 +141,7 @@ The commands above will display in the Command Log as:
 <DocsImage
   src="/img/api/uncheck/test-unchecking-a-checkbox.png"
   alt="Command Log uncheck"
-></DocsImage>
+/>
 
 When clicking on `uncheck` within the command log, the console outputs the
 following:
@@ -149,7 +149,7 @@ following:
 <DocsImage
   src="/img/api/uncheck/console-shows-events-from-clicking-the-checkbox.png"
   alt="Console Log uncheck"
-></DocsImage>
+/>
 
 ## History
 

--- a/docs/api/assertions/and.mdx
+++ b/docs/api/assertions/and.mdx
@@ -282,7 +282,7 @@ The commands above will display in the Command Log as:
 <DocsImage
   src="/img/api/and/cypress-and-command-log.png"
   alt="Command log for assertions"
-></DocsImage>
+/>
 
 When clicking on `assert` within the command log, the console outputs the
 following:
@@ -290,7 +290,7 @@ following:
 <DocsImage
   src="/img/api/and/cypress-assertions-console-log.png"
   alt="console.log for assertions"
-></DocsImage>
+/>
 
 ## See also
 

--- a/docs/api/assertions/should.mdx
+++ b/docs/api/assertions/should.mdx
@@ -180,7 +180,7 @@ assertions within it throw.
 You cannot invoke Cypress commands inside of a `.should()` callback function.
 Use Cypress commands before or after `.should()` instead.
 
-**<Icon name="exclamation-triangle" color="red"></Icon> Incorrect Usage**
+**<Icon name="exclamation-triangle" color="red" /> Incorrect Usage**
 
 ```javascript
 cy.get('p').should(($p) => {
@@ -189,7 +189,7 @@ cy.get('p').should(($p) => {
 })
 ```
 
-**<Icon name="check-circle" color="green"></Icon> Correct Usage**
+**<Icon name="check-circle" color="green" /> Correct Usage**
 
 ```javascript
 cy.get('p')

--- a/docs/api/assertions/should.mdx
+++ b/docs/api/assertions/should.mdx
@@ -348,7 +348,7 @@ more context.
 <DocsImage
   src="/img/api/should/expect-with-message.png"
   alt="Expect assertions with messages"
-></DocsImage>
+/>
 
 #### Compare text values of two elements
 
@@ -497,7 +497,7 @@ The commands above will display in the Command Log as:
 <DocsImage
   src="/img/api/should/should-command-shows-up-as-assert-for-each-assertion.png"
   alt="Command Log should"
-></DocsImage>
+/>
 
 When clicking on `assert` within the command log, the console outputs the
 following:
@@ -505,7 +505,7 @@ following:
 <DocsImage
   src="/img/api/should/assertion-in-console-log-shows-actual-versus-expected-data.png"
   alt="Console Log should"
-></DocsImage>
+/>
 
 ## History
 

--- a/docs/api/commands/blur.mdx
+++ b/docs/api/commands/blur.mdx
@@ -142,7 +142,7 @@ The commands above will display in the Command Log as:
 <DocsImage
   src="/img/api/blur/blur-input-command-log.png"
   alt="command log for blur"
-></DocsImage>
+/>
 
 When clicking on the `blur` command within the command log, the console outputs
 the following:
@@ -150,7 +150,7 @@ the following:
 <DocsImage
   src="/img/api/blur/console-showing-blur-command.png"
   alt="console.log for blur"
-></DocsImage>
+/>
 
 ## See also
 

--- a/docs/api/commands/clearallcookies.mdx
+++ b/docs/api/commands/clearallcookies.mdx
@@ -23,7 +23,7 @@ cy.clearAllCookies(options)
 
 ### Usage
 
-**<Icon name="check-circle" color="green"></Icon> Correct Usage**
+**<Icon name="check-circle" color="green" /> Correct Usage**
 
 ```javascript
 cy.clearAllCookies() // Clear all cookies
@@ -31,7 +31,7 @@ cy.clearAllCookies() // Clear all cookies
 
 ### Arguments
 
-**<Icon name="angle-right"></Icon> options** **_(Object)_**
+**<Icon name="angle-right" /> options** **_(Object)_**
 
 Pass in an options object to change the default behavior of
 `cy.clearAllCookies()`.

--- a/docs/api/commands/clearalllocalstorage.mdx
+++ b/docs/api/commands/clearalllocalstorage.mdx
@@ -25,7 +25,7 @@ cy.clearAllLocalStorage(options)
 
 ### Usage
 
-**<Icon name="check-circle" color="green"></Icon> Correct Usage**
+**<Icon name="check-circle" color="green" /> Correct Usage**
 
 ```javascript
 cy.clearAllLocalStorage()
@@ -33,7 +33,7 @@ cy.clearAllLocalStorage()
 
 ### Arguments
 
-**<Icon name="angle-right"></Icon> options** **_(Object)_**
+**<Icon name="angle-right" /> options** **_(Object)_**
 
 Pass in an options object to change the default behavior of
 `cy.clearAllLocalStorage()`.

--- a/docs/api/commands/clearallsessionstorage.mdx
+++ b/docs/api/commands/clearallsessionstorage.mdx
@@ -25,7 +25,7 @@ cy.clearAllSessionStorage(options)
 
 ### Usage
 
-**<Icon name="check-circle" color="green"></Icon> Correct Usage**
+**<Icon name="check-circle" color="green" /> Correct Usage**
 
 ```javascript
 cy.clearAllSessionStorage()
@@ -33,7 +33,7 @@ cy.clearAllSessionStorage()
 
 ### Arguments
 
-**<Icon name="angle-right"></Icon> options** **_(Object)_**
+**<Icon name="angle-right" /> options** **_(Object)_**
 
 Pass in an options object to change the default behavior of
 `cy.clearAllSessionStorage()`.

--- a/docs/api/commands/clearcookie.mdx
+++ b/docs/api/commands/clearcookie.mdx
@@ -106,7 +106,7 @@ The commands above will display in the Command Log as:
 <DocsImage
   src="/img/api/clearcookie/clear-cookie-in-browser-tests.png"
   alt="Command Log for clearcookie"
-></DocsImage>
+/>
 
 When clicking on `clearCookie` within the command log, the console outputs the
 following:
@@ -114,7 +114,7 @@ following:
 <DocsImage
   src="/img/api/clearcookie/cleared-cookie-shown-in-console.png"
   alt="console.log for clearcookie"
-></DocsImage>
+/>
 
 ## See also
 

--- a/docs/api/commands/clearcookies.mdx
+++ b/docs/api/commands/clearcookies.mdx
@@ -101,7 +101,7 @@ The commands above will display in the Command Log as:
 <DocsImage
   src="/img/api/clearcookies/clear-all-cookies-in-cypress-tests.png"
   alt="Command Log"
-></DocsImage>
+/>
 
 When clicking on `clearCookies` within the command log, the console outputs the
 following:
@@ -109,7 +109,7 @@ following:
 <DocsImage
   src="/img/api/clearcookies/inspect-cleared-cookies-in-console.png"
   alt="Console Log"
-></DocsImage>
+/>
 
 ## See also
 

--- a/docs/api/commands/clearlocalstorage.mdx
+++ b/docs/api/commands/clearlocalstorage.mdx
@@ -103,7 +103,7 @@ The commands above will display in the Command Log as:
 <DocsImage
   src="/img/api/clearlocalstorage/clear-ls-localstorage-in-command-log.png"
   alt="Command log for clearLocalStorage"
-></DocsImage>
+/>
 
 When clicking on `clearLocalStorage` within the command log, the console outputs
 the following:
@@ -111,7 +111,7 @@ the following:
 <DocsImage
   src="/img/api/clearlocalstorage/local-storage-object-shown-in-console.png"
   alt="console.log for clearLocalStorage"
-></DocsImage>
+/>
 
 ## See also
 

--- a/docs/api/commands/clock.mdx
+++ b/docs/api/commands/clock.mdx
@@ -306,7 +306,7 @@ The command above will display in the Command Log as:
 <DocsImage
   src="/img/api/clock/clock-displays-in-command-log.png"
   alt="Command Log clock"
-></DocsImage>
+/>
 
 When clicking on the `clock` command within the command log, the console outputs
 the following:
@@ -314,7 +314,7 @@ the following:
 <DocsImage
   src="/img/api/clock/clock-displays-methods-replaced-in-console.png"
   alt="console.log clock command"
-></DocsImage>
+/>
 
 ## History
 

--- a/docs/api/commands/exec.mdx
+++ b/docs/api/commands/exec.mdx
@@ -221,10 +221,7 @@ if (Cypress.platform === 'win32') {
 
 The command above will display in the Command Log as:
 
-<DocsImage
-  src="/img/api/exec/exec-cat-in-shell.png"
-  alt="Command Log exec"
-/>
+<DocsImage src="/img/api/exec/exec-cat-in-shell.png" alt="Command Log exec" />
 
 When clicking on the `exec` command within the command log, the console outputs
 the following:

--- a/docs/api/commands/exec.mdx
+++ b/docs/api/commands/exec.mdx
@@ -224,7 +224,7 @@ The command above will display in the Command Log as:
 <DocsImage
   src="/img/api/exec/exec-cat-in-shell.png"
   alt="Command Log exec"
-></DocsImage>
+/>
 
 When clicking on the `exec` command within the command log, the console outputs
 the following:
@@ -232,7 +232,7 @@ the following:
 <DocsImage
   src="/img/api/exec/console-shows-code-shell-stderr-and-stdout-for-exec.png"
   alt="console.log exec"
-></DocsImage>
+/>
 
 ## See also
 

--- a/docs/api/commands/focus.mdx
+++ b/docs/api/commands/focus.mdx
@@ -138,7 +138,7 @@ The commands above will display in the Command Log as:
 <DocsImage
   src="/img/api/focus/get-input-then-focus.png"
   alt="Command Log focus"
-></DocsImage>
+/>
 
 When clicking on the `focus` command within the command log, the console outputs
 the following:
@@ -146,7 +146,7 @@ the following:
 <DocsImage
   src="/img/api/focus/console-log-textarea-that-was-focused-on.png"
   alt="console.log focus"
-></DocsImage>
+/>
 
 ## See also
 

--- a/docs/api/commands/getallcookies.mdx
+++ b/docs/api/commands/getallcookies.mdx
@@ -13,7 +13,7 @@ cy.getAllCookies(options)
 
 ### Usage
 
-**<Icon name="check-circle" color="green"></Icon> Correct Usage**
+**<Icon name="check-circle" color="green" /> Correct Usage**
 
 ```javascript
 cy.getAllCookies() // Get all cookies
@@ -21,7 +21,7 @@ cy.getAllCookies() // Get all cookies
 
 ### Arguments
 
-**<Icon name="angle-right"></Icon> options** **_(Object)_**
+**<Icon name="angle-right" /> options** **_(Object)_**
 
 Pass in an options object to change the default behavior of
 `cy.getAllCookies()`.

--- a/docs/api/commands/getalllocalstorage.mdx
+++ b/docs/api/commands/getalllocalstorage.mdx
@@ -15,7 +15,7 @@ cy.getAllLocalStorage(options)
 
 ### Usage
 
-**<Icon name="check-circle" color="green"></Icon> Correct Usage**
+**<Icon name="check-circle" color="green" /> Correct Usage**
 
 ```javascript
 cy.getAllLocalStorage()
@@ -23,7 +23,7 @@ cy.getAllLocalStorage()
 
 ### Arguments
 
-**<Icon name="angle-right"></Icon> options** **_(Object)_**
+**<Icon name="angle-right" /> options** **_(Object)_**
 
 Pass in an options object to change the default behavior of
 `cy.getAllLocalStorage()`.

--- a/docs/api/commands/getallsessionstorage.mdx
+++ b/docs/api/commands/getallsessionstorage.mdx
@@ -15,7 +15,7 @@ cy.getAllSessionStorage(options)
 
 ### Usage
 
-**<Icon name="check-circle" color="green"></Icon> Correct Usage**
+**<Icon name="check-circle" color="green" /> Correct Usage**
 
 ```javascript
 cy.getAllSessionStorage()
@@ -23,7 +23,7 @@ cy.getAllSessionStorage()
 
 ### Arguments
 
-**<Icon name="angle-right"></Icon> options** **_(Object)_**
+**<Icon name="angle-right" /> options** **_(Object)_**
 
 Pass in an options object to change the default behavior of
 `cy.getAllSessionStorage()`.

--- a/docs/api/commands/getcookie.mdx
+++ b/docs/api/commands/getcookie.mdx
@@ -154,7 +154,7 @@ The commands above will display in the Command Log as:
 <DocsImage
   src="/img/api/getcookie/get-browser-cookie-and-make-assertions-about-object.png"
   alt="Command Log getcookie"
-></DocsImage>
+/>
 
 When clicking on `getCookie` within the command log, the console outputs the
 following:
@@ -162,7 +162,7 @@ following:
 <DocsImage
   src="/img/api/getcookie/inspect-cookie-object-properties-in-console.png"
   alt="Console Log getcookie"
-></DocsImage>
+/>
 
 ## History
 

--- a/docs/api/commands/getcookies.mdx
+++ b/docs/api/commands/getcookies.mdx
@@ -110,7 +110,7 @@ The commands above will display in the Command Log as:
 <DocsImage
   src="/img/api/getcookies/get-browser-cookies-and-inspect-all-properties.png"
   alt="Command Log getcookies"
-></DocsImage>
+/>
 
 When clicking on `getCookies` within the command log, the console outputs the
 following:
@@ -118,7 +118,7 @@ following:
 <DocsImage
   src="/img/api/getcookies/test-application-cookies.png"
   alt="Console Log getcookies"
-></DocsImage>
+/>
 
 ## History
 

--- a/docs/api/commands/go.mdx
+++ b/docs/api/commands/go.mdx
@@ -116,7 +116,7 @@ The commands above will display in the Command Log as:
 <DocsImage
   src="/img/api/go/test-showing-go-back-browser-button.png"
   alt="Command Log go"
-></DocsImage>
+/>
 
 When clicking on the `go` command within the command log, the console outputs
 the following:
@@ -124,7 +124,7 @@ the following:
 <DocsImage
   src="/img/api/go/window-is-logged-when-go-back-in-browser-history.png"
   alt="console Log go"
-></DocsImage>
+/>
 
 ## See also
 

--- a/docs/api/commands/intercept.mdx
+++ b/docs/api/commands/intercept.mdx
@@ -1356,7 +1356,7 @@ an overlapping `cy.intercept()`:
 <DocsImage
   src="/img/api/intercept/middleware-algo.png"
   alt="Middleware Algorithm"
-></DocsImage>
+/>
 
 ### Request phase
 
@@ -1500,7 +1500,7 @@ cache, and will not send an HTTP request. Thus, they cannot be intercepted by
 <DocsImage
   src="/img/api/intercept/devtools-cached-responses.png"
   alt="Screenshot of Chrome DevTools showing cached responses."
-></DocsImage>
+/>
 
 If you would like to intercept resources that normally send cache headers, here
 are some workarounds:
@@ -1555,7 +1555,7 @@ it('cy.intercept command log', () => {
 <DocsImage
   src="/img/api/intercept/command-log-routes-ui.png"
   alt="Screenshot of Command Log Routes UI"
-></DocsImage>
+/>
 
 When HTTP requests are made, Cypress will log them in the Command Log and
 indicate whether they matched a `cy.intercept()` by the presence of a yellow
@@ -1564,7 +1564,7 @@ badge on the right hand side:
 <DocsImage
   src="/img/api/intercept/command-log-fetches.png"
   alt="Screenshot of example fetches"
-></DocsImage>
+/>
 
 The circular indicator is filled if the request went to the destination server,
 but unfilled if the request was stubbed with a response.
@@ -1575,7 +1575,7 @@ information about the request and response to the console:
 <DocsImage
   src="/img/api/intercept/console-props.png"
   alt="Screenshot of cy.intercept console output"
-></DocsImage>
+/>
 
 [Read more about request logging in Cypress.](/guides/guides/network-requests#Command-Log)
 

--- a/docs/api/commands/log.mdx
+++ b/docs/api/commands/log.mdx
@@ -82,7 +82,7 @@ The commands above will display in the Command Log as:
 <DocsImage
   src="/img/api/log/custom-command-log-with-any-message.png"
   alt="Command Log log"
-></DocsImage>
+/>
 
 When clicking on `log` within the command log, the console outputs the
 following:
@@ -90,7 +90,7 @@ following:
 <DocsImage
   src="/img/api/log/console-shows-logs-message-and-any-arguments.png"
   alt="Console Log log"
-></DocsImage>
+/>
 
 ## See also
 

--- a/docs/api/commands/origin.mdx
+++ b/docs/api/commands/origin.mdx
@@ -14,8 +14,7 @@ limitation determined by standard web security features of the browser. The
 :::caution
 
 <strong class="alert-header">
-  <Icon name="exclamation-triangle"></Icon>
-  Obstructive Third Party Code
+  <Icon name="exclamation-triangle" /> Obstructive Third Party Code
 </strong>
 
 By default Cypress will search through the response streams coming from your
@@ -227,7 +226,7 @@ Here the cross-origin page is visited prior to the `cy.origin` block, but any
 interactions with the window are performed within the block which can
 communicate with the cross-origin page
 
-#### <Icon name="exclamation-triangle" color="red"></Icon> Incorrect Usage
+#### <Icon name="exclamation-triangle" color="red" /> Incorrect Usage
 
 ```js
 // Do things in primary origin...

--- a/docs/api/commands/origin.mdx
+++ b/docs/api/commands/origin.mdx
@@ -353,7 +353,7 @@ Cypress.Commands.add('login', (username, password) => {
 
 ### How to Test Multiple Origins
 
-<DocsVideo src="https://youtube.com/embed/Fohrq5GZSD8"></DocsVideo>
+<DocsVideo src="https://youtube.com/embed/Fohrq5GZSD8" />
 
 In this video we walk through how to test multiple origins in a single test. We
 also look at how to use the `cy.session()` command to cache session information

--- a/docs/api/commands/origin.mdx
+++ b/docs/api/commands/origin.mdx
@@ -13,7 +13,7 @@ limitation determined by standard web security features of the browser. The
 
 :::caution
 
-<strong class="alert-header">
+<strong>
   <Icon name="exclamation-triangle" /> Obstructive Third Party Code
 </strong>
 

--- a/docs/api/commands/pause.mdx
+++ b/docs/api/commands/pause.mdx
@@ -104,7 +104,7 @@ The commands above will display in the Command Log as:
 <DocsImage
   src="/img/api/pause/initial-pause-in-gui-highlights-the-pause-command.png"
   alt="Pause command on intial pause"
-></DocsImage>
+/>
 
 When clicking on "Next: 'click'" at the top of the Command Log, the Command Log
 will run only the next command and pause again.
@@ -114,42 +114,42 @@ will run only the next command and pause again.
 <DocsImage
   src="/img/api/pause/next-goes-on-to-next-command-during-pause.png"
   alt="Pause command after clicking next"
-></DocsImage>
+/>
 
 #### Click "Next" again
 
 <DocsImage
   src="/img/api/pause/continue-in-pause-command-just-like-debugger.png"
   alt="Continue to next command during pause"
-></DocsImage>
+/>
 
 #### Click "Next" again
 
 <DocsImage
   src="/img/api/pause/pause-goes-to-show-next-click.png"
   alt="Pause command"
-></DocsImage>
+/>
 
 #### Click "Next" again
 
 <DocsImage
   src="/img/api/pause/clicking-on-canvas-continues-as-we-click-next.png"
   alt="Pause command"
-></DocsImage>
+/>
 
 #### Click "Next" again
 
 <DocsImage
   src="/img/api/pause/last-next-click-before-out-test-is-finished.png"
   alt="Pause command"
-></DocsImage>
+/>
 
 #### Click "Next" again, then 'Resume'
 
 <DocsImage
   src="/img/api/pause/next-then-resume-shows-our-test-has-ended.png"
   alt="Pause command"
-></DocsImage>
+/>
 
 ## See also
 

--- a/docs/api/commands/readfile.mdx
+++ b/docs/api/commands/readfile.mdx
@@ -233,7 +233,7 @@ The command above will display in the Command Log as:
 <DocsImage
   src="/img/api/readfile/readfile-can-get-content-of-system-files-in-tests.png"
   alt="Command Log readFile"
-></DocsImage>
+/>
 
 When clicking on the `readFile` command within the command log, the console
 outputs the following:
@@ -241,7 +241,7 @@ outputs the following:
 <DocsImage
   src="/img/api/readfile/console-log-shows-content-from-file-formatted-as-javascript.png"
   alt="Console Log readFile"
-></DocsImage>
+/>
 
 ## History
 

--- a/docs/api/commands/reload.mdx
+++ b/docs/api/commands/reload.mdx
@@ -97,7 +97,7 @@ The commands above will display in the Command Log as:
 <DocsImage
   src="/img/api/reload/test-page-after-reload-button.png"
   alt="Command Log reload"
-></DocsImage>
+/>
 
 When clicking on `reload` within the command log, the console outputs the
 following:
@@ -105,7 +105,7 @@ following:
 <DocsImage
   src="/img/api/reload/command-log-for-reload-cypress.png"
   alt="Console Log reload"
-></DocsImage>
+/>
 
 ## See also
 

--- a/docs/api/commands/request.mdx
+++ b/docs/api/commands/request.mdx
@@ -400,7 +400,7 @@ The commands above will display in the Command Log as:
 <DocsImage
   src="/img/api/request/testing-request-url-and-its-response-body-headers.png"
   alt="Command Log request"
-></DocsImage>
+/>
 
 When clicking on `request` within the command log, the console outputs the
 following:
@@ -408,7 +408,7 @@ following:
 <DocsImage
   src="/img/api/request/console-log-request-response-body-headers-status-url.png"
   alt="Console Log request"
-></DocsImage>
+/>
 
 ## History
 

--- a/docs/api/commands/screenshot.mdx
+++ b/docs/api/commands/screenshot.mdx
@@ -337,7 +337,7 @@ The commands above will display in the Command Log as:
 <DocsImage
   src="/img/api/screenshot/command-log-shows-name-of-screenshot-taken.png"
   alt="Command Log screenshot"
-></DocsImage>
+/>
 
 When clicking on `screenshot` within the command log, the console outputs the
 following:
@@ -345,7 +345,7 @@ following:
 <DocsImage
   src="/img/api/screenshot/console-logs-exactly-where-screenshot-was-saved-in-file-system.png"
   alt="Console Log screenshot"
-></DocsImage>
+/>
 
 ## History
 

--- a/docs/api/commands/scrollintoview.mdx
+++ b/docs/api/commands/scrollintoview.mdx
@@ -118,7 +118,7 @@ The commands above will display in the Command Log as:
 <DocsImage
   src="/img/api/scrollintoview/command-log-for-scrollintoview.png"
   alt="command log scrollintoview"
-></DocsImage>
+/>
 
 When clicking on the `scrollintoview` command within the command log, the
 console outputs the following:
@@ -126,7 +126,7 @@ console outputs the following:
 <DocsImage
   src="/img/api/scrollintoview/console-log-for-scrollintoview.png"
   alt="console.log scrollintoview"
-></DocsImage>
+/>
 
 ## See also
 

--- a/docs/api/commands/scrollto.mdx
+++ b/docs/api/commands/scrollto.mdx
@@ -49,7 +49,7 @@ and `bottomRight`.
 <DocsImage
   src="/img/api/coordinates-diagram.jpg"
   alt="cypress-command-positions-diagram"
-></DocsImage>
+/>
 
 **<Icon name="angle-right" /> x** **_(Number, String)_**
 
@@ -205,7 +205,7 @@ The commands above will display in the Command Log as:
 <DocsImage
   src="/img/api/scrollto/command-log-scrollto.png"
   alt="command log for scrollTo"
-></DocsImage>
+/>
 
 When clicking on `scrollTo` within the command log, the console outputs the
 following:
@@ -213,7 +213,7 @@ following:
 <DocsImage
   src="/img/api/scrollto/console-log-scrollto.png"
   alt="console.log for scrollTo"
-></DocsImage>
+/>
 
 ## History
 

--- a/docs/api/commands/session.mdx
+++ b/docs/api/commands/session.mdx
@@ -585,8 +585,8 @@ and allows you to switch sessions without first having to explicitly log out.
 
 |                            |               Page cleared (test)               |              Session data cleared               |
 | -------------------------- | :---------------------------------------------: | :---------------------------------------------: |
-| Before `setup`             | <Icon name="check-circle" color="green"></Icon> | <Icon name="check-circle" color="green"></Icon> |
-| Before `cy.session()` ends | <Icon name="check-circle" color="green"></Icon> |                                                 |
+| Before `setup`             | <Icon name="check-circle" color="green" /> | <Icon name="check-circle" color="green" /> |
+| Before `cy.session()` ends | <Icon name="check-circle" color="green" /> |                                                 |
 
 Note: [`cy.visit()`](/api/commands/visit) must be explicitly called afterwards
 to ensure the page to test is loaded.
@@ -598,7 +598,7 @@ clear, however, the session data will clear when `cy.session()` runs.
 
 |                            | Page cleared (test) |              Session data cleared               |
 | -------------------------- | :-----------------: | :---------------------------------------------: |
-| Before `setup`             |                     | <Icon name="check-circle" color="green"></Icon> |
+| Before `setup`             |                     | <Icon name="check-circle" color="green" /> |
 | Before `cy.session()` ends |                     |                                                 |
 
 [`cy.visit()`](/api/commands/visit) does not need to be called afterwards to

--- a/docs/api/commands/session.mdx
+++ b/docs/api/commands/session.mdx
@@ -633,7 +633,7 @@ button in the [Instrument Panel](#The-Instrument-Panel).
 <DocsImage
   src="/img/api/session/sessions-panel.png"
   alt="Sessions Instrument Panel"
-></DocsImage>
+/>
 
 For debugging purposes, all spec and global sessions can be cleared with the
 [`Cypress.session.clearAllSavedSessions()`](/api/cypress-api/session) method.
@@ -786,7 +786,7 @@ and global sessions and re-run the spec file (see
 <DocsImage
   src="/img/api/session/sessions-panel.png"
   alt="Sessions Instrument Panel"
-></DocsImage>
+/>
 
 ### The command log
 
@@ -799,21 +799,21 @@ session `id` value:
   <DocsImage
     src="/img/api/session/session-collapsed-new.png"
     alt="New session (collapsed)"
-  ></DocsImage>
+  />
 
 - A saved session was found, and used:
 
   <DocsImage
     src="/img/api/session/session-collapsed-restored.png"
     alt="Saved session (collapsed)"
-  ></DocsImage>
+  />
 
 - A saved session was found, but the `validate` function failed, so the session
   was recreated and saved:
   <DocsImage
     src="/img/api/session/session-collapsed-recreated.png"
     alt="Recreated session (collapsed)"
-  ></DocsImage>
+  />
 
 Note that in cases where the `validate` function fails immediately after `setup`
 creates the session, the test will fail with an error.
@@ -830,7 +830,7 @@ remainder of the test.
 <DocsImage
   src="/img/api/session/session-expanded.png"
   alt="Recreated session (expanded)"
-></DocsImage>
+/>
 
 ### Printing to the console
 
@@ -842,7 +842,7 @@ data, including cookies, `localStorage` and `sessionStorage`.
 <DocsImage
   src="/img/api/session/print-session-to-console.png"
   alt="Session console output"
-></DocsImage>
+/>
 
 ## History
 

--- a/docs/api/commands/session.mdx
+++ b/docs/api/commands/session.mdx
@@ -583,10 +583,10 @@ isolation is enabled with `testIsolation=true` (default in Cypress 12), This
 guarantees consistent behavior whether a session is being created or restored
 and allows you to switch sessions without first having to explicitly log out.
 
-|                            |               Page cleared (test)               |              Session data cleared               |
-| -------------------------- | :---------------------------------------------: | :---------------------------------------------: |
+|                            |            Page cleared (test)             |            Session data cleared            |
+| -------------------------- | :----------------------------------------: | :----------------------------------------: |
 | Before `setup`             | <Icon name="check-circle" color="green" /> | <Icon name="check-circle" color="green" /> |
-| Before `cy.session()` ends | <Icon name="check-circle" color="green" /> |                                                 |
+| Before `cy.session()` ends | <Icon name="check-circle" color="green" /> |                                            |
 
 Note: [`cy.visit()`](/api/commands/visit) must be explicitly called afterwards
 to ensure the page to test is loaded.
@@ -596,10 +596,10 @@ to ensure the page to test is loaded.
 When test isolation is disabled with `testIsolation=false`, the page will not
 clear, however, the session data will clear when `cy.session()` runs.
 
-|                            | Page cleared (test) |              Session data cleared               |
-| -------------------------- | :-----------------: | :---------------------------------------------: |
+|                            | Page cleared (test) |            Session data cleared            |
+| -------------------------- | :-----------------: | :----------------------------------------: |
 | Before `setup`             |                     | <Icon name="check-circle" color="green" /> |
-| Before `cy.session()` ends |                     |                                                 |
+| Before `cy.session()` ends |                     |                                            |
 
 [`cy.visit()`](/api/commands/visit) does not need to be called afterwards to
 ensure the page to test is loaded.

--- a/docs/api/commands/setcookie.mdx
+++ b/docs/api/commands/setcookie.mdx
@@ -109,7 +109,7 @@ The commands above will display in the Command Log as:
 <DocsImage
   src="/img/api/setcookie/set-cookie-on-browser-for-testing.png"
   alt="Command Log setcookie"
-></DocsImage>
+/>
 
 When clicking on `setCookie` within the command log, the console outputs the
 following:
@@ -117,7 +117,7 @@ following:
 <DocsImage
   src="/img/api/setcookie/see-cookie-properties-expiry-domain-and-others-in-test.png"
   alt="Console Log setcookie"
-></DocsImage>
+/>
 
 ## History
 

--- a/docs/api/commands/spy.mdx
+++ b/docs/api/commands/spy.mdx
@@ -106,7 +106,7 @@ You will see the following in the command log:
 <DocsImage
   src="/img/api/spy/using-spy-with-alias.png"
   alt="spies with aliases"
-></DocsImage>
+/>
 
 ## Notes
 
@@ -157,7 +157,7 @@ The command above will display in the Command Log as:
 <DocsImage
   src="/img/api/spy/spying-shows-any-aliases-and-also-any-assertions-made.png"
   alt="Command Log spy"
-></DocsImage>
+/>
 
 When clicking on the `spy-1` event within the command log, the console outputs
 the following:
@@ -165,7 +165,7 @@ the following:
 <DocsImage
   src="/img/api/spy/console-shows-spy-arguments-calls-and-the-object-being-spied.png"
   alt="Console Log spy"
-></DocsImage>
+/>
 
 ## History
 

--- a/docs/api/commands/stub.mdx
+++ b/docs/api/commands/stub.mdx
@@ -188,7 +188,7 @@ You will see the following in the command log:
 <DocsImage
   src="/img/api/stub/stubs-with-aliases-and-error-in-command-log.png"
   alt="stubs with aliases"
-></DocsImage>
+/>
 
 ## Notes
 
@@ -230,7 +230,7 @@ The command above will display in the Command Log as:
 <DocsImage
   src="/img/api/stub/stub-in-command-log.png"
   alt="Command Log stub"
-></DocsImage>
+/>
 
 When clicking on the `(stub-1)` event within the command log, the console
 outputs the following:
@@ -238,7 +238,7 @@ outputs the following:
 <DocsImage
   src="/img/api/stub/inspect-the-stubbed-object-and-any-calls-or-arguments-made.png"
   alt="Console Log stub"
-></DocsImage>
+/>
 
 ## History
 

--- a/docs/api/commands/stub.mdx
+++ b/docs/api/commands/stub.mdx
@@ -227,10 +227,7 @@ expect(stub).to.be.called
 
 The command above will display in the Command Log as:
 
-<DocsImage
-  src="/img/api/stub/stub-in-command-log.png"
-  alt="Command Log stub"
-/>
+<DocsImage src="/img/api/stub/stub-in-command-log.png" alt="Command Log stub" />
 
 When clicking on the `(stub-1)` event within the command log, the console
 outputs the following:

--- a/docs/api/commands/submit.mdx
+++ b/docs/api/commands/submit.mdx
@@ -125,7 +125,7 @@ The commands above will display in the Command Log as:
 <DocsImage
   src="/img/api/submit/form-submit-shows-in-command-log-of-cypress.png"
   alt="Command Log submit"
-></DocsImage>
+/>
 
 When clicking on `submit` within the command log, the console outputs the
 following:
@@ -133,7 +133,7 @@ following:
 <DocsImage
   src="/img/api/submit/console-shows-what-form-was-submitted.png"
   alt="Console Log submit"
-></DocsImage>
+/>
 
 ## History
 

--- a/docs/api/commands/task.mdx
+++ b/docs/api/commands/task.mdx
@@ -536,7 +536,7 @@ configure the countFiles task in the Cypress configuration and call it in a spec
 <DocsImage
   src="/img/api/task/task-count-files.png"
   alt="Command Log task"
-></DocsImage>
+/>
 
 When clicking on the `task` command within the command log, the console outputs
 the following:
@@ -544,7 +544,7 @@ the following:
 <DocsImage
   src="/img/api/task/console-shows-task-result.png"
   alt="Console Log task"
-></DocsImage>
+/>
 
 ## History
 

--- a/docs/api/commands/task.mdx
+++ b/docs/api/commands/task.mdx
@@ -533,10 +533,7 @@ The command above will display in the Command Log as:
 configure the countFiles task in the Cypress configuration and call it in a spec file as shown in above example
 -->
 
-<DocsImage
-  src="/img/api/task/task-count-files.png"
-  alt="Command Log task"
-/>
+<DocsImage src="/img/api/task/task-count-files.png" alt="Command Log task" />
 
 When clicking on the `task` command within the command log, the console outputs
 the following:

--- a/docs/api/commands/tick.mdx
+++ b/docs/api/commands/tick.mdx
@@ -147,7 +147,7 @@ The command above will display in the Command Log as:
 <DocsImage
   src="/img/api/tick/tick-machine-clock-1-second-in-time.png"
   alt="Console Log tick"
-></DocsImage>
+/>
 
 When clicking on the `tick` command within the command log, the console outputs
 the following:
@@ -155,7 +155,7 @@ the following:
 <DocsImage
   src="/img/api/tick/console-shows-same-clock-object-as-clock-command.png"
   alt="Console Log tick"
-></DocsImage>
+/>
 
 ## History
 

--- a/docs/api/commands/viewport.mdx
+++ b/docs/api/commands/viewport.mdx
@@ -159,7 +159,7 @@ describe('Logo', () => {
 <DocsImage
   src="/img/api/viewport/loop-through-an-array-of-multiple-viewports.png"
   alt="Command Log of multiple viewports"
-></DocsImage>
+/>
 
 ### Preset
 
@@ -308,7 +308,7 @@ The commands above will display in the Command Log as:
 <DocsImage
   src="/img/api/viewport/viewport-size-width-and-height-changes-and-is-shown-in-the-commands.png"
   alt="Command Log viewport"
-></DocsImage>
+/>
 
 When clicking on `viewport` within the command log, the console outputs the
 following:
@@ -316,7 +316,7 @@ following:
 <DocsImage
   src="/img/api/viewport/console-log-shows-width-and-height-of-tested-viewport.png"
   alt="Console Log viewport"
-></DocsImage>
+/>
 
 ## History
 

--- a/docs/api/commands/visit.mdx
+++ b/docs/api/commands/visit.mdx
@@ -435,7 +435,7 @@ The commands above will display in the Command Log as:
 <DocsImage
   src="/img/api/visit/visit-example-page-in-before-each-of-test.png"
   alt="Command Log visit"
-></DocsImage>
+/>
 
 When clicking on `visit` within the command log, the console outputs the
 following:
@@ -443,7 +443,7 @@ following:
 <DocsImage
   src="/img/api/visit/visit-shows-any-redirect-or-cookies-set-in-the-console.png"
   alt="console Log visit"
-></DocsImage>
+/>
 
 ## History
 

--- a/docs/api/commands/wait.mdx
+++ b/docs/api/commands/wait.mdx
@@ -236,7 +236,7 @@ found, you will get an error message that looks like this:
 <DocsImage
   src="/img/api/wait/error-for-no-matching-route-when-waiting-in-test.png"
   alt="Error for no matching request"
-></DocsImage>
+/>
 
 Once Cypress detects that a matching request has begun its request, it then
 switches over to the 2nd waiting period. This duration is configured by the
@@ -250,7 +250,7 @@ message that looks like this:
 <DocsImage
   src="/img/api/wait/timeout-error-when-waiting-for-route-response.png"
   alt="Timeout error for request wait"
-></DocsImage>
+/>
 
 This gives you the best of both worlds - a fast error feedback loop when
 requests never go out and a much longer duration for the actual external
@@ -305,7 +305,7 @@ it('assets/img/api/wait/command-log-when-waiting-for-aliased-route.png', () => {
 <DocsImage
   src="/img/api/wait/command-log-when-waiting-for-aliased-route.png"
   alt="Command Log wait"
-></DocsImage>
+/>
 
 When clicking on `wait` within the command log, the console outputs the
 following:
@@ -313,7 +313,7 @@ following:
 <DocsImage
   src="/img/api/wait/wait-console-log-displays-all-the-data-of-the-route-request-and-response.png"
   alt="Console Log wait"
-></DocsImage>
+/>
 
 ## History
 

--- a/docs/api/commands/within.mdx
+++ b/docs/api/commands/within.mdx
@@ -209,7 +209,7 @@ The commands above will display in the Command Log as:
 <DocsImage
   src="/img/api/within/go-within-other-dom-elements.png"
   alt="Command Log within"
-></DocsImage>
+/>
 
 When clicking on the `within` command within the command log, the console
 outputs the following:
@@ -217,7 +217,7 @@ outputs the following:
 <DocsImage
   src="/img/api/within/within-shows-its-yield-in-console-log.png"
   alt="Console Log within"
-></DocsImage>
+/>
 
 ## History
 

--- a/docs/api/commands/wrap.mdx
+++ b/docs/api/commands/wrap.mdx
@@ -109,7 +109,7 @@ it('should wait for promises to resolve', () => {
 <DocsImage
   src="/img/api/wrap/cypress-wrapped-promise-waits-to-resolve.gif"
   alt="Wrap of promises"
-></DocsImage>
+/>
 
 #### Application example <E2EOnlyBadge />
 
@@ -218,7 +218,7 @@ The commands above will display in the Command Log as:
 <DocsImage
   src="/img/api/wrap/wrapped-object-in-cypress-tests.png"
   alt="Command Log wrap"
-></DocsImage>
+/>
 
 When clicking on the `wrap` command within the command log, the console outputs
 the following:
@@ -226,7 +226,7 @@ the following:
 <DocsImage
   src="/img/api/wrap/console-log-only-shows-yield-of-wrap.png"
   alt="Console Log wrap"
-></DocsImage>
+/>
 
 ## History
 

--- a/docs/api/commands/writefile.mdx
+++ b/docs/api/commands/writefile.mdx
@@ -234,7 +234,7 @@ The command above will display in the Command Log as:
 <DocsImage
   src="/img/api/writefile/write-data-to-system-file-for-testing.png"
   alt="Command Log writeFile"
-></DocsImage>
+/>
 
 When clicking on the `writeFile` command within the command log, the console
 outputs the following:
@@ -242,7 +242,7 @@ outputs the following:
 <DocsImage
   src="/img/api/writefile/console-log-shows-contents-written-to-file.png"
   alt="Console Log writeFile"
-></DocsImage>
+/>
 
 ## History
 

--- a/docs/api/cypress-api/cookies.mdx
+++ b/docs/api/cypress-api/cookies.mdx
@@ -46,7 +46,7 @@ cy.setCookie('foo', 'bar')
 <DocsImage
   src="/img/api/cookies/cookies-in-console-log.png"
   alt="Console log when debugging cookies"
-></DocsImage>
+/>
 
 #### Turn off verbose debugging output
 
@@ -63,7 +63,7 @@ Now when Cypress logs cookies they will only include the `name` and `value`.
 <DocsImage
   src="/img/api/cookies/debugger-console-log-of-cookies.png"
   alt="Console log cookies with debug"
-></DocsImage>
+/>
 
 Debugging will be turned on until you explicitly turn it off.
 

--- a/docs/api/cypress-api/cookies.mdx
+++ b/docs/api/cypress-api/cookies.mdx
@@ -17,7 +17,7 @@ Cypress.Cookies.debug(enable, options)
 
 Whether cookie debugging should be enabled.
 
-**<Icon name="angle-right"></Icon> options** **_(Object)_**
+**<Icon name="angle-right" /> options** **_(Object)_**
 
 Pass in an options object to control the behavior of `Cookies.debug()`.
 

--- a/docs/api/cypress-api/custom-commands.mdx
+++ b/docs/api/cypress-api/custom-commands.mdx
@@ -488,7 +488,7 @@ cy.get('#username').type('username@email.com')
 cy.get('#password').type('superSecret123')
 ```
 
-<DocsImage src="/img/api/custom-commands/custom-command-type-no-masked-password.png"></DocsImage>
+<DocsImage src="/img/api/custom-commands/custom-command-type-no-masked-password.png" />
 
 You may want to mask some values passed to the [.type()](/api/commands/type)
 command so that sensitive data does not display in screenshots or videos of your
@@ -520,7 +520,7 @@ cy.get('#password').type('superSecret123', { sensitive: true })
 Now our sensitive password is not printed to the Cypress Command Log when
 `sensitive: true` is passed as an option to [.type()](/api/commands/type).
 
-<DocsImage src="/img/api/custom-commands/custom-command-type-masked-password.png"></DocsImage>
+<DocsImage src="/img/api/custom-commands/custom-command-type-masked-password.png" />
 
 :::info
 

--- a/docs/api/cypress-api/custom-queries.mdx
+++ b/docs/api/cypress-api/custom-queries.mdx
@@ -49,7 +49,7 @@ Cypress.Commands.addQuery(name, callbackFn)
 
 ### Usage
 
-**<Icon name="check-circle" color="green"></Icon> Correct Usage**
+**<Icon name="check-circle" color="green" /> Correct Usage**
 
 ```javascript
 Cypress.Commands.addQuery('getById', function (id) {
@@ -59,11 +59,11 @@ Cypress.Commands.addQuery('getById', function (id) {
 
 ### Arguments
 
-**<Icon name="angle-right"></Icon> name** **_(String)_**
+**<Icon name="angle-right" /> name** **_(String)_**
 
 The name of the query you're adding.
 
-**<Icon name="angle-right"></Icon> callbackFn** **_(Function)_**
+**<Icon name="angle-right" /> callbackFn** **_(Function)_**
 
 Pass a function that receives the arguments passed to the query.
 
@@ -361,9 +361,8 @@ already quite expressive and powerful.
 
 Don't do things like:
 
-- **<Icon name="exclamation-triangle" color="red"></Icon>** `cy.getButton()`
-- **<Icon name="exclamation-triangle" color="red"></Icon>**
-  `.getFirstTableRow()`
+- **<Icon name="exclamation-triangle" color="red" />** `cy.getButton()`
+- **<Icon name="exclamation-triangle" color="red" />** `.getFirstTableRow()`
 
 Both of these are wrapping `cy.get(selector)`. It's completely unnecessary. Just
 call `.get('button')` or `.get('tr:first')`.

--- a/docs/api/cypress-api/cypress-log.mdx
+++ b/docs/api/cypress-api/cypress-log.mdx
@@ -63,7 +63,7 @@ properties shown on click of the command.
 <DocsImage
   src="/img/api/Cypress.log-custom-logging-and-console.png"
   alt="Custom logging of custom command"
-></DocsImage>
+/>
 
 ## See also
 

--- a/docs/api/cypress-api/session.mdx
+++ b/docs/api/cypress-api/session.mdx
@@ -31,7 +31,7 @@ Clearing all session and automatically re-running the spec
 
 ### Arguments
 
-**<Icon name="angle-right"></Icon> id** **_(String)_**
+**<Icon name="angle-right" /> id** **_(String)_**
 
 The name of the session used to retrieve data storage and cookie data.
 

--- a/docs/api/cypress-api/session.mdx
+++ b/docs/api/cypress-api/session.mdx
@@ -27,7 +27,7 @@ Clearing all session and automatically re-running the spec
 <DocsImage
   src="/img/api/session/sessions-panel.png"
   alt="Sessions Instrument Panel"
-></DocsImage>
+/>
 
 ### Arguments
 

--- a/docs/api/events/catalog-of-events.mdx
+++ b/docs/api/events/catalog-of-events.mdx
@@ -490,4 +490,4 @@ Developer Tools console.
 <DocsImage
   src="/img/api/catalog-of-events/console-log-events-debug.png"
   alt="console log events for debugging"
-></DocsImage>
+/>

--- a/docs/api/plugins/browser-launch-api.mdx
+++ b/docs/api/plugins/browser-launch-api.mdx
@@ -219,7 +219,7 @@ opening a new tab and typing `chrome://version` url.
 <DocsImage
   src="/img/api/chrome-switches.png"
   alt="See all Chrome switches"
-></DocsImage>
+/>
 
 ## Examples
 
@@ -326,7 +326,7 @@ without having to have the necessary hardware to test.
 <DocsImage
   src="/img/api/browser-launch-fake-video.gif"
   alt="Enable fake video for testing"
-></DocsImage>
+/>
 
 You can however send your own video file for testing by passing a Chrome command
 line switch pointing to a video file.

--- a/docs/api/plugins/browser-launch-api.mdx
+++ b/docs/api/plugins/browser-launch-api.mdx
@@ -216,10 +216,7 @@ If you are running Cypress tests using a Chromium-based browser, you can see ALL
 currently set command line switches and the browser version information by
 opening a new tab and typing `chrome://version` url.
 
-<DocsImage
-  src="/img/api/chrome-switches.png"
-  alt="See all Chrome switches"
-/>
+<DocsImage src="/img/api/chrome-switches.png" alt="See all Chrome switches" />
 
 ## Examples
 

--- a/docs/api/plugins/configuration-api.mdx
+++ b/docs/api/plugins/configuration-api.mdx
@@ -56,7 +56,7 @@ Resolved values will show up in the "Settings" tab.
 <DocsImage
   src="/img/guides/configuration/plugin-configuration.png"
   alt="Resolved configuration in the Desktop app"
-></DocsImage>
+/>
 
 ### Promises
 

--- a/docs/api/queries/as.mdx
+++ b/docs/api/queries/as.mdx
@@ -214,7 +214,7 @@ Aliases of routes display in the routes instrument panel:
 <DocsImage
   src="/img/api/as/routes-table-in-command-log.png"
   alt="Command log for route"
-></DocsImage>
+/>
 
 ## History
 

--- a/docs/api/queries/as.mdx
+++ b/docs/api/queries/as.mdx
@@ -47,7 +47,7 @@ The name of the alias to be referenced later within a
 [`cy.get()`](/api/commands/get) or [`cy.wait()`](/api/commands/wait) command
 using an `@` prefix.
 
-**<Icon name="angle-right"></Icon> options** **_(Object)_**
+**<Icon name="angle-right" /> options** **_(Object)_**
 
 Pass in an options object to change the default behavior of `.as()`.
 

--- a/docs/api/queries/children.mdx
+++ b/docs/api/queries/children.mdx
@@ -146,7 +146,7 @@ The commands above will display in the Command Log as:
 <DocsImage
   src="/img/api/children/children-elements-shown-in-command-log.png"
   alt="Command log for children"
-></DocsImage>
+/>
 
 When clicking on the `children` command within the command log, the console
 outputs the following:
@@ -154,7 +154,7 @@ outputs the following:
 <DocsImage
   src="/img/api/children/children-yielded-in-console.png"
   alt="console.log for children"
-></DocsImage>
+/>
 
 ## See also
 

--- a/docs/api/queries/closest.mdx
+++ b/docs/api/queries/closest.mdx
@@ -98,7 +98,7 @@ The commands above will display in the Command Log as:
 <DocsImage
   src="/img/api/closest/find-closest-nav-element-in-test.png"
   alt="Command Log closest"
-></DocsImage>
+/>
 
 When clicking on the `closest` command within the command log, the console
 outputs the following:
@@ -106,7 +106,7 @@ outputs the following:
 <DocsImage
   src="/img/api/closest/closest-console-logs-elements-found.png"
   alt="console.log closest"
-></DocsImage>
+/>
 
 ## See also
 

--- a/docs/api/queries/contains.mdx
+++ b/docs/api/queries/contains.mdx
@@ -283,7 +283,7 @@ Rendered result:
 <DocsImage
   src="/img/api/contains/contains-pre-exception.png"
   alt="The result of pre tag"
-></DocsImage>
+/>
 
 To reflect this behavior, Cypress also doesn't ignore them.
 
@@ -482,7 +482,7 @@ The commands above will display in the Command Log as:
 <DocsImage
   src="/img/api/contains/find-el-that-contains-text.png"
   alt="Command Log contains"
-></DocsImage>
+/>
 
 When clicking on the `contains` command within the command log, the console
 outputs the following:
@@ -490,7 +490,7 @@ outputs the following:
 <DocsImage
   src="/img/api/contains/see-elements-found-from-contains-in-console.png"
   alt="console.log contains"
-></DocsImage>
+/>
 
 ## History
 

--- a/docs/api/queries/debug.mdx
+++ b/docs/api/queries/debug.mdx
@@ -86,7 +86,7 @@ The commands above will display in the Command Log as:
 <DocsImage
   src="/img/api/debug/how-debug-displays-in-command-log.png"
   alt="Command Log debug"
-></DocsImage>
+/>
 
 When clicking on the `debug` command within the command log, the console outputs
 the following:
@@ -94,7 +94,7 @@ the following:
 <DocsImage
   src="/img/api/debug/console-gives-all-debug-info-for-command.png"
   alt="console.log debug"
-></DocsImage>
+/>
 
 ## See also
 

--- a/docs/api/queries/document.mdx
+++ b/docs/api/queries/document.mdx
@@ -83,7 +83,7 @@ The command above will display in the Command Log as:
 <DocsImage
   src="/img/api/document/get-document-of-application-in-command-log.png"
   alt="Command log document"
-></DocsImage>
+/>
 
 When clicking on `document` within the command log, the console outputs the
 following:
@@ -91,7 +91,7 @@ following:
 <DocsImage
   src="/img/api/document/console-yields-the-document-of-aut.png"
   alt="console.log document"
-></DocsImage>
+/>
 
 ## See also
 

--- a/docs/api/queries/eq.mdx
+++ b/docs/api/queries/eq.mdx
@@ -161,7 +161,7 @@ The commands above will display in the Command Log as:
 <DocsImage
   src="/img/api/eq/find-element-at-index.png"
   alt="Command log eq"
-></DocsImage>
+/>
 
 When clicking on the `eq` command within the command log, the console outputs
 the following:
@@ -169,7 +169,7 @@ the following:
 <DocsImage
   src="/img/api/eq/see-element-and-list-when-using-eq.png"
   alt="console.log eq"
-></DocsImage>
+/>
 
 ## See also
 

--- a/docs/api/queries/eq.mdx
+++ b/docs/api/queries/eq.mdx
@@ -158,10 +158,7 @@ cy.get('.left-nav.nav').find('>li').eq(3)
 
 The commands above will display in the Command Log as:
 
-<DocsImage
-  src="/img/api/eq/find-element-at-index.png"
-  alt="Command log eq"
-/>
+<DocsImage src="/img/api/eq/find-element-at-index.png" alt="Command log eq" />
 
 When clicking on the `eq` command within the command log, the console outputs
 the following:

--- a/docs/api/queries/filter.mdx
+++ b/docs/api/queries/filter.mdx
@@ -155,7 +155,7 @@ The commands above will display in the Command Log as:
 <DocsImage
   src="/img/api/filter/filter-el-by-selector.png"
   alt="Command Log filter"
-></DocsImage>
+/>
 
 When clicking on the `filter` command within the command log, the console
 outputs the following:
@@ -163,7 +163,7 @@ outputs the following:
 <DocsImage
   src="/img/api/filter/console-shows-list-and-filtered-element.png"
   alt="console.log filter"
-></DocsImage>
+/>
 
 ## See also
 

--- a/docs/api/queries/find.mdx
+++ b/docs/api/queries/find.mdx
@@ -106,7 +106,7 @@ The commands above will display in the Command Log as:
 <DocsImage
   src="/img/api/find/find-li-of-uls-in-test.png"
   alt="Command Log find"
-></DocsImage>
+/>
 
 When clicking on the `find` command within the command log, the console outputs
 the following:
@@ -114,7 +114,7 @@ the following:
 <DocsImage
   src="/img/api/find/find-in-console-shows-list-and-yields.png"
   alt="console.log find"
-></DocsImage>
+/>
 
 ## History
 

--- a/docs/api/queries/first.mdx
+++ b/docs/api/queries/first.mdx
@@ -103,7 +103,7 @@ The commands above will display in the Command Log as:
 <DocsImage
   src="/img/api/first/get-the-first-in-list-of-elements.png"
   alt="Command Log first"
-></DocsImage>
+/>
 
 When clicking on `first` within the command log, the console outputs the
 following:
@@ -111,7 +111,7 @@ following:
 <DocsImage
   src="/img/api/first/console-log-the-first-element.png"
   alt="console.log first"
-></DocsImage>
+/>
 
 ## See also
 

--- a/docs/api/queries/focused.mdx
+++ b/docs/api/queries/focused.mdx
@@ -94,7 +94,7 @@ The commands above will display in the Command Log as:
 <DocsImage
   src="/img/api/focused/make-assertion-about-focused-element.png"
   alt="Command Log focused"
-></DocsImage>
+/>
 
 When clicking on the `focused` command within the command log, the console
 outputs the following:
@@ -102,7 +102,7 @@ outputs the following:
 <DocsImage
   src="/img/api/focused/currently-focused-element-in-an-input.png"
   alt="console focused"
-></DocsImage>
+/>
 
 ## See also
 

--- a/docs/api/queries/get.mdx
+++ b/docs/api/queries/get.mdx
@@ -252,7 +252,7 @@ The commands above will display in the Command Log as:
 <DocsImage
   src="/img/api/get/get-element-and-make-an-assertion.png"
   alt="Command Log get"
-></DocsImage>
+/>
 
 When clicking on the `get` command within the command log, the console outputs
 the following:
@@ -260,7 +260,7 @@ the following:
 <DocsImage
   src="/img/api/get/console-log-get-command-and-elements-found.png"
   alt="Console Log get"
-></DocsImage>
+/>
 
 ## History
 

--- a/docs/api/queries/hash.mdx
+++ b/docs/api/queries/hash.mdx
@@ -102,7 +102,7 @@ The commands above will display in the Command Log as:
 <DocsImage
   src="/img/api/hash/test-url-hash-for-users-page.png"
   alt="Command Log for hash"
-></DocsImage>
+/>
 
 When clicking on `hash` within the command log, the console outputs the
 following:
@@ -110,7 +110,7 @@ following:
 <DocsImage
   src="/img/api/hash/hash-command-yields-url-after-hash.png"
   alt="Console Log for hash"
-></DocsImage>
+/>
 
 ## See also
 

--- a/docs/api/queries/invoke.mdx
+++ b/docs/api/queries/invoke.mdx
@@ -242,7 +242,7 @@ cy.wrap(english).invoke('greeting').should('equal', 'bye')
   src="/img/api/invoke/invoke-retries.gif"
   alt="Invoke retries example"
   width-600
-></DocsImage>
+/>
 
 ## Rules
 
@@ -280,7 +280,7 @@ The commands above will display in the Command Log as:
 <DocsImage
   src="/img/api/invoke/invoke-jquery-show-on-element-for-testing.png"
   alt="Command Log for invoke"
-></DocsImage>
+/>
 
 When clicking on `invoke` within the command log, the console outputs the
 following:
@@ -288,7 +288,7 @@ following:
 <DocsImage
   src="/img/api/invoke/log-function-invoked-and-return.png"
   alt="Console Log for invoke"
-></DocsImage>
+/>
 
 ## History
 

--- a/docs/api/queries/its.mdx
+++ b/docs/api/queries/its.mdx
@@ -230,7 +230,7 @@ The commands above will display in the Command Log as:
 <DocsImage
   src="/img/api/its/xhr-response-its-response-body-for-testing.png"
   alt="Command Log for its"
-></DocsImage>
+/>
 
 When clicking on `its` within the command log, the console outputs the
 following:
@@ -238,7 +238,7 @@ following:
 <DocsImage
   src="/img/api/its/response-body-yielded-with-its-command-log.png"
   alt="Console Log for its"
-></DocsImage>
+/>
 
 ## History
 

--- a/docs/api/queries/last.mdx
+++ b/docs/api/queries/last.mdx
@@ -103,7 +103,7 @@ The commands above will display in the Command Log as:
 <DocsImage
   src="/img/api/last/find-the-last-button-in-a-form.png"
   alt="Command Log for last"
-></DocsImage>
+/>
 
 When clicking on `last` within the command log, the console outputs the
 following:
@@ -111,7 +111,7 @@ following:
 <DocsImage
   src="/img/api/last/inspect-last-element-in-console.png"
   alt="Console Log for last"
-></DocsImage>
+/>
 
 ## See also
 

--- a/docs/api/queries/location.mdx
+++ b/docs/api/queries/location.mdx
@@ -141,7 +141,7 @@ cy.window().then((win) => {
 <DocsImage
   src="/img/api/location/window-location-object-printed-in-console-log.png"
   alt="Console.log of window.location"
-></DocsImage>
+/>
 
 #### Console output of `.location()`
 
@@ -154,7 +154,7 @@ cy.location().then((loc) => {
 <DocsImage
   src="/img/api/location/special-cypress-location-object-logged-in-console-output.png"
   alt="Console Log of Cypress location command"
-></DocsImage>
+/>
 
 ## Rules
 
@@ -187,7 +187,7 @@ The commands above will display in the Command Log as:
 <DocsImage
   src="/img/api/location/make-assertion-about-location-url-in-tests.png"
   alt="Command Log of Cypress location command"
-></DocsImage>
+/>
 
 When clicking on `location` within the command log, the console outputs the
 following:
@@ -195,7 +195,7 @@ following:
 <DocsImage
   src="/img/api/location/location-object-in-console-log.png"
   alt="Console Log of Cypress location command"
-></DocsImage>
+/>
 
 ## See also
 

--- a/docs/api/queries/next.mdx
+++ b/docs/api/queries/next.mdx
@@ -148,7 +148,7 @@ The commands above will display in the Command Log as:
 <DocsImage
   src="/img/api/next/find-next-element-when-testing-dom.png"
   alt="Command Log next"
-></DocsImage>
+/>
 
 When clicking on `next` within the command log, the console outputs the
 following:
@@ -156,7 +156,7 @@ following:
 <DocsImage
   src="/img/api/next/elements-next-command-applied-to.png"
   alt="Console Log next"
-></DocsImage>
+/>
 
 ## See also
 

--- a/docs/api/queries/nextall.mdx
+++ b/docs/api/queries/nextall.mdx
@@ -129,7 +129,7 @@ The commands above will display in the Command Log as:
 <DocsImage
   src="/img/api/nextall/next-all-traversal-command-for-the-dom.png"
   alt="Command Log nextAll"
-></DocsImage>
+/>
 
 When clicking on `nextAll` within the command log, the console outputs the
 following:
@@ -137,7 +137,7 @@ following:
 <DocsImage
   src="/img/api/nextall/all-next-elements-are-logged-in-console.png"
   alt="Console Log nextAll"
-></DocsImage>
+/>
 
 ## See also
 

--- a/docs/api/queries/nextuntil.mdx
+++ b/docs/api/queries/nextuntil.mdx
@@ -129,7 +129,7 @@ The commands above will display in the Command Log as:
 <DocsImage
   src="/img/api/nextuntil/find-next-elements-until-selector.png"
   alt="Command Log nextUntil"
-></DocsImage>
+/>
 
 When clicking on `nextUntil` within the command log, the console outputs the
 following:
@@ -137,7 +137,7 @@ following:
 <DocsImage
   src="/img/api/nextuntil/console-log-of-next-elements-until.png"
   alt="Console Log nextUntil"
-></DocsImage>
+/>
 
 ## See also
 

--- a/docs/api/queries/not.mdx
+++ b/docs/api/queries/not.mdx
@@ -113,7 +113,7 @@ The commands above will display in the Command Log as:
 <DocsImage
   src="/img/api/not/filter-elements-with-not-and-optional-selector.png"
   alt="Command Log not"
-></DocsImage>
+/>
 
 When clicking on `not` within the command log, the console outputs the
 following:
@@ -121,7 +121,7 @@ following:
 <DocsImage
   src="/img/api/not/log-elements-found-when-using-cy-not.png"
   alt="Console Log not"
-></DocsImage>
+/>
 
 ## See also
 

--- a/docs/api/queries/parent.mdx
+++ b/docs/api/queries/parent.mdx
@@ -140,7 +140,7 @@ The commands above will display in the Command Log as:
 <DocsImage
   src="/img/api/parent/get-parent-element-just-like-jquery.png"
   alt="Command Log parent"
-></DocsImage>
+/>
 
 When clicking on the `parent` command within the command log, the console
 outputs the following:
@@ -148,7 +148,7 @@ outputs the following:
 <DocsImage
   src="/img/api/parent/parent-command-found-elements-for-console-log.png"
   alt="Console Log parent"
-></DocsImage>
+/>
 
 ## See also
 

--- a/docs/api/queries/parents.mdx
+++ b/docs/api/queries/parents.mdx
@@ -125,7 +125,7 @@ cy.get('li.active').parents()
 <DocsImage
   src="/img/api/parents/get-all-parents-of-a-dom-element.png"
   alt="Command Log parents"
-></DocsImage>
+/>
 
 When clicking on the `parents` command within the command log, the console
 outputs the following:
@@ -133,7 +133,7 @@ outputs the following:
 <DocsImage
   src="/img/api/parents/parents-elements-displayed-in-devtools-console.png"
   alt="Console Log parents"
-></DocsImage>
+/>
 
 ## See also
 

--- a/docs/api/queries/parentsuntil.mdx
+++ b/docs/api/queries/parentsuntil.mdx
@@ -129,7 +129,7 @@ The commands above will display in the Command Log as:
 <DocsImage
   src="/img/api/parentsuntil/get-all-parents-until-nav-selector.png"
   alt="Command Log parentsUntil"
-></DocsImage>
+/>
 
 When clicking on `parentsUntil` within the command log, the console outputs the
 following:
@@ -137,7 +137,7 @@ following:
 <DocsImage
   src="/img/api/parentsuntil/show-parents-until-nav-in-console.png"
   alt="Console Log parentsUntil"
-></DocsImage>
+/>
 
 ## See also
 

--- a/docs/api/queries/prev.mdx
+++ b/docs/api/queries/prev.mdx
@@ -129,7 +129,7 @@ The commands above will display in the Command Log as:
 <DocsImage
   src="/img/api/prev/find-prev-element-in-list-of-els.png"
   alt="Command Log prev"
-></DocsImage>
+/>
 
 When clicking on `prev` within the command log, the console outputs the
 following:
@@ -137,7 +137,7 @@ following:
 <DocsImage
   src="/img/api/prev/previous-element-in-console-log.png"
   alt="Console Log prev"
-></DocsImage>
+/>
 
 ## See also
 

--- a/docs/api/queries/prevall.mdx
+++ b/docs/api/queries/prevall.mdx
@@ -129,7 +129,7 @@ The commands above will display in the Command Log as:
 <DocsImage
   src="/img/api/prevall/find-all-previous-elements-with-optional-selector.png"
   alt="Command Log prevAll"
-></DocsImage>
+/>
 
 When clicking on `prevAll` within the command log, the console outputs the
 following:
@@ -137,7 +137,7 @@ following:
 <DocsImage
   src="/img/api/prevall/console-log-all-previous-elements-traversed.png"
   alt="Console Log prevAll"
-></DocsImage>
+/>
 
 ## See also
 

--- a/docs/api/queries/prevuntil.mdx
+++ b/docs/api/queries/prevuntil.mdx
@@ -129,7 +129,7 @@ The commands above will display in the Command Log as:
 <DocsImage
   src="/img/api/prevuntil/prev-until-finding-elements-in-command-log.png"
   alt="Command Log prevUntil"
-></DocsImage>
+/>
 
 When clicking on `prevUntil` within the command log, the console outputs the
 following:
@@ -137,7 +137,7 @@ following:
 <DocsImage
   src="/img/api/prevuntil/console-log-previous-elements-until-defined-el.png"
   alt="Console Log prevUntil"
-></DocsImage>
+/>
 
 ## See also
 

--- a/docs/api/queries/root.mdx
+++ b/docs/api/queries/root.mdx
@@ -98,7 +98,7 @@ The commands above will display in the Command Log as:
 <DocsImage
   src="/img/api/root/find-root-element-and-assert.png"
   alt="Command Log root"
-></DocsImage>
+/>
 
 When clicking on the `root` command within the command log, the console outputs
 the following:
@@ -106,7 +106,7 @@ the following:
 <DocsImage
   src="/img/api/root/console-log-root-which-is-usually-the-main-document.png"
   alt="Console Log root"
-></DocsImage>
+/>
 
 ## See also
 

--- a/docs/api/queries/shadow.mdx
+++ b/docs/api/queries/shadow.mdx
@@ -101,7 +101,7 @@ The commands above will display in the Command Log as:
 <DocsImage
   src="/img/api/shadow/shadow-command-log.png"
   alt="Command Log shadow"
-></DocsImage>
+/>
 
 When clicking on the `shadow` command within the command log, the console
 outputs the following:
@@ -109,7 +109,7 @@ outputs the following:
 <DocsImage
   src="/img/api/shadow/shadow-in-console.png"
   alt="console.log shadow"
-></DocsImage>
+/>
 
 ## See also
 

--- a/docs/api/queries/siblings.mdx
+++ b/docs/api/queries/siblings.mdx
@@ -112,7 +112,7 @@ The commands above will display in the Command Log as:
 <DocsImage
   src="/img/api/siblings/find-siblings-of-dom-elements-to-test.png"
   alt="Command Log siblings"
-></DocsImage>
+/>
 
 When clicking on `siblings` within the command log, the console outputs the
 following:
@@ -120,7 +120,7 @@ following:
 <DocsImage
   src="/img/api/siblings/console-log-of-sibling-elements.png"
   alt="Console Log siblings"
-></DocsImage>
+/>
 
 ## History
 

--- a/docs/api/queries/title.mdx
+++ b/docs/api/queries/title.mdx
@@ -74,7 +74,7 @@ The commands above will display in the Command Log as:
 <DocsImage
   src="/img/api/title/test-title-of-website-or-webapp.png"
   alt="Command Log title"
-></DocsImage>
+/>
 
 When clicking on `title` within the command log, the console outputs the
 following:
@@ -82,7 +82,7 @@ following:
 <DocsImage
   src="/img/api/title/see-the-string-yielded-in-the-console.png"
   alt="Console Log title"
-></DocsImage>
+/>
 
 ## History
 

--- a/docs/api/queries/url.mdx
+++ b/docs/api/queries/url.mdx
@@ -148,14 +148,14 @@ The commands above will display in the Command Log as:
 <DocsImage
   src="/img/api/url/test-url-of-website-or-web-application.png"
   alt="Command Log url"
-></DocsImage>
+/>
 
 When clicking on URL within the Command Log, the console outputs the following:
 
 <DocsImage
   src="/img/api/url/console-log-of-browser-url-string.png"
   alt="Console Log url"
-></DocsImage>
+/>
 
 ## History
 

--- a/docs/api/queries/window.mdx
+++ b/docs/api/queries/window.mdx
@@ -229,7 +229,7 @@ The commands above will display in the Command Log as:
 <DocsImage
   src="/img/api/window/window-command-log-for-cypress-tests.png"
   alt="Command Log window"
-></DocsImage>
+/>
 
 When clicking on `window` within the command log, the console outputs the
 following:
@@ -237,7 +237,7 @@ following:
 <DocsImage
   src="/img/api/window/console-shows-the-applications-window-object-being-tested.png"
   alt="Console Log window"
-></DocsImage>
+/>
 
 ## History
 

--- a/docs/examples/applications.mdx
+++ b/docs/examples/applications.mdx
@@ -36,7 +36,7 @@ Cypress.
 <DocsImage
   src="/img/examples/public-project-kitchen-sink.png"
   alt="kitchensink running"
-></DocsImage>
+/>
 
 ## TodoMVC
 
@@ -61,7 +61,7 @@ vanilla Selenium.
 <DocsImage
   src="/img/examples/public-project-todomvc.png"
   alt="TodoMvc testing in Cypress"
-></DocsImage>
+/>
 
 ## TodoMVC Redux
 
@@ -81,7 +81,7 @@ Through a combination of end-to-end and unit tests shows how you can achieve
 <DocsImage
   src="/img/examples/todomvc-redux-100percent.png"
   alt="TodoMVC Redux application code coverage report"
-></DocsImage>
+/>
 
 ## Realworld
 
@@ -106,7 +106,7 @@ Shows a full blogging application, "Conduit", with back end code and a database.
 <DocsImage
   src="/img/examples/realworld-app.png"
   alt="Realworld test in Cypress"
-></DocsImage>
+/>
 
 ## Angular-playground
 

--- a/docs/examples/tutorials.mdx
+++ b/docs/examples/tutorials.mdx
@@ -80,7 +80,7 @@ then jump right into getting Cypress up and running.
   url="https://github.com/cypress-io/cypress-tutorial-build-todo/tree/01_setup"
 />
 
-<DocsVideo src="https://vimeo.com/240554515"></DocsVideo>
+<DocsVideo src="https://vimeo.com/240554515" />
 
 ### 2. Text inputs
 
@@ -96,7 +96,7 @@ some best practices like using `beforeEach` and defining our application's
   url="https://github.com/cypress-io/cypress-tutorial-build-todo/tree/02_inputs"
 />
 
-<DocsVideo src="https://vimeo.com/240554808"></DocsVideo>
+<DocsVideo src="https://vimeo.com/240554808" />
 
 ### 3. Form submission and XHRs
 
@@ -112,7 +112,7 @@ implement the code to properly display an error message.
   url="https://github.com/cypress-io/cypress-tutorial-build-todo/tree/03_form_sub"
 />
 
-<DocsVideo src="https://vimeo.com/241063147"></DocsVideo>
+<DocsVideo src="https://vimeo.com/241063147" />
 
 ### 4. Loading data with fixtures
 
@@ -157,7 +157,7 @@ convenience, you can copy it from here and paste it in as you follow along.
   url="https://github.com/cypress-io/cypress-tutorial-build-todo/tree/04_custom_cmd"
 />
 
-<DocsVideo src="https://vimeo.com/241773142"></DocsVideo>
+<DocsVideo src="https://vimeo.com/241773142" />
 
 ### 5. Todo item behavior
 
@@ -175,7 +175,7 @@ way to hold onto references to previously queried DOM elements using
   url="https://github.com/cypress-io/cypress-tutorial-build-todo/tree/05_todo_items"
 />
 
-<DocsVideo src="https://vimeo.com/242954792"></DocsVideo>
+<DocsVideo src="https://vimeo.com/242954792" />
 
 ### 6. Toggling and debugging
 
@@ -196,7 +196,7 @@ be less error prone, relying on the test to help us get it right.
   url="https://github.com/cypress-io/cypress-tutorial-build-todo/tree/06_toggle_debug"
 />
 
-<DocsVideo src="https://vimeo.com/242961930"></DocsVideo>
+<DocsVideo src="https://vimeo.com/242961930" />
 
 ### 7. Filters and data-driven tests
 
@@ -215,7 +215,7 @@ multiple variations of the filter behavior in a single test.
   url="https://github.com/cypress-io/cypress-tutorial-build-todo/tree/07_data_driven"
 />
 
-<DocsVideo src="https://vimeo.com/244696145"></DocsVideo>
+<DocsVideo src="https://vimeo.com/244696145" />
 
 ### 8. Full end-to-end tests part 1
 
@@ -233,7 +233,7 @@ responses in our tests to avoid flake caused by unpredictable response times.
   url="https://github.com/cypress-io/cypress-tutorial-build-todo/tree/08_smoke_1"
 />
 
-<DocsVideo src="https://vimeo.com/245387683"></DocsVideo>
+<DocsVideo src="https://vimeo.com/245387683" />
 
 ### 9. Full end-to-end tests part 2
 
@@ -251,4 +251,4 @@ tests in a CI environment.
   url="https://github.com/cypress-io/cypress-tutorial-build-todo/tree/09_smoke_2"
 />
 
-<DocsVideo src="https://vimeo.com/245388948"></DocsVideo>
+<DocsVideo src="https://vimeo.com/245388948" />

--- a/docs/examples/workshop.mdx
+++ b/docs/examples/workshop.mdx
@@ -70,10 +70,7 @@ on:
 
 ## ReactJSDay 2019 Testing Course
 
-<DocsImage
-  src="/img/examples/reactjsday-course.png"
-  alt="ReactJS Day"
-/>
+<DocsImage src="/img/examples/reactjsday-course.png" alt="ReactJS Day" />
 
 This is the
 [reference repository](https://github.com/NoriSte/reactjsday-2019-testing-course)

--- a/docs/examples/workshop.mdx
+++ b/docs/examples/workshop.mdx
@@ -8,7 +8,7 @@ sidebar_position: 50
 <DocsImage
   src="/img/examples/end-to-end-testing-workshop.jpg"
   alt="End-to-end Testing Workshop"
-></DocsImage>
+/>
 
 Cypress has put together a full day workshop that teaches how to test a modern
 web application using Cypress. You can preview the slides here:
@@ -48,7 +48,7 @@ testers good Cypress practices.
 <DocsImage
   src="/img/examples/cypress-workshop-ci.png"
   alt="Cypress on CI workshop"
-></DocsImage>
+/>
 
 Cypress team has prepared a 4 hour workshop that shows how to successfully run
 Cypress tests on several popular continuous integration services. You can
@@ -73,7 +73,7 @@ on:
 <DocsImage
   src="/img/examples/reactjsday-course.png"
   alt="ReactJS Day"
-></DocsImage>
+/>
 
 This is the
 [reference repository](https://github.com/NoriSte/reactjsday-2019-testing-course)

--- a/docs/faq/questions/cloud-faq.mdx
+++ b/docs/faq/questions/cloud-faq.mdx
@@ -3,7 +3,7 @@ title: Cypress Cloud
 hide_table_of_contents: true
 ---
 
-## <Icon name="angle-right"></Icon> What is Cypress Cloud?
+## <Icon name="angle-right" /> What is Cypress Cloud?
 
 <DocsImage
   src="/img/dashboard/dashboard-runs-list.png"
@@ -90,11 +90,11 @@ provider's `stdout` output, you can log into
 screenshots and video of the tests running. It should be instantly clear what
 the problem was.
 
-## <Icon name="angle-right"></Icon> Can I host Cypress Cloud data myself?
+## <Icon name="angle-right" /> Can I host Cypress Cloud data myself?
 
 No. A self-hosted version of Cypress Cloud is not available at this time.
 
-## <Icon name="angle-right"></Icon> Can I choose not to use Cypress Cloud?
+## <Icon name="angle-right" /> Can I choose not to use Cypress Cloud?
 
 Of course. Cypress Cloud is a separate service from the Cypress app and will
 always remain optional. We hope you'll find a tremendous amount of value in it,
@@ -175,7 +175,7 @@ parallel. If there is NO common variable, try using the commit SHA string.
 Assuming you do not run the same tests more than once against the same commit,
 it might be good enough for the job.
 
-## <Icon name="angle-right"></Icon> Can I delete a run from Cypress Cloud?
+## <Icon name="angle-right" /> Can I delete a run from Cypress Cloud?
 
 You can [archive a run](/guides/cloud/runs#Archive-run) so that it does not
 display in the runs list or in analytics.
@@ -190,7 +190,7 @@ You can delete your Cypress account from
 account cannot be undone! By deleting your Cypress account, all associated data
 in your account will be permanently deleted.
 
-## <Icon name="angle-right"></Icon> What happens if I downgrade my account?
+## <Icon name="angle-right" /> What happens if I downgrade my account?
 
 Downgrading your account will **not** result in loss of access to Cypress Cloud.
 
@@ -215,7 +215,7 @@ by:
 4. Review your organization's usage
 5. Scroll down and select **Upgrade** under your plan of choice
 
-## <Icon name="angle-right"></Icon> I'm working at a restrictive VPN. Which subdomains do I have to allow on
+## <Icon name="angle-right" /> I'm working at a restrictive VPN. Which subdomains do I have to allow on
 
 my VPN for Cypress Cloud to work properly?
 

--- a/docs/faq/questions/cloud-faq.mdx
+++ b/docs/faq/questions/cloud-faq.mdx
@@ -8,7 +8,7 @@ hide_table_of_contents: true
 <DocsImage
   src="/img/dashboard/dashboard-runs-list.png"
   alt="Cloud Screenshot"
-></DocsImage>
+/>
 
 [Cypress Cloud](https://on.cypress.io/cloud) gives you access to tests you've
 recorded - typically when running Cypress tests from your

--- a/docs/faq/questions/using-cypress-faq.mdx
+++ b/docs/faq/questions/using-cypress-faq.mdx
@@ -651,7 +651,7 @@ You can find your project's record key inside of the _Settings_ tab.
 <DocsImage
   src="/img/dashboard/record-key-shown-in-desktop-gui-configuration.jpg"
   alt="Record Key in Configuration Tab"
-></DocsImage>
+/>
 
 For further detail see the
 [Identification](/guides/cloud/projects#Identification) section of the
@@ -687,7 +687,7 @@ email's functionality and visual style:
   src="/img/guides/references/email-test.png"
   title="The HTML email loaded during the test"
   alt="The test finds and clicks the Confirm registration button"
-></DocsImage>
+/>
 
 3. You can use a 3rd party email service that provides temporary email addresses
    for testing. Some of these services even offer a
@@ -799,7 +799,7 @@ describe('Logo', () => {
 <DocsImage
   src="/img/faq/questions/command-log-of-dynamic-url-test.png"
   alt="Command Log multiple urls"
-></DocsImage>
+/>
 
 ## <Icon name="angle-right" /> How do I require or import node modules in Cypress?
 

--- a/docs/guides/cloud/analytics.mdx
+++ b/docs/guides/cloud/analytics.mdx
@@ -9,14 +9,14 @@ time, run duration and visibility into tests suite size over time.
 <DocsImage
   src="/img/dashboard/analytics/dashboard-analytics-overview.png"
   alt="Cloud Analytics Screenshot"
-></DocsImage>
+/>
 
 ## Run status
 
 <DocsImage
   src="/img/dashboard/analytics/dashboard-analytics-runs-over-time.png"
   alt="Cloud Analytics Runs Over Time Screenshot"
-></DocsImage>
+/>
 
 This report shows the number of runs your organization has recorded to Cypress
 Cloud, broken down by the final status of the run. Each run represents a single
@@ -28,7 +28,7 @@ local machine.
 <DocsImage
   src="/img/dashboard/analytics/dashboard-analytics-runs-over-time-filters.png"
   alt="Cloud Analytics Runs Over Time Filters Screenshot"
-></DocsImage>
+/>
 
 Results may be filtered by:
 
@@ -41,7 +41,7 @@ Results may be filtered by:
 <DocsImage
   src="/img/dashboard/analytics/dashboard-analytics-runs-over-time-graph.png"
   alt="Cloud Analytics Runs Over Time Graph Screenshot"
-></DocsImage>
+/>
 
 The total runs over time are displayed for passed, failed, running, timed out
 and errored tests, respective of the filters selected.
@@ -56,7 +56,7 @@ This can be done via the download icon to the right of the filters.
 <DocsImage
   src="/img/dashboard/analytics/dashboard-analytics-runs-over-time-kpi.png"
   alt="Cloud Analytics Runs Over Time KPI Screenshot"
-></DocsImage>
+/>
 
 Total runs, average per day, passed runs and failed runs are the computed
 respective of the filters selected.
@@ -64,7 +64,7 @@ respective of the filters selected.
 <DocsImage
   src="/img/dashboard/analytics/dashboard-analytics-runs-over-time-table.png"
   alt="Cloud Analytics Runs Over Time Table Screenshot"
-></DocsImage>
+/>
 
 A table of results grouped by date for the time range filter is displayed with
 passed, failed, running, timed out and errored columns.
@@ -74,7 +74,7 @@ passed, failed, running, timed out and errored columns.
 <DocsImage
   src="/img/dashboard/analytics/dashboard-analytics-run-duration.png"
   alt="Cloud Analytics Run Duration Screenshot"
-></DocsImage>
+/>
 
 This report shows the average duration of a Cypress run for your project,
 including how test parallelization is impacting your total run time. Note that
@@ -86,7 +86,7 @@ away from its typical duration.
 <DocsImage
   src="/img/dashboard/analytics/dashboard-analytics-run-duration-filters.png"
   alt="Cloud Analytics Run Duration Filters Screenshot"
-></DocsImage>
+/>
 
 Results may be filtered by:
 
@@ -100,7 +100,7 @@ Results may be filtered by:
 <DocsImage
   src="/img/dashboard/analytics/dashboard-analytics-run-duration-graph.png"
   alt="Cloud Analytics Run Duration Graph Screenshot"
-></DocsImage>
+/>
 
 The average run duration over time is displayed respective of the filters
 selected.
@@ -113,7 +113,7 @@ analysis. This can be done via the download icon to the right of the filters.
 <DocsImage
   src="/img/dashboard/analytics/dashboard-analytics-run-duration-kpi.png"
   alt="Cloud Analytics Run Duration KPI Screenshot"
-></DocsImage>
+/>
 
 Average parallelization, average run duration and time saved from
 parallelization are computed respective of the filters selected.
@@ -121,7 +121,7 @@ parallelization are computed respective of the filters selected.
 <DocsImage
   src="/img/dashboard/analytics/dashboard-analytics-run-duration-table.png"
   alt="Cloud Analytics Run Duration Table Screenshot"
-></DocsImage>
+/>
 
 A table of results grouped by date for the time range filter is displayed with
 average runtime, concurrency and time saved from parallelization columns.
@@ -131,7 +131,7 @@ average runtime, concurrency and time saved from parallelization columns.
 <DocsImage
   src="/img/dashboard/analytics/dashboard-analytics-test-suite-size.png"
   alt="Cloud Analytics Test Suite Size Screenshot"
-></DocsImage>
+/>
 
 This report shows how your test suite is growing over time. It calculates the
 average number of test cases executed per run for each day in the given time
@@ -143,7 +143,7 @@ represent the size of your test suite.
 <DocsImage
   src="/img/dashboard/analytics/dashboard-analytics-test-suite-size-filters.png"
   alt="Cloud Analytics Test Suite Size Filters Screenshot"
-></DocsImage>
+/>
 
 Results may be filtered by:
 
@@ -157,7 +157,7 @@ Results may be filtered by:
 <DocsImage
   src="/img/dashboard/analytics/dashboard-analytics-test-suite-size-graph.png"
   alt="Cloud Analytics Test Suite Size Graph Screenshot"
-></DocsImage>
+/>
 
 The average test suite size over time is displayed respective of the filters
 selected.
@@ -170,7 +170,7 @@ analysis. This can be done via the download icon to the right of the filters.
 <DocsImage
   src="/img/dashboard/analytics/dashboard-analytics-test-suite-size-kpi.png"
   alt="Cloud Analytics Test Suite Size KPI Screenshot"
-></DocsImage>
+/>
 
 Unique tests and number of spec files are computed respective of the filters
 selected.
@@ -178,7 +178,7 @@ selected.
 <DocsImage
   src="/img/dashboard/analytics/dashboard-analytics-test-suite-size-table.png"
   alt="Cloud Analytics Test Suite Size Table Screenshot"
-></DocsImage>
+/>
 
 A table of results grouped by date for the time range filter is displayed with
 unique tests and spec files.
@@ -188,7 +188,7 @@ unique tests and spec files.
 <DocsImage
   src="/img/dashboard/analytics/dashboard-analytics-top-failures.png"
   alt="Cloud Analytics Top Failures Screenshot"
-></DocsImage>
+/>
 
 This report shows the top failures in your test suite.
 
@@ -197,7 +197,7 @@ This report shows the top failures in your test suite.
 <DocsImage
   src="/img/dashboard/analytics/dashboard-analytics-top-failures-filters.png"
   alt="Cloud Analytics Top Failures Filters Screenshot"
-></DocsImage>
+/>
 
 Results can be seen through custom grouping by using the "View By" dropdown. It
 can be grouped by:
@@ -224,7 +224,7 @@ Results may also be filtered by:
 <DocsImage
   src="/img/dashboard/analytics/dashboard-analytics-top-failures-graph.png"
   alt="Cloud Analytics Top Failures Graph Screenshot"
-></DocsImage>
+/>
 
 The number of tests by failure rate is displayed respective of the filters
 selected.
@@ -239,7 +239,7 @@ This can be done via the download icon to the right of the filters.
 <DocsImage
   src="/img/dashboard/analytics/dashboard-analytics-top-failures-kpi.png"
   alt="Cloud Analytics Top Failures KPI Screenshot"
-></DocsImage>
+/>
 
 The main key performance indicators tracked are:
 
@@ -249,7 +249,7 @@ The main key performance indicators tracked are:
 <DocsImage
   src="/img/dashboard/analytics/dashboard-analytics-top-failures-table.png"
   alt="Cloud Analytics Top Failures Table Screenshot"
-></DocsImage>
+/>
 
 A table of results grouped by failure rate is displayed with spec files and
 total runs.
@@ -259,7 +259,7 @@ total runs.
 <DocsImage
   src="/img/dashboard/analytics/dashboard-analytics-slowest-tests.png"
   alt="Cloud Analytics Slowest Tests Screenshot"
-></DocsImage>
+/>
 
 This report shows the slowest tests in a test suite.
 
@@ -268,7 +268,7 @@ This report shows the slowest tests in a test suite.
 <DocsImage
   src="/img/dashboard/analytics/dashboard-analytics-slowest-tests-filters.png"
   alt="Cloud Analytics Slowest Tests Filters Screenshot"
-></DocsImage>
+/>
 
 Results can be seen through custom grouping by using the "View By" dropdown. It
 can be grouped by:
@@ -296,7 +296,7 @@ Results may also be filtered by:
 <DocsImage
   src="/img/dashboard/analytics/dashboard-analytics-slowest-tests-graph.png"
   alt="Cloud Analytics Slowest Tests Graph Screenshot"
-></DocsImage>
+/>
 
 The slowest tests are displayed by duration of time.
 
@@ -308,7 +308,7 @@ analysis. This can be done via the download icon to the right of the filters.
 <DocsImage
   src="/img/dashboard/analytics/dashboard-analytics-slowest-tests-kpi.png"
   alt="Cloud Analytics Slowest Tests KPI Screenshot"
-></DocsImage>
+/>
 
 The main key performance indicators tracked are:
 
@@ -318,7 +318,7 @@ The main key performance indicators tracked are:
 <DocsImage
   src="/img/dashboard/analytics/dashboard-analytics-slowest-tests-table.png"
   alt="Cloud Analytics Slowest Tests Table Screenshot"
-></DocsImage>
+/>
 
 A table of results grouped by median duration and total runs.
 
@@ -330,4 +330,4 @@ suite.
 <DocsImage
   src="/img/dashboard/analytics/dashboard-analytics-common-errors.png"
   alt="Cloud Analytics Slowest Tests Table Screenshot"
-></DocsImage>
+/>

--- a/docs/guides/cloud/flaky-test-management.mdx
+++ b/docs/guides/cloud/flaky-test-management.mdx
@@ -68,7 +68,7 @@ in and out via the "Flaky" filter within this page.
 <DocsImage
   src="/img/dashboard/flaky-test-management/flaky-runs-view.png"
   alt="Flagging flaky tests runs in Cypress Cloud"
-></DocsImage>
+/>
 
 Any failure across multiple test run attempts triggered by test retrying will
 result in a given test case to be flagged as flaky.
@@ -107,7 +107,7 @@ needed to resolve flake issues.
 <DocsImage
   src="/img/dashboard/flaky-test-management/flake-analytics.png"
   alt="Flaky tests analytics"
-></DocsImage>
+/>
 
 Selecting any of the flaky test cases in the analytics page will reveal a test
 case details panel that shows:
@@ -123,7 +123,7 @@ of flake over time to assist with debugging the root cause.
 <DocsImage
   src="/img/dashboard/flaky-test-management/flake-panel.png"
   alt="Flaky tests analytics details panel"
-></DocsImage>
+/>
 
 ### Failure Rate vs Flake Rate
 
@@ -134,7 +134,7 @@ each flaky test case within the flaky tests analytics page:
 <DocsImage
   src="/img/dashboard/flaky-test-management/flake-v-fail-2.png"
   alt="flake rate vs fail rate"
-></DocsImage>
+/>
 
 A test case flagged as flaky could have still passed after multiple test retry
 attempts. The test result status of individual test retry attempts is separate
@@ -150,7 +150,7 @@ while exhibiting flake as demonstrated below:
 <DocsImage
   src="/img/dashboard/flaky-test-management/flake-v-fail-1.png"
   alt="flake rate vs fail rate"
-></DocsImage>
+/>
 
 ## Flake Alerting
 
@@ -177,7 +177,7 @@ project's GitHub integration settings:
 <DocsImage
   src="/img/dashboard/flaky-test-management/gh-flake.png"
   alt="GitHub flake alert settings"
-></DocsImage>
+/>
 
 After enabling GitHub flake alerting, GitHub PR comments will show the number of
 flaky tests associated with the PR within the test summary, and include a
@@ -186,7 +186,7 @@ flaky tests associated with the PR within the test summary, and include a
 <DocsImage
   src="/img/dashboard/flaky-test-management/flake-pr-comment.png"
   alt="GitHub flake alert pr comment"
-></DocsImage>
+/>
 
 ### Slack
 
@@ -195,7 +195,7 @@ Flake alerting via Slack can be enabled within Slack integration settings:
 <DocsImage
   src="/img/dashboard/flaky-test-management/slack-flake.png"
   alt="Slack flake alert settings"
-></DocsImage>
+/>
 
 After enabling Slack alerts, Cypress Cloud will send Slack messages whenever
 flaky tests are detected:
@@ -203,7 +203,7 @@ flaky tests are detected:
 <DocsImage
   src="/img/dashboard/flaky-test-management/flake-slack-alert.png"
   alt="Slack flake alert"
-></DocsImage>
+/>
 
 ## See Also
 

--- a/docs/guides/cloud/flaky-test-management.mdx
+++ b/docs/guides/cloud/flaky-test-management.mdx
@@ -35,7 +35,7 @@ Test retries is **disabled by default**, and you can
 
 :::tip
 
-<strong class="alert-header">
+<strong>
   <Icon name="star" /> Premium Cypress Cloud Feature
 </strong>
 
@@ -77,7 +77,7 @@ result in a given test case to be flagged as flaky.
 
 :::tip
 
-<strong class="alert-header">
+<strong>
   <Icon name="star" /> Premium Cypress Cloud Feature
 </strong>
 
@@ -156,7 +156,7 @@ while exhibiting flake as demonstrated below:
 
 :::tip
 
-<strong class="alert-header">
+<strong>
   <Icon name="star" /> Premium Cypress Cloud Feature
 </strong>
 

--- a/docs/guides/cloud/flaky-test-management.mdx
+++ b/docs/guides/cloud/flaky-test-management.mdx
@@ -36,7 +36,7 @@ Test retries is **disabled by default**, and you can
 :::tip
 
 <strong class="alert-header">
-  <Icon name="star"></Icon> Premium Cypress Cloud Feature
+  <Icon name="star" /> Premium Cypress Cloud Feature
 </strong>
 
 **Test flake detection** is available to users with a
@@ -78,7 +78,7 @@ result in a given test case to be flagged as flaky.
 :::tip
 
 <strong class="alert-header">
-  <Icon name="star"></Icon> Premium Cypress Cloud Feature
+  <Icon name="star" /> Premium Cypress Cloud Feature
 </strong>
 
 **Test flake analytics** are available to users with a
@@ -157,7 +157,7 @@ while exhibiting flake as demonstrated below:
 :::tip
 
 <strong class="alert-header">
-  <Icon name="star"></Icon> Premium Cypress Cloud Feature
+  <Icon name="star" /> Premium Cypress Cloud Feature
 </strong>
 
 **Test flake alerting** is available to users with a

--- a/docs/guides/cloud/github-integration.mdx
+++ b/docs/guides/cloud/github-integration.mdx
@@ -30,7 +30,7 @@ If you are still facing issues after this, please
 
 :::tip
 
-<strong class="alert-header">
+<strong>
   <Icon name="star" /> Premium Cypress Cloud Feature
 </strong>
 

--- a/docs/guides/cloud/github-integration.mdx
+++ b/docs/guides/cloud/github-integration.mdx
@@ -31,7 +31,7 @@ If you are still facing issues after this, please
 :::tip
 
 <strong class="alert-header">
-  <Icon name="star"></Icon> Premium Cypress Cloud Feature
+  <Icon name="star" /> Premium Cypress Cloud Feature
 </strong>
 
 GitHub Enterprise integration is included in our

--- a/docs/guides/cloud/github-integration.mdx
+++ b/docs/guides/cloud/github-integration.mdx
@@ -12,7 +12,7 @@ integration.
 <DocsImage
   src="/img/dashboard/github-integration/pull-request-cypress-integration-comments-github-checks.jpg"
   alt="Cypress GitHub App PR"
-></DocsImage>
+/>
 
 :::caution
 
@@ -65,13 +65,13 @@ process via your organization's settings page or a project's settings page in
      src="/img/dashboard/select-cypress-organization.png"
      alt="Select an organization"
      width-600
-   ></DocsImage>
+   />
 3. Visit the selected organization's **Integrations** page via the side
    navigation.
    <DocsImage
      src="/img/dashboard/navigate-to-organization-integrations.png"
      alt="Install Cypress GitHub from Integrations"
-   ></DocsImage>
+   />
 4. Click the **Install GitHub Integration** or **Install GitHub Enterprise
    Integration** button.
 
@@ -88,23 +88,23 @@ This installation method is not applicable to GitHub Enterprise.
      src="/img/dashboard/select-cypress-organization.png"
      alt="Select an organization"
      width-600
-   ></DocsImage>
+   />
 2. Select the project you wish to integrate with a GitHub repository.
    <DocsImage
      src="/img/dashboard/select-cypress-project.png"
      alt="Select a project"
-   ></DocsImage>
+   />
 3. Go to the project's settings page.
    <DocsImage
      src="/img/dashboard/visit-project-settings.png"
      alt="Visit project settings"
-   ></DocsImage>
+   />
 4. Scroll down to the **GitHub Integration** section.
 5. Click the **Install the Cypress GitHub App** button.
    <DocsImage
      src="/img/dashboard/github-integration/install-github-cypress-app-project-settings.png"
      alt="Install GitHub Cypress App"
-   ></DocsImage>
+   />
 
 ### Cypress GitHub app installation process
 
@@ -119,14 +119,14 @@ to GitHub.com to complete the installation:
    <DocsImage
      src="/img/dashboard/github-integration/select-gh-org.jpg"
      alt="Select a GitHub organization"
-   ></DocsImage>
+   />
 
 2. Choose to associate **All repositories** or only select GitHub repositories
    with your Cypress GitHub App installation.
    <DocsImage
      src="/img/dashboard/github-integration/select-all-gh-repos.jpg"
      alt="Select All GitHub repositories"
-   ></DocsImage>
+   />
 
 :::info
 
@@ -138,7 +138,7 @@ installation if you choose <strong>All repositories</strong>.
 <DocsImage
   src="/img/dashboard/github-integration/select-gh-repos.jpg"
   alt="Select specific GitHub repositories"
-></DocsImage>
+/>
 
 3. Click the **Install** button to complete the installation.
 
@@ -158,7 +158,7 @@ them into Cypress Cloud, and complete the activation process.
   src="/img/dashboard/github-integration/ghe/ghe-01.png"
   alt="Create new GitHub App"
   id="cypress-github-enterprise-app-installation-process-1"
-></DocsImage>
+/>
 
 2. Complete the **Register new GitHub app** section.
    - Enter a **GitHub App name**. Name may contain only dashes, letters and
@@ -171,7 +171,7 @@ them into Cypress Cloud, and complete the activation process.
   src="/img/dashboard/github-integration/ghe/ghe-02.png"
   alt="Configure new GitHub App"
   id="cypress-github-enterprise-app-installation-process-2"
-></DocsImage>
+/>
 
 3. Complete the **Webhook** section.
    - Enter the **Webhook URL**, https://cloud.cypress.io/webhooks/github-app
@@ -182,7 +182,7 @@ them into Cypress Cloud, and complete the activation process.
   src="/img/dashboard/github-integration/ghe/ghe-03.png"
   alt="Configure app webhook"
   id="cypress-github-enterprise-app-installation-process-3"
-></DocsImage>
+/>
 
 4. Set the **Repository Permissions**. Below are the minimum permissions
    required for the new GitHub App.
@@ -193,7 +193,7 @@ them into Cypress Cloud, and complete the activation process.
   src="/img/dashboard/github-integration/ghe/ghe-04.png"
   alt="Configure app permissions"
   id="cypress-github-enterprise-app-installation-process-4"
-></DocsImage>
+/>
 
 5. Skip to the bottom of the form and click the **Create GitHub App** button.
    Your new GitHub App is now created, and you'll be taken to the settings page.
@@ -218,19 +218,19 @@ them into Cypress Cloud, and complete the activation process.
   src="/img/dashboard/github-integration/ghe/ghe-05.png"
   alt="Collect new app info"
   id="cypress-github-enterprise-app-installation-process-5"
-></DocsImage>
+/>
 
 <DocsImage
   src="/img/dashboard/github-integration/ghe/ghe-06.png"
   alt="Generate client secret"
   id="cypress-github-enterprise-app-installation-process-6"
-></DocsImage>
+/>
 
 <DocsImage
   src="/img/dashboard/github-integration/ghe/ghe-07.png"
   alt="Generate private key"
   id="cypress-github-enterprise-app-installation-process-7"
-></DocsImage>
+/>
 
 7. In Cypress Cloud, click the **Next Step** button and you will be taken to the
    GitHub Enterprise app authorization page. Click the **Authorize \[your app
@@ -240,7 +240,7 @@ them into Cypress Cloud, and complete the activation process.
   src="/img/dashboard/github-integration/ghe/ghe-08.png"
   alt="Authorize GitHub App"
   id="cypress-github-enterprise-app-installation-process-8"
-></DocsImage>
+/>
 
 8. On your newly-authorized GitHub App, click the **Install** button.
 
@@ -248,7 +248,7 @@ them into Cypress Cloud, and complete the activation process.
   src="/img/dashboard/github-integration/ghe/ghe-09.png"
   alt="Install GitHub App"
   id="cypress-github-enterprise-app-installation-process-9"
-></DocsImage>
+/>
 
 9. Nearly there! On the GitHub App installation page, choose whether you want to
    install the app against all repos or select specific ones, then click the
@@ -258,7 +258,7 @@ them into Cypress Cloud, and complete the activation process.
   src="/img/dashboard/github-integration/ghe/ghe-10.png"
   alt="Confirm installation of GitHub App"
   id="cypress-github-enterprise-app-installation-process-10"
-></DocsImage>
+/>
 
 10. Finally you will be returned to Cypress Cloud. Congratulations, you have
     installed Cypress Cloud GitHub Enterprise integration! You are now ready to
@@ -274,7 +274,7 @@ can now enable GitHub Integration for _any_ Cypress project.
    <DocsImage
      src="/img/dashboard/visit-project-settings.png"
      alt="Visit project settings"
-   ></DocsImage>
+   />
 
 2. Scroll down to the GitHub Integration or GitHub Enterprise Integration
    section.
@@ -290,14 +290,14 @@ organization's Integrations page:
 <DocsImage
   src="/img/dashboard/github-integration/org-settings-with-no-enabled-projects.png"
   alt="Org GitHub Integration settings"
-></DocsImage>
+/>
 
 3. Select a GitHub repository to associate with the project.
 
 <DocsImage
   src="/img/dashboard/github-integration/project-settings-repo-selection.png"
   alt="Associate GitHub repo with Cypress project"
-></DocsImage>
+/>
 
 Once a GitHub repository is associated with a Cypress project, the GitHub
 integration will be immediately enabled:
@@ -305,7 +305,7 @@ integration will be immediately enabled:
 <DocsImage
   src="/img/dashboard/github-integration/project-settings-selected-repo.png"
   alt="GitHub integration enabled for Cypress project"
-></DocsImage>
+/>
 
 You can also see all GitHub Integration enabled Cypress projects within your
 organizations **Integrations** page:
@@ -313,7 +313,7 @@ organizations **Integrations** page:
 <DocsImage
   src="/img/dashboard/github-integration/org-settings-with-projects.png"
   alt="Integrations page"
-></DocsImage>
+/>
 
 ## Status checks
 
@@ -331,13 +331,13 @@ The Cypress GitHub App reports commit status checks in two separate styles:
   <DocsImage
     src="/img/dashboard/github-integration/status-checks-per-group-failed.png"
     alt="Status checks per group"
-  ></DocsImage>
+  />
 
 - **Or one check per spec file.**
   <DocsImage
     src="/img/dashboard/github-integration/status-checks-per-spec.png"
     alt="Status checks per spec"
-  ></DocsImage>
+  />
 
 Each status check will report the number of test failures or passes, and the
 associated **Details** link will direct you to the test run's page within
@@ -347,7 +347,7 @@ traces, screenshots, and video recordings:
 <DocsImage
   src="/img/dashboard/dashboard-fail-tab.png"
   alt="Cypress Cloud failure tab"
-></DocsImage>
+/>
 
 ### Disable status checks
 
@@ -357,7 +357,7 @@ integration settings:
 <DocsImage
   src="/img/dashboard/github-integration/status-check-settings.png"
   alt="Status checks settings"
-></DocsImage>
+/>
 
 ## Pull request comments
 
@@ -382,7 +382,7 @@ An example of a Cypress pull-request comment can be seen below:
 <DocsImage
   src="/img/dashboard/github-integration/pr-comment-fail.jpg"
   alt="Cypress GitHub App PR comment"
-></DocsImage>
+/>
 
 ### Disable PR comments
 
@@ -392,7 +392,7 @@ if not needed within a project's GitHub Integration settings:
 <DocsImage
   src="/img/dashboard/github-integration/pr-comments-settings.png"
   alt="Status checks settings"
-></DocsImage>
+/>
 
 ## Uninstall the Cypress GitHub app
 

--- a/docs/guides/cloud/introduction.mdx
+++ b/docs/guides/cloud/introduction.mdx
@@ -60,7 +60,7 @@ results broken down by browser and OS.
 <DocsImage
   src="/img/dashboard/dashboard-runs-list.png"
   alt="Cloud Screenshot"
-></DocsImage>
+/>
 
 For users of the open-source [Cypress app](/guides/core-concepts/cypress-app),
 we've integrated test run information from Cypress Cloud so developers can see
@@ -69,7 +69,7 @@ the latest results across the team, and identify areas of concern.
 <DocsImage
   src="/img/dashboard/v10/runs-list-in-cypress-app.png"
   alt="Runs List"
-></DocsImage>
+/>
 
 ### Run tests in parallel, in priority order, or not at all
 
@@ -88,7 +88,7 @@ Cloud if you need to.
 <DocsImage
   src="/img/dashboard/introduction/orchestration-diagram.png"
   alt="Diagram comparing serial and parallel test configurations"
-></DocsImage>
+/>
 
 ### Integrate with source control providers
 
@@ -109,7 +109,7 @@ instances too.
 <DocsImage
   src="/img/dashboard/github-integration/status-checks-per-spec.png"
   alt="Status checks per spec"
-></DocsImage>
+/>
 
 ### Collaborate and organize
 
@@ -124,7 +124,7 @@ directly from specific test failures.
 <DocsImage
   src="/img/dashboard/cypress-slack-integration-channel-feed.png"
   alt="Cypress notification feed in Slack channel"
-></DocsImage>
+/>
 
 Lastly you can use our flexible adminstrative functions to configure Cypress
 Cloud however you want, grouping [projects](/guides/cloud/projects) into

--- a/docs/guides/cloud/introduction.mdx
+++ b/docs/guides/cloud/introduction.mdx
@@ -25,7 +25,7 @@ tools.
 
 <!-- textlint-disable -->
 
-<DocsVideo src="https://vimeo.com/736212167"></DocsVideo>
+<DocsVideo src="https://vimeo.com/736212167" />
 
 <!-- textlint-enable -->
 

--- a/docs/guides/cloud/introduction.mdx
+++ b/docs/guides/cloud/introduction.mdx
@@ -136,9 +136,7 @@ checking [usage](/guides/cloud/organizations#Billing-Usage), and administering
 
 :::info
 
-<strong>
-  Have a question you don't see answered here?
-</strong>
+<strong>Have a question you don't see answered here?</strong>
 
 [We have answered some common questions about Cypress Cloud in our FAQ](/faq/questions/cloud-faq).
 

--- a/docs/guides/cloud/introduction.mdx
+++ b/docs/guides/cloud/introduction.mdx
@@ -7,7 +7,7 @@ sidebar_label: Introduction
 :::tip
 
 <strong class="alert-header">
-  <Icon name="star"></Icon> Get Started
+  <Icon name="star" /> Get Started
 </strong>
 
 To get started with Cypress Cloud,
@@ -31,7 +31,7 @@ tools.
 
 :::info
 
-##### <Icon name="graduation-cap"></Icon> Real World Example <Badge type="success">New</Badge>
+##### <Icon name="graduation-cap" /> Real World Example <Badge type="success">New</Badge>
 
 The Cypress
 [Real World App (RWA)](https://github.com/cypress-io/cypress-realworld-app)
@@ -39,7 +39,7 @@ leverages [Cypress Cloud in CI](https://cloud.cypress.io/projects/7s5okt) to
 test over 300 test cases in parallel across 25 machines, multiple browsers,
 multiple device sizes, and multiple operating systems.
 
-Check out the <Icon name="github"></Icon>
+Check out the <Icon name="github" />
 [Real World App in Cypress Cloud](https://cloud.cypress.io/projects/7s5okt).
 
 :::
@@ -151,7 +151,7 @@ Once you log in to [Cypress Cloud](https://on.cypress.io/cloud) you can view any
 
 **Here are some of our own public projects you can view:**
 
-- [<Icon name="folder-open"></Icon> cypress-realworld-app](https://cloud.cypress.io/projects/7s5okt)
-- [<Icon name="folder-open"></Icon> cypress-example-recipes](https://cloud.cypress.io/#/projects/6p53jw)
-- [<Icon name="folder-open"></Icon> cypress-example-kitchensink](https://cloud.cypress.io/#/projects/4b7344)
-- [<Icon name="folder-open"></Icon> cypress-example-todomvc](https://cloud.cypress.io/#/projects/245obj)
+- [<Icon name="folder-open" /> cypress-realworld-app](https://cloud.cypress.io/projects/7s5okt)
+- [<Icon name="folder-open" /> cypress-example-recipes](https://cloud.cypress.io/#/projects/6p53jw)
+- [<Icon name="folder-open" /> cypress-example-kitchensink](https://cloud.cypress.io/#/projects/4b7344)
+- [<Icon name="folder-open" /> cypress-example-todomvc](https://cloud.cypress.io/#/projects/245obj)

--- a/docs/guides/cloud/introduction.mdx
+++ b/docs/guides/cloud/introduction.mdx
@@ -6,7 +6,7 @@ sidebar_label: Introduction
 
 :::tip
 
-<strong class="alert-header">
+<strong>
   <Icon name="star" /> Get Started
 </strong>
 
@@ -136,7 +136,7 @@ checking [usage](/guides/cloud/organizations#Billing-Usage), and administering
 
 :::info
 
-<strong class="alert-header">
+<strong>
   Have a question you don't see answered here?
 </strong>
 

--- a/docs/guides/cloud/jira-integration.mdx
+++ b/docs/guides/cloud/jira-integration.mdx
@@ -5,7 +5,7 @@ sidebar_position: 100
 
 :::tip
 
-<strong class="alert-header">
+<strong>
   <Icon name="star" /> Premium Cypress Cloud Feature
 </strong>
 

--- a/docs/guides/cloud/jira-integration.mdx
+++ b/docs/guides/cloud/jira-integration.mdx
@@ -28,48 +28,48 @@ workflow to enable:
    <DocsImage
      src="/img/dashboard/jira-integration/dashboard-jira-integration-install.png"
      alt="Cypress Cloud Integrations"
-   ></DocsImage>
+   />
 1. Click the "Get it Now" button on the
    [Atlassian Marketplace Cypress for Jira page](https://marketplace.atlassian.com/apps/1224341/cypress-for-jira?hosting=cloud&tab=overview)
    <DocsImage
      src="/img/dashboard/jira-integration/dashboard-jira-atlassian-get-it-now.png"
      alt="Atlassian Marketplace Cypress for Jira"
-   ></DocsImage>
+   />
 1. Login to Jira, Choose a site to install your app and click "Install app".
    <DocsImage
      src="/img/dashboard/jira-integration/dashboard-jira-atlassian-choose-site.png"
      alt="Atlassian Marketplace Cypress for Jira Choose Site"
-   ></DocsImage>
+   />
 1. On the "Add to Jira" screen, confirm installation by clicking "Get it now"
    <DocsImage
      src="/img/dashboard/jira-integration/dashboard-jira-atlassian-confirm-install.png"
      alt="Atlassian Marketplace Cypress for Jira Installation Confirmation"
-   ></DocsImage>
+   />
 1. Once installed, click the `Get Started` link in the notification.
    <DocsImage
      src="/img/dashboard/jira-integration/dashboard-jira-atlassian-success.png"
      alt="Atlassian Marketplace Cypress for Jira Installation Success"
-   ></DocsImage>
+   />
 1. On the next page, click the `Click to Finish Installation` button to be
    redirected to [Cypress Cloud](https://cloud.cypress.io/) and choose the
    Cypress Organization for integration.
    <DocsImage
      src="/img/dashboard/jira-integration/dashboard-jira-atlassian-finish-install-step.png"
      alt="Atlassian Marketplace Cypress for Jira Installation Finish Installation"
-   ></DocsImage>
+   />
 1. Once redirected to [Cypress Cloud](https://cloud.cypress.io/), select the
    organization to integrate with
    [Atlassian Marketplace Cypress for Jira](https://marketplace.atlassian.com/apps/1224341/cypress-for-jira?hosting=cloud&tab=overview).
    <DocsImage
      src="/img/dashboard/jira-integration/dashboard-jira-integration-choose-cypress-org.png"
      alt="Cypress Cloud Select Organization for Jira Integration"
-   ></DocsImage>
+   />
 1. The Jira Integration is complete. A list of projects permitted is provided on
    the Jira Integration page. {' '}
    <DocsImage
      src="/img/dashboard/jira-integration/dashboard-jira-integration-completed.png"
      alt="Cypress Cloud Jira Integration"
-   ></DocsImage>
+   />
 
 ## Creating a Jira issue for a test case
 
@@ -95,7 +95,7 @@ Let's walk through creating a Jira issue for a failing test:
    <DocsImage
      src="/img/dashboard/jira-integration/dashboard-jira-integration-create-issue.png"
      alt="Create Jira Issue Button"
-   ></DocsImage>
+   />
 
 3. Complete and submit the Jira issue creation form by selecting the Jira
    project, issue type, assignee, and additional fields.
@@ -103,7 +103,7 @@ Let's walk through creating a Jira issue for a failing test:
    <DocsImage
      src="/img/dashboard/jira-integration/dashboard-jira-integration-modal.png"
      alt="Create Jira Issue Modal"
-   ></DocsImage>
+   />
 
 4. Once the issue is created, a log and reference of the issue will appear
    within results panel of test.
@@ -111,7 +111,7 @@ Let's walk through creating a Jira issue for a failing test:
    <DocsImage
      src="/img/dashboard/jira-integration/dashboard-jira-integration-inline-issue.png"
      alt="Jira Issue in Cypress Failure Context"
-   ></DocsImage>
+   />
 
 :::info
 
@@ -123,12 +123,12 @@ associated test.
 <DocsImage
   src="/img/dashboard/jira-integration/dashboard-jira-integration-jira-issue.png"
   alt="Jira Issue of Cypress Failure"
-></DocsImage>
+/>
 
 <DocsImage
   src="/img/dashboard/jira-integration/dashboard-jira-integration-jira-issue.png"
   alt="Jira Issue of Cypress Failure"
-></DocsImage>
+/>
 
 :::
 

--- a/docs/guides/cloud/jira-integration.mdx
+++ b/docs/guides/cloud/jira-integration.mdx
@@ -6,7 +6,7 @@ sidebar_position: 100
 :::tip
 
 <strong class="alert-header">
-  <Icon name="star"></Icon> Premium Cypress Cloud Feature
+  <Icon name="star" /> Premium Cypress Cloud Feature
 </strong>
 
 **Jira integration** is available to users with a

--- a/docs/guides/cloud/organizations.mdx
+++ b/docs/guides/cloud/organizations.mdx
@@ -9,7 +9,7 @@ Organizations are used to group projects and manage access to those projects.
   src="/img/dashboard/organizations-listed-in-dashboard.png"
   alt="Organizations"
   width-600
-></DocsImage>
+/>
 
 ## Features
 
@@ -32,7 +32,7 @@ with Cypress teams.
 <DocsImage
   src="/img/dashboard/organizations/cypress-organization-UUID.gif"
   alt="Locate UUID gif"
-></DocsImage>
+/>
 
 ## Managing Organizations
 
@@ -46,13 +46,13 @@ switcher and clicking **<Icon name="plus"></Icon> Create new organization**.
   src="/img/dashboard/create-org.png"
   alt="Create new organization"
   width-600
-></DocsImage>
+/>
 
 <DocsImage
   src="/img/dashboard/add-organization-dialog.png"
   alt="Add Organization dialog"
   width-600
-></DocsImage>
+/>
 
 ### Personal Org
 
@@ -72,7 +72,7 @@ organization, you can convert it to a professional organization via the
 <DocsImage
   src="/img/dashboard/convert-to-professional-org-button.jpg"
   alt="Convert org for billing"
-></DocsImage>
+/>
 
 Click the **Convert organization** button, provide a name for the organization,
 and hit **Convert organization**. This will do two things:
@@ -87,7 +87,7 @@ and hit **Convert organization**. This will do two things:
   src="/img/dashboard/convert-to-professional-org-modal.jpg"
   alt="Convert org to new org"
   width-600
-></DocsImage>
+/>
 
 ### Delete Org
 
@@ -98,7 +98,7 @@ to another organization before you can delete the organization.
 <DocsImage
   src="/img/dashboard/remove-organization-dialog.png"
   alt="Delete Organization"
-></DocsImage>
+/>
 
 ## Billing & Usage
 
@@ -123,34 +123,46 @@ Follow the following process to request an OSS plan:
 
 1. [Login](https://on.cypress.io/dashboard) to the Cypress Dashboard, or
    [create an account](https://on.cypress.io/dashboard) if you are a new user.
+
    <DocsImage
      src="/img/dashboard/oss-plan-1-login.png"
      alt="Login or Create Account"
-   ></DocsImage>
+   />
+
 2. Go the [Organizations page](https://on.cypress.io/dashboard/organizations) to
    select the Organization you want to associate with an OSS plan. If you have
    no Organizations, you can create one by clicking the **+ Add Organization**
    button.
 
-> **Note**: Personal organizations cannot be used with an OSS plan.
+:::tip
+
+**Note**: Personal organizations cannot be used with an OSS plan.
+
+:::
 
 <DocsImage
   src="/img/dashboard/oss-plan-2-select-org.png"
   alt="Select or add organization"
-></DocsImage>{' '}
+/>
 
-5. Go to the **Billing & Usage** page, and then click on the **Apply for an open
+3. Go to the **Billing & Usage** page, and then click on the **Apply for an open
    source plan** link at the bottom of the page.
+
    <DocsImage
      src="/img/dashboard/oss-plan-3-billing.png"
      alt="Click Apply for an open source plan"
-   ></DocsImage> 4. Fill in and submit the OSS plan request form.
+   />
+
+4. Fill in and submit the OSS plan request form.
+
    <DocsImage
      src="/img/dashboard/oss-plan-4-apply.png"
      alt="OSS plan request form"
-   ></DocsImage> 5. You'll receive an email confirming your request. The Cypress
-   Team will review your request and, if approved, an OSS plan subscription will
-   be applied to your Organization.
+   />
+
+5. You'll receive an email confirming your request. The Cypress Team will review
+   your request and, if approved, an OSS plan subscription will be applied to
+   your Organization.
 
 If you have any questions regarding the OSS plan, please feel free
 [contact us](mailto:hello@cypress.io).
@@ -194,7 +206,7 @@ Organization to set up SSO.
      src="/img/dashboard/organizations/integrations-nenu-screenshot.png"
      alt="Enable SSO"
      width-600
-   ></DocsImage>
+   />
 1. Scroll down to the **Enterprise SSO** section. Select your SSO provider and
    take note of the information provided and required. Keep this window open and
    continue to the
@@ -228,17 +240,17 @@ below, refer to
    <DocsImage
      src="/img/dashboard/organizations/okta-admin-cypress-sso-setup.png"
      alt="Okta Admin"
-   ></DocsImage>
+   />
 1. Create a new SAML-based Web application.
    <DocsImage
      src="/img/dashboard/organizations/okta-add-application-step1-cypress-sso.png"
      alt="Create Okta SAML App"
-   ></DocsImage>
+   />
    <DocsImage
      src="/img/dashboard/organizations/okta-add-application-step3-cypress-sso.png"
      alt="Create Okta SAML App"
      width-600
-   ></DocsImage>
+   />
 1. Supply the following information requested in the Okta setup wizard:
 
 - **App name:** `Cypress Cloud`
@@ -257,7 +269,7 @@ below, refer to
   <DocsImage
     src="/img/dashboard/organizations/okta-download-certificate-for-cypress-dashboard.png"
     alt="Download Certificate"
-  ></DocsImage>
+  />
 
 1. Navigate to the **Assignments** tab and grant your users access to Cypress
    Cloud.
@@ -272,7 +284,7 @@ configuring a SAML integration.
 <DocsImage
   src="/img/dashboard/organizations/enterprise-SSO-SAML.png"
   alt="SAML SSO"
-></DocsImage>
+/>
 
 1. Log into the admin interface for your identity provider.
 1. Work through the setup wizard supplying the information requested:

--- a/docs/guides/cloud/organizations.mdx
+++ b/docs/guides/cloud/organizations.mdx
@@ -40,7 +40,7 @@ with Cypress teams.
 
 You can create an organization from within
 [Cypress Cloud](https://on.cypress.io/cloud) by opening the organization
-switcher and clicking **<Icon name="plus"></Icon> Create new organization**.
+switcher and clicking **<Icon name="plus" /> Create new organization**.
 
 <DocsImage
   src="/img/dashboard/create-org.png"
@@ -180,7 +180,7 @@ If you have any questions regarding the OSS plan, please feel free
 :::tip
 
 <strong class="alert-header">
-  <Icon name="star"></Icon> Premium Cypress Cloud Feature
+  <Icon name="star" /> Premium Cypress Cloud Feature
 </strong>
 
 Enterprise SSO is included in our

--- a/docs/guides/cloud/organizations.mdx
+++ b/docs/guides/cloud/organizations.mdx
@@ -179,7 +179,7 @@ If you have any questions regarding the OSS plan, please feel free
 
 :::tip
 
-<strong class="alert-header">
+<strong>
   <Icon name="star" /> Premium Cypress Cloud Feature
 </strong>
 
@@ -219,7 +219,7 @@ Follow the instructions below for your specific SSO provider.
 
 :::caution
 
-<strong class="alert-header">Smart Card Authentication</strong>
+<strong>Smart Card Authentication</strong>
 
 For Smart Card implementation, please reach out to
 [Support](mailto:support@cypress.io) for assistance.

--- a/docs/guides/cloud/projects.mdx
+++ b/docs/guides/cloud/projects.mdx
@@ -32,7 +32,7 @@ Make sure you [install](/guides/getting-started/installing-cypress) and
      src="/img/dashboard/projects/setup-a-project-1.png"
      alt="Connect to Cloud"
      no-border
-   ></DocsImage>
+   />
 4. Choose who owns the project. You can personally own it or select an
    organization you're a member of. If you don't have any organizations, click
    **Create organization**. Organizations work just like they do in GitHub and
@@ -42,7 +42,7 @@ Make sure you [install](/guides/getting-started/installing-cypress) and
      src="/img/dashboard/projects/setup-a-project-2.png"
      alt="Choose an Organization"
      no-border
-   ></DocsImage>
+   />
 5. If you don't have any existing projects, you'll have the opportunity to
    create a new one here. If you have existing projects and want to create a new
    one, you can click "Create a new project" to make a new one.
@@ -59,7 +59,7 @@ Make sure you [install](/guides/getting-started/installing-cypress) and
   src="/img/dashboard/projects/setup-a-project-3.png"
   alt="Create a New Project"
   no-border
-></DocsImage>
+/>
 
 6. Alternatively, if you've already created a project in Cypress Cloud, you can
    link your project by selecting it from the dropdown. Make sure to select a
@@ -68,7 +68,7 @@ Make sure you [install](/guides/getting-started/installing-cypress) and
      src="/img/dashboard/projects/setup-a-project-4.png"
      alt="Choose a Project"
      no-border
-   ></DocsImage>
+   />
 7. Click **Setup Project**.
 8. Now you should see a view explaining how to record your first run with your
    record key.
@@ -76,7 +76,7 @@ Make sure you [install](/guides/getting-started/installing-cypress) and
      src="/img/dashboard/projects/setup-a-project-5.png"
      alt="Record Instructions"
      no-border
-   ></DocsImage>
+   />
 9. After setting up your project, Cypress inserts a unique
    [projectId](#Identification) into your Cypress configuration file. If you're
    using source control, we recommend that you check your configuration file,
@@ -107,12 +107,12 @@ them in [Cypress Cloud](https://on.cypress.io/cloud) and in the Runs tab of
 <DocsImage
   src="/img/dashboard/dashboard-runs-list.png"
   alt="Cloud Screenshot"
-></DocsImage>
+/>
 
 <DocsImage
   src="/img/dashboard/runs-list-in-desktop-gui.png"
   alt="Runs List"
-></DocsImage>
+/>
 
 ## Identification
 
@@ -202,7 +202,7 @@ You can create multiple Record Keys for a project, or delete existing ones from
 <DocsImage
   src="/img/dashboard/record-keys-in-project-settings-dashboard.png"
   alt="Record key in project settings"
-></DocsImage>
+/>
 
 You can also find your Record Key inside of the _Settings_ tab in the Cypress
 App.
@@ -210,7 +210,7 @@ App.
 <DocsImage
   src="/img/dashboard/record-key-shown-in-desktop-gui-configuration.jpg"
   alt="Record Key in Configuration Tab"
-></DocsImage>
+/>
 
 ## Record keys
 
@@ -224,17 +224,17 @@ used.
    <DocsImage
      src="/img/dashboard/select-cypress-project.png"
      alt="Select a project"
-   ></DocsImage>
+   />
 3. Go to the project's **Settings** page.
    <DocsImage
      src="/img/dashboard/visit-project-settings.png"
      alt="Visit project settings"
-   ></DocsImage>
+   />
 4. Here you will see a **Record Keys** section
    <DocsImage
      src="/img/dashboard/record-keys-in-project-settings-dashboard.png"
      alt="Record keys in Cloud"
-   ></DocsImage>
+   />
 5. Click **Create New Key**. A new key will be automatically generated for your
    project.
 
@@ -245,17 +245,17 @@ used.
    <DocsImage
      src="/img/dashboard/select-cypress-project.png"
      alt="Select a project"
-   ></DocsImage>
+   />
 3. Go to the project's **Settings** page.
    <DocsImage
      src="/img/dashboard/visit-project-settings.png"
      alt="Visit project settings"
-   ></DocsImage>
+   />
 4. Here you will see a **Record Keys** section
    <DocsImage
      src="/img/dashboard/record-keys-in-project-settings-dashboard.png"
      alt="Record keys in Cloud"
-   ></DocsImage>
+   />
 5. Click **Delete** beside the record key you want to delete.
 
 ## Parallelization settings
@@ -270,7 +270,7 @@ learn more.
 <DocsImage
   src="/img/dashboard/run-completion-delay.jpg"
   alt="Run completion delay settings"
-></DocsImage>
+/>
 
 ## GitHub Integration
 
@@ -280,7 +280,7 @@ project settings page.
 <DocsImage
   src="/img/dashboard/visit-project-settings.png"
   alt="Visit project settings"
-></DocsImage>
+/>
 
 See our [GitHub Integration guide](/guides/cloud/github-integration) to learn
 more.
@@ -293,7 +293,7 @@ project settings page.
 <DocsImage
   src="/img/dashboard/visit-project-settings.png"
   alt="Visit project settings"
-></DocsImage>
+/>
 
 See our [Slack Integration guide](/guides/cloud/slack-integration) to learn
 more.
@@ -311,7 +311,7 @@ test count to other developers viewing your project's README file.
    <DocsImage
      src="/img/dashboard/badges/dashboard-badge-configure-button.png"
      alt="README Badge configure button"
-   ></DocsImage>
+   />
 
 - **Note**: README badges are currently only available for public projects.
 
@@ -334,7 +334,7 @@ test count to other developers viewing your project's README file.
 <DocsImage
   src="/img/dashboard/badges/dashboard-badge-configuration.png"
   alt="README Badge configuration form"
-></DocsImage>
+/>
 
 See also
 [Highlight your project's test status with Cypress README badges](https://www.cypress.io/blog/2020/09/02/highlight-your-projects-test-status-with-cypress-readme-badges/)
@@ -347,7 +347,7 @@ Visit your project settings to see who has access to your project's runs.
 <DocsImage
   src="/img/dashboard/visit-project-settings.png"
   alt="Visit project settings"
-></DocsImage>
+/>
 
 ### Public vs Private
 
@@ -368,18 +368,18 @@ Visit your project settings to see who has access to your project's runs.
    <DocsImage
      src="/img/dashboard/select-cypress-project.png"
      alt="Select a project"
-   ></DocsImage>
+   />
 3. Go to the project's **Settings** page.
    <DocsImage
      src="/img/dashboard/visit-project-settings.png"
      alt="Visit project settings"
-   ></DocsImage>
+   />
 4. Here you will see a section displaying **Access to Runs**. Choose the
    appropriate access you'd like to assign for the project here.
    <DocsImage
      src="/img/dashboard/access-to-runs.png"
      alt="access-to-runs"
-   ></DocsImage>
+   />
 
 ## Transfer ownership
 
@@ -395,23 +395,23 @@ in the organization. Projects can only be transferred from
    <DocsImage
      src="/img/dashboard/select-cypress-project.png"
      alt="Select a project"
-   ></DocsImage>
+   />
 3. Go to the project's **Settings** page.
    <DocsImage
      src="/img/dashboard/visit-project-settings.png"
      alt="Visit project settings"
-   ></DocsImage>
+   />
 4. Scroll down to the **Transfer Ownership** section and click **Transfer
    Ownership**.
    <DocsImage
      src="/img/dashboard/transfer-ownership-button.png"
      alt="Transfer ownership button"
-   ></DocsImage>
+   />
 5. Select the user or organization, then click **Transfer**.
    <DocsImage
      src="/img/dashboard/transfer-ownership-of-project-dialog.png"
      alt="Transfer Project dialog"
-   ></DocsImage>
+   />
 
 ### Cancel project transfer
 
@@ -421,7 +421,7 @@ organization's projects and clicking **Cancel Transfer**.
 <DocsImage
   src="/img/dashboard/cancel-transfer-of-project.png"
   alt="Cancel pending transfer of project"
-></DocsImage>
+/>
 
 ### Accept or reject transferred project
 
@@ -432,12 +432,12 @@ notification in the sidebar and clicking 'Accept' or 'Reject'.
 <DocsImage
   src="/img/dashboard/see-pending-transfer.png"
   alt="See pending transfer"
-></DocsImage>
+/>
 
 <DocsImage
   src="/img/dashboard/accept-or-reject-transfer-of-project.png"
   alt="Accept or reject a transferred project"
-></DocsImage>
+/>
 
 ## Delete Project
 
@@ -450,16 +450,16 @@ test runs. Deleting projects can only be done from
    <DocsImage
      src="/img/dashboard/select-cypress-project.png"
      alt="Select a project"
-   ></DocsImage>
+   />
 3. Go to the project's **Settings** page.
    <DocsImage
      src="/img/dashboard/visit-project-settings.png"
      alt="Visit project settings"
-   ></DocsImage>
+   />
 4. At the very bottom of the Settings page click the **Remove Project** button.
    <DocsImage
      src="/img/dashboard/remove-project-dialog.png"
      alt="Delete project dialog"
-   ></DocsImage>
+   />
 5. Confirm that you want to delete the project by clicking **Yes, Remove
    Project**.

--- a/docs/guides/cloud/projects.mdx
+++ b/docs/guides/cloud/projects.mdx
@@ -109,10 +109,7 @@ them in [Cypress Cloud](https://on.cypress.io/cloud) and in the Runs tab of
   alt="Cloud Screenshot"
 />
 
-<DocsImage
-  src="/img/dashboard/runs-list-in-desktop-gui.png"
-  alt="Runs List"
-/>
+<DocsImage src="/img/dashboard/runs-list-in-desktop-gui.png" alt="Runs List" />
 
 ## Identification
 
@@ -376,10 +373,7 @@ Visit your project settings to see who has access to your project's runs.
    />
 4. Here you will see a section displaying **Access to Runs**. Choose the
    appropriate access you'd like to assign for the project here.
-   <DocsImage
-     src="/img/dashboard/access-to-runs.png"
-     alt="access-to-runs"
-   />
+   <DocsImage src="/img/dashboard/access-to-runs.png" alt="access-to-runs" />
 
 ## Transfer ownership
 

--- a/docs/guides/cloud/runs.mdx
+++ b/docs/guides/cloud/runs.mdx
@@ -272,10 +272,7 @@ canceled by members of the project.
   run details page
 - Click **Yes, cancel this run** to confirm. **Note: this cannot be undone**
 
-<DocsVideo
-  src="/img/snippets/cancelling-run.mp4"
-  title="Cloud cancel runs"
-/>
+<DocsVideo src="/img/snippets/cancelling-run.mp4" title="Cloud cancel runs" />
 
 ### What happens when a run is canceled?
 

--- a/docs/guides/cloud/runs.mdx
+++ b/docs/guides/cloud/runs.mdx
@@ -275,7 +275,7 @@ canceled by members of the project.
 <DocsVideo
   src="/img/snippets/cancelling-run.mp4"
   title="Cloud cancel runs"
-></DocsVideo>
+/>
 
 ### What happens when a run is canceled?
 

--- a/docs/guides/cloud/runs.mdx
+++ b/docs/guides/cloud/runs.mdx
@@ -330,7 +330,7 @@ Cypress Cloud.
 - Visit the archived run. The archived run can be accessed by the URL of the
   run. The format is:
   `https://cloud.cypress.io/projects/{project ID}/runs/{run number}`
-- Click **<Icon name="history"></Icon> Restore from archive**
+- Click **<Icon name="history" /> Restore from archive**
   <DocsImage
     src="/img/dashboard/restore-from-archive.png"
     alt="restore-from-archive"

--- a/docs/guides/cloud/slack-integration.mdx
+++ b/docs/guides/cloud/slack-integration.mdx
@@ -9,7 +9,7 @@ teams' Slack channels.
 <DocsImage
   src="/img/dashboard/cypress-slack-integration-channel-feed.png"
   alt="Cypress notification feed in Slack channel"
-></DocsImage>
+/>
 
 ## Install the Cypress Slack app
 
@@ -32,13 +32,13 @@ your Cypress Cloud organization and your Slack workspace.
      src="/img/dashboard/select-cypress-organization.png"
      alt="Select an organization"
      width-600
-   ></DocsImage>
+   />
 1. Visit the selected organization's **Integrations** page via the side
    navigation.
    <DocsImage
      src="/img/dashboard/navigate-to-organization-integrations.png"
      alt="Install Cypress Slack from Integrations"
-   ></DocsImage>
+   />
 1. Click the **Install Slack Integration** button.
 1. You'll see a popup window that requests permission for Cypress to access the
    workspace and allows you to choose your Slack workspace and channel to
@@ -114,17 +114,17 @@ additional channel.
      src="/img/dashboard/select-cypress-organization.png"
      alt="Select an organization"
      width-600
-   ></DocsImage>
+   />
 1. Select the project you wish to integrate with Slack.
    <DocsImage
      src="/img/dashboard/select-cypress-project.png"
      alt="Select a project"
-   ></DocsImage>
+   />
 1. Go to the project's settings page.
    <DocsImage
      src="/img/dashboard/visit-project-settings.png"
      alt="Visit project settings"
-   ></DocsImage>
+   />
 1. Scroll down to the **Slack Integration** section.
 1. Click **Add Slack Channel**.
 1. You'll see a popup window that allows you to choose the channel to associate

--- a/docs/guides/cloud/smart-orchestration.mdx
+++ b/docs/guides/cloud/smart-orchestration.mdx
@@ -47,7 +47,7 @@ time.**
 
 :::tip
 
-<strong class="alert-header">
+<strong>
   <Icon name="star" /> Premium Cypress Cloud Feature
 </strong>
 
@@ -117,7 +117,7 @@ failure will:
 
 :::tip
 
-<strong class="alert-header">
+<strong>
   <Icon name="star" /> Premium Cypress Cloud Feature
 </strong>
 

--- a/docs/guides/cloud/smart-orchestration.mdx
+++ b/docs/guides/cloud/smart-orchestration.mdx
@@ -48,7 +48,7 @@ time.**
 :::tip
 
 <strong class="alert-header">
-  <Icon name="star"></Icon> Premium Cypress Cloud Feature
+  <Icon name="star" /> Premium Cypress Cloud Feature
 </strong>
 
 **Spec Prioritization** is a _Smart Orchestration_ feature available to users
@@ -118,7 +118,7 @@ failure will:
 :::tip
 
 <strong class="alert-header">
-  <Icon name="star"></Icon> Premium Cypress Cloud Feature
+  <Icon name="star" /> Premium Cypress Cloud Feature
 </strong>
 
 **Auto Cancellation** is a _Smart Orchestration_ feature available to users with

--- a/docs/guides/cloud/smart-orchestration.mdx
+++ b/docs/guides/cloud/smart-orchestration.mdx
@@ -73,7 +73,7 @@ To enable or disable this feature at the Project level (must be an admin user):
 <DocsImage
   src="/img/guides/cloud/smart-orchestration/spec-prioritization-active.png"
   alt="Enable Spec Prioritization"
-></DocsImage>
+/>
 
 :::note
 
@@ -157,7 +157,7 @@ To enable or disable this feature at the Project level (must be an admin user):
 <DocsImage
   src="/img/guides/cloud/smart-orchestration/auto-cancellation-active.png"
   alt="Enable Auto Cancellation"
-></DocsImage>
+/>
 
 :::note
 

--- a/docs/guides/cloud/users.mdx
+++ b/docs/guides/cloud/users.mdx
@@ -24,7 +24,7 @@ users will see all projects and tests run for the organization.
 <DocsImage
   src="/img/dashboard/invite-user-dialog.png"
   alt="Invite User dialog"
-></DocsImage>
+/>
 
 ### Sign Up with an Invitation:
 
@@ -108,7 +108,7 @@ deny them access.
 <DocsImage
   src="/img/dashboard/request-access-to-organization.png"
   alt="Request access to project"
-></DocsImage>
+/>
 
 ## User updates
 

--- a/docs/guides/component-testing/angular/quickstart.mdx
+++ b/docs/guides/component-testing/angular/quickstart.mdx
@@ -66,9 +66,7 @@ the configuration wizard.
 <DocsImage
   src="/img/guides/component-testing/select-test-type.jpg"
   caption="Choose Component Testing"
->
-  {' '}
-</DocsImage>
+/>
 
 The Project Setup screen automatically detects your framework, which, in our
 case, is Angular. Click "Next Step" to continue.
@@ -76,9 +74,7 @@ case, is Angular. Click "Next Step" to continue.
 <DocsImage
   src="/img/guides/component-testing/project-setup-angular.jpg"
   caption="Angular is automatically detected"
->
-  {' '}
-</DocsImage>
+/>
 
 The next screen checks that all the required dependencies are installed. All the
 items should have green checkboxes on them, indicating everything is good, so
@@ -87,9 +83,7 @@ click "Continue".
 <DocsImage
   src="/img/guides/component-testing/dependency-detection-angular.jpg"
   caption="All necessary dependencies are installed"
->
-  {' '}
-</DocsImage>
+/>
 
 Next, Cypress generates all the necessary configuration files and gives you a
 list of all the changes it made to your project. Click "Continue".
@@ -97,7 +91,7 @@ list of all the changes it made to your project. Click "Continue".
 <DocsImage
   src="/img/guides/component-testing/scaffolded-files.jpg"
   caption="The Cypress launchpad will scaffold all of these files for you"
-></DocsImage>
+/>
 
 After setting up component testing, you will be at the browser selection screen.
 
@@ -107,17 +101,13 @@ to open the Cypress test runner.
 <DocsImage
   src="/img/guides/component-testing/select-browser.jpg"
   caption="Choose your browser"
->
-  {' '}
-</DocsImage>
+/>
 
 When the test runner appears, it won't find any specs because we haven't created
 any yet. However, we don't currently have a component, either. Let's change
 that!
 
-<DocsImage src="/img/guides/component-testing/create-your-first-spec.jpg">
-  {' '}
-</DocsImage>
+<DocsImage src="/img/guides/component-testing/create-your-first-spec.jpg" />
 
 ### Creating a Component
 
@@ -226,9 +216,7 @@ Switch back to the browser you opened for testing, and you should now see the
 **stepper.component.cy.ts** file in the spec list. Click it to see the spec
 execute.
 
-<DocsImage src="/img/guides/component-testing/first-test-run-angular.jpg">
-  {' '}
-</DocsImage>
+<DocsImage src="/img/guides/component-testing/first-test-run-angular.jpg" />
 
 Our first test verifies the component can mount in it's default state without
 any errors. If there is a runtime error during test execution, the test will

--- a/docs/guides/component-testing/overview.mdx
+++ b/docs/guides/component-testing/overview.mdx
@@ -84,7 +84,7 @@ component in action and interact with it in the test runner:
 <DocsVideo
   src="/img/vuetify-color-picker-example.webm"
   caption="Vuetify's</a> VColorPicker tests, after being moved to Cypress from Jest."
-></DocsVideo>
+/>
 
 You can use the browser developer tools to inspect the DOM, play around with
 styles, and use the debugger to step through your code.

--- a/docs/guides/component-testing/react/quickstart.mdx
+++ b/docs/guides/component-testing/react/quickstart.mdx
@@ -61,9 +61,7 @@ the configuration wizard.
 <DocsImage
   src="/img/guides/component-testing/select-test-type.jpg"
   caption="Choose Component Testing"
->
-  {' '}
-</DocsImage>
+/>
 
 The Project Setup screen automatically detects your framework and bundler,
 which, in our case, is React and Vite. Click "Next Step" to continue.
@@ -71,9 +69,7 @@ which, in our case, is React and Vite. Click "Next Step" to continue.
 <DocsImage
   src="/img/guides/component-testing/project-setup-react.jpg"
   caption="React and Vite are automatically detected"
->
-  {' '}
-</DocsImage>
+/>
 
 The next screen checks that all the required dependencies are installed. All the
 items should have green checkboxes on them, indicating everything is good, so
@@ -82,9 +78,7 @@ click "Continue".
 <DocsImage
   src="/img/guides/component-testing/dependency-detection-react.jpg"
   caption="All necessary dependencies are installed"
->
-  {' '}
-</DocsImage>
+/>
 
 Next, Cypress generates all the necessary configuration files and gives you a
 list of all the changes it made to your project. Click "Continue".
@@ -92,7 +86,7 @@ list of all the changes it made to your project. Click "Continue".
 <DocsImage
   src="/img/guides/component-testing/scaffolded-files.jpg"
   caption="The Cypress launchpad will scaffold all of these files for you"
-></DocsImage>
+/>
 
 After setting up component testing, you will be at the browser selection screen.
 
@@ -102,15 +96,13 @@ to open the Cypress test runner.
 <DocsImage
   src="/img/guides/component-testing/select-browser.jpg"
   caption="Choose your browser"
->
-  {' '}
-</DocsImage>
+/>
 
 When the test runner appears, it won't find any specs because we haven't created
 any yet. However, we don't currently have a component, either. Let's change
 that!
 
-<DocsImage src="/img/guides/component-testing/create-your-first-spec-cfc.jpg"></DocsImage>
+<DocsImage src="/img/guides/component-testing/create-your-first-spec-cfc.jpg" />
 
 ### Creating a Component
 
@@ -174,7 +166,7 @@ A modal will pop up listing all the component files that are found in your app
 files from this list). Expand the row for **Stepper.jsx** and select the
 **Stepper** component:
 
-<DocsImage src="/img/guides/component-testing/create-from-component-react.jpg"></DocsImage>
+<DocsImage src="/img/guides/component-testing/create-from-component-react.jpg" />
 
 A spec file was created at **src/component/Stepper.cy.jsx**:
 
@@ -216,9 +208,7 @@ Now it's time to see the test in action.
 Switch back to the browser you opened for testing, and you should now see the
 **Stepper.cy.jsx** file in the spec list. Click it to see the spec execute.
 
-<DocsImage src="/img/guides/component-testing/first-test-run-react.jpg">
-  {' '}
-</DocsImage>
+<DocsImage src="/img/guides/component-testing/first-test-run-react.jpg" />
 
 Our first test verifies the component can mount in it's default state without
 any errors. If there is a runtime error during test execution, the test will

--- a/docs/guides/component-testing/styling-components.mdx
+++ b/docs/guides/component-testing/styling-components.mdx
@@ -5,7 +5,7 @@ sidebar_position: 20
 
 :::info
 
-## <Icon name="graduation-cap"></Icon> What you'll learn
+## <Icon name="graduation-cap" /> What you'll learn
 
 - How to load CSS libraries like Tailwind or Bootstrap
 - How to render icon fonts like Font Awesome

--- a/docs/guides/component-testing/svelte/quickstart.mdx
+++ b/docs/guides/component-testing/svelte/quickstart.mdx
@@ -62,9 +62,7 @@ the configuration wizard.
 <DocsImage
   src="/img/guides/component-testing/select-test-type.jpg"
   caption="Choose Component Testing"
->
-  {' '}
-</DocsImage>
+/>
 
 The Project Setup screen automatically detects your framework and bundler,
 which, in our case, is Svelte and Vite. Click "Next Step" to continue.
@@ -72,9 +70,7 @@ which, in our case, is Svelte and Vite. Click "Next Step" to continue.
 <DocsImage
   src="/img/guides/component-testing/project-setup-svelte.jpg"
   caption="Svelte and Vite are automatically detected"
->
-  {' '}
-</DocsImage>
+/>
 
 The next screen checks that all the required dependencies are installed. All the
 items should have green checkboxes on them, indicating everything is good, so
@@ -83,9 +79,7 @@ click "Continue".
 <DocsImage
   src="/img/guides/component-testing/dependency-detection-svelte.jpg"
   caption="All necessary dependencies are installed"
->
-  {' '}
-</DocsImage>
+/>
 
 Next, Cypress generates all the necessary configuration files and gives you a
 list of all the changes it made to your project. Click "Continue".
@@ -93,7 +87,7 @@ list of all the changes it made to your project. Click "Continue".
 <DocsImage
   src="/img/guides/component-testing/scaffolded-files.jpg"
   caption="The Cypress launchpad will scaffold all of these files for you"
-></DocsImage>
+/>
 
 After setting up component testing, you will be at the browser selection screen.
 
@@ -103,17 +97,13 @@ to open the Cypress test runner.
 <DocsImage
   src="/img/guides/component-testing/select-browser.jpg"
   caption="Choose your browser"
->
-  {' '}
-</DocsImage>
+/>
 
 When the test runner appears, it won't find any specs because we haven't created
 any yet. However, we don't currently have a component, either. Let's change
 that!
 
-<DocsImage src="/img/guides/component-testing/create-your-first-spec.jpg">
-  {' '}
-</DocsImage>
+<DocsImage src="/img/guides/component-testing/create-your-first-spec.jpg" />
 
 ### Creating a Component
 
@@ -201,9 +191,7 @@ Now it's time to see the test in action.
 Switch back to the browser you opened for testing, and you should now see the
 **Stepper.cy.js** file in the spec list. Click it to see the spec execute.
 
-<DocsImage src="/img/guides/component-testing/first-test-run-svelte.jpg">
-  {' '}
-</DocsImage>
+<DocsImage src="/img/guides/component-testing/first-test-run-svelte.jpg" />
 
 Our first test verifies the component can mount in it's default state without
 any errors. If there is a runtime error during test execution, the test will

--- a/docs/guides/component-testing/vue/overview.mdx
+++ b/docs/guides/component-testing/vue/overview.mdx
@@ -83,7 +83,7 @@ Cypress Component Testing works with Vue CLI.
 
 :::caution
 
-<strong class="alert-header">PWA Caveat</strong>
+<strong>PWA Caveat</strong>
 
 If you use the Vue CLI's PWA feature, there is a known caveat regarding
 configuration. See

--- a/docs/guides/component-testing/vue/quickstart.mdx
+++ b/docs/guides/component-testing/vue/quickstart.mdx
@@ -61,9 +61,7 @@ the configuration wizard.
 <DocsImage
   src="/img/guides/component-testing/select-test-type.jpg"
   caption="Choose Component Testing"
->
-  {' '}
-</DocsImage>
+/>
 
 The Project Setup screen automatically detects your framework and bundler,
 which, in our case, is Vue and Vite. Click "Next Step" to continue.
@@ -71,9 +69,7 @@ which, in our case, is Vue and Vite. Click "Next Step" to continue.
 <DocsImage
   src="/img/guides/component-testing/project-setup-vue.jpg"
   caption="Vue and Vite are automatically detected"
->
-  {' '}
-</DocsImage>
+/>
 
 The next screen checks that all the required dependencies are installed. All the
 items should have green checkboxes on them, indicating everything is good, so
@@ -82,9 +78,7 @@ click "Continue".
 <DocsImage
   src="/img/guides/component-testing/dependency-detection-vue.jpg"
   caption="All necessary dependencies are installed"
->
-  {' '}
-</DocsImage>
+/>
 
 Next, Cypress generates all the necessary configuration files and gives you a
 list of all the changes it made to your project. Click "Continue".
@@ -92,7 +86,7 @@ list of all the changes it made to your project. Click "Continue".
 <DocsImage
   src="/img/guides/component-testing/scaffolded-files.jpg"
   caption="The Cypress launchpad will scaffold all of these files for you"
-></DocsImage>
+/>
 
 After setting up component testing, you will be at the browser selection screen.
 
@@ -102,15 +96,13 @@ to open the Cypress test runner.
 <DocsImage
   src="/img/guides/component-testing/select-browser.jpg"
   caption="Choose your browser"
->
-  {' '}
-</DocsImage>
+/>
 
 When the test runner appears, it won't find any specs because we haven't created
 any yet. However, we don't currently have a component, either. Let's change
 that!
 
-<DocsImage src="/img/guides/component-testing/create-your-first-spec-cfc.jpg"></DocsImage>
+<DocsImage src="/img/guides/component-testing/create-your-first-spec-cfc.jpg" />
 
 ### Creating a Component
 
@@ -169,7 +161,7 @@ spec" screen, click "Create from component".
 A modal will pop up listing all the components that are found in your app.
 Select the **Stepper.vue** component:
 
-<DocsImage src="/img/guides/component-testing/create-from-component-vue.jpg"></DocsImage>
+<DocsImage src="/img/guides/component-testing/create-from-component-vue.jpg" />
 
 A spec file was created at **src/component/Stepper.cy.js**:
 
@@ -213,9 +205,7 @@ Now it's time to see the test in action.
 Switch back to the browser you opened for testing, on click on the "Okay, run
 the spec" button to execute it.
 
-<DocsImage src="/img/guides/component-testing/first-test-run-vue.jpg">
-  {' '}
-</DocsImage>
+<DocsImage src="/img/guides/component-testing/first-test-run-vue.jpg" />
 
 Our first test verifies the component can mount in it's default state without
 any errors. If there is a runtime error during test execution, the test will

--- a/docs/guides/continuous-integration/ci-provider-examples.mdx
+++ b/docs/guides/continuous-integration/ci-provider-examples.mdx
@@ -25,7 +25,7 @@ For the following CI Providers we have in depth guides.
   color="gray"
   url="https://dashboard.cypress.io/projects/7s5okt"
   callout="See CircleCI + Cypress Cloud in action"
- />
+/>
 
 <br />
 <br />

--- a/docs/guides/continuous-integration/ci-provider-examples.mdx
+++ b/docs/guides/continuous-integration/ci-provider-examples.mdx
@@ -19,13 +19,13 @@ For the following CI Providers we have in depth guides.
 
 ### CircleCI
 
-<Icon name="book" color="gray" url="circleci" callout="CircleCI Guide"></Icon> <br />
+<Icon name="book" color="gray" url="circleci" callout="CircleCI Guide" /> <br />
 <Icon
   name="external-link-alt"
   color="gray"
   url="https://dashboard.cypress.io/projects/7s5okt"
   callout="See CircleCI + Cypress Cloud in action"
-></Icon>
+ />
 
 <br />
 <br />

--- a/docs/guides/continuous-integration/circleci.mdx
+++ b/docs/guides/continuous-integration/circleci.mdx
@@ -15,10 +15,7 @@ title: CircleCI
 
 <DocsVideo src="https://youtube.com/embed/J-xbNtKgXfY" />
 
-<DocsVideo
-  src="/img/snippets/running-in-ci.mp4"
-  title="Cypress in CircleCI"
-/>
+<DocsVideo src="/img/snippets/running-in-ci.mp4" title="Cypress in CircleCI" />
 
 <!-- textlint-enable -->
 

--- a/docs/guides/continuous-integration/circleci.mdx
+++ b/docs/guides/continuous-integration/circleci.mdx
@@ -13,12 +13,12 @@ title: CircleCI
 
 <!-- textlint-disable -->
 
-<DocsVideo src="https://youtube.com/embed/J-xbNtKgXfY"></DocsVideo>
+<DocsVideo src="https://youtube.com/embed/J-xbNtKgXfY" />
 
 <DocsVideo
   src="/img/snippets/running-in-ci.mp4"
   title="Cypress in CircleCI"
-></DocsVideo>
+/>
 
 <!-- textlint-enable -->
 

--- a/docs/guides/continuous-integration/github-actions.mdx
+++ b/docs/guides/continuous-integration/github-actions.mdx
@@ -53,7 +53,7 @@ Cypress in the GitHub Actions platform.
 
 :::info
 
-<strong class="alert-header">GitHub Action Version Number</strong>
+<strong>GitHub Action Version Number</strong>
 
 We recommend using the explicit version number of the Cypress GitHub Action to
 prevent accidentally running tests with a new version of the action that may

--- a/docs/guides/continuous-integration/github-actions.mdx
+++ b/docs/guides/continuous-integration/github-actions.mdx
@@ -12,7 +12,7 @@ title: GitHub Actions
 
 :::
 
-<DocsVideo src="https://youtube.com/embed/videoseries?list=PL8GlT7H3xOcLJMIPhxlZ8W9kgbeMqW7cH"></DocsVideo>
+<DocsVideo src="https://youtube.com/embed/videoseries?list=PL8GlT7H3xOcLJMIPhxlZ8W9kgbeMqW7cH" />
 
 :::info
 
@@ -35,7 +35,7 @@ in the [GitHub Action Documentation](https://docs.github.com/en/actions).
 
 ## Cypress GitHub Action
 
-<DocsVideo src="https://youtube.com/embed/N0TOFWy1Xvg"></DocsVideo>
+<DocsVideo src="https://youtube.com/embed/N0TOFWy1Xvg" />
 
 Workflows can be packaged and shared as
 [GitHub Actions](https://github.com/features/actions). GitHub maintains many,
@@ -76,7 +76,7 @@ jobs:
 
 ## Basic Setup
 
-<DocsVideo src="https://youtube.com/embed/vVr7DXDdUks"></DocsVideo>
+<DocsVideo src="https://youtube.com/embed/vVr7DXDdUks" />
 
 The example below is basic CI setup and job using the
 [Cypress GitHub Action](https://github.com/marketplace/actions/cypress-io) to
@@ -248,7 +248,7 @@ jobs:
 
 ## Parallelization
 
-<DocsVideo src="https://youtube.com/embed/96Yn_IiQUJI"></DocsVideo>
+<DocsVideo src="https://youtube.com/embed/96Yn_IiQUJI" />
 
 [Cypress Cloud](/guides/cloud/introduction) offers the ability to
 [parallelize and group test runs](/guides/guides/parallelization) along with
@@ -429,7 +429,7 @@ ui-chrome-tests:
 
 ## Using Cypress Cloud with GitHub Actions
 
-<DocsVideo src="https://youtube.com/embed/Oqq-_QZWzhg"></DocsVideo>
+<DocsVideo src="https://youtube.com/embed/Oqq-_QZWzhg" />
 
 In the GitHub Actions configuration we have defined in the previous section, we
 are leveraging three useful features of

--- a/docs/guides/continuous-integration/github-actions.mdx
+++ b/docs/guides/continuous-integration/github-actions.mdx
@@ -476,7 +476,7 @@ file.
 <DocsImage
   src="/img/guides/github-actions/rwa-run-matrix.png"
   alt="Cypress Real World App GitHub Actions Matrix"
-></DocsImage>
+/>
 
 ## Common Problems and Solutions
 

--- a/docs/guides/continuous-integration/introduction.mdx
+++ b/docs/guides/continuous-integration/introduction.mdx
@@ -17,13 +17,13 @@ sidebar_position: 10
 
 ## What is Continuous Integration?
 
-<DocsVideo src="https://youtube.com/embed/USX6AntcPyg"></DocsVideo>
+<DocsVideo src="https://youtube.com/embed/USX6AntcPyg" />
 
 ## Setting up CI
 
 <!-- textlint-disable -->
 
-<DocsVideo src="https://youtube.com/embed/saYovXS9Llk"></DocsVideo>
+<DocsVideo src="https://youtube.com/embed/saYovXS9Llk" />
 
 <!-- textlint-enable -->
 

--- a/docs/guides/continuous-integration/introduction.mdx
+++ b/docs/guides/continuous-integration/introduction.mdx
@@ -408,14 +408,14 @@ Typically you'd set this inside of your CI provider.
 <DocsImage
   src="/img/guides/continuous-integration/cypress-record-key-as-environment-variable.png"
   alt="Record key environment variable"
-></DocsImage>
+/>
 
 **_TravisCI Environment Variable_**
 
 <DocsImage
   src="/img/guides/continuous-integration/cypress-record-key-as-env-var-travis.png"
   alt="Travis key environment variable"
-></DocsImage>
+/>
 
 #### Git information
 

--- a/docs/guides/core-concepts/cypress-app.mdx
+++ b/docs/guides/core-concepts/cypress-app.mdx
@@ -44,7 +44,7 @@ profile control in the top right of the window.
 <DocsImage
   src="/img/guides/core-concepts/cypress-app/the-launchpad.png"
   alt="The Launchpad"
-></DocsImage>
+/>
 
 The Launchpad is your portal to Cypress, helping with onboarding, choosing a
 testing type and launching a browser.
@@ -59,7 +59,7 @@ to go straight to the Spec Explorer.
 <DocsImage
   src="/img/guides/core-concepts/cypress-app/spec-explorer.png"
   alt="The Spec Explorer"
-></DocsImage>
+/>
 
 On choosing your browser in the Launchpad, you'll be presented with a list of
 your specs, their names, locations, and information about your latest recorded
@@ -130,7 +130,7 @@ Clicking on the flake indicator will take you to the spec’s
 <DocsImage
   src="/img/guides/core-concepts/cypress-app/spec-page.png"
   alt="Spec Explorer"
-></DocsImage>
+/>
 
 To run a spec, simply click the row with the spec you would like to run. You
 will be taken to the [Test Runner](#The-Test-Runner) and the spec will execute.
@@ -160,7 +160,7 @@ Running a large number of specs sequentially can consume more resources.
 <DocsImage
   src="/img/guides/core-concepts/cypress-app/recorded-runs.png"
   alt="Recorded Runs"
-></DocsImage>
+/>
 
 This screen shows detailed information about the most recently recorded
 [test runs](/guides/cloud/runs) across all git branches, latest first. This data
@@ -181,7 +181,7 @@ the Application or Component Under Test, and exploring its DOM.
 <DocsImage
   src="/img/guides/core-concepts/cypress-app/test-runner.png"
   alt="The Test Runner"
-></DocsImage>
+/>
 
 ## Command Log
 
@@ -194,7 +194,7 @@ executed in relevant `before`, `beforeEach`, `afterEach`, and `after` hooks.
   src="/img/guides/core-concepts/cypress-app/command-log.png"
   alt="Cypress app"
   width-600
-></DocsImage>
+/>
 
 ### Open files in your IDE
 
@@ -205,7 +205,7 @@ file where the code is located. Clicking on this link will open the file in your
 <DocsImage
   src="/img/guides/core-concepts/cypress-app/open-file-in-IDE.gif"
   alt="Open file in your IDE"
-></DocsImage>
+/>
 
 ### Time traveling
 
@@ -228,7 +228,7 @@ Log changes the state of the [AUT](#Application-Under-Test) preview:
 <DocsImage
   src="/img/guides/core-concepts/cypress-app/first-test-hover-contains.png"
   alt="Hovering over the contains tab highlights the dom element in the App in the Cypress app"
-></DocsImage>
+/>
 
 Cypress automatically travels back in time to a snapshot of when a hovered-over
 command resolved. Additionally, since [`cy.contains()`](/api/commands/contains)
@@ -241,7 +241,7 @@ the URL that was present when the snapshot was taken.
 <DocsImage
   src="/img/guides/core-concepts/cypress-app/first-test-url-revert.png"
   alt="The url address bar shows https://example.cypress.io/"
-></DocsImage>
+/>
 
 ### Pinning snapshots
 
@@ -256,7 +256,7 @@ purple, and does three other things worth noting:
 <DocsImage
   src="/img/guides/core-concepts/cypress-app/first-test-click-revert.png"
   alt="A click on the click command in the Command Log with Cypress app labeled as 1, 2, 3"
-></DocsImage>
+/>
 
 #### 1. Pinned snapshots
 
@@ -296,7 +296,7 @@ Notice these look different (they are gray and without a number).
 <DocsImage
   src="/img/guides/core-concepts/cypress-app/first-test-page-load.png"
   alt="Command log shows 'Page load --page loaded--' and 'New url https://example.cypress.io/'"
-></DocsImage>
+/>
 
 **Cypress logs out page events for:**
 
@@ -329,21 +329,21 @@ it('intercept command log', () => {
 <DocsImage
   src="/img/guides/core-concepts/cypress-app/instrument-panel-routes.png"
   alt="Routes Instrument Panel"
-></DocsImage>
+/>
 
 #### Stubs
 
 <DocsImage
   src="/img/guides/core-concepts/cypress-app/instrument-panel-stubs.png"
   alt="Stubs Instrument Panel"
-></DocsImage>
+/>
 
 #### Spies
 
 <DocsImage
   src="/img/guides/core-concepts/cypress-app/instrument-panel-spies.png"
   alt="Spies Instrument Panel"
-></DocsImage>
+/>
 
 ## Preview pane
 
@@ -376,7 +376,7 @@ DOM is completely available for debugging.
 <DocsImage
   src="/img/guides/core-concepts/cypress-app/application-under-test.png"
   alt="Application Under Test"
-></DocsImage>
+/>
 
 The AUT also displays in the size and orientation specified in your tests. You
 can change the size or orientation with the
@@ -394,7 +394,7 @@ The image below shows that our application is displaying at `1000px` width,
 <DocsImage
   src="/img/guides/core-concepts/cypress-app/viewport-scaling.png"
   alt="Viewport Scaling"
-></DocsImage>
+/>
 
 _Note: The right-hand side may also be used to display syntax errors in your
 test file that prevent the tests from running._
@@ -402,7 +402,7 @@ test file that prevent the tests from running._
 <DocsImage
   src="/img/guides/core-concepts/cypress-app/aut-error-e2e.png"
   alt="Errors"
-></DocsImage>
+/>
 
 _Note: Internally, the AUT renders within an iframe. This can sometimes cause
 unexpected behaviors
@@ -450,7 +450,7 @@ available for debugging.
 <DocsImage
   src="/img/guides/core-concepts/v10/component-under-test.png"
   alt="Cypress app showing mounted component and password assertion"
-></DocsImage>
+/>
 
 The CUT also displays in the size and orientation specified in your tests. You
 can change the size or orientation with the
@@ -468,7 +468,7 @@ The image below shows that our application is displaying at `500px` width,
 <DocsImage
   src="/img/guides/core-concepts/cypress-app/viewport-scaling-ct.png"
   alt="Cypress app showing mounted component test viewport scale"
-></DocsImage>
+/>
 
 _Note: The right-hand side may also be used to display syntax errors in your
 spec file that prevent the tests from running._
@@ -476,7 +476,7 @@ spec file that prevent the tests from running._
 <DocsImage
   src="/img/guides/core-concepts/cypress-app/aut-error-ct.png"
   alt="Cypress app showing error as application under test"
-></DocsImage>
+/>
 
 _Note: Internally, the CUT renders within an iframe. This can sometimes cause
 unexpected behaviors
@@ -545,7 +545,7 @@ to preview a unique selector for that element in the tooltip.
 <DocsImage
   src="/img/guides/core-concepts/cypress-app/open-selector-playground.gif"
   alt="Opening selector playground and hovering over elements"
-></DocsImage>
+/>
 
 Click on the element and its selector will appear at the top. From there, you
 can copy it to your clipboard ( <Icon name="copy" /> ) or print it to the
@@ -554,7 +554,7 @@ console ( <Icon name="terminal" /> ).
 <DocsImage
   src="/img/guides/core-concepts/cypress-app/copy-selector-in-selector-playground.gif"
   alt="Clicking an element, copying its selector to clipboard, printing it to the console"
-></DocsImage>
+/>
 
 ### Running experiments
 
@@ -568,7 +568,7 @@ highlight those elements in your app.
 <DocsImage
   src="/img/guides/core-concepts/cypress-app/typing-a-selector-to-find-in-playground.gif"
   alt="Type a selector to see what elements it matches"
-></DocsImage>
+/>
 
 #### Switching to contains
 
@@ -583,7 +583,7 @@ matches the text, even if multiple elements on the page contain the text.
 <DocsImage
   src="/img/guides/core-concepts/cypress-app/cy-contains-in-selector-playground.gif"
   alt="Experiment with cy.contains"
-></DocsImage>
+/>
 
 #### Disabling highlights
 
@@ -594,7 +594,7 @@ off will allow you to interact with your app more easily.
 <DocsImage
   src="/img/guides/core-concepts/cypress-app/turn-off-highlight-in-selector-playground.gif"
   alt="Turn off highlighting"
-></DocsImage>
+/>
 
 ## Keyboard shortcuts
 
@@ -610,7 +610,7 @@ Cypress.
 <DocsImage
   src="/img/guides/core-concepts/cypress-app/keyboard-shortcuts.png"
   alt="Tooltips show keyboard shortcuts"
-></DocsImage>
+/>
 
 ## Debugging
 
@@ -637,7 +637,7 @@ selector.
 <DocsImage
   src="/img/guides/core-concepts/cypress-app/first-test-console-output.png"
   alt="Cypress app with get command pinned and console log open showing the yielded element"
-></DocsImage>
+/>
 
 **We can see Cypress output additional information in the console:**
 
@@ -686,7 +686,7 @@ forward through each command in the test.
 <DocsImage
   src="/img/guides/core-concepts/cypress-app/first-test-paused.png"
   alt="Cypress app shows label saying 'Paused' with Command Log showing 'Pause'"
-></DocsImage>
+/>
 
 In action:
 

--- a/docs/guides/core-concepts/cypress-app.mdx
+++ b/docs/guides/core-concepts/cypress-app.mdx
@@ -493,7 +493,7 @@ The Selector Playground is an interactive feature that helps you:
 <DocsVideo
   src="/img/snippets/selector-playground.mp4"
   title="Selector Playground demo"
-></DocsVideo>
+/>
 
 :::info
 
@@ -693,7 +693,7 @@ In action:
 <DocsVideo
   src="/img/snippets/first-test-debugging-30fps.mp4"
   title="Pause test runner demo"
-></DocsVideo>
+/>
 
 ## History
 

--- a/docs/guides/core-concepts/cypress-app.mdx
+++ b/docs/guides/core-concepts/cypress-app.mdx
@@ -22,7 +22,7 @@ Cypress testing experience.
 
 :::info
 
-<strong class="alert-header">Cypress Cloud integration</strong>
+<strong>Cypress Cloud integration</strong>
 
 When you configure the open-source Cypress app to record tests to
 [Cypress Cloud](/guides/cloud/introduction), you'll see data from your latest
@@ -103,7 +103,7 @@ Again, this analysis comes from Cypress Cloud.
 
 :::info
 
-<strong class="alert-header">What is a flaky test?</strong>
+<strong>What is a flaky test?</strong>
 
 A test is considered to be [flaky](/guides/cloud/flaky-test-management) when it
 can pass and fail across multiple retry attempts without any code changes.
@@ -142,7 +142,7 @@ It is also possible to run multiple specs sequentially using the
 
 :::caution
 
-<strong class="alert-header">Experimental Run All Specs</strong>
+<strong>Experimental Run All Specs</strong>
 
 `experimentalRunAllSpecs` currently works with End to End Testing.
 

--- a/docs/guides/core-concepts/interacting-with-elements.mdx
+++ b/docs/guides/core-concepts/interacting-with-elements.mdx
@@ -230,10 +230,7 @@ the command in the [Command Log](/guides/core-concepts/cypress-app#Command-Log).
 Additionally we'll display a red "hitbox" - which is a dot indicating the
 coordinates of the event.
 
-<DocsImage
-  src="/img/guides/core-concepts/v10/hitbox.png"
-  alt="Hitbox"
-/>
+<DocsImage src="/img/guides/core-concepts/v10/hitbox.png" alt="Hitbox" />
 
 ## Debugging
 

--- a/docs/guides/core-concepts/interacting-with-elements.mdx
+++ b/docs/guides/core-concepts/interacting-with-elements.mdx
@@ -225,7 +225,7 @@ the command in the [Command Log](/guides/core-concepts/cypress-app#Command-Log).
 <DocsImage
   src="/img/guides/core-concepts/v10/coords.png"
   alt="Event coordinates"
-></DocsImage>
+/>
 
 Additionally we'll display a red "hitbox" - which is a dot indicating the
 coordinates of the event.
@@ -233,7 +233,7 @@ coordinates of the event.
 <DocsImage
   src="/img/guides/core-concepts/v10/hitbox.png"
   alt="Hitbox"
-></DocsImage>
+/>
 
 ## Debugging
 

--- a/docs/guides/core-concepts/introduction-to-cypress.mdx
+++ b/docs/guides/core-concepts/introduction-to-cypress.mdx
@@ -449,7 +449,7 @@ is in order.
 
 :::info
 
-<strong class="alert-header">
+<strong>
   Don't continue a chain after acting on the DOM
 </strong>
 

--- a/docs/guides/core-concepts/introduction-to-cypress.mdx
+++ b/docs/guides/core-concepts/introduction-to-cypress.mdx
@@ -741,7 +741,7 @@ say our application shows a random number on load.
 <DocsImage
   src="/img/guides/core-concepts/v10/reload-page.gif"
   alt="Manually reloading the browser page until the number 7 appears"
-></DocsImage>
+/>
 
 We want the test to stop when it finds the number 7. If any other number is
 displayed the test reloads the page and checks again.
@@ -819,7 +819,7 @@ The test runs and correctly finishes.
 <DocsImage
   src="/img/guides/core-concepts/v10/lucky-7.gif"
   alt="Test reloads the page until the number 7 appears"
-></DocsImage>
+/>
 
 You can see a short video going through this example at
 

--- a/docs/guides/core-concepts/introduction-to-cypress.mdx
+++ b/docs/guides/core-concepts/introduction-to-cypress.mdx
@@ -449,9 +449,7 @@ is in order.
 
 :::info
 
-<strong>
-  Don't continue a chain after acting on the DOM
-</strong>
+<strong>Don't continue a chain after acting on the DOM</strong>
 
 While it's possible in Cypress to act on the DOM and then continue chaining,
 this is usually unsafe, and can lead to stale elements. See the

--- a/docs/guides/core-concepts/retry-ability.mdx
+++ b/docs/guides/core-concepts/retry-ability.mdx
@@ -57,7 +57,7 @@ commands regardless of types, with passing assertions showing in green.
 <DocsImage
   src="/img/guides/retry-ability/command-assertions.png"
   alt="Cypress tests showing commands and assertions"
-></DocsImage>
+/>
 
 Let's look at the last chain of commands:
 
@@ -121,7 +121,7 @@ the spinning indicators, meaning Cypress is requerying for them.
 <DocsImage
   src="/img/guides/retry-ability/retry-assertion.gif"
   alt="Retrying assertion"
-></DocsImage>
+/>
 
 Within a few milliseconds after the DOM updates, `cy.find()` finds an element
 and the `should('have.length', 1)` assertion passes
@@ -166,7 +166,7 @@ itself failed.
 <DocsImage
   src="/img/guides/retry-ability/second-assertion-fails.gif"
   alt="Retrying multiple assertions"
-></DocsImage>
+/>
 
 ## Built-in assertions
 
@@ -184,7 +184,7 @@ cy.get('.todo-list li') // query
 <DocsImage
   src="/img/guides/retry-ability/eq.gif"
   alt="Retrying built-in assertion"
-></DocsImage>
+/>
 
 Only queries can be retried, but most other commands still have built-in
 _waiting_. For example, as described in the "Assertions" section of
@@ -360,7 +360,7 @@ const Clicker = ({ click }) => (
 <DocsImage
   src="/img/guides/retry-ability/delay-click.png"
   alt="Expect fails the test without waiting for the delayed stub"
-></DocsImage>
+/>
 
 The test finishes before the component calls the `click` prop twice, and without
 retrying the assertion `expect(onClick).to.be.calledTwice`.
@@ -389,7 +389,7 @@ it('calls the click prop', () => {
 <DocsImage
   src="/img/guides/retry-ability/click-twice.gif"
   alt="Retrying the assertions using a stub alias"
-></DocsImage>
+/>
 
 ### Use `.should()` with a callback
 
@@ -414,7 +414,7 @@ Below is an example where the number value is set after a delay:
 <DocsImage
   src="/img/guides/retry-ability/random-number.gif"
   alt="Random number"
-></DocsImage>
+/>
 
 ### <Icon name="exclamation-triangle" color="red"></Icon> Incorrectly waiting for values
 
@@ -437,7 +437,7 @@ the test only runs the entire chain once before failing.
 <DocsImage
   src="/img/guides/retry-ability/random-number-first-attempt.png"
   alt="First attempt at writing the test"
-></DocsImage>
+/>
 
 #### <Icon name="check-circle" color="green" /> Correctly waiting for values
 
@@ -462,7 +462,7 @@ to get the number. When the number is finally set in the application, then the
 <DocsImage
   src="/img/guides/retry-ability/random-number-callback.gif"
   alt="Random number using callback"
-></DocsImage>
+/>
 
 ## See also
 

--- a/docs/guides/core-concepts/retry-ability.mdx
+++ b/docs/guides/core-concepts/retry-ability.mdx
@@ -270,7 +270,7 @@ The following test might have problems if:
 - Your JS framework re-rendered asynchronously
 - Your app code reacted to an event firing and removed the element
 
-#### <Icon name="exclamation-triangle" color="red"></Icon> Incorrectly chaining commands
+#### <Icon name="exclamation-triangle" color="red" /> Incorrectly chaining commands
 
 ```javascript
 cy.get('.new-todo')
@@ -279,7 +279,7 @@ cy.get('.new-todo')
   .should('have.class', 'active') // assertion after an action - bad
 ```
 
-#### <Icon name="check-circle" color="green"></Icon> Correctly ending chains after an action
+#### <Icon name="check-circle" color="green" /> Correctly ending chains after an action
 
 To avoid these issues entirely, it is better to split up the above chain of
 commands.
@@ -323,7 +323,7 @@ As another example, when confirming that the button component invokes the
 [cypress/react](https://github.com/cypress-io/cypress/tree/master/npm/react)
 mounting library, the following test might or might not work:
 
-#### <Icon name="exclamation-triangle" color="red"></Icon> Incorrectly checking if the stub was called
+#### <Icon name="exclamation-triangle" color="red" /> Incorrectly checking if the stub was called
 
 ```js
 const Clicker = ({ click }) => (
@@ -367,7 +367,7 @@ retrying the assertion `expect(onClick).to.be.calledTwice`.
 
 It could also fail if React decides to rerender the DOM between clicks.
 
-#### <Icon name="check-circle" color="green"></Icon> Correctly waiting for the stub to be called
+#### <Icon name="check-circle" color="green" /> Correctly waiting for the stub to be called
 
 We recommend aliasing the stub using the [`.as`](/api/commands/as) command and
 using `cy.get('@alias').should(...)` assertions.
@@ -416,7 +416,7 @@ Below is an example where the number value is set after a delay:
   alt="Random number"
 />
 
-### <Icon name="exclamation-triangle" color="red"></Icon> Incorrectly waiting for values
+### <Icon name="exclamation-triangle" color="red" /> Incorrectly waiting for values
 
 You may want to write a test like below, to test that the number is between 1
 and 10, although **this will not work as intended**. The test yields the

--- a/docs/guides/core-concepts/variables-and-aliases.mdx
+++ b/docs/guides/core-concepts/variables-and-aliases.mdx
@@ -533,7 +533,7 @@ Aliasing your intercepted routes enables you to:
 <DocsImage
   src="/img/guides/core-concepts/v10/aliasing-routes.png"
   alt="Alias commands"
-></DocsImage>
+/>
 
 Here's an example of aliasing an intercepted route and waiting on it to
 complete.

--- a/docs/guides/core-concepts/variables-and-aliases.mdx
+++ b/docs/guides/core-concepts/variables-and-aliases.mdx
@@ -515,9 +515,9 @@ _Usually_, replaying previous commands will return what you expect, but not
 always. It is recommended that you **alias elements before running commands**.
 
 - `cy.get('nav').find('header').find('[data-testid="user"]').as('user').click()`
-  <Icon name="check-circle" color="green"></Icon> (good)
+  <Icon name="check-circle" color="green" /> (good)
 - `cy.get('nav').find('header').find('[data-testid="user"]').click().as('user')`
-  <Icon name="exclamation-triangle" color="red"></Icon> (bad)
+  <Icon name="exclamation-triangle" color="red" /> (bad)
 
 :::
 

--- a/docs/guides/core-concepts/writing-and-organizing-tests.mdx
+++ b/docs/guides/core-concepts/writing-and-organizing-tests.mdx
@@ -306,7 +306,7 @@ matching `supportFile` files will result in an error when Cypress loads.
 :::info
 
 <strong>
-  <Icon name="cogs"></Icon> supportFile per testing type
+  <Icon name="cogs" /> supportFile per testing type
 </strong>
 
 Depending on which [testing type](/guides/core-concepts/testing-types) you are

--- a/docs/guides/core-concepts/writing-and-organizing-tests.mdx
+++ b/docs/guides/core-concepts/writing-and-organizing-tests.mdx
@@ -244,7 +244,7 @@ module API option, if specified)
 <DocsImage
   src="/img/dashboard/videos-of-recorded-test-run.png"
   alt="Video of test runs"
-></DocsImage>
+/>
 
 Instead of administering assets yourself, you can
 [save them to the cloud with Cypress Cloud](/guides/cloud/runs#Run-details).
@@ -349,7 +349,7 @@ beforeEach(() => {
 <DocsImage
   src="/img/guides/core-concepts/v10/global-hooks.png"
   alt="Global hooks for tests"
-></DocsImage>
+/>
 
 :::info
 
@@ -790,7 +790,7 @@ file by clicking on it.
 <DocsImage
   src="/img/guides/core-concepts/v10/run-single-spec.gif"
   alt="Running a single spec"
-></DocsImage>
+/>
 
 ## Test statuses
 
@@ -805,7 +805,7 @@ assertions. The test screenshot below shows a passed test:
 <DocsImage
   src="/img/guides/core-concepts/v10/todo-mvc-passing-test.png"
   alt="Cypress with a single passed test"
-></DocsImage>
+/>
 
 Note that a test can pass after several
 [test retries](/guides/guides/test-retries). In that case the Command Log shows
@@ -819,7 +819,7 @@ be a user hitting this bug!
 <DocsImage
   src="/img/guides/core-concepts/v10/todo-mvc-failing-test.png"
   alt="Cypress with a single failed test"
-></DocsImage>
+/>
 
 After a test fails, the screenshots and videos can help find the problem so it
 can be fixed.
@@ -854,7 +854,7 @@ file.
 <DocsImage
   src="/img/guides/core-concepts/v10/todo-mvc-pending-tests.png"
   alt="Cypress with three pending test"
-></DocsImage>
+/>
 
 So remember - if you (the test writer) knowingly skip a test using one of the
 above three ways, Cypress counts it as a _pending_ test.
@@ -893,7 +893,7 @@ If the `beforeEach` hook completes and both tests finish, two tests are passing.
 <DocsImage
   src="/img/guides/core-concepts/v10/todo-mvc-2-tests-passing.png"
   alt="Cypress showing two passing tests"
-></DocsImage>
+/>
 
 But what happens if a command inside the `beforeEach` hook fails? For example,
 let's pretend we want to visit a non-existent page `/does-not-exist` instead of
@@ -914,7 +914,7 @@ would also fail due to the `beforeEach` hook failure.
 <DocsImage
   src="/img/guides/core-concepts/v10/todo-mvc-failed-and-skipped-tests.png"
   alt="Cypress showing one failed and one skipped test"
-></DocsImage>
+/>
 
 If we collapse the test commands, we can see the empty box marking the skipped
 test "adds 2 todos".
@@ -922,7 +922,7 @@ test "adds 2 todos".
 <DocsImage
   src="/img/guides/core-concepts/v10/todo-mvc-skipped-test.png"
   alt="Cypress showing one skipped test"
-></DocsImage>
+/>
 
 The tests that were meant to be executed but were skipped due to some run-time
 problem are marked "skipped" by Cypress.

--- a/docs/guides/end-to-end-testing/introduction/testing-your-app.mdx
+++ b/docs/guides/end-to-end-testing/introduction/testing-your-app.mdx
@@ -501,7 +501,7 @@ Cypress.Commands.add('login', (username, password) => {
 
 :::info
 
-<strong class="alert-header">Third-Party Login</strong>
+<strong>Third-Party Login</strong>
 
 If your app implements login via a third-party authentication provider such as
 [Auth0](https://auth0.com/) or [Okta](https://www.okta.com/), you can use the

--- a/docs/guides/end-to-end-testing/introduction/testing-your-app.mdx
+++ b/docs/guides/end-to-end-testing/introduction/testing-your-app.mdx
@@ -17,7 +17,7 @@ slug: /guides/end-to-end-testing/testing-your-app
 
 <!-- textlint-disable terminology -->
 
-<DocsVideo src="https://youtube.com/embed/5XQOK0v_YRE"></DocsVideo>
+<DocsVideo src="https://youtube.com/embed/5XQOK0v_YRE" />
 
 <!-- textlint-enable -->
 

--- a/docs/guides/end-to-end-testing/introduction/testing-your-app.mdx
+++ b/docs/guides/end-to-end-testing/introduction/testing-your-app.mdx
@@ -109,7 +109,7 @@ Once that file is created, you should see it in the list of spec files.
 <DocsImage
   src="/img/guides/getting-started/e2e/v10/testing-your-app-home-page-spec.png"
   alt="List of files including home_page.cy.js"
-></DocsImage>
+/>
 
 Now you'll need to add in the following code in your test file to visit your
 server:
@@ -136,7 +136,7 @@ it('successfully loads', () => {
 <DocsImage
   src="/img/guides/getting-started/e2e/v10/testing-your-app-visit-fail.png"
   alt="Error in Cypress showing cy.visit failed"
-></DocsImage>
+/>
 
 If you've started your server, then you should see your application loaded and
 working.

--- a/docs/guides/end-to-end-testing/introduction/writing-your-first-end-to-end-test.mdx
+++ b/docs/guides/end-to-end-testing/introduction/writing-your-first-end-to-end-test.mdx
@@ -25,7 +25,7 @@ spec</strong> button.
 <DocsImage
   src="/img/guides/end-to-end-testing/writing-your-first-end-to-end-test/create-new-empty-spec.png"
   alt="Cypress with the Create new empty spec button highlighted"
-></DocsImage>
+/>
 
 On clicking it, you should see a dialog where you can enter the name of your new
 spec. Just accept the default name for now.
@@ -33,7 +33,7 @@ spec. Just accept the default name for now.
 <DocsImage
   src="/img/guides/end-to-end-testing/writing-your-first-end-to-end-test/enter-path-for-new-spec.png"
   alt="The new spec path dialog"
-></DocsImage>
+/>
 
 The newly-generated spec is displayed in a confirmation dialog. Just go ahead
 and close it with the ✕ button.
@@ -41,7 +41,7 @@ and close it with the ✕ button.
 <DocsImage
   src="/img/guides/end-to-end-testing/writing-your-first-end-to-end-test/new-spec-added-confirmation.png"
   alt="The new spec confirmation dialog"
-></DocsImage>
+/>
 
 Once we've created that file, you should see it immediately displayed in the
 list of end-to-end specs. Cypress monitors your spec files for any changes and
@@ -50,7 +50,7 @@ automatically displays any changes.
 <DocsImage
   src="/img/guides/end-to-end-testing/writing-your-first-end-to-end-test/spec-list-with-new-spec.png"
   alt="Cypress showing the spec list with the newly created spec"
-></DocsImage>
+/>
 
 Even though we haven't written any code yet - that's okay - let's click on your
 new spec and watch Cypress launch it. Spoiler alert: it's probably going to
@@ -87,7 +87,7 @@ be passing in green).
 <DocsImage
   src="/img/guides/getting-started/e2e/v10/first-test.png"
   alt="My first test shown passing in Cypress"
-></DocsImage>
+/>
 
 :::info
 
@@ -130,7 +130,7 @@ describe('My First Test', () => {
 <DocsImage
   src="/img/guides/getting-started/e2e/v10/first-test-failing.png"
   alt="Failing test"
-></DocsImage>
+/>
 
 [Cypress](/guides/core-concepts/cypress-app) gives you a visual structure of
 suites, tests, and assertions. Soon you'll also see commands, page events,
@@ -297,7 +297,7 @@ describe('My First Test', () => {
 <DocsImage
   src="/img/guides/getting-started/e2e/v10/first-test-failing-contains.png"
   alt="Test failing to not find content 'hype'"
-></DocsImage>
+/>
 
 :::caution
 

--- a/docs/guides/end-to-end-testing/introduction/writing-your-first-end-to-end-test.mdx
+++ b/docs/guides/end-to-end-testing/introduction/writing-your-first-end-to-end-test.mdx
@@ -217,7 +217,7 @@ have failed.
 <DocsVideo
   src="/img/snippets/first-test-visit-30fps.mp4"
   title="First test with cy.visit()"
-></DocsVideo>
+/>
 
 :::danger
 
@@ -317,7 +317,7 @@ Before we add another command - let's get this test back to passing. Replace
 <DocsVideo
   src="/img/snippets/first-test-contains-30fps.mp4"
   title="First test with cy.contains()"
-></DocsVideo>
+/>
 
 ### <Icon name="mouse-pointer" /> Step 3: Click an element
 
@@ -348,7 +348,7 @@ Now we can assert something about this new page!
 <DocsVideo
   src="/img/snippets/first-test-click-30fps.mp4"
   title="First test with .click()"
-></DocsVideo>
+/>
 
 <IntellisenseCodeCompletion />
 
@@ -463,7 +463,7 @@ outcomes.
 <DocsVideo
   src="/img/snippets/first-test-assertions-30fps.mp4"
   title="First test with assertions"
-></DocsVideo>
+/>
 
 :::info
 

--- a/docs/guides/end-to-end-testing/migration/protractor-to-cypress.mdx
+++ b/docs/guides/end-to-end-testing/migration/protractor-to-cypress.mdx
@@ -106,7 +106,7 @@ app's logic.
 <DocsVideo
   src="/img/guides/migrating-to-cypress/DevTools.mp4"
   title="interacting with tests in a browser"
-></DocsVideo>
+/>
 
 ### Faster feedback loops
 
@@ -122,7 +122,7 @@ confidence.
 <DocsVideo
   src="/img/guides/migrating-to-cypress/codeframe-ex.webm"
   title="auto-reloading"
-></DocsVideo>
+/>
 
 ### Time travel through tests
 
@@ -138,7 +138,7 @@ simulated **real user behavior**.
 <DocsVideo
   src="/img/guides/migrating-to-cypress/interactivity.mp4"
   title="Time travel debugging"
-></DocsVideo>
+/>
 
 ### Gain Visibility in Headless Mode with Screenshots and Videos
 
@@ -468,7 +468,7 @@ to use in your Cypress tests.
 <DocsVideo
   src="/img/snippets/selector-playground.mp4"
   title="Selector Playground"
-></DocsVideo>
+/>
 
 ### How to Interact with DOM Elements
 

--- a/docs/guides/end-to-end-testing/testing-strategies/amazon-cognito-authentication.mdx
+++ b/docs/guides/end-to-end-testing/testing-strategies/amazon-cognito-authentication.mdx
@@ -263,7 +263,7 @@ describe('Cognito', function () {
 })
 ```
 
-<DocsVideo src="https://vimeo.com/789093851"></DocsVideo>
+<DocsVideo src="https://vimeo.com/789093851" />
 
 Lastly, we can refactor our login command to take advantage of
 [`cy.session()`](/api/commands/session) to store our logged in user so we don't
@@ -289,7 +289,7 @@ Cypress.Commands.add('loginByCognito', (username, password) => {
 })
 ```
 
-<DocsVideo src="https://vimeo.com/789093817"></DocsVideo>
+<DocsVideo src="https://vimeo.com/789093817" />
 
 ### Programmatic Login
 

--- a/docs/guides/end-to-end-testing/testing-strategies/amazon-cognito-authentication.mdx
+++ b/docs/guides/end-to-end-testing/testing-strategies/amazon-cognito-authentication.mdx
@@ -395,7 +395,7 @@ describe('Cognito', function () {
 
 :::info
 
-<strong class="alert-header">Programmatic Login</strong>
+<strong>Programmatic Login</strong>
 
 Unlike programmatic login, authenticating with
 [`cy.origin()`](/api/commands/origin) does not require adapting the application

--- a/docs/guides/end-to-end-testing/testing-strategies/auth0-authentication.mdx
+++ b/docs/guides/end-to-end-testing/testing-strategies/auth0-authentication.mdx
@@ -211,7 +211,7 @@ describe('Auth0', function () {
 })
 ```
 
-<DocsVideo src="https://vimeo.com/789093942"></DocsVideo>
+<DocsVideo src="https://vimeo.com/789093942" />
 
 Lastly, we can refactor our login command to take advantage of
 [`cy.session()`](/api/commands/session) to store our logged in user so we don't
@@ -247,7 +247,7 @@ Cypress.Commands.add('loginToAuth0', (username: string, password: string) => {
 })
 ```
 
-<DocsVideo src="https://vimeo.com/789093910"></DocsVideo>
+<DocsVideo src="https://vimeo.com/789093910" />
 
 ### Programmatic Login
 

--- a/docs/guides/end-to-end-testing/testing-strategies/azure-active-directory-authentication.mdx
+++ b/docs/guides/end-to-end-testing/testing-strategies/azure-active-directory-authentication.mdx
@@ -196,7 +196,7 @@ describe('Azure Active Directory Authentication', () => {
 })
 ```
 
-<DocsVideo src="https://vimeo.com/789095126"></DocsVideo>
+<DocsVideo src="https://vimeo.com/789095126" />
 
 We now have working authentication and tests! But we are logging in before every
 test, which is not only time consuming, but also can lead to API rate limiting
@@ -240,7 +240,7 @@ Cypress.Commands.add('loginToAAD', (username: string, password: string) => {
 })
 ```
 
-<DocsVideo src="https://vimeo.com/789095038"></DocsVideo>
+<DocsVideo src="https://vimeo.com/789095038" />
 
 With the use of [`cy.session()`](/api/commands/session), our tests should now
 run quicker!

--- a/docs/guides/end-to-end-testing/testing-strategies/azure-active-directory-authentication.mdx
+++ b/docs/guides/end-to-end-testing/testing-strategies/azure-active-directory-authentication.mdx
@@ -5,7 +5,7 @@ slug: /guides/end-to-end-testing/azure-active-directory-authentication
 
 :::info
 
-## <Icon name="graduation-cap"></Icon> What you'll learn
+## <Icon name="graduation-cap" /> What you'll learn
 
 - Log in to
   [Azure Active Directory](https://learn.microsoft.com/en-us/azure/active-directory/fundamentals/active-directory-whatis)

--- a/docs/guides/end-to-end-testing/testing-strategies/okta-authentication.mdx
+++ b/docs/guides/end-to-end-testing/testing-strategies/okta-authentication.mdx
@@ -155,7 +155,7 @@ describe('Okta', function () {
 })
 ```
 
-<DocsVideo src="https://vimeo.com/789093739"></DocsVideo>
+<DocsVideo src="https://vimeo.com/789093739" />
 
 Lastly, we can refactor our login command to take advantage of
 [`cy.session()`](/api/commands/session) to store our logged in user so we don't
@@ -178,7 +178,7 @@ Cypress.Commands.add('loginByOkta', (username: string, password: string) => {
 })
 ```
 
-<DocsVideo src="https://vimeo.com/789093688"></DocsVideo>
+<DocsVideo src="https://vimeo.com/789093688" />
 
 ### Programmatic Login
 

--- a/docs/guides/end-to-end-testing/testing-strategies/social-authentication.mdx
+++ b/docs/guides/end-to-end-testing/testing-strategies/social-authentication.mdx
@@ -5,7 +5,7 @@ slug: /guides/end-to-end-testing/social-authentication
 
 :::info
 
-## <Icon name="graduation-cap"></Icon> What you'll learn
+## <Icon name="graduation-cap" /> What you'll learn
 
 - Log into your application via Google, Facebook, or Microsoft through the UI
   with [`cy.origin()`](/api/commands/origin) using Auth0 social connections. The
@@ -18,7 +18,7 @@ slug: /guides/end-to-end-testing/social-authentication
 :::caution
 
 <strong class="alert-header">
-  <Icon name="exclamation-triangle"></Icon> Not recommended in CI
+  <Icon name="exclamation-triangle" /> Not recommended in CI
 </strong>
 
 Cypress does **not** recommend testing social connection authentication as a

--- a/docs/guides/end-to-end-testing/testing-strategies/social-authentication.mdx
+++ b/docs/guides/end-to-end-testing/testing-strategies/social-authentication.mdx
@@ -95,7 +95,7 @@ Select the dropdown and go to `Applications`
 
 Here is what this process should look like for Facebook setup:
 
-<DocsVideo src="https://vimeo.com/789093604"></DocsVideo>
+<DocsVideo src="https://vimeo.com/789093604" />
 
 ## Testing with Cypress
 
@@ -335,7 +335,7 @@ describe('Social Logins Demo', () => {
 
 Here is a sample of what all 3 should look like in order.
 
-<DocsVideo src="https://vimeo.com/789093473"></DocsVideo>
+<DocsVideo src="https://vimeo.com/789093473" />
 
 Lastly, we can refactor our login command to take advantage of
 [`cy.session()`](/api/commands/session) to store our logged in user so we don't
@@ -419,7 +419,7 @@ Cypress.Commands.add(
 )
 ```
 
-<DocsVideo src="https://vimeo.com/789093516"></DocsVideo>
+<DocsVideo src="https://vimeo.com/789093516" />
 
 With the use of [`cy.session()`](/api/commands/session), our tests should now
 run quicker!

--- a/docs/guides/end-to-end-testing/testing-strategies/social-authentication.mdx
+++ b/docs/guides/end-to-end-testing/testing-strategies/social-authentication.mdx
@@ -17,7 +17,7 @@ slug: /guides/end-to-end-testing/social-authentication
 
 :::caution
 
-<strong class="alert-header">
+<strong>
   <Icon name="exclamation-triangle" /> Not recommended in CI
 </strong>
 

--- a/docs/guides/getting-started/installing-cypress.mdx
+++ b/docs/guides/getting-started/installing-cypress.mdx
@@ -39,10 +39,7 @@ in the correct directory.
 
 :::
 
-<DocsVideo
-  src="/img/snippets/installing-cli.mp4"
-  title="Install via CLI"
-/>
+<DocsVideo src="/img/snippets/installing-cli.mp4" title="Install via CLI" />
 
 :::info
 

--- a/docs/guides/getting-started/installing-cypress.mdx
+++ b/docs/guides/getting-started/installing-cypress.mdx
@@ -42,7 +42,7 @@ in the correct directory.
 <DocsVideo
   src="/img/snippets/installing-cli.mp4"
   title="Install via CLI"
-></DocsVideo>
+/>
 
 :::info
 
@@ -109,7 +109,7 @@ to install any dependencies.
 <DocsVideo
   src="/img/snippets/installing-global.mp4"
   title="Install via direct download"
-></DocsVideo>
+/>
 
 :::info
 

--- a/docs/guides/getting-started/opening-the-app.mdx
+++ b/docs/guides/getting-started/opening-the-app.mdx
@@ -81,7 +81,7 @@ You can [read more about the CLI here](/guides/guides/command-line).
 <DocsImage
   src="/img/guides/getting-started/opening-the-app/launchpad.png"
   alt="The Launchpad window"
-></DocsImage>
+/>
 
 On opening Cypress, your testing journey begins with the Launchpad. Its job is
 to guide you through the decisions and configuration tasks you need to complete
@@ -95,7 +95,7 @@ steps in order.
 <DocsImage
   src="/img/guides/getting-started/opening-the-app/choose-testing-type.png"
   alt="The Launchpad test type selector"
-></DocsImage>
+/>
 
 The Launchpad presents you with your biggest decision first: What type of
 testing shall I do?
@@ -114,7 +114,7 @@ just choose **E2E** for now - you can always change this later!
 <DocsImage
   src="/img/guides/getting-started/opening-the-app/scaffolded-files.png"
   alt="The Launchpad scaffolded files list"
-></DocsImage>
+/>
 
 On the next step, the Launchpad will scaffold out a set of configuration files
 appropriate to your chosen testing type, and the changes will be listed for you
@@ -127,7 +127,7 @@ just scroll down and hit "Continue".
 <DocsImage
   src="/img/guides/getting-started/opening-the-app/select-browser.png"
   alt="The Launchpad browser selector"
-></DocsImage>
+/>
 
 Lastly, you're presented with the list of compatible browsers Cypress found on
 your system. To understand more about your options here, see

--- a/docs/guides/guides/command-line.mdx
+++ b/docs/guides/guides/command-line.mdx
@@ -439,7 +439,7 @@ Cypress Cloud will display any tags sent with the appropriate run.
 <DocsImage
   src="/img/dashboard/dashboard-run-with-tags.png"
   alt="Cypress run in Cypress Cloud displaying flags"
-></DocsImage>
+/>
 
 #### Exit code
 

--- a/docs/guides/guides/cross-browser-testing.mdx
+++ b/docs/guides/guides/cross-browser-testing.mdx
@@ -27,7 +27,7 @@ the browser selection menu of [Cypress](/guides/core-concepts/cypress-app).
 <DocsImage
   src="/img/guides/cross-browser-testing/v10/browser-select-FF.png"
   alt="Cypress with Firefox selected as the browser"
-></DocsImage>
+/>
 
 The desired browser can also specified via the
 [`--browser`](/guides/guides/command-line#Options) flag when using

--- a/docs/guides/guides/cross-origin-testing.mdx
+++ b/docs/guides/guides/cross-origin-testing.mdx
@@ -4,7 +4,7 @@ title: Cross Origin Testing
 
 :::info
 
-<strong class="alert-header"> Note </strong>
+<strong> Note </strong>
 
 As of Cypress [v12.0.0](https://on.cypress.io/changelog#12-0-0), Cypress has the
 capability to visit multiple origins in a single test via the

--- a/docs/guides/guides/cross-origin-testing.mdx
+++ b/docs/guides/guides/cross-origin-testing.mdx
@@ -73,10 +73,10 @@ the `http://localhost:3000` URL is considered to be a different origin from the
 
 The rules are:
 
-- <Icon name="exclamation-triangle" color="red"></Icon> You **cannot** [visit](/api/commands/visit)
+- <Icon name="exclamation-triangle" color="red" /> You **cannot** [visit](/api/commands/visit)
   two domains of different superdomains in the same test and continue to interact
   with the page without the use of the [`cy.origin()`](/api/commands/origin) command.
-- <Icon name="check-circle" color="green"></Icon> You **can** [visit](/api/commands/visit)
+- <Icon name="check-circle" color="green" /> You **can** [visit](/api/commands/visit)
   two or more domains of different origin in **different** tests without needing
   [`cy.origin()`](/api/commands/origin).
 

--- a/docs/guides/guides/debugging.mdx
+++ b/docs/guides/guides/debugging.mdx
@@ -111,7 +111,7 @@ interact with it in the console.
 <DocsImage
   src="/img/guides/debugging/debugging-subject.png"
   alt="Debugging Subject"
-></DocsImage>
+/>
 
 Use [`.debug()`](/api/commands/debug) to quickly inspect any (or many!) part(s)
 of your application during the test. You can attach it to any Cypress chain of
@@ -164,7 +164,7 @@ information here.
 <DocsImage
   src="/img/api/type/console-log-of-typing-with-entire-key-events-table-for-each-character.png"
   alt="Console Log type"
-></DocsImage>
+/>
 
 ## Errors
 
@@ -251,7 +251,7 @@ Cypress emits multiple events you can listen to as shown below.
 <DocsImage
   src="/img/api/catalog-of-events/console-log-events-debug.png"
   alt="console log events for debugging"
-></DocsImage>
+/>
 
 ## Run Cypress command outside the test
 

--- a/docs/guides/guides/launching-browsers.mdx
+++ b/docs/guides/guides/launching-browsers.mdx
@@ -43,7 +43,7 @@ browser by using the drop down near the top right corner:
 <DocsImage
   src="/img/guides/launching-browsers/v10/browser-list-dropdown.png"
   alt="Select a different browser"
-></DocsImage>
+/>
 
 ### Browser versions supported
 
@@ -315,7 +315,7 @@ other browser of the `chromium` family.
 <DocsImage
   src="/img/guides/launching-browsers/v10/brave-running-tests.png"
   alt="Brave browser executing end-to-end tests"
-></DocsImage>
+/>
 
 If you modify the list of browsers, you can see the
 [resolved configuration](/guides/references/configuration#Resolved-Configuration)
@@ -392,7 +392,7 @@ the same browser icons in your dock.
 <DocsImage
   src="/img/guides/launching-browsers/v10/multiple-chrome-icons.png"
   alt="Cypress icon with 2 Google Chrome icons"
-></DocsImage>
+/>
 
 We understand that when Cypress is running in its own profile it can be
 difficult to tell the difference between your normal browser and Cypress.
@@ -409,7 +409,7 @@ the chrome of the browser. You'll always be able to visually distinguish these.
 <DocsImage
   src="/img/guides/launching-browsers/v10/cypress-browser-chrome.png"
   alt="Cypress Browser with darker chrome"
-></DocsImage>
+/>
 
 ## Troubleshooting
 

--- a/docs/guides/guides/network-requests.mdx
+++ b/docs/guides/guides/network-requests.mdx
@@ -210,7 +210,7 @@ Cypress displays this under "Routes" in the Command Log.
 <DocsImage
   src="/img/guides/network-requests/v10/server-routing-table.png"
   alt="Routing Table"
-></DocsImage>
+/>
 
 When a new test runs, Cypress will restore the default behavior and remove all
 routes and stubs. For a complete reference of the API and options, refer to the
@@ -432,7 +432,7 @@ it('test', () => {
 <DocsImage
   src="/img/guides/network-requests/v10/clear-source-of-failure.png"
   alt="Wait Failure"
-></DocsImage>
+/>
 
 Now we know exactly why our test failed. It had nothing to do with the DOM.
 Instead we can see that either our request never went out or a request went out
@@ -539,7 +539,7 @@ test in the Command Log. Here is an example of what this looks like:
 <DocsImage
   src="/img/guides/network-requests/command-log-requests.png"
   alt="Screenshot of fetch and XHR requests"
-></DocsImage>
+/>
 
 The circular indicator on the left side indicates if the request went to the
 destination server or not. If the circle is solid, the request went to the
@@ -568,7 +568,7 @@ The Command Log will look like this:
 <DocsImage
   src="/img/guides/network-requests/command-log-stubbed.png"
   alt="Screenshot of stubbed fetch and unstubbed XHR requests"
-></DocsImage>
+/>
 
 The `fetch` request now has an open circle, to indicate that it has been
 stubbed. Also, note that the alias for the `cy.intercept()` is now displayed on
@@ -578,7 +578,7 @@ more information about how the request was handled:
 <DocsImage
   src="/img/guides/network-requests/command-log-stubbed-tooltip.png"
   alt="Screenshot of stubbed fetch request with tooltip and unstubbed XHR request"
-></DocsImage>
+/>
 
 Additionally, the request will be flagged if the request and/or response was
 modified by a `cy.intercept()` handler function. If we add this code to modify
@@ -606,7 +606,7 @@ but the request was still fulfilled from the destination (filled indicator):
 <DocsImage
   src="/img/guides/network-requests/command-log-req-modified.png"
   alt="Screenshot of request that has had the req modified"
-></DocsImage>
+/>
 
 As you can see, "req modified" is displayed in the badge, to indicate the
 request object was modified. "res modified" and "req + res modified" can also be
@@ -621,7 +621,7 @@ following:
 <DocsImage
   src="/img/guides/network-requests/request-console-props.png"
   alt="Screenshot of request that has had the req modified"
-></DocsImage>
+/>
 
 ## See also
 

--- a/docs/guides/guides/parallelization.mdx
+++ b/docs/guides/guides/parallelization.mdx
@@ -286,10 +286,7 @@ as the browser being tested:
   cypress run --record --group Linux/Electron
   ```
 
-<DocsImage
-  src="/img/guides/parallelization/browser.png"
-  alt="browser"
-/>
+<DocsImage src="/img/guides/parallelization/browser.png" alt="browser" />
 
 ### Grouping to label parallelization
 
@@ -352,10 +349,7 @@ cypress run --record --group package/customer --spec 'cypress/e2e/packages/custo
 cypress run --record --group package/guest --spec 'cypress/e2e/packages/guest/**/*'
 ```
 
-<DocsImage
-  src="/img/guides/parallelization/monorepo.png"
-  alt="monorepo"
-/>
+<DocsImage src="/img/guides/parallelization/monorepo.png" alt="monorepo" />
 
 This pattern is especially useful for projects in a monorepo. Each segment of
 the monorepo can be assigned its own group, and larger segments can be

--- a/docs/guides/guides/parallelization.mdx
+++ b/docs/guides/guides/parallelization.mdx
@@ -38,7 +38,7 @@ CI strategies when using parallelization.
 <DocsImage
   src="/img/guides/parallelization/parallelization-diagram.png"
   alt="Parallelization Diagram"
-></DocsImage>
+/>
 
 ## Splitting up your test suite
 
@@ -106,7 +106,7 @@ which sends back one spec at a time to each application to run.
 <DocsImage
   src="/img/guides/parallelization/parallelization-overview.png"
   alt="Parallelization Overview"
-></DocsImage>
+/>
 
 ## Balance strategy
 
@@ -125,7 +125,7 @@ regarding the spec file.
 <DocsImage
   src="/img/guides/parallelization/load-balancing.png"
   alt="Spec duration forecasting"
-></DocsImage>
+/>
 
 With a duration estimation for each spec file of a test run, Cypress can
 distribute spec files to available CI resources in descending order of spec run
@@ -222,7 +222,7 @@ duration, while the run without parallelization did not.
 <DocsImage
   src="/img/guides/parallelization/1-vs-2-machines.png"
   alt="Without parallelization vs parallelizing across 2 machines"
-></DocsImage>
+/>
 
 Parallelizing our tests across 2 machines saved us almost 50% of the total run
 time, and we can further decrease the build time by adding more machines.
@@ -248,7 +248,7 @@ runs can be utilized independently of Cypress parallelization.
 <DocsImage
   src="/img/guides/parallelization/machines-view-grouping-expanded.png"
   alt="Machines view grouping expanded"
-></DocsImage>
+/>
 
 :::info
 
@@ -289,7 +289,7 @@ as the browser being tested:
 <DocsImage
   src="/img/guides/parallelization/browser.png"
   alt="browser"
-></DocsImage>
+/>
 
 ### Grouping to label parallelization
 
@@ -326,7 +326,7 @@ in Cypress Cloud, as shown below:
 <DocsImage
   src="/img/guides/parallelization/timeline-collapsed.png"
   alt="Timeline view with grouping and parallelization"
-></DocsImage>
+/>
 
 ### Grouping by spec context
 
@@ -355,7 +355,7 @@ cypress run --record --group package/guest --spec 'cypress/e2e/packages/guest/**
 <DocsImage
   src="/img/guides/parallelization/monorepo.png"
   alt="monorepo"
-></DocsImage>
+/>
 
 This pattern is especially useful for projects in a monorepo. Each segment of
 the monorepo can be assigned its own group, and larger segments can be
@@ -373,7 +373,7 @@ the CI build ID via the
 <DocsImage
   src="/img/guides/parallelization/ci-build-id.png"
   alt="CI Machines linked by ci-build-id"
-></DocsImage>
+/>
 
 ### CI Build ID environment variables by provider
 
@@ -420,7 +420,7 @@ the last known CI machine has completed as shown in the diagram below:
 <DocsImage
   src="/img/guides/parallelization/run-completion-delay.png"
   alt="Test run completion delay"
-></DocsImage>
+/>
 
 This **delay is 60 seconds by default**, but is
 [configurable within Cypress Cloud project settings page](/guides/cloud/projects#Run-completion-delay).
@@ -440,7 +440,7 @@ chronologically across all available machines.
 <DocsImage
   src="/img/guides/parallelization/timeline-view-small.png"
   alt="Timeline view with parallelization"
-></DocsImage>
+/>
 
 ### Bar Chart View
 
@@ -450,7 +450,7 @@ each other.
 <DocsImage
   src="/img/guides/parallelization/bar-chart-view.png"
   alt="Bar Chart view with parallelization"
-></DocsImage>
+/>
 
 ### Machines View
 
@@ -461,7 +461,7 @@ test run.
 <DocsImage
   src="/img/guides/parallelization/machines-view.png"
   alt="Machines view with parallelization"
-></DocsImage>
+/>
 
 ## Next Steps
 

--- a/docs/guides/guides/test-retries.mdx
+++ b/docs/guides/guides/test-retries.mdx
@@ -298,10 +298,7 @@ failed attempts, and the error for failed attempts.
 
 You can also see the Flaky Rate for a given test.
 
-<DocsImage
-  src="/img/guides/test-retries/flaky-rate.png"
-  alt="Flaky rate"
-/>
+<DocsImage src="/img/guides/test-retries/flaky-rate.png" alt="Flaky rate" />
 
 For a comprehensive view of how flake is affecting your overall test suite, you
 can review the

--- a/docs/guides/guides/test-retries.mdx
+++ b/docs/guides/guides/test-retries.mdx
@@ -68,7 +68,7 @@ Assuming we have configured test retries with `2` retry attempts (for a total of
 2. If the <Icon name="times" color="red" /> test fails, Cypress will tell you
    that the first attempt failed and will attempt to run the test a second time.
 
-<DocsImage src="/img/guides/test-retries/v10/attempt-2-start.png"></DocsImage>
+<DocsImage src="/img/guides/test-retries/v10/attempt-2-start.png" />
 
 3. If the <Icon name="check-circle" color="green" /> test passes after the
    second attempt, Cypress will continue with any remaining tests.
@@ -76,17 +76,17 @@ Assuming we have configured test retries with `2` retry attempts (for a total of
 4. If the <Icon name="times" color="red" /> test fails a second time, Cypress
    will make the final third attempt to re-run the test.
 
-<DocsImage src="/img/guides/test-retries/v10/attempt-3-start.png"></DocsImage>
+<DocsImage src="/img/guides/test-retries/v10/attempt-3-start.png" />
 
 5. If the <Icon name="times" color="red" /> test fails a third time, Cypress
    will mark the test as failed and then move on to run any remaining tests.
 
-<DocsImage src="/img/guides/test-retries/v10/attempt-3-fail.png"></DocsImage>
+<DocsImage src="/img/guides/test-retries/v10/attempt-3-fail.png" />
 
 The following is a screen capture of what test retries looks like on the same
 failed test when run via [cypress run](/guides/guides/command-line#cypress-run).
 
-<DocsImage src="/img/guides/test-retries/cli-error-message.png"></DocsImage>
+<DocsImage src="/img/guides/test-retries/cli-error-message.png" />
 
 During [cypress open](/guides/guides/command-line#cypress-open) you will be able
 to see the number of attempts made in the
@@ -294,14 +294,14 @@ failed attempts, and the error for failed attempts.
 <DocsImage
   src="/img/guides/test-retries/flake-artifacts-and-errors.png"
   alt="Flake artifacts and errors"
-></DocsImage>
+/>
 
 You can also see the Flaky Rate for a given test.
 
 <DocsImage
   src="/img/guides/test-retries/flaky-rate.png"
   alt="Flaky rate"
-></DocsImage>
+/>
 
 For a comprehensive view of how flake is affecting your overall test suite, you
 can review the

--- a/docs/guides/guides/test-retries.mdx
+++ b/docs/guides/guides/test-retries.mdx
@@ -285,7 +285,7 @@ Test Results tab on the Run Details page.
 <DocsVideo
   src="/img/guides/test-retries/flaky-test-filter.mp4"
   title="Flaky test filter"
-></DocsVideo>
+/>
 
 Clicking on a Test Result will open the Test Case History screen. This
 demonstrates the number of failed attempts, the screenshots and/or videos of

--- a/docs/guides/guides/web-security.mdx
+++ b/docs/guides/guides/web-security.mdx
@@ -425,7 +425,7 @@ in this case.
 <DocsImage
   src="/img/guides/web-security/chrome-web-security-stdout-warning.jpg"
   alt="chromeWebSecurity warning in stdout"
-></DocsImage>
+/>
 
 If you rely on disabling web security, you will not be able to run tests on
 browsers that do not support this feature.

--- a/docs/guides/overview/why-cypress.mdx
+++ b/docs/guides/overview/why-cypress.mdx
@@ -141,7 +141,7 @@ configure. You can write your first passing test in 60 seconds.
 <DocsVideo
   src="/img/snippets/installing-cli.mp4"
   title="Installing and opening Cypress"
-></DocsVideo>
+/>
 
 ### <Icon name="code" /> Writing tests
 
@@ -151,7 +151,7 @@ comes fully baked, on top of tools you are familiar with already.
 <DocsVideo
   src="/img/snippets/writing-tests.mp4"
   title="Writing Tests"
-></DocsVideo>
+/>
 
 ### <Icon name="play-circle" /> Running tests
 
@@ -161,7 +161,7 @@ in real time as you develop your applications. TDD FTW!
 <DocsVideo
   src="/img/snippets/running-tests.mp4"
   title="Running Tests"
-></DocsVideo>
+/>
 
 ### <Icon name="bug" /> Debugging tests
 
@@ -171,7 +171,7 @@ the developer tools you know and love.
 <DocsVideo
   src="/img/snippets/debugging.mp4"
   title="Debugging Tests"
-></DocsVideo>
+/>
 
 ## Test types
 

--- a/docs/guides/overview/why-cypress.mdx
+++ b/docs/guides/overview/why-cypress.mdx
@@ -148,30 +148,21 @@ configure. You can write your first passing test in 60 seconds.
 Tests written in Cypress are meant to be easy to read and understand. Our API
 comes fully baked, on top of tools you are familiar with already.
 
-<DocsVideo
-  src="/img/snippets/writing-tests.mp4"
-  title="Writing Tests"
-/>
+<DocsVideo src="/img/snippets/writing-tests.mp4" title="Writing Tests" />
 
 ### <Icon name="play-circle" /> Running tests
 
 Cypress runs as fast as your browser can render content. You can watch tests run
 in real time as you develop your applications. TDD FTW!
 
-<DocsVideo
-  src="/img/snippets/running-tests.mp4"
-  title="Running Tests"
-/>
+<DocsVideo src="/img/snippets/running-tests.mp4" title="Running Tests" />
 
 ### <Icon name="bug" /> Debugging tests
 
 Readable error messages help you to debug quickly. You also have access to all
 the developer tools you know and love.
 
-<DocsVideo
-  src="/img/snippets/debugging.mp4"
-  title="Debugging Tests"
-/>
+<DocsVideo src="/img/snippets/debugging.mp4" title="Debugging Tests" />
 
 ## Test types
 

--- a/docs/guides/references/advanced-installation.mdx
+++ b/docs/guides/references/advanced-installation.mdx
@@ -299,7 +299,7 @@ functionality that has not yet been released, here is how:
    <DocsImage
      src="/img/guides/install/develop-commit-comment-link.png"
      alt="Example of a commit for which pre-releases are available. Comment link highlighted in red."
-   ></DocsImage>
+   />
 3. You should see several comments from the `cypress-bot` user with instructions
    for installing Cypress pre-releases. Pick the one that corresponds to your
    operating system and CPU architecture, and follow the instructions there to
@@ -327,7 +327,7 @@ address, which changes often.
 <DocsImage
   src="/img/guides/install/vcxsrv-extra-settings.png"
   alt="Disable access control in vcxsrv"
-></DocsImage>
+/>
 
 In your `.bashrc` (or equivalent such as `.zshrc`) set the `DISPLAY` environment
 variable.
@@ -374,7 +374,7 @@ Rules > New Rule.
 <DocsImage
   src="/img/guides/install/windows-firewall-disable-vcxsrv.png"
   alt="Add rule to allow connections for vcxsrv"
-></DocsImage>
+/>
 
 Select Program and click on next. On the This program path, browse and select
 path to VcxSrv. On the next page select allow the connection and click next. On
@@ -383,7 +383,7 @@ the next page, select all three options (Domain, Private, Public).
 <DocsImage
   src="/img/guides/install/rule-application-selection.png"
   alt="Select inbound rule application cases for vcxsrv"
-></DocsImage>
+/>
 
 Give the rule a suitable name and description and click finish. WSL2 should now
 be able to open a GUI from shell.

--- a/docs/guides/references/best-practices.mdx
+++ b/docs/guides/references/best-practices.mdx
@@ -435,7 +435,7 @@ email's functionality and visual style:
   src="/img/guides/references/email-test.png"
   title="The HTML email loaded during the test"
   alt="The test finds and clicks the Confirm registration button"
-></DocsImage>
+/>
 
 3. In other cases, you should try using [`cy.request()`](/api/commands/request)
    command to query the endpoint on your server that tells you what email has
@@ -1060,7 +1060,7 @@ port.
 <DocsImage
   src="/img/guides/references/cypress-loads-in-localhost-and-random-port.png"
   alt="Url address shows localhost:53927/__/#tests/integration/organizations/list_spec.coffee"
-></DocsImage>
+/>
 
 As soon as it encounters a [cy.visit()](/api/commands/visit), Cypress then
 switches to the url of the main window to the url specified in your visit. This
@@ -1088,7 +1088,7 @@ load the main window in the `baseUrl` you specified as soon as your tests start.
 <DocsImage
   src="/img/guides/references/cypress-loads-window-in-base-url-localhost.png"
   alt="Url address bar shows localhost:8484/__tests/integration/organizations/list_spec.coffee"
-></DocsImage>
+/>
 
 Having a `baseUrl` set gives you the added bonus of seeing an error if your
 server is not running during `cypress open` at the specified `baseUrl`.
@@ -1096,7 +1096,7 @@ server is not running during `cypress open` at the specified `baseUrl`.
 <DocsImage
   src="/img/guides/references/cypress-ensures-baseUrl-server-is-running.png"
   alt="Cypress Launchpad with warning about how Cypress could not verify server set as the baseUrl is running"
-></DocsImage>
+/>
 
 We also display an error if your server is not running at the specified
 `baseUrl` during `cypress run` after several retries.
@@ -1104,7 +1104,7 @@ We also display an error if your server is not running at the specified
 <DocsImage
   src="/img/guides/references/cypress-verifies-server-is-running-during-cypress-run.png"
   alt="The terminal warns and retries when the url at your baseUrl is not running"
-></DocsImage>
+/>
 
 ### Usage of `baseUrl` in depth
 

--- a/docs/guides/references/changelog.mdx
+++ b/docs/guides/references/changelog.mdx
@@ -1593,7 +1593,7 @@ into your overall development experience. Read more about 10.0 in
 
 **Breaking Changes:**
 
-**<Icon name="exclamation-triangle" color="red"></Icon> Please run
+**<Icon name="exclamation-triangle" color="red" /> Please run
 `cypress open` to go through our interactive migration which will guide you in
 updating your files and configuration options. Read our
 [Migration Guide](/guides/references/migration-guide) which explains some
@@ -2970,7 +2970,7 @@ of 1, and a screen size of 1280x720 by default.
 
 **Breaking Changes:**
 
-**<Icon name="exclamation-triangle" color="red"></Icon> Please read our
+**<Icon name="exclamation-triangle" color="red" /> Please read our
 [Migration Guide](/guides/references/migration-guide) which explains the changes
 in more detail and how to change your code to migrate to Cypress 8.0.**
 
@@ -3469,7 +3469,7 @@ components using your favorite developer tools. Read our
 
 **Breaking Changes:**
 
-**<Icon name="exclamation-triangle" color="red"></Icon> Please read our
+**<Icon name="exclamation-triangle" color="red" /> Please read our
 [Migration Guide](/guides/references/migration-guide) which explains the changes
 in more detail and how to change your code to migrate to Cypress 7.0.**
 
@@ -4216,7 +4216,7 @@ and wait on any type of HTTP request originating from your app. See our guide on
 
 **Breaking Changes:**
 
-**<Icon name="exclamation-triangle" color="red"></Icon> Please read our
+**<Icon name="exclamation-triangle" color="red" /> Please read our
 [Migration Guide](/guides/references/migration-guide) which explains the changes
 in more detail and how to change your code to migrate to Cypress 6.0.**
 
@@ -4799,7 +4799,7 @@ failed test prior to marking it as failed. Read our new guide on
 
 **Breaking Changes:**
 
-**<Icon name="exclamation-triangle" color="red"></Icon> Please read our
+**<Icon name="exclamation-triangle" color="red" /> Please read our
 [Migration Guide](/guides/references/migration-guide) which explains the changes
 in more detail and how to change your code to migrate to Cypress 5.0.**
 
@@ -6049,7 +6049,7 @@ bring new powerful features.
 
 **Breaking Changes:**
 
-**<Icon name="exclamation-triangle" color="red"></Icon> Please read our
+**<Icon name="exclamation-triangle" color="red" /> Please read our
 [Migration Guide](/guides/references/migration-guide) which explains the changes
 in more detail and how to change your code to migrate to Cypress 4.0.**
 

--- a/docs/guides/references/changelog.mdx
+++ b/docs/guides/references/changelog.mdx
@@ -1593,9 +1593,9 @@ into your overall development experience. Read more about 10.0 in
 
 **Breaking Changes:**
 
-**<Icon name="exclamation-triangle" color="red" /> Please run
-`cypress open` to go through our interactive migration which will guide you in
-updating your files and configuration options. Read our
+**<Icon name="exclamation-triangle" color="red" /> Please run `cypress open` to
+go through our interactive migration which will guide you in updating your files
+and configuration options. Read our
 [Migration Guide](/guides/references/migration-guide) which explains some
 breaking changes in more detail.**
 

--- a/docs/guides/references/configuration.mdx
+++ b/docs/guides/references/configuration.mdx
@@ -183,7 +183,7 @@ The Node version is used in Cypress to:
   [supportFile](#Folders-Files).
 - Execute code in the config file.
 
-<DocsImage src="/img/guides/configuration/test-runner-settings-nodejs-version.jpg" alt="Node version in Settings in Cypress"></DocsImage>
+<DocsImage src="/img/guides/configuration/test-runner-settings-nodejs-version.jpg" alt="Node version in Settings in Cypress" />
 
 ### Experiments
 
@@ -470,7 +470,7 @@ highlighted to show where the value has been set via the following ways:
 <DocsImage
   src="/img/guides/configuration/v10/see-resolved-configuration.png"
   alt="See resolved configuration"
-></DocsImage>
+/>
 
 ## Notes
 
@@ -542,7 +542,7 @@ matched.
 <DocsImage
   src="/img/guides/references/v10/blocked-host.png"
   alt="Network tab of dev tools with analytics.js request selected and the response header highlighted"
-></DocsImage>
+/>
 
 ### devServer
 
@@ -644,7 +644,7 @@ time this routine has taken to the bottom of the Cypress Command Log.
 <DocsImage
   src="/img/guides/configuration/firefox-gc-interval-in-command-log.jpg"
   alt="GC duration shown"
-></DocsImage>
+/>
 
 #### Configuration
 

--- a/docs/guides/references/configuration_legacy.mdx
+++ b/docs/guides/references/configuration_legacy.mdx
@@ -170,7 +170,7 @@ The Node version is used in Cypress to:
 <DocsImage
   src="/img/guides/configuration/test-runner-settings-nodejs-version.jpg"
   alt="Node version in Settings in Test Runner"
-></DocsImage>
+/>
 
 ### Experiments
 
@@ -461,7 +461,7 @@ value has been set via the following ways:
 <DocsImage
   src="/img/guides/configuration/see-resolved-configuration.jpg"
   alt="See resolved configuration"
-></DocsImage>
+/>
 
 ## Notes
 
@@ -534,7 +534,7 @@ send a `503` status code. As a convenience it also sets a
 <DocsImage
   src="/img/guides/references/v10/blocked-host.png"
   alt="Network tab of dev tools with analytics.js request selected and the response header highlighted "
-></DocsImage>
+/>
 
 ### modifyObstructiveCode
 
@@ -594,7 +594,7 @@ time this routine has taken to the bottom of the Command Log in the Test Runner.
 <DocsImage
   src="/img/guides/configuration/firefox-gc-interval-in-command-log.jpg"
   alt="GC duration shown"
-></DocsImage>
+/>
 
 #### Configuration
 

--- a/docs/guides/references/configuration_legacy.mdx
+++ b/docs/guides/references/configuration_legacy.mdx
@@ -22,7 +22,7 @@ will be written in this file too.
 
 :::caution
 
-<strong class="alert-header">Change Configuration File</strong>
+<strong>Change Configuration File</strong>
 
 You can change the configuration file or turn off the use of a configuration
 file by using the
@@ -56,7 +56,7 @@ default values.
 
 :::tip
 
-<strong class="alert-header">Core Concept</strong>
+<strong>Core Concept</strong>
 
 [Timeouts are a core concept](/guides/core-concepts/introduction-to-cypress#Timeouts)
 you should understand well. The default values listed here are meaningful.
@@ -515,7 +515,7 @@ included**.
 
 :::caution
 
-<strong class="alert-header">Subdomains</strong>
+<strong>Subdomains</strong>
 
 Be cautious for URL's which have no subdomain.
 

--- a/docs/guides/references/configuration_legacy.mdx
+++ b/docs/guides/references/configuration_legacy.mdx
@@ -335,7 +335,7 @@ We provide two options to override the configuration while your test are
 running, `Cypress.config()` and suite-specific or test-specific configuration
 overrides.
 
-<Icon name="exclamation-triangle" color="red"></Icon> **Note:** The configuration
+<Icon name="exclamation-triangle" color="red" /> **Note:** The configuration
 values below are all writeable and **can be changed** via per test configuration.
 Any other configuration values are readonly and cannot be changed at run time.
 
@@ -475,11 +475,11 @@ To see a working example of this please check out our
 
 To block a host:
 
-- <Icon name="check-circle" color="green"></Icon> Pass only the host
-- <Icon name="check-circle" color="green"></Icon> Use wildcard `*` patterns
-- <Icon name="check-circle" color="green"></Icon> Include the port other than `80`
+- <Icon name="check-circle" color="green" /> Pass only the host
+- <Icon name="check-circle" color="green" /> Use wildcard `*` patterns
+- <Icon name="check-circle" color="green" /> Include the port other than `80`
   and `443`
-- <Icon name="exclamation-triangle" color="red"></Icon> Do **NOT** include protocol:
+- <Icon name="exclamation-triangle" color="red" /> Do **NOT** include protocol:
   `http://` or `https://`
 
 :::info
@@ -521,9 +521,9 @@ Be cautious for URL's which have no subdomain.
 
 For instance given a URL: `https://google.com/search?q=cypress`
 
-- <Icon name="check-circle" color="green"></Icon> Matches `google.com`
-- <Icon name="check-circle" color="green"></Icon> Matches `*google.com`
-- <Icon name="exclamation-triangle" color="red"></Icon> Does NOT match `*.google.com`
+- <Icon name="check-circle" color="green" /> Matches `google.com`
+- <Icon name="check-circle" color="green" /> Matches `*google.com`
+- <Icon name="exclamation-triangle" color="red" /> Does NOT match `*.google.com`
 
 :::
 
@@ -684,7 +684,7 @@ IntelliSense is available for Cypress while editing your configuration file.
 
 ## Common problems
 
-#### <Icon name="angle-right"></Icon> `baseUrl` is not set
+#### <Icon name="angle-right" /> `baseUrl` is not set
 
 Make sure you do not accidentally place the <code>baseUrl</code> or another
 top-level config variable into the <code>env</code> block. The following
@@ -716,7 +716,7 @@ object.
 You can also find a few tips on setting the `baseUrl` in this
 [short video](https://www.youtube.com/watch?v=f5UaXuAc52c).
 
-#### <Icon name="angle-right"></Icon> Test files not found when using `spec` parameter
+#### <Icon name="angle-right" /> Test files not found when using `spec` parameter
 
 When using the `--spec <path or mask>` argument, make it relative to the
 project's folder. If the specs are still missing, run Cypress with

--- a/docs/guides/references/configuration_legacy.mdx
+++ b/docs/guides/references/configuration_legacy.mdx
@@ -335,9 +335,9 @@ We provide two options to override the configuration while your test are
 running, `Cypress.config()` and suite-specific or test-specific configuration
 overrides.
 
-<Icon name="exclamation-triangle" color="red" /> **Note:** The configuration
-values below are all writeable and **can be changed** via per test configuration.
-Any other configuration values are readonly and cannot be changed at run time.
+<Icon name="exclamation-triangle" color="red" /> **Note:** The configuration values
+below are all writeable and **can be changed** via per test configuration. Any other
+configuration values are readonly and cannot be changed at run time.
 
 - `animationDistanceThreshold`
 - `baseUrl`
@@ -477,10 +477,10 @@ To block a host:
 
 - <Icon name="check-circle" color="green" /> Pass only the host
 - <Icon name="check-circle" color="green" /> Use wildcard `*` patterns
-- <Icon name="check-circle" color="green" /> Include the port other than `80`
-  and `443`
-- <Icon name="exclamation-triangle" color="red" /> Do **NOT** include protocol:
-  `http://` or `https://`
+- <Icon name="check-circle" color="green" /> Include the port other than `80` and
+  `443`
+- <Icon name="exclamation-triangle" color="red" /> Do **NOT** include protocol: `http://`
+  or `https://`
 
 :::info
 

--- a/docs/guides/references/cypress-studio.mdx
+++ b/docs/guides/references/cypress-studio.mdx
@@ -102,7 +102,7 @@ in.
 <DocsImage
   src="/img/guides/cypress-studio/run-spec-1.png"
   alt="Cypress Studio"
-></DocsImage>
+/>
 
 Once the browser is open, run the spec created in the previous step.
 
@@ -123,7 +123,7 @@ Cypress Studio is directly integrated with the
 <DocsImage
   src="/img/guides/cypress-studio/extend-activate-studio.png"
   alt="Activate Cypress Studio"
-></DocsImage>
+/>
 
 :::tip
 
@@ -139,7 +139,7 @@ command in the test.
 <DocsImage
   src="/img/guides/cypress-studio/extend-ready.png"
   alt="Cypress Studio Ready"
-></DocsImage>
+/>
 
 Now, we can begin updating the test to create a new transaction between users.
 
@@ -152,14 +152,14 @@ click recorded in the Command Log.
 <DocsImage
   src="/img/guides/cypress-studio/extend-click-new-transaction.png"
   alt="Cypress Studio Recording Click"
-></DocsImage>
+/>
 
 Next, we can start typing in the name of a user that we want to pay.
 
 <DocsImage
   src="/img/guides/cypress-studio/extend-type-user-name.png"
   alt="Cypress Studio Recording Type"
-></DocsImage>
+/>
 
 Once we see the name come up in the results, we want to add an assertion to
 ensure that our search function works correctly. Right clicking on the user's
@@ -169,7 +169,7 @@ element contains the correct text (the user's name).
 <DocsImage
   src="/img/guides/cypress-studio/extend-assert-user-name.png"
   alt="Cypress Studio Add Assertion"
-></DocsImage>
+/>
 
 We can then click on that user in order to progress to the next screen. We will
 complete the transaction form by clicking on and typing in the amount and
@@ -178,7 +178,7 @@ description inputs.
 <DocsImage
   src="/img/guides/cypress-studio/extend-type-transaction-form.png"
   alt="Cypress Studio Recording Type"
-></DocsImage>
+/>
 
 :::tip
 
@@ -194,7 +194,7 @@ is enabled.
 <DocsImage
   src="/img/guides/cypress-studio/extend-assert-button-enabled.png"
   alt="Cypress Studio Add Assertion"
-></DocsImage>
+/>
 
 Finally, we will click the "Pay" button and get presented with a confirmation
 page of our new transaction.
@@ -202,7 +202,7 @@ page of our new transaction.
 <DocsImage
   src="/img/guides/cypress-studio/extend-save-test.png"
   alt="Cypress Studio Save Commands"
-></DocsImage>
+/>
 
 To discard the interactions, click the "Cancel" button to exit Cypress Studio.
 If satisfied with the interactions with the application, click "Save Commands"
@@ -258,7 +258,7 @@ clicking "Add New Test" on our defined `describe` block.
 <DocsImage
   src="/img/guides/cypress-studio/add-test-1.png"
   alt="Cypress Studio Add Test"
-></DocsImage>
+/>
 
 We are launched into Cypress Studio and can begin interacting with our
 application to generate the test.
@@ -269,22 +269,22 @@ For this test, we will add a new bank account. Our interactions are as follows:
    <DocsImage
      src="/img/guides/cypress-studio/add-test-2.png"
      alt="Cypress Studio Begin Add Test"
-   ></DocsImage>
+   />
 2. Click the "Create" button on Bank Accounts page
    <DocsImage
      src="/img/guides/cypress-studio/add-test-create.png"
      alt="Cypress Studio Add Test Create Bank Account"
-   ></DocsImage>
+   />
 3. Fill out the bank account information
    <DocsImage
      src="/img/guides/cypress-studio/add-test-form-complete.png"
      alt="Cypress Studio Add Test Complete Bank Account Form"
-   ></DocsImage>
+   />
 4. Click the "Save" button {' '}
    <DocsImage
      src="/img/guides/cypress-studio/add-test-form-save.png"
      alt="Cypress Studio Add Test Save Bank Account"
-   ></DocsImage>
+   />
 
 To discard the interactions, click the "Cancel" button to exit Cypress Studio.
 
@@ -295,14 +295,14 @@ will be saved to the file.
 <DocsImage
   src="/img/guides/cypress-studio/add-test-save-test.png"
   alt="Cypress Studio Add Test Completed Run"
-></DocsImage>
+/>
 
 Once saved, the file will be run again in Cypress.
 
 <DocsImage
   src="/img/guides/cypress-studio/add-test-final.png"
   alt="Cypress Studio Add Test Completed Run"
-></DocsImage>
+/>
 
 Finally, viewing our test code, we can see that the test is updated after
 clicking "Save Commands" with the actions we recorded in Cypress Studio.

--- a/docs/guides/references/cypress-studio.mdx
+++ b/docs/guides/references/cypress-studio.mdx
@@ -6,7 +6,7 @@ e2eSpecific: true
 :::caution
 
 <strong>
-  <Icon name="exclamation-triangle"></Icon>
+  <Icon name="exclamation-triangle" />
   Experimental
 </strong>
 
@@ -52,7 +52,7 @@ generate test code when interacting with the DOM inside of the Cypress Studio.
 You can also generate assertions by right clicking on an element that you would
 like to assert on.
 
-The Cypress <Icon name="github"></Icon>
+The Cypress <Icon name="github" />
 [Real World App (RWA)](https://github.com/cypress-io/cypress-realworld-app) is
 an open source project implementing a payment application to demonstrate
 real-world usage of Cypress testing methods, patterns, and workflows. It will be

--- a/docs/guides/references/error-messages.mdx
+++ b/docs/guides/references/error-messages.mdx
@@ -137,7 +137,7 @@ better way to accomplish what you're trying to do. Read through the
 [chat with someone in Discord](https://discord.gg/ncdA3Jz63n), or
 [open an issue](https://github.com/cypress-io/cypress/issues/new/choose).
 
-### <Icon name="exclamation-triangle" color="red"></Icon> `cy...()` failed because the page updated
+### <Icon name="exclamation-triangle" color="red" /> `cy...()` failed because the page updated
 
 Getting this error means you've tried to interact with a "dead" DOM element -
 meaning the current subject has been removed from the DOM.
@@ -487,7 +487,7 @@ separate tests.
 See our [Web Security](/guides/guides/web-security#Limitations) documentation
 for more information and workarounds.
 
-### <Icon name="exclamation-triangle" color="red"></Icon> `cy.visit()` succeeded, but commands are timing out
+### <Icon name="exclamation-triangle" color="red" /> `cy.visit()` succeeded, but commands are timing out
 
 As of Cypress [v12.0.0](https://on.cypress.io/changelog#12-0-0), users can
 navigate to multiple domains in a single test. The following test will succeed
@@ -535,7 +535,7 @@ it('navigates to docs.cypress.io and runs additional commands', () => {
 See our [Web Security](/guides/guides/web-security#Limitations) documentation
 for more information and workarounds.
 
-### <Icon name="exclamation-triangle" color="red"></Icon> `Cypress.addParentCommand()` / `Cypress.addDualCommand()` / `Cypress.addChildCommand()` has been removed and replaced by `Cypress.Commands.add()`
+### <Icon name="exclamation-triangle" color="red" /> `Cypress.addParentCommand()` / `Cypress.addDualCommand()` / `Cypress.addChildCommand()` has been removed and replaced by `Cypress.Commands.add()`
 
 In version [0.20.0](/guides/references/changelog), we removed the commands for
 adding custom commands and replaced them with, what we believe to be, a simpler
@@ -597,7 +597,7 @@ The version of Mocha was upgraded with Cypress 4.0. Mocha 3+ no longer allows
 returning a promise and invoking a done callback. Read more about it in the
 [4.0 migration guide](/guides/references/migration-guide#Mocha-upgrade).
 
-### <Icon name="exclamation-triangle" color="red"></Icon> CypressError: Timed out retrying: Expected to find element: ‘…’, but never found it. Queried from element: <…>
+### <Icon name="exclamation-triangle" color="red" /> CypressError: Timed out retrying: Expected to find element: ‘…’, but never found it. Queried from element: <…>
 
 If you get this error in a case where the element is definitely visible in the
 DOM, your document might contain malformed HTML. In such cases,

--- a/docs/guides/references/error-messages.mdx
+++ b/docs/guides/references/error-messages.mdx
@@ -452,7 +452,7 @@ it('does not forget to return a promise', () => {
 
 :::caution
 
-<strong class="alert-header">Note</strong>
+<strong>Note</strong>
 
 This error only pertains to Cypress version `v11.0.0` and under. As of Cypress
 [v12.0.0](https://on.cypress.io/changelog#12-0-0), users can navigate to
@@ -466,7 +466,7 @@ See our [Web Security](/guides/guides/web-security#Limitations) documentation.
 
 :::caution
 
-<strong class="alert-header">Note</strong>
+<strong>Note</strong>
 
 This error only pertains to Cypress version `v11.0.0` and under. As of Cypress
 [v12.0.0](https://on.cypress.io/changelog#12-0-0), users can navigate to

--- a/docs/guides/references/error-messages.mdx
+++ b/docs/guides/references/error-messages.mdx
@@ -164,7 +164,7 @@ describe('detachment example', () => {
 <DocsImage
   src="/img/guides/references/cypress-method-failed-page-updated.png"
   alt="cy.method() failed because the page updated"
-></DocsImage>
+/>
 
 Cypress errors because after a command, the subject becomes 'fixed' to a
 specific element - since it can't retry commands, if the element becomes
@@ -517,7 +517,7 @@ And will result in the following error:
 <DocsImage
   src="/img/guides/references/cy-visit-subsequent-commands-timed-out.png"
   alt="cy.visit() subsequent commands timed out"
-></DocsImage>
+/>
 
 In order to fix this, our `cy.get()` command **must** be wrapped with the
 [`cy.origin()`](/api/commands/origin) command, like so:

--- a/docs/guides/references/migration-guide.mdx
+++ b/docs/guides/references/migration-guide.mdx
@@ -745,7 +745,7 @@ This guide details the changes and how to change your code to migrate to Cypress
 version 10.0.
 [See the full changelog for version 10.0](/guides/references/changelog#10-0-0).
 
-<DocsVideo src="https://youtube.com/embed/mIqKNhLlPcU"></DocsVideo>
+<DocsVideo src="https://youtube.com/embed/mIqKNhLlPcU" />
 
 ### Cypress Changes
 

--- a/docs/guides/references/migration-guide.mdx
+++ b/docs/guides/references/migration-guide.mdx
@@ -2520,7 +2520,7 @@ cy.get('#dropdon').should('not.contain', 'Cypress')
 <DocsImage
   src="/img/guides/migration-guide/el-incorrectly-passes-existence-check.png"
   alt="non-existent element before 6.0"
-></DocsImage>
+/>
 
 In 6.0, these assertions will now correctly fail, telling us that the `#dropdon`
 element doesn't exist in the DOM.
@@ -2528,7 +2528,7 @@ element doesn't exist in the DOM.
 <DocsImage
   src="/img/guides/migration-guide/el-correctly-fails-existence-check.png"
   alt="non-existent element in 6.0"
-></DocsImage>
+/>
 
 #### Assertions on non-existent elements
 

--- a/docs/guides/references/proxy-configuration.mdx
+++ b/docs/guides/references/proxy-configuration.mdx
@@ -256,4 +256,4 @@ steps:
 <DocsImage
   src="/img/guides/configuration/test-runner-settings-proxy-configuration.jpg"
   alt="Proxy configuration in the Desktop app"
-></DocsImage>
+/>

--- a/docs/guides/references/troubleshooting.mdx
+++ b/docs/guides/references/troubleshooting.mdx
@@ -395,10 +395,7 @@ Reload the browser and turn on 'Verbose' logs to see debug messages within the
 Developer Tools console. You will only see the **cypress\:driver** package logs
 that run in the browser, as you can see below.
 
-<DocsImage
-  src="/img/api/debug/debug-driver.jpg"
-  alt="Debug logs in browser"
-/>
+<DocsImage src="/img/api/debug/debug-driver.jpg" alt="Debug logs in browser" />
 
 ## Log memory and CPU usage
 

--- a/docs/guides/references/troubleshooting.mdx
+++ b/docs/guides/references/troubleshooting.mdx
@@ -398,7 +398,7 @@ that run in the browser, as you can see below.
 <DocsImage
   src="/img/api/debug/debug-driver.jpg"
   alt="Debug logs in browser"
-></DocsImage>
+/>
 
 ## Log memory and CPU usage
 
@@ -424,7 +424,7 @@ In the resulting output, processes are grouped by their name.
 <DocsImage
   src="/img/guides/troubleshooting/troubleshooting-cypress-process-profiler-cli.jpg"
   alt="Process printout of Cypress in CLI"
-></DocsImage>
+/>
 
 By default, process information is collected and summarized is printed once
 every 10 seconds. You can override this interval by setting the
@@ -467,7 +467,7 @@ as a JSON file if a test fails.
 <DocsImage
   src="/img/api/debug/failed-log.png"
   alt="cypress-failed-log terminal output"
-></DocsImage>
+/>
 
 ## Hacking on Cypress
 

--- a/docs/guides/tooling/IDE-integration.mdx
+++ b/docs/guides/tooling/IDE-integration.mdx
@@ -90,21 +90,21 @@ command definition, a code example and a link to the full documentation page.
 <DocsVideo
   src="/img/snippets/intellisense-cypress-assertion-matchers.mp4"
   title="Intellisense Autocomplete Cypress commands"
-></DocsVideo>
+/>
 
 ##### Signature help when writing and hovering on Cypress commands
 
 <DocsVideo
   src="/img/snippets/intellisense-method-signature-examples.mp4"
   title="Intellisense on hover"
-></DocsVideo>
+/>
 
 ##### Autocomplete while typing assertion chains, including only showing DOM assertions if testing on a DOM element.
 
 <DocsVideo
   src="/img/snippets/intellisense-assertion-chainers.mp4"
   title="Intellisense Autocomplete DOM assertions"
-></DocsVideo>
+/>
 
 #### Set up in your Dev Environment
 
@@ -132,7 +132,7 @@ your spec file.
 <DocsVideo
   src="/img/snippets/intellisense-setup.mp4"
   title="Intellisense triple-slash directive"
-></DocsVideo>
+/>
 
 If you write [custom commands](/api/cypress-api/custom-commands) and provide
 TypeScript definitions for them, you can use the triple slash directives to show

--- a/docs/guides/tooling/IDE-integration.mdx
+++ b/docs/guides/tooling/IDE-integration.mdx
@@ -13,7 +13,7 @@ and column of interest.
 <DocsImage
   src="/img/guides/core-concepts/cypress-app/open-file-in-IDE.gif"
   alt="Open file in your IDE"
-></DocsImage>
+/>
 
 The first time you click a file path, Cypress will prompt you to select which
 location you prefer to open the file. You can choose to open it in your:
@@ -39,7 +39,7 @@ under **File Opener Preference**.
 <DocsImage
   src="/img/guides/IDE-integration/file-opener-preference-settings-tab.png"
   alt="screenshot of Cypress test-runner settings tab with file opener preference panel"
-></DocsImage>
+/>
 
 ## Extensions & Plugins
 

--- a/docs/guides/tooling/code-coverage.mdx
+++ b/docs/guides/tooling/code-coverage.mdx
@@ -730,8 +730,7 @@ There is a series of videos we have recorded showing code coverage in Cypress
 
 #### Check code coverage robustly using 3rd party tool
 
-<DocsVideo src="https://youtube.com/embed/dwU5gUG2"/>
- 
+<DocsVideo src="https://youtube.com/embed/dwU5gUG2" />
 #### Adding code coverage badge to your project
 
 <DocsVideo src="https://youtube.com/embed/bNVRxb-MKGo" />

--- a/docs/guides/tooling/code-coverage.mdx
+++ b/docs/guides/tooling/code-coverage.mdx
@@ -15,7 +15,7 @@ title: Code Coverage
 
 <!-- textlint-disable -->
 
-<DocsVideo src="https://youtube.com/embed/C8g5X4vCZJA"></DocsVideo>
+<DocsVideo src="https://youtube.com/embed/C8g5X4vCZJA" />
 
 <!-- textlint-enable -->
 
@@ -718,31 +718,31 @@ There is a series of videos we have recorded showing code coverage in Cypress
 
 <!-- textlint-disable terminology -->
 
-<DocsVideo src="https://youtube.com/embed/edgeQZ8UpD0"></DocsVideo>
+<DocsVideo src="https://youtube.com/embed/edgeQZ8UpD0" />
 
 #### Get code coverage reports from Cypress tests
 
-<DocsVideo src="https://youtube.com/embed/y8StkffYra0"></DocsVideo>
+<DocsVideo src="https://youtube.com/embed/y8StkffYra0" />
 
 #### Excluding code from code coverage reports
 
-<DocsVideo src="https://youtube.com/embed/DlceMpRpbAw"></DocsVideo>
+<DocsVideo src="https://youtube.com/embed/DlceMpRpbAw" />
 
 #### Check code coverage robustly using 3rd party tool
 
-<DocsVideo src="https://youtube.com/embed/dwU5gUG2"></DocsVideo>
-
+<DocsVideo src="https://youtube.com/embed/dwU5gUG2"/>
+ 
 #### Adding code coverage badge to your project
 
-<DocsVideo src="https://youtube.com/embed/bNVRxb-MKGo"></DocsVideo>
+<DocsVideo src="https://youtube.com/embed/bNVRxb-MKGo" />
 
 #### Show code coverage in commit status check
 
-<DocsVideo src="https://youtube.com/embed/AAl4HmJ3YuM"></DocsVideo>
+<DocsVideo src="https://youtube.com/embed/AAl4HmJ3YuM" />
 
 #### Checking code coverage on pull request
 
-<DocsVideo src="https://youtube.com/embed/9Eq_gIshK0o"></DocsVideo>
+<DocsVideo src="https://youtube.com/embed/9Eq_gIshK0o" />
 
 <!-- textlint-enable -->
 

--- a/docs/guides/tooling/code-coverage.mdx
+++ b/docs/guides/tooling/code-coverage.mdx
@@ -217,7 +217,7 @@ object. We can see the counters if we serve the `instrumented` folder instead of
 <DocsImage
   src="/img/guides/code-coverage/coverage-object.png"
   alt="Code coverage object"
-></DocsImage>
+/>
 
 If we drill into the coverage object we can see the statements executed in each
 file. For example the file `src/index.js` has the following information:
@@ -225,7 +225,7 @@ file. For example the file `src/index.js` has the following information:
 <DocsImage
   src="/img/guides/code-coverage/coverage-statements.png"
   alt="Covered statements counters in a from the index file"
-></DocsImage>
+/>
 
 In green, we highlighted the 4 statements present in that file. The first three
 statements were each executed once and the last statement was never executed (it
@@ -262,7 +262,7 @@ for full example projects showing different code coverage setups.
 <DocsImage
   src="/img/guides/code-coverage/source-map.png"
   alt="Bundled code and source mapped originals"
-></DocsImage>
+/>
 
 A really nice feature of both [nyc](https://github.com/istanbuljs/nyc) and
 [`babel-plugin-istanbul`](https://github.com/istanbuljs/babel-plugin-istanbul)
@@ -329,7 +329,7 @@ tests finish. We have highlighted these commands using a green rectangle below.
 <DocsImage
   src="/img/guides/code-coverage/coverage-plugin-commands.png"
   alt="coverage plugin commands"
-></DocsImage>
+/>
 
 After the tests complete, the final code coverage is saved to a `.nyc_output`
 folder. It is a JSON file from which we can generate a report in a variety of
@@ -368,7 +368,7 @@ the browser.
 <DocsImage
   src="/img/guides/code-coverage/circleci-coverage-report.png"
   alt="coverage HTML report on CircleCI"
-></DocsImage>
+/>
 
 ## Code coverage as a guide
 
@@ -402,7 +402,7 @@ our application.
 <DocsImage
   src="/img/guides/code-coverage/single-test.png"
   alt="Coverage report after a single test"
-></DocsImage>
+/>
 
 Even better, we can drill down into the individual source files to see what code
 we missed. In our example application, the main state logic is in the
@@ -411,7 +411,7 @@ we missed. In our example application, the main state logic is in the
 <DocsImage
   src="/img/guides/code-coverage/todos-coverage.png"
   alt="Main application logic coverage"
-></DocsImage>
+/>
 
 Notice how the **ADD_TODO** action was executed 3 times - because our test has
 added 3 todo items, and the **COMPLETE_TODO** action was executed just once -
@@ -430,14 +430,14 @@ We can write more E2E tests.
 <DocsImage
   src="/img/guides/code-coverage/more-tests.png"
   alt="Cypress passed more tests"
-></DocsImage>
+/>
 
 The produced HTML report shows 99% code coverage
 
 <DocsImage
   src="/img/guides/code-coverage/almost-100.png"
   alt="99 percent code coverage"
-></DocsImage>
+/>
 
 Every source file but 1 is covered at 100%. We can have great confidence in our
 application, and safely refactor the code knowing that we have a robust set of
@@ -470,7 +470,7 @@ Let's look at the one file that has a "missed" line. It is the
 <DocsImage
   src="/img/guides/code-coverage/selectors.png"
   alt="Selectors file with a line not covered by end-to-end tests"
-></DocsImage>
+/>
 
 The source line not covered by the end-to-end tests shows an edge case NOT
 reachable from the UI. Yet this switch case is definitely worth testing - at
@@ -504,7 +504,7 @@ The test passes, even if there is no web application visited.
 <DocsImage
   src="/img/guides/code-coverage/unit-test.png"
   alt="Unit test for selector"
-></DocsImage>
+/>
 
 Previously we instrumented the application code (either using a build step or
 inserting a plugin into the Babel pipeline). In the example above, we are NOT
@@ -555,7 +555,7 @@ should see the coverage information for the application source files.
 <DocsImage
   src="/img/guides/code-coverage/code-coverage-in-unit-test.png"
   alt="Code coverage in the unit test"
-></DocsImage>
+/>
 
 The code coverage information in unit tests and end-to-end tests has the same
 format; the
@@ -566,7 +566,7 @@ coverage from the `cypress/e2e/selectors.cy.js` file after running the test.
 <DocsImage
   src="/img/guides/code-coverage/unit-test-coverage.png"
   alt="Selectors code coverage"
-></DocsImage>
+/>
 
 Our unit test is hitting the line we could not reach from the end-to-end tests,
 and if we execute all spec files - we will get 100% code coverage.
@@ -574,7 +574,7 @@ and if we execute all spec files - we will get 100% code coverage.
 <DocsImage
   src="/img/guides/code-coverage/100percent.png"
   alt="Full code coverage"
-></DocsImage>
+/>
 
 ## Full stack code coverage
 
@@ -681,7 +681,7 @@ example:
 <DocsImage
   src="/img/guides/code-coverage/full-coverage.png"
   alt="Combined code coverage report from front and back end code"
-></DocsImage>
+/>
 
 You can explore the above combined full stack coverage report at the
 [coveralls.io/github/cypress-io/cypress-example-conduit-app](https://coveralls.io/github/cypress-io/cypress-example-conduit-app)

--- a/docs/guides/tooling/reporters.mdx
+++ b/docs/guides/tooling/reporters.mdx
@@ -347,7 +347,7 @@ results, timing information, and even test bodies are included.
 <DocsImage
   src="/img/guides/reporters/mochawesome-report.png"
   alt="Mochawesome HTML report"
-></DocsImage>
+/>
 
 For more information, see
 [Integrating Mochawesome reporter with Cypress's](http://antontelesh.github.io/testing/2019/02/04/mochawesome-merge.html)

--- a/docs/guides/tooling/visual-testing.mdx
+++ b/docs/guides/tooling/visual-testing.mdx
@@ -37,7 +37,7 @@ it('completes todo', () => {
 <DocsImage
   src="/img/guides/visual-testing/completed-test.gif"
   alt="Passing Cypress functional test"
-></DocsImage>
+/>
 
 Cypress does NOT see how the page actually looks though. For example, Cypress
 will not see if the CSS class `completed` grays out the label element and adds a
@@ -46,7 +46,7 @@ strike-through line.
 <DocsImage
   src="/img/guides/visual-testing/completed-item.png"
   alt="Completed item style"
-></DocsImage>
+/>
 
 You could technically write a functional test asserting the CSS properties using
 the [`have.css` assertion](/guides/references/assertions#CSS), but these may
@@ -110,7 +110,7 @@ image (_Actual result_) does not have it.
 <DocsImage
   src="/img/guides/visual-testing/diff.png"
   alt="Baseline vs current image"
-></DocsImage>
+/>
 
 Like most image comparison tools, the plugin also shows a difference view on
 mouse hover:
@@ -118,7 +118,7 @@ mouse hover:
 <DocsImage
   src="/img/guides/visual-testing/diff-2.png"
   alt="Highlighted changes"
-></DocsImage>
+/>
 
 ## Tooling
 

--- a/docs/guides/tooling/visual-testing.mdx
+++ b/docs/guides/tooling/visual-testing.mdx
@@ -137,7 +137,7 @@ First joint webinar with Applitools
 
 <!-- textlint-disable -->
 
-<DocsVideo src="https://youtube.com/embed/qVRjhABuyG0"></DocsVideo>
+<DocsVideo src="https://youtube.com/embed/qVRjhABuyG0" />
 
 <!-- textlint-enable -->
 
@@ -146,7 +146,7 @@ Second joint webinar with Applitools with a focus on
 
 <!-- textlint-disable -->
 
-<DocsVideo src="https://youtube.com/embed/Bxh_ebMk1aM"></DocsVideo>
+<DocsVideo src="https://youtube.com/embed/Bxh_ebMk1aM" />
 
 <!-- textlint-enable -->
 
@@ -163,7 +163,7 @@ Second joint webinar with Applitools with a focus on
 
 <!-- textlint-disable -->
 
-<DocsVideo src="https://youtube.com/embed/MXfZeE9RQDw"></DocsVideo>
+<DocsVideo src="https://youtube.com/embed/MXfZeE9RQDw" />
 
 <!-- textlint-enable -->
 
@@ -197,7 +197,7 @@ to see these Percy and Cypress in action.
 
 <!-- textlint-disable -->
 
-<DocsVideo src="https://youtube.com/embed/C_p12IvN5HU"></DocsVideo>
+<DocsVideo src="https://youtube.com/embed/C_p12IvN5HU" />
 
 <!-- textlint-enable -->
 

--- a/docs/partials/_anatomy-of-an-error.mdx
+++ b/docs/partials/_anatomy-of-an-error.mdx
@@ -26,4 +26,4 @@ Cypress test.
 <DocsImage
   src="/img/guides/core-concepts/cypress-app/command-failure-error.png"
   alt="example command failure error"
-></DocsImage>
+/>

--- a/docs/partials/_document-domain-workaround.mdx
+++ b/docs/partials/_document-domain-workaround.mdx
@@ -1,6 +1,6 @@
 :::caution
 
-<strong class="alert-header">
+<strong>
   <Icon name="exclamation-triangle" /> Disabling document.domain Injection
 </strong>
 

--- a/docs/partials/_document-domain-workaround.mdx
+++ b/docs/partials/_document-domain-workaround.mdx
@@ -1,7 +1,7 @@
 :::caution
 
 <strong class="alert-header">
-  <Icon name="exclamation-triangle"></Icon> Disabling document.domain Injection
+  <Icon name="exclamation-triangle" /> Disabling document.domain Injection
 </strong>
 
 In some cases, `document.domain` injection may cause issues. As of Cypress

--- a/docs/partials/_import-mount-functions.mdx
+++ b/docs/partials/_import-mount-functions.mdx
@@ -51,7 +51,7 @@ import { mount } from 'cypress/vue2'
 
 :::info
 
-<strong class="alert-header">A note for Angular users</strong>
+<strong>A note for Angular users</strong>
 
 The `mount()` command exported from the
 [cypress/angular](https://github.com/cypress-io/cypress/tree/develop/npm/angular)


### PR DESCRIPTION
This wave of markdown clean up removes unnecessary component closing tags and a CSS class that came over from the previous site implementaiton. 🧹 💨 