### PR TITLE
Typo in changelog regarding version 9.2.1

### DIFF
--- a/docs/guides/references/changelog.mdx
+++ b/docs/guides/references/changelog.mdx
@@ -2554,7 +2554,7 @@ _Released 1/18/2022_
 - Upgraded `electron` from `15.2.0` to `15.3.4`. Addressed in
   [#19351](https://github.com/cypress-io/cypress/issues/19351).
 
-# 9.2.1
+## 9.2.1
 
 _Released 1/10/2022_
 


### PR DESCRIPTION
Typo which does not recognize the version 9.2.1 as a new section.