### PR TITLE
docs: updating supported browser versions

### DIFF
--- a/docs/guides/guides/launching-browsers.mdx
+++ b/docs/guides/guides/launching-browsers.mdx
@@ -49,8 +49,8 @@ browser by using the drop down near the top right corner:
 
 Cypress supports the browser versions below:
 
-- Chrome 64 and above.
-- Edge 79 and above.
+- Chrome 80 and above.
+- Edge 80 and above.
 - Firefox 86 and above.
 
 ### Download specific Chrome version


### PR DESCRIPTION
Cypress uses the [nullish coalescing operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing#browser_compatibility) which isn't available until Chromium 80.