### PR TITLE
Remove Cypress fiddle from debugging page

### DIFF
--- a/docs/guides/guides/debugging.mdx
+++ b/docs/guides/guides/debugging.mdx
@@ -271,14 +271,6 @@ The `cy.now()` command is an internal command and may change in the future.
 
 :::
 
-## Cypress fiddle
-
-While learning Cypress it may be a good idea to try small tests against some
-HTML. We have written a
-[@cypress/fiddle](https://github.com/cypress-io/cypress-fiddle) plugin for this.
-It can quickly mount any given HTML and run some Cypress test commands against
-it.
-
 ## Troubleshooting Cypress
 
 There are times when you will encounter errors or unexpected behavior with

--- a/docs/guides/references/changelog.mdx
+++ b/docs/guides/references/changelog.mdx
@@ -7144,9 +7144,8 @@ _Released 10/23/2019_
 - Added a new section on troubleshooting problems with Xvfb to the
   [Continuous Integration](/guides/continuous-integration/introduction#Xvfb)
   doc.
-- Added a section to our Debugging
-  doc about our `cypress-fiddle` plugin used for playing around with small test
-  cases.
+- Added a section to our Debugging doc about our `cypress-fiddle` plugin used
+  for playing around with small test cases.
 - Added a section to our [Debugging](/guides/guides/debugging#Patch-Cypress) doc
   explaining how to patch an installed version of Cypress.
 - Mention not needing to decode portions of the `url` in the `cy.route()` doc.

--- a/docs/guides/references/changelog.mdx
+++ b/docs/guides/references/changelog.mdx
@@ -7144,7 +7144,7 @@ _Released 10/23/2019_
 - Added a new section on troubleshooting problems with Xvfb to the
   [Continuous Integration](/guides/continuous-integration/introduction#Xvfb)
   doc.
-- Added a section to our [Debugging](/guides/guides/debugging#Cypress-fiddle)
+- Added a section to our Debugging
   doc about our `cypress-fiddle` plugin used for playing around with small test
   cases.
 - Added a section to our [Debugging](/guides/guides/debugging#Patch-Cypress) doc


### PR DESCRIPTION
cypress-fiddle project has been archived since it's not actively maintained. I removed it from the Debugging page. I left it on the plugins page since it has a 'community' flag, perhaps someone would find value from it or want to fork it, but they'd be able to clearly see it's not actively maintained from the archived repo.