### PR TITLE
docs: Mention webkit experiment in cross-browser section

### DIFF
--- a/docs/guides/overview/why-cypress.mdx
+++ b/docs/guides/overview/why-cypress.mdx
@@ -122,7 +122,9 @@ do that no other testing framework can:
   results for zero-configuration debugging.
 - **Cross browser Testing:** Run tests within Firefox and Chrome-family browsers
   (including Edge and Electron) locally and
-  [optimally in a Continuous Integration pipeline](/guides/guides/cross-browser-testing).
+  [optimally in a Continuous Integration pipeline](/guides/guides/cross-browser-testing). 
+  Expirimental support is also provided for Safari's browser engine,
+  [WebKit](/guides/guides/launching-browsers#WebKit-Experimental).
 - **Smart Orchestration:** Once you're set up to record to Cypress Cloud, easily
   [parallelize](/guides/guides/parallelization) your test suite, rerun failed
   specs first with


### PR DESCRIPTION
We refer to WebKit in several parts of our documentation, it would make sense to include it in the "Why Cypress?" overview as well.