### PR TITLE
Update Buildkite CI build id env variables

### DIFF
--- a/docs/guides/guides/parallelization.mdx
+++ b/docs/guides/guides/parallelization.mdx
@@ -381,6 +381,7 @@ build ID for a test run:
 | Azure Pipelines | `BUILD_BUILDNUMBER`                      |
 | Bamboo          | `bamboo_buildNumber`                     |
 | Bitbucket       | `BITBUCKET_BUILD_NUMBER`                 |
+| Buildkite       | `BUILDKITE_BUILD_ID`                     |
 | Circle          | `CIRCLE_WORKFLOW_ID`, `CIRCLE_BUILD_NUM` |
 | Codeship        | `CI_BUILD_NUMBER`                        |
 | Codeship Basic  | `CI_BUILD_NUMBER`                        |


### PR DESCRIPTION
The build id for Buildkite is being created with `BUILDKITE_BUILD_ID` when the user do not specify a custom ci-build-id 