### PR TITLE
fix typo descendents to descendants

### DIFF
--- a/docs/guides/references/assertions.mdx
+++ b/docs/guides/references/assertions.mdx
@@ -115,7 +115,7 @@ You will commonly use these chainers after using DOM commands like:
 | exist                   | `.should('exist')`<br />`expect($nonexistent).not.to.exist`                                                                  |
 | match(_selector_)       | `.should('match', ':empty')`<br />`expect($emptyEl).to.match(':empty')`                                                      |
 | contain(_text_)         | `.should('contain', 'text')`<br />`expect($el).to.contain('text')`                                                           |
-| descendants(_selector_) | `.should('have.descendents', 'div')`<br />`expect($el).to.have.descendants('div')`                                           |
+| descendants(_selector_) | `.should('have.descendants', 'div')`<br />`expect($el).to.have.descendants('div')`                                           |
 
 <!-- textlint-enable -->
 


### PR DESCRIPTION
changing ".should('have.descend**e**nts', 'div')" to ".should('have.descend**a**nts', 'div')", which is correct.