### PR TITLE
Update assertions reference

### DIFF
--- a/docs/guides/references/assertions.mdx
+++ b/docs/guides/references/assertions.mdx
@@ -25,57 +25,55 @@ guide.
 
 <Icon name="github" url="https://github.com/chaijs/chai" />
 
-### BDD Assertions
-
 These chainers are available for BDD assertions (`expect`/`should`). Aliases
 listed can be used interchangeably with their original chainer. You can see the
 entire list of available BDD Chai assertions [here](http://chaijs.com/api/bdd/).
 
-| Chainer                                                                                                                | Example                                                                                                                                 |
-| ---------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| not                                                                                                                    | `expect(name).to.not.equal('Jane')`                                                                                                     |
-| deep                                                                                                                   | `expect(obj).to.deep.equal({ name: 'Jane' })`                                                                                           |
-| nested                                                                                                                 | `expect({a: {b: ['x', 'y']}}).to.have.nested.property('a.b[1]')`<br />`expect({a: {b: ['x', 'y']}}).to.nested.include({'a.b[1]': 'y'})` |
-| ordered                                                                                                                | `expect([1, 2]).to.have.ordered.members([1, 2]).but.not.have.ordered.members([2, 1])`                                                   |
-| any                                                                                                                    | `expect(arr).to.have.any.keys('age')`                                                                                                   |
-| all                                                                                                                    | `expect(arr).to.have.all.keys('name', 'age')`                                                                                           |
-| a(_type_) <br /><small class="aliases"><strong>Aliases: </strong>an</small>                                            | `expect('test').to.be.a('string')`                                                                                                      |
-| include(_value_) <br /><small class="aliases"><strong>Aliases: </strong>contain, includes, contains</small>            | `expect([1,2,3]).to.include(2)`                                                                                                         |
-| ok                                                                                                                     | `expect(undefined).to.not.be.ok`                                                                                                        |
-| true                                                                                                                   | `expect(true).to.be.true`                                                                                                               |
-| false                                                                                                                  | `expect(false).to.be.false`                                                                                                             |
-| null                                                                                                                   | `expect(null).to.be.null`                                                                                                               |
-| undefined                                                                                                              | `expect(undefined).to.be.undefined`                                                                                                     |
-| exist                                                                                                                  | `expect(myVar).to.exist`                                                                                                                |
-| empty                                                                                                                  | `expect([]).to.be.empty`                                                                                                                |
-| arguments <br /><small class="aliases"><strong>Aliases: </strong>Arguments</small>                                     | `expect(arguments).to.be.arguments`                                                                                                     |
-| equal(_value_) <br /><small class="aliases"><strong>Aliases: </strong>equals, eq</small>                               | `expect(42).to.equal(42)`                                                                                                               |
-| deep.equal(_value_)                                                                                                    | `expect({ name: 'Jane' }).to.deep.equal({ name: 'Jane' })`                                                                              |
-| eql(_value_) <br /><small class="aliases"><strong>Aliases: </strong>eqls</small>                                       | `expect({ name: 'Jane' }).to.eql({ name: 'Jane' })`                                                                                     |
-| greaterThan(_value_) <br /><small class="aliases"><strong>Aliases: </strong>gt, above</small>                          | `expect(10).to.be.greaterThan(5)`                                                                                                       |
-| least(_value_)<br /><small class="aliases"><strong>Aliases: </strong>gte</small>                                       | `expect(10).to.be.at.least(10)`                                                                                                         |
-| lessThan(_value_) <br /><small class="aliases"><strong>Aliases: </strong>lt, below</small>                             | `expect(5).to.be.lessThan(10)`                                                                                                          |
-| most(_value_) <br /><small class="aliases"><strong>Aliases: </strong>lte</small>                                       | `expect('test').to.have.length.of.at.most(4)`                                                                                           |
-| within(_start_, _finish_)                                                                                              | `expect(7).to.be.within(5,10)`                                                                                                          |
-| instanceOf(_constructor_) <br /><small class="aliases"><strong>Aliases: </strong>instanceof</small>                    | `expect([1, 2, 3]).to.be.instanceOf(Array)`                                                                                             |
-| property(_name_, _[value]_)                                                                                            | `expect(obj).to.have.property('name')`                                                                                                  |
-| deep.property(_name_, _[value]_)                                                                                       | `expect(deepObj).to.have.deep.property('tests[1]', 'e2e')`                                                                              |
-| ownProperty(_name_) <br /><small class="aliases"><strong>Aliases: </strong>haveOwnProperty, own.property</small>       | `expect('test').to.have.ownProperty('length')`                                                                                          |
-| ownPropertyDescriptor(_name_) <br /><small class="aliases"><strong>Aliases: </strong>haveOwnPropertyDescriptor</small> | `expect({a: 1}).to.have.ownPropertyDescriptor('a')`                                                                                     |
-| lengthOf(_value_)                                                                                                      | `expect('test').to.have.lengthOf(3)`                                                                                                    |
-| match(_RegExp_) <br /><small class="aliases"><strong>Aliases: </strong>matches</small>                                 | `expect('testing').to.match(/^test/)`                                                                                                   |
-| string(_string_)                                                                                                       | `expect('testing').to.have.string('test')`                                                                                              |
-| keys(_key1_, _[key2]_, _[...]_) <br /><small class="aliases"><strong>Aliases: </strong>key</small>                     | `expect({ pass: 1, fail: 2 }).to.have.keys('pass', 'fail')`                                                                             |
-| throw(_constructor_) <br /><small class="aliases"><strong>Aliases: </strong>throws, Throw</small>                      | `expect(fn).to.throw(Error)`                                                                                                            |
-| respondTo(_method_) <br /><small class="aliases"><strong>Aliases: </strong>respondsTo</small>                          | `expect(obj).to.respondTo('getName')`                                                                                                   |
-| itself                                                                                                                 | `expect(Foo).itself.to.respondTo('bar')`                                                                                                |
-| satisfy(_method_) <br /><small class="aliases"><strong>Aliases: </strong>satisfies</small>                             | `expect(1).to.satisfy((num) => { return num > 0 })`                                                                                     |
-| closeTo(_expected_, _delta_) <br /><small class="aliases"><strong>Aliases: </strong>approximately</small>              | `expect(1.5).to.be.closeTo(1, 0.5)`                                                                                                     |
-| members(_set_)                                                                                                         | `expect([1, 2, 3]).to.include.members([3, 2])`                                                                                          |
-| oneOf(_values_)                                                                                                        | `expect(2).to.be.oneOf([1,2,3])`                                                                                                        |
-| change(_function_) <br /><small class="aliases"><strong>Aliases: </strong>changes</small>                              | `expect(fn).to.change(obj, 'val')`                                                                                                      |
-| increase(_function_) <br /><small class="aliases"><strong>Aliases: </strong>increases</small>                          | `expect(fn).to.increase(obj, 'val')`                                                                                                    |
-| decrease(_function_) <br /><small class="aliases"><strong>Aliases: </strong>decreases</small>                          | `expect(fn).to.decrease(obj, 'val')`                                                                                                    |
+| Chainer                                                                                                                | Example                                                                                                                                                                                                                |
+| ---------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| not                                                                                                                    | `.should('not.equal', 'Jane')`<br />`expect(name).to.not.equal('Jane')`                                                                                                                                                |
+| deep                                                                                                                   | `.should('deep.equal', { name: 'Jane' })`<br />`expect(obj).to.deep.equal({ name: 'Jane' })`                                                                                                                           |
+| nested                                                                                                                 | `.should('have.nested.property', 'a.b[1]')`<br />`.should('nested.include', {'a.b[1]': 'y'})`<br />`expect({a: {b: 'x'}}).to.have.nested.property('a.b')`<br />`expect({a: {b: 'x'}}).to.nested.include({'a.b': 'x'})` |
+| ordered                                                                                                                | `.should('have.ordered.members', [1, 2])`<br />`expect([1, 2]).to.have.ordered.members([1, 2])`<br />`expect([1, 2]).not.to.have.ordered.members([2, 1])`                                                              |
+| any                                                                                                                    | `.should('have.any.keys', 'age')`<br />`expect(arr).to.have.any.keys('age')`                                                                                                                                           |
+| all                                                                                                                    | `.should('have.all.keys', 'name', 'age')`<br />`expect(arr).to.have.all.keys('name', 'age')`                                                                                                                           |
+| a(_type_) <br /><small class="aliases"><strong>Aliases: </strong>an</small>                                            | `.should('be.a', 'string')`<br />`expect('test').to.be.a('string')`                                                                                                                                                    |
+| include(_value_) <br /><small class="aliases"><strong>Aliases: </strong>contain, includes, contains</small>            | `.should('include', 2)`<br />`expect([1,2,3]).to.include(2)`                                                                                                                                                           |
+| ok                                                                                                                     | `.should('not.be.ok')`<br />`expect(undefined).to.not.be.ok`                                                                                                                                                           |
+| true                                                                                                                   | `.should('be.true')`<br />`expect(true).to.be.true`                                                                                                                                                                    |
+| false                                                                                                                  | `.should('be.false')`<br />`expect(false).to.be.false`                                                                                                                                                                 |
+| null                                                                                                                   | `.should('be.null')`<br />`expect(null).to.be.null`                                                                                                                                                                    |
+| undefined                                                                                                              | `.should('be.undefined')`<br />`expect(undefined).to.be.undefined`                                                                                                                                                     |
+| exist                                                                                                                  | `.should('exist')`<br />`expect(myVar).to.exist`                                                                                                                                                                       |
+| empty                                                                                                                  | `.should('be.empty')`<br />`expect([]).to.be.empty`                                                                                                                                                                    |
+| arguments <br /><small class="aliases"><strong>Aliases: </strong>Arguments</small>                                     | `.should('be.arguments')`<br />`expect(arguments).to.be.arguments`                                                                                                                                                     |
+| equal(_value_) <br /><small class="aliases"><strong>Aliases: </strong>equals, eq</small>                               | `.should('equal', 42)`<br />`expect(42).to.equal(42)`                                                                                                                                                                  |
+| deep.equal(_value_)                                                                                                    | `.should('deep.equal', { name: 'Jane' })`<br />`expect({ name: 'Jane' }).to.deep.equal({ name: 'Jane' })`                                                                                                              |
+| eql(_value_) <br /><small class="aliases"><strong>Aliases: </strong>eqls</small>                                       | `.should('eql', { name: 'Jane' })`<br />`expect({ name: 'Jane' }).to.eql({ name: 'Jane' })`                                                                                                                            |
+| greaterThan(_value_) <br /><small class="aliases"><strong>Aliases: </strong>gt, above</small>                          | `.should('be.greaterThan', 5)`<br />`expect(10).to.be.greaterThan(5)`                                                                                                                                                  |
+| least(_value_)<br /><small class="aliases"><strong>Aliases: </strong>gte</small>                                       | `.should('be.at.least', 10)`<br />`expect(10).to.be.at.least(10)`                                                                                                                                                      |
+| lessThan(_value_) <br /><small class="aliases"><strong>Aliases: </strong>lt, below</small>                             | `.should('be.lessThan', 10)`<br />`expect(5).to.be.lessThan(10)`                                                                                                                                                       |
+| most(_value_) <br /><small class="aliases"><strong>Aliases: </strong>lte</small>                                       | `.should('have.length.of.at.most', 4)`<br />`expect('test').to.have.length.of.at.most(4)`                                                                                                                              |
+| within(_start_, _finish_)                                                                                              | `.should('be.within', 5, 10)`<br />`expect(7).to.be.within(5, 10)`                                                                                                                                                     |
+| instanceOf(_constructor_) <br /><small class="aliases"><strong>Aliases: </strong>instanceof</small>                    | `.should('be.instanceOf', Array)`<br />`expect([1, 2, 3]).to.be.instanceOf(Array)`                                                                                                                                     |
+| property(_name_, _[value]_)                                                                                            | `.should('have.property', 'name')`<br />`expect(obj).to.have.property('name')`                                                                                                                                         |
+| deep.property(_name_, _[value]_)                                                                                       | `.should('have.deep.property', 'tests[1]', 'e2e')`<br />`expect(deepObj).to.have.deep.property('tests[1]', 'e2e')`                                                                                                     |
+| ownProperty(_name_) <br /><small class="aliases"><strong>Aliases: </strong>haveOwnProperty, own.property</small>       | `.should('have.ownProperty', 'length')`<br />`expect('test').to.have.ownProperty('length')`                                                                                                                            |
+| ownPropertyDescriptor(_name_) <br /><small class="aliases"><strong>Aliases: </strong>haveOwnPropertyDescriptor</small> | `.should('have.ownPropertyDescriptor', 'a')`<br />`expect({a: 1}).to.have.ownPropertyDescriptor('a')`                                                                                                                  |
+| lengthOf(_value_)                                                                                                      | `.should('have.lengthOf', 4)`<br />`expect('test').to.have.lengthOf(4)`                                                                                                                                                |
+| match(_RegExp_) <br /><small class="aliases"><strong>Aliases: </strong>matches</small>                                 | `.should('to.match', /^test/)`<br />`expect('testing').to.match(/^test/)`                                                                                                                                              |
+| string(_string_)                                                                                                       | `.should('have.string', 'test')`<br />`expect('testing').to.have.string('test')`                                                                                                                                       |
+| keys(_key1_, _[key2]_, _[...]_) <br /><small class="aliases"><strong>Aliases: </strong>key</small>                     | `.should('have.keys', 'pass', 'fail')`<br />`expect({ pass: 1, fail: 2 }).to.have.keys('pass', 'fail')`                                                                                                                |
+| throw(_constructor_) <br /><small class="aliases"><strong>Aliases: </strong>throws, Throw</small>                      | `.should('throw', Error)`<br />`expect(fn).to.throw(Error)`                                                                                                                                                            |
+| respondTo(_method_) <br /><small class="aliases"><strong>Aliases: </strong>respondsTo</small>                          | `.should('respondTo', 'getName')`<br />`expect(obj).to.respondTo('getName')`                                                                                                                                           |
+| itself                                                                                                                 | `.should('itself.respondTo', 'getName')`<br />`expect(Foo).itself.to.respondTo('bar')`                                                                                                                                 |
+| satisfy(_method_) <br /><small class="aliases"><strong>Aliases: </strong>satisfies</small>                             | `.should('satisfy', (num) => num > 0)`<br />`expect(1).to.satisfy((num) => num > 0)`                                                                                                                                   |
+| closeTo(_expected_, _delta_) <br /><small class="aliases"><strong>Aliases: </strong>approximately</small>              | `.should('be.closeTo', 1, 0.5)`<br />`expect(1.5).to.be.closeTo(1, 0.5)`                                                                                                                                               |
+| members(_set_)                                                                                                         | `.should('include.members', [3, 2])`<br />`expect([1, 2, 3]).to.include.members([3, 2])`                                                                                                                               |
+| oneOf(_values_)                                                                                                        | `.should('be.oneOf', [1, 2, 3])`<br />`expect(2).to.be.oneOf([1,2,3])`                                                                                                                                                 |
+| change(_function_) <br /><small class="aliases"><strong>Aliases: </strong>changes</small>                              | `.should('change', obj, 'val')`<br />`expect(fn).to.change(obj, 'val')`                                                                                                                                                |
+| increase(_function_) <br /><small class="aliases"><strong>Aliases: </strong>increases</small>                          | `.should('increase', obj, 'val')`<br />`expect(fn).to.increase(obj, 'val')`                                                                                                                                            |
+| decrease(_function_) <br /><small class="aliases"><strong>Aliases: </strong>decreases</small>                          | `.should('decrease', obj, 'val')`<br />`expect(fn).to.decrease(obj, 'val')`                                                                                                                                            |
 
 These getters are also available for BDD assertions. They don't actually do
 anything, but they enable you to write clear, english sentences.
@@ -83,53 +81,6 @@ anything, but they enable you to write clear, english sentences.
 | Chainable getters                                                                           |
 | ------------------------------------------------------------------------------------------- |
 | `to`, `be`, `been`, `is`, `that`, `which`, `and`, `has`, `have`, `with`, `at`, `of`, `same` |
-
-### TDD Assertions
-
-These assertions are available for TDD assertions (`assert`). You can see the
-entire list of available Chai assertions [here](http://chaijs.com/api/assert/).
-
-| Assertion                                                   | Example                                                |
-| ----------------------------------------------------------- | ------------------------------------------------------ |
-| .isOk(_object_, _[message]_)                                | `assert.isOk('everything', 'everything is ok')`        |
-| .isNotOk(_object_, _[message]_)                             | `assert.isNotOk(false, 'this will pass')`              |
-| .equal(_actual_, _expected_, _[message]_)                   | `assert.equal(3, 3, 'vals equal')`                     |
-| .notEqual(_actual_, _expected_, _[message]_)                | `assert.notEqual(3, 4, 'vals not equal')`              |
-| .strictEqual(_actual_, _expected_, _[message]_)             | `assert.strictEqual(true, true, 'bools strict eq')`    |
-| .notStrictEqual(_actual_, _expected_, _[message]_)          | `assert.notStrictEqual(5, '5', 'not strict eq')`       |
-| .deepEqual(_actual_, _expected_, _[message]_)               | `assert.deepEqual({ id: '1' }, { id: '1' })`           |
-| .notDeepEqual(_actual_, _expected_, _[message]_)            | `assert.notDeepEqual({ id: '1' }, { id: '2' })`        |
-| .isAbove(_valueToCheck_, _valueToBeAbove_, _[message]_)     | `assert.isAbove(6, 1, '6 greater than 1')`             |
-| .isAtLeast(_valueToCheck_, _valueToBeAtLeast_, _[message]_) | `assert.isAtLeast(5, 2, '5 gt or eq to 2')`            |
-| .isBelow(_valueToCheck_, _valueToBeBelow_, _[message]_)     | `assert.isBelow(3, 6, '3 strict lt 6')`                |
-| .isAtMost(_valueToCheck_, _valueToBeAtMost_, _[message]_)   | `assert.isAtMost(4, 4, '4 lt or eq to 4')`             |
-| .isTrue(_value_, _[message]_)                               | `assert.isTrue(true, 'this val is true')`              |
-| .isNotTrue(_value_, _[message]_)                            | `assert.isNotTrue('tests are no fun', 'val not true')` |
-| .isFalse(_value_, _[message]_)                              | `assert.isFalse(false, 'val is false')`                |
-| .isNotFalse(_value_, _[message]_)                           | `assert.isNotFalse('tests are fun', 'val not false')`  |
-| .isNull(_value_, _[message]_)                               | `assert.isNull(err, 'there was no error')`             |
-| .isNotNull(_value_, _[message]_)                            | `assert.isNotNull('hello', 'is not null')`             |
-| .isNaN(_value_, _[message]_)                                | `assert.isNaN(NaN, 'NaN is NaN')`                      |
-| .isNotNaN(_value_, _[message]_)                             | `assert.isNotNaN(5, '5 is not NaN')`                   |
-| .exists(_value_, _[message]_)                               | `assert.exists(5, '5 is not null or undefined')`       |
-| .notExists(_value_, _[message]_)                            | `assert.notExists(null, 'val is null or undefined')`   |
-| .isUndefined(_value_, _[message]_)                          | `assert.isUndefined(undefined, 'val is undefined')`    |
-| .isDefined(_value_, _[message]_)                            | `assert.isDefined('hello', 'val has been defined')`    |
-| .isFunction(_value_, _[message]_)                           | `assert.isFunction(x => x * x, 'val is func')`         |
-| .isNotFunction(_value_, _[message]_)                        | `assert.isNotFunction(5, 'val not funct')`             |
-| .isObject(_value_, _[message]_)                             | `assert.isObject({num: 5}, 'val is object')`           |
-| .isNotObject(_value_, _[message]_)                          | `assert.isNotObject(3, 'val not object')`              |
-| .isArray(_value_, _[message]_)                              | `assert.isArray(['unit', 'e2e'], 'val is array')`      |
-| .isNotArray(_value_, _[message]_)                           | `assert.isNotArray('e2e', 'val not array')`            |
-| .isString(_value_, _[message]_)                             | `assert.isString('e2e', 'val is string')`              |
-| .isNotString(_value_, _[message]_)                          | `assert.isNotString(2, 'val not string')`              |
-| .isNumber(_value_, _[message]_)                             | `assert.isNumber(2, 'val is number')`                  |
-| .isNotNumber(_value_, _[message]_)                          | `assert.isNotNumber('e2e', 'val not number')`          |
-| .isFinite(_value_, _[message]_)                             | `assert.isFinite('e2e', 'val is finite')`              |
-| .isBoolean(_value_, _[message]_)                            | `assert.isBoolean(true, 'val is bool')`                |
-| .isNotBoolean(_value_, _[message]_)                         | `assert.isNotBoolean('true', 'val not bool')`          |
-| .typeOf(_value_, _name_, _[message]_)                       | `assert.typeOf('e2e', 'string', 'val is string')`      |
-| .notTypeOf(_value_, _name_, _[message]_)                    | `assert.notTypeOf('e2e', 'number', 'val not number')`  |
 
 ## Chai-jQuery
 
@@ -142,29 +93,29 @@ You will commonly use these chainers after using DOM commands like:
 
 <!-- textlint-disable -->
 
-| Chainers                | Assertion                                                              |
-| ----------------------- | ---------------------------------------------------------------------- |
-| attr(_name_, _[value]_) | `expect($el).to.have.attr('foo', 'bar')`                               |
-| prop(_name_, _[value]_) | `expect($el).to.have.prop('disabled', false)`                          |
-| css(_name_, _[value]_)  | `expect($el).to.have.css('background-color', 'rgb(0, 0, 0)')`          |
-| data(_name_, _[value]_) | `expect($el).to.have.data('foo', 'bar')`                               |
-| class(_className_)      | `expect($el).to.have.class('foo')`                                     |
-| id(_id_)                | `expect($el).to.have.id('foo')`                                        |
-| html(_html_)            | `expect($el).to.have.html('I love testing')`                           |
-| text(_text_)            | `expect($el).to.have.text('I love testing')`                           |
-| value(_value_)          | `expect($el).to.have.value('test@dev.com')`                            |
-| visible                 | `expect($el).to.be.visible`                                            |
-| hidden                  | `expect($el).to.be.hidden`                                             |
-| selected                | `expect($option).not.to.be.selected`                                   |
-| checked                 | `expect($input).not.to.be.checked`                                     |
-| focus[ed]               | `expect($input).not.to.be.focused`<br />`expect($input).to.have.focus` |
-| enabled                 | `expect($input).to.be.enabled`                                         |
-| disabled                | `expect($input).to.be.disabled`                                        |
-| empty                   | `expect($el).not.to.be.empty`                                          |
-| exist                   | `expect($nonexistent).not.to.exist`                                    |
-| match(_selector_)       | `expect($emptyEl).to.match(':empty')`                                  |
-| contain(_text_)         | `expect($el).to.contain('text')`                                       |
-| descendants(_selector_) | `expect($el).to.have.descendants('div')`                               |
+| Chainers                | Assertion                                                                                                                    |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| attr(_name_, _[value]_) | `.should('have.attr', 'bar')`<br />`expect($el).to.have.attr('foo', 'bar')`                                                  |
+| prop(_name_, _[value]_) | `.should('have.prop', 'disabled', false)`<br />`expect($el).to.have.prop('disabled', false)`                                 |
+| css(_name_, _[value]_)  | `.should('have.css', 'background-color', 'rgb(0, 0, 0)')`<br />`expect($el).to.have.css('background-color', 'rgb(0, 0, 0)')` |
+| data(_name_, _[value]_) | `.should('have.data', 'foo', 'bar')`<br />`expect($el).to.have.data('foo', 'bar')`                                           |
+| class(_className_)      | `.should('have.class', 'foo')`<br />`expect($el).to.have.class('foo')`                                                       |
+| id(_id_)                | `.should('have.id', 'foo')`<br />`expect($el).to.have.id('foo')`                                                             |
+| html(_html_)            | `.should('have.html', 'I love testing')`<br />`expect($el).to.have.html('with Cypress')`                                     |
+| text(_text_)            | `.should('have.text', 'I love testing)`<br />`expect($el).to.have.text('with Cypress')`                                      |
+| value(_value_)          | `.should('have.value', 'test@dev.com')`<br />`expect($el).to.have.value('test@dev.com')`                                     |
+| visible                 | `.should('be.visible')`<br />`expect($el).to.be.visible`                                                                     |
+| hidden                  | `.should('be.hidden')`<br />`expect($el).to.be.hidden`                                                                       |
+| selected                | `.should('be.selected')`<br />`expect($option).not.to.be.selected`                                                           |
+| checked                 | `.should('be.checked')`<br />`expect($input).not.to.be.checked`                                                              |
+| focus[ed]               | `.should('have.focus')`<br />`expect($input).not.to.be.focused`<br />`expect($input).to.have.focus`                          |
+| enabled                 | `.should('be.enabled')`<br />`expect($input).to.be.enabled`                                                                  |
+| disabled                | `.should('be.disabled')`<br />`expect($input).to.be.disabled`                                                                |
+| empty                   | `.should('be.empty')`<br />`expect($el).not.to.be.empty`                                                                     |
+| exist                   | `.should('exist')`<br />`expect($nonexistent).not.to.exist`                                                                  |
+| match(_selector_)       | `.should('match', ':empty')`<br />`expect($emptyEl).to.match(':empty')`                                                      |
+| contain(_text_)         | `.should('contain', 'text')`<br />`expect($el).to.contain('text')`                                                           |
+| descendants(_selector_) | `.should('have.descendents', 'div')`<br />`expect($el).to.have.descendants('div')`                                           |
 
 <!-- textlint-enable -->
 
@@ -175,31 +126,31 @@ You will commonly use these chainers after using DOM commands like:
 These chainers are used on assertions with [`cy.stub()`](/api/commands/stub) and
 [`cy.spy()`](/api/commands/spy).
 
-| Sinon.JS property/method | Assertion                                                               |
-| ------------------------ | ----------------------------------------------------------------------- |
-| called                   | `expect(spy).to.be.called`                                              |
-| callCount                | `expect(spy).to.have.callCount(n)`                                      |
-| calledOnce               | `expect(spy).to.be.calledOnce`                                          |
-| calledTwice              | `expect(spy).to.be.calledTwice`                                         |
-| calledThrice             | `expect(spy).to.be.calledThrice`                                        |
-| calledBefore             | `expect(spy1).to.be.calledBefore(spy2)`                                 |
-| calledAfter              | `expect(spy1).to.be.calledAfter(spy2)`                                  |
-| calledWithNew            | `expect(spy).to.be.calledWithNew`                                       |
-| alwaysCalledWithNew      | `expect(spy).to.always.be.calledWithNew`                                |
-| calledOn                 | `expect(spy).to.be.calledOn(context)`                                   |
-| alwaysCalledOn           | `expect(spy).to.always.be.calledOn(context)`                            |
-| calledWith               | `expect(spy).to.be.calledWith(...args)`                                 |
-| alwaysCalledWith         | `expect(spy).to.always.be.calledWith(...args)`                          |
-| calledOnceWith           | `expect(spy).to.be.calledOnceWith(...args)`                             |
-| calledWithExactly        | `expect(spy).to.be.calledWithExactly(...args)`                          |
-| alwaysCalledWithExactly  | `expect(spy).to.always.be.calledWithExactly(...args)`                   |
-| calledOnceWithExactly    | `expect(spy).to.be.calledOnceWithExactly(...args)`                      |
-| calledWithMatch          | `expect(spy).to.be.calledWithMatch(...args)`                            |
-| alwaysCalledWithMatch    | `expect(spy).to.always.be.calledWithMatch(...args)`                     |
-| returned                 | `expect(spy).to.have.returned(returnVal)`                               |
-| alwaysReturned           | `expect(spy).to.have.always.returned(returnVal)`                        |
-| threw                    | `expect(spy).to.have.thrown(errorObjOrErrorTypeStringOrNothing)`        |
-| alwaysThrew              | `expect(spy).to.have.always.thrown(errorObjOrErrorTypeStringOrNothing)` |
+| Sinon.JS property/method | Assertion                                                                                                                   |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------------------- |
+| called                   | `.should('have.been.called')`<br />`expect(spy).to.be.called`                                                               |
+| callCount                | `.should('have.callCount', 3)`<br />`expect(spy).to.have.callCount(n)`                                                      |
+| calledOnce               | `.should('have.been.calledOnce')`<br />`expect(spy).to.be.calledOnce`                                                       |
+| calledTwice              | `.should('have.been.calledTwice')`<br />`expect(spy).to.be.calledTwice`                                                     |
+| calledThrice             | `.should('have.been.calledThrice')`<br />`expect(spy).to.be.calledThrice`                                                   |
+| calledBefore             | `.should('have.been.calledBefore', spy2)`<br />`expect(spy1).to.be.calledBefore(spy2)`                                      |
+| calledAfter              | `.should('have.been.calledAfter', spy2)`<br />`expect(spy1).to.be.calledAfter(spy2)`                                        |
+| calledWithNew            | `.should('have.been.calledWithNew')`<br />`expect(spy).to.be.calledWithNew`                                                 |
+| alwaysCalledWithNew      | `.should('have.always.been.calledWithNew')`<br />`expect(spy).to.always.be.calledWithNew`                                   |
+| calledOn                 | `.should('have.been.calledOn', context)`<br />`expect(spy).to.be.calledOn(context)`                                         |
+| alwaysCalledOn           | `.should('have.always.been.calledOn', context)`<br />`expect(spy).to.always.be.calledOn(context)`                           |
+| calledWith               | `.should('have.been.calledWith', ['arg1, 'arg2'])`<br />`expect(spy).to.be.calledWith(...args)`                             |
+| alwaysCalledWith         | `.should('have.always.been.calledWith', ['arg1', 'arg2'])`<br />`expect(spy).to.always.be.calledWith(...args)`              |
+| calledOnceWith           | `.should('have.been.calledOnceWith', ['arg1', 'arg2'])`<br />`expect(spy).to.be.calledOnceWith(...args)`                    |
+| calledWithExactly        | `.should('have.been.calledWithExactly', ['arg1, 'arg2'])`<br />`expect(spy).to.be.calledWithExactly(...args)`               |
+| alwaysCalledWithExactly  | `.should('have.always.been.calledWithExactly', ['arg1, 'arg2'])`<br />`expect(spy).to.always.be.calledWithExactly(...args)` |
+| calledOnceWithExactly    | `.should('have.been.calledOnceWithExactly', ['arg1, 'arg2'])`<br />`expect(spy).to.be.calledOnceWithExactly(...args)`       |
+| calledWithMatch          | `.should('have.been.calledWithMatch', ['arg1, 'arg2'])`<br />`expect(spy).to.be.calledWithMatch(...args)`                   |
+| alwaysCalledWithMatch    | `.should('have.always.been.calledWithMatch', ['arg1, 'arg2'])`<br />`expect(spy).to.always.be.calledWithMatch(...args)`     |
+| returned                 | `.should('have.returned', 'foo')`<br />`expect(spy).to.have.returned(returnVal)`                                            |
+| alwaysReturned           | `.should('have.always.returned', 'foo')`<br />`expect(spy).to.have.always.returned(returnVal)`                              |
+| threw                    | `.should('have.thrown', TypeError)`<br />`expect(spy).to.have.thrown(errorObjOrErrorTypeStringOrNothing)`                   |
+| alwaysThrew              | `.should('have.always.thrown', 'TypeError')`<br />`expect(spy).to.have.always.thrown(errorObjOrErrorTypeStringOrNothing)`   |
 
 ## Adding New Assertions
 
@@ -396,7 +347,6 @@ pass when the application behaves in multiple unexpected ways:
   Todo
 - The app deletes a Todo instead of adding a new Todo
 - The app adds a blank Todo
-- An infinite variety of possible application mistakes
 
 ```javascript
 cy.get('[data-testid="todos"]').should('have.length', 2)
@@ -405,27 +355,6 @@ cy.get('[data-testid="new-todo"]').type('Write tests{enter}')
 // using negative assertion to check it's
 // not a number of items
 cy.get('[data-testid="todos"]').should('not.have.length', 2)
-```
-
-**Recommendation**
-
-We recommend using negative assertions to verify that a specific condition is no
-longer present after the application performs an action. For example, when a
-previously completed item is unchecked, we might verify that a CSS class is
-removed.
-
-```javascript
-// at first the item is marked completed
-cy.contains('[data-testid="todos"]', 'Write tests')
-  .should('have.class', 'completed')
-  .find('[data-testid="toggle"]')
-  .click()
-
-// the CSS class has been removed
-cy.contains('[data-testid="todos"]', 'Write tests').should(
-  'not.have.class',
-  'completed'
-)
 ```
 
 :::info


### PR DESCRIPTION
As part of https://github.com/cypress-io/cypress-documentation/pull/5053, I was reviewing our guides, and think that the assertions reference could be improved to be more useful when writing tests.

I've done three things in this PR.
1. Added `.should()` examples of each assertion. Users should write their assertions like this in order to maintain retry-ability. Providing this as the first example in each case will help them make fewer mistakes. Also, I've always wished it were like this when I reference the page in my own test writing. I'm "users".
2. Removed the TDD style assertions list. We do not use it anywhere in our own codebase, and we have no tests around it. It also doesn't work with `.should() / .and()`, which is how we recommend users write tests.
3. Removed a contradictory section on negative assertions that is at odds with the text above it.