### PR TITLE
Update introduction-to-cypress.mdx

### DIFF
--- a/docs/guides/core-concepts/introduction-to-cypress.mdx
+++ b/docs/guides/core-concepts/introduction-to-cypress.mdx
@@ -836,7 +836,7 @@ commands that were enqueued using the `cy.*` command chains.
 it('hides the thing when it is clicked', () => {
   -{cy.visit('/my/resource/path')::cy.mount(<MyComponent />)}- // 1.
 
-    cy.get('.hides-when-clicked') // 2
+  cy.get('.hides-when-clicked') // 2
     .should('be.visible') // 3
     .click() // 4
 


### PR DESCRIPTION
Fix code block indentation for Core concepts → Introduction to Cypress → Chains of Commands → Commands Run Serially.

Direct URL: https://docs.cypress.io/guides/core-concepts/introduction-to-cypress#Commands-Run-Serially