### PR TITLE
add pnpm and yarn to github-action capabilities

### DIFF
--- a/docs/guides/continuous-integration/github-actions.mdx
+++ b/docs/guides/continuous-integration/github-actions.mdx
@@ -45,9 +45,9 @@ actions used below.
 
 The Cypress team maintains the official
 [Cypress GitHub Action](https://github.com/marketplace/actions/cypress-io) for
-running Cypress tests. This action provides npm installation, custom caching,
-additional configuration options and simplifies setup of advanced workflows with
-Cypress in the GitHub Actions platform.
+running Cypress tests. This action provides npm, pnpm or yarn installation,
+custom caching, additional configuration options and simplifies setup of
+advanced workflows with Cypress in the GitHub Actions platform.
 
 ### Explicit Version Number
 


### PR DESCRIPTION
In addition to handling npm-based repositories https://github.com/cypress-io/github-action offers pnpm, Yarn Classic and Yarn Modern support. See https://github.com/cypress-io/github-action#examples

![image](https://user-images.githubusercontent.com/66998419/227557691-05e3e37c-d7eb-4513-8770-79d722cc52e3.png)

`pnpm` and `yarn` are now explicitly mentioned in 

https://docs.cypress.io/guides/continuous-integration/github-actions


