### PR TITLE
docs: delete videos without failing/retried tests

### DIFF
--- a/docs/guides/guides/screenshots-and-videos.mdx
+++ b/docs/guides/guides/screenshots-and-videos.mdx
@@ -149,18 +149,21 @@ import fs from 'fs'
 ```
 
 ```ts
-on('after:spec', (spec: Cypress.Spec, results: CypressCommandLine.RunResult) => {
-  if (results && results.video) {
-    // Do we have failures for any retry attempts?
-    const failures = results.tests.some((test) =>
-      test.attempts.some((attempt) => attempt.state === 'failed')
-    )
-    if (!failures) {
-      // delete the video if the spec passed and no tests retried
-      fs.unlinkSync(results.video)
+on(
+  'after:spec',
+  (spec: Cypress.Spec, results: CypressCommandLine.RunResult) => {
+    if (results && results.video) {
+      // Do we have failures for any retry attempts?
+      const failures = results.tests.some((test) =>
+        test.attempts.some((attempt) => attempt.state === 'failed')
+      )
+      if (!failures) {
+        // delete the video if the spec passed and no tests retried
+        fs.unlinkSync(results.video)
+      }
     }
   }
-})
+)
 ```
 
 :::

--- a/docs/guides/guides/screenshots-and-videos.mdx
+++ b/docs/guides/guides/screenshots-and-videos.mdx
@@ -145,22 +145,19 @@ retry attempts or failures when using Cypress
 :::cypress-config-plugin-example
 
 ```ts
-// need to install these dependencies
-// npm i lodash del --save-dev
-import _ from 'lodash'
-import del from 'del'
+import fs from 'fs'
 ```
 
 ```ts
-on('after:spec', (spec, results) => {
+on('after:spec', (spec: Cypress.Spec, results: CypressCommandLine.RunResult) => {
   if (results && results.video) {
     // Do we have failures for any retry attempts?
-    const failures = _.some(results.tests, (test) => {
-      return _.some(test.attempts, { state: 'failed' })
-    })
+    const failures = results.tests.some((test) =>
+      test.attempts.some((attempt) => attempt.state === 'failed')
+    )
     if (!failures) {
       // delete the video if the spec passed and no tests retried
-      return del(results.video)
+      fs.unlinkSync(results.video)
     }
   }
 })


### PR DESCRIPTION
The current example in the docs requires `del` and `lodash` packages to be installed.
This action can be achieved using only `Array.prototype.some()` and the Node `fs` library.