### PR TITLE
Fix a typo - should refer to at sign instead of ampersand

### DIFF
--- a/docs/guides/component-testing/vue/quickstart.mdx
+++ b/docs/guides/component-testing/vue/quickstart.mdx
@@ -368,7 +368,7 @@ we click the increment button.
 The next line is a bit different. We've seen how we can use the `cy.get()`
 method to select elements, but we can also use it to grab any aliases we've set
 up previously. We use `cy.get()` to grab the alias to the spy (by prepending an
-ampersand to the alias name). We assert that the method was called with the
+at sign to the alias name). We assert that the method was called with the
 expected value.
 
 With that, the `Stepper` component is well tested. Nice job!


### PR DESCRIPTION
In the `Testing Vue Components with Events` section towards the end of the document, the text should say "at sign" instead of "ampersand".