### PR TITLE
Remove obsolete CI provider "shippable" from CI example list

### DIFF
--- a/docs/guides/continuous-integration/ci-provider-examples.mdx
+++ b/docs/guides/continuous-integration/ci-provider-examples.mdx
@@ -226,10 +226,6 @@ and
 - [Basic .semaphore.yml](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/basic/.semaphore.yml)
 - [Parallel .semaphore.yml](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.semaphore/semaphore.yml)
 
-### Shippable
-
-- [shippable.yml](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/shippable.yml)
-
 ### AppVeyor
 
 - [Basic Example (appveyor.yml)](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/appveyor.yml)


### PR DESCRIPTION
This PR removes the obsolete CI provider "Shippable" from [CI Provider Examples](https://docs.cypress.io/guides/continuous-integration/ci-provider-examples#Shippable). The CI provider "Shippable" is no longer operating and the link to https://github.com/cypress-io/cypress-example-kitchensink/blob/master/shippable.yml is therefore obsolete.

## Background

The former CI provider "Shippable" no longer provides a service.

- https://app.shippable.com/github/cypress-io/cypress-example-kitchensink is no longer reachable.
- http://docs.shippable.com/ is no longer reachable.
- Shippable's GitHub repositories under https://github.com/Shippable have not been updated since September 2021.

- See [We’ve Acquired Shippable to Complete DevOps Pipeline Automation From Code to Production](https://jfrog.com/blog/weve-acquired-shippable-to-complete-devops-pipeline-automation-from-code-to-production/) February 21, 2019. JFrog stated they would replace shippable with [JFrog Pipelines](https://www.jfrog.com/confluence/display/JFROG/JFrog+Pipelines) however it seems there is no simple migration from a `Shippable` workflow to a `JFrog Pipelines` workflow. `JFrog Pipelines` would have to be treated like a completely new CI provider.

## Related PR

- https://github.com/cypress-io/cypress-example-kitchensink/pull/601