### PR TITLE
Correct specific version number for GitHub Action

### DIFF
--- a/docs/guides/continuous-integration/github-actions.mdx
+++ b/docs/guides/continuous-integration/github-actions.mdx
@@ -71,7 +71,7 @@ For Example:
 jobs:
   cypress-run:
     steps:
-      uses: cypress-io/github-action@v5.2.0
+      uses: cypress-io/github-action@v5.1.0
 ```
 
 ## Basic Setup


### PR DESCRIPTION
The [GitHub Actions documentation](https://docs.cypress.io/guides/continuous-integration/github-actions) currently specifies version 5.2.0 of `cypress-io/github-action`  as an example for running a specific version number of the action, however this version doesn't exist yet.

I've switched it out for the latest version of the action (5.1.0).