### PR TITLE
Remove invalid `firefoxGcInterval` configuration

### DIFF
--- a/docs/guides/references/configuration.mdx
+++ b/docs/guides/references/configuration.mdx
@@ -607,126 +607,6 @@ The `**/node_modules/**` pattern is automatically added to `excludeSpecPattern`
 and does not need to be specified (and can't be overridden). See [`e2e`](#e2e)
 or [`component`](#component) testing-specific options.
 
-### firefoxGcInterval
-
-:::caution
-
-The following section only applies if you are using a version of Firefox older
-than Firefox 80. `firefoxGcInterval` has no effect if you are using Firefox 80
-or newer, since the garbage collection bug was fixed in Firefox 80. It is
-recommended to upgrade your version of Firefox to avoid this workaround.
-
-:::
-
-Firefox versions 79 and earlier have a
-[bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1608501) where it does not
-run its internal garbage collection (GC) fast enough, which can lead to
-consuming all available system memory and crashing.
-
-Cypress prevents Firefox from crashing by forcing Firefox to run its GC cleanup
-routines between tests.
-
-Running GC is an expensive and **blocking** routine. It adds significant time to
-the overall run, and causes Firefox to "freeze" for the duration of GC cleanup.
-This causes the browser not to respond to any user input.
-
-Cypress runs GC cleanup during
-[cypress run](/guides/guides/command-line#cypress-run) only because we don't
-expect users to interact with the browser - since this is typically run in CI.
-We've disabled running GC during
-[cypress open](/guides/guides/command-line#cypress-open) because users typically
-interact with the browser.
-
-Because GC adds additional time to the overall run, we've added the amount of
-time this routine has taken to the bottom of the Cypress Command Log.
-
-<DocsImage
-  src="/img/guides/configuration/firefox-gc-interval-in-command-log.jpg"
-  alt="GC duration shown"
-/>
-
-#### Configuration
-
-You can control how often GC cleanup runs via the `firefoxGcInterval`
-configuration value.
-
-`firefoxGcInterval` controls whether Cypress forces Firefox to run GC cleanup
-and how frequently.
-
-By default, we force GC cleanup between every test during
-[cypress run](/guides/guides/command-line#cypress-run), but do not run any GC
-cleanup during [cypress open](/guides/guides/command-line#cypress-open) using
-the configuration below:
-
-:::cypress-config-example
-
-```ts
-{
-  firefoxGcInterval: {
-    runMode: 1,
-    openMode: null,
-  },
-}
-```
-
-:::
-
-You can override how often Cypress runs GC cleanup by setting the
-`firefoxGcInterval` config value to:
-
-- `null`, to disable it for both
-  [cypress run](/guides/guides/command-line#cypress-run) and
-  [cypress open](/guides/guides/command-line#cypress-open)
-- a `number`, which sets the interval for both
-  [cypress run](/guides/guides/command-line#cypress-run) and
-  [cypress open](/guides/guides/command-line#cypress-open)
-- an `object` to set different intervals for each mode
-
-**Examples**
-
-Turn off GC cleanup all modes
-
-:::cypress-config-example
-
-```ts
-{
-  firefoxGcInterval: null,
-}
-```
-
-:::
-
-Run GC cleanup before every other test during
-[cypress run](/guides/guides/command-line#cypress-run) and
-[cypress open](/guides/guides/command-line#cypress-open)
-
-:::cypress-config-example
-
-```ts
-{
-  firefoxGcInterval: 2,
-}
-```
-
-:::
-
-Run GC cleanup before every 3rd test during
-[cypress run](/guides/guides/command-line#cypress-run) and disable running GC
-cleanup during [cypress open](/guides/guides/command-line#cypress-open).
-
-:::cypress-config-example
-
-```ts
-{
-  firefoxGcInterval: {
-    runMode: 3,
-    openMode: null,
-  },
-}
-```
-
-:::
-
 ### isInteractive
 
 You can open Cypress in the interactive mode via the `cypress open` command, and
@@ -864,7 +744,7 @@ DEBUG=cypress:cli,cypress:server:specs
 | [10.4.0](/guides/references/changelog#10-4-0) | Added `e2e.testIsolation` option.                                                     |
 | [10.0.0](/guides/references/changelog#10-0-0) | Reworked page to support new `cypress.config.js` and deprecated `cypress.json` files. |
 | [8.7.0](/guides/references/changelog#8-7-0)   | Added `slowTestThreshold` option.                                                     |
-| [8.0.0](/guides/references/changelog#8-0-0)   | Added `clientCertificates` option.                                                    |
+| [8.0.0](/guides/references/changelog#8-0-0)   | Added `clientCertificates` option and removed `firefoxGcInterval` configuration.      |
 | [7.0.0](/guides/references/changelog#7-0-0)   | Added `e2e` and `component` options.                                                  |
 | [7.0.0](/guides/references/changelog#7-0-0)   | Added `redirectionLimit` option.                                                      |
 | [6.1.0](/guides/references/changelog#6-1-0)   | Added `scrollBehavior` option.                                                        |


### PR DESCRIPTION
Removed in Cypress 8.0.0 when Firefox < 86 support was dropped. Addressed in https://github.com/cypress-io/cypress/pull/17368. 

See warning message when this configuration is passed: https://github.com/cypress-io/cypress/blob/1c5a67fa927e16620966e977f12cd8a7c3ff69fc/packages/errors/src/errors.ts#L1231