### PR TITLE
URL to Cypress Version 10: Fundamentals changed.

### DIFF
--- a/src/data/courses.json
+++ b/src/data/courses.json
@@ -18,8 +18,8 @@
       "sourceUrl": "https://egghead.io"
     },
     {
-      "title": "Cypress 10 Fundamentals",
-      "url": "https://university.blazemeter.com/users/sign_in?next=%2Fenrollments%2F130677466%2Fdetails",
+      "title": "Cypress Version 10: Fundamentals",
+      "url": "https://university.blazemeter.com/users/sign_in?next=%2Fenrollments%2F156391687%2Fdetails",
       "author": "Gleb Bahmutov",
       "authorTwitter": "bahmutov",
       "sourceName": "Blazemeter University",


### PR DESCRIPTION
The ID for the course has changed and was redirecting to a page with the info: "You are not authorized to view this resource Check with your administrator if you think this is in error."

I've changed it to the new link, and also altered the title for the course that has a small difference in the BlazeMeter webpage, so It now matches the one found on the website.