### PR TITLE
fix(guides): incorrect angular options API configuration

### DIFF
--- a/docs/guides/component-testing/angular/overview.mdx
+++ b/docs/guides/component-testing/angular/overview.mdx
@@ -83,28 +83,30 @@ import { defineConfig } from 'cypress'
 
 export default {
   component: {
-    framework: 'angular',
-    bundler: 'webpack',
-    options: {
-      projectConfig: {
-        root: '',
-        sourceRoot: 'apps/my-app',
-        buildOptions: {
-          outputPath: 'dist/my-app',
-          index: 'apps/my-app/src/index.html',
-          main: 'apps/my-app/src/main.ts',
-          polyfills: 'apps/my-app/src/polyfills.ts',
-          tsConfig: 'apps/my-app/tsconfig.app.json',
-          inlineStyleLanguage: 'scss',
-          assets: ['apps/my-app/src/favicon.ico', 'apps/my-app/src/assets'],
-          styles: ['apps/my-app/src/styles.scss'],
-          scripts: [],
-          buildOptimizer: false,
-          optimization: false,
-          vendorChunk: true,
-          extractLicenses: false,
-          sourceMap: true,
-          namedChunks: true,
+    devServer: {
+      framework: 'angular',
+      bundler: 'webpack',
+      options: {
+        projectConfig: {
+          root: '',
+          sourceRoot: 'apps/my-app',
+          buildOptions: {
+            outputPath: 'dist/my-app',
+            index: 'apps/my-app/src/index.html',
+            main: 'apps/my-app/src/main.ts',
+            polyfills: 'apps/my-app/src/polyfills.ts',
+            tsConfig: 'apps/my-app/tsconfig.app.json',
+            inlineStyleLanguage: 'scss',
+            assets: ['apps/my-app/src/favicon.ico', 'apps/my-app/src/assets'],
+            styles: ['apps/my-app/src/styles.scss'],
+            scripts: [],
+            buildOptimizer: false,
+            optimization: false,
+            vendorChunk: true,
+            extractLicenses: false,
+            sourceMap: true,
+            namedChunks: true,
+          },
         },
       },
     },


### PR DESCRIPTION
This PR wraps the current `options API` configuration and puts it inside the `devServer` option where it is suppose to live. 