### PR TITLE
docs: remove unneeded module.exports in plugin examples

### DIFF
--- a/docs/api/plugins/after-run-api.mdx
+++ b/docs/api/plugins/after-run-api.mdx
@@ -51,39 +51,36 @@ awaited before Cypress proceeds running your specs.
 :::cypress-config-plugin-example
 
 ```ts
-module.exports = (on, config) => {
-  on('after:run', (results) => {
-    // results will look something like this when run via `cypress run`:
-    // {
-    //   totalDuration: 81,
-    //   totalSuites: 0,
-    //   totalTests: 1,
-    //   totalFailed: 0,
-    //   totalPassed: 1,
-    //   totalPending: 0,
-    //   totalSkipped: 0,
-    //   browserName: 'electron',
-    //   browserVersion: '59.0.3071.115',
-    //   osName: 'darwin',
-    //   osVersion: '16.7.0',
-    //   cypressVersion: '3.1.0',
-    //   config: {
-    //     projectId: '1qv3w7',
-    //     baseUrl: 'http://example.com',
-    //     viewportWidth: 1000,
-    //     viewportHeight: 660,
-    //     // ... more properties...
-    //   }
-    //   // ... more properties...
-    //   }
-    // }
-
-    if (results) {
-      // results will be undefined in interactive mode
-      console.log(results.totalPassed, 'out of', results.totalTests, 'passed')
-    }
-  })
-}
+on('after:run', (results) => {
+  // results will look something like this when run via `cypress run`:
+  // {
+  //   totalDuration: 81,
+  //   totalSuites: 0,
+  //   totalTests: 1,
+  //   totalFailed: 0,
+  //   totalPassed: 1,
+  //   totalPending: 0,
+  //   totalSkipped: 0,
+  //   browserName: 'electron',
+  //   browserVersion: '59.0.3071.115',
+  //   osName: 'darwin',
+  //   osVersion: '16.7.0',
+  //   cypressVersion: '3.1.0',
+  //   config: {
+  //     projectId: '1qv3w7',
+  //     baseUrl: 'http://example.com',
+  //     viewportWidth: 1000,
+  //     viewportHeight: 660,
+  //     // ... more properties...
+  //   }
+  //   // ... more properties...
+  //   }
+  // }
+  if (results) {
+    // results will be undefined in interactive mode
+    console.log(results.totalPassed, 'out of', results.totalTests, 'passed')
+  }
+})
 ```
 
 :::

--- a/docs/api/plugins/after-spec-api.mdx
+++ b/docs/api/plugins/after-spec-api.mdx
@@ -56,43 +56,40 @@ further specs if there are any.
 :::cypress-config-plugin-example
 
 ```javascript
-module.exports = (on, config) => {
-  on('after:spec', (spec, results) => {
-    // spec will look something like this:
-    // {
-    //   name: 'login.cy.js',
-    //   relative: 'cypress/e2e/login.cy.js',
-    //   absolute: '/Users/janelane/my-app/cypress/e2e/login.cy.js',
-    // }
-
-    // results will look something like this:
-    // {
-    //   stats: {
-    //     suites: 0,
-    //     tests: 1,
-    //     passes: 1,
-    //     pending: 0,
-    //     skipped: 0,
-    //     failures: 0,
-    //     // ...more properties
-    //   }
-    //   reporter: 'spec',
-    //   tests: [
-    //     {
-    //       title: ['login', 'logs user in'],
-    //       state: 'passed',
-    //       body: 'function () {}',
-    //       // ...more properties...
-    //     }
-    //   ],
-    //   error: null,
-    //   video: '/Users/janelane/my-app/cypress/videos/login.cy.js.mp4',
-    //   screenshots: [],
-    //   // ...more properties...
-    // }
-    console.log('Finished running', spec.relative)
-  })
-}
+on('after:spec', (spec, results) => {
+  // spec will look something like this:
+  // {
+  //   name: 'login.cy.js',
+  //   relative: 'cypress/e2e/login.cy.js',
+  //   absolute: '/Users/janelane/my-app/cypress/e2e/login.cy.js',
+  // }
+  // results will look something like this:
+  // {
+  //   stats: {
+  //     suites: 0,
+  //     tests: 1,
+  //     passes: 1,
+  //     pending: 0,
+  //     skipped: 0,
+  //     failures: 0,
+  //     // ...more properties
+  //   }
+  //   reporter: 'spec',
+  //   tests: [
+  //     {
+  //       title: ['login', 'logs user in'],
+  //       state: 'passed',
+  //       body: 'function () {}',
+  //       // ...more properties...
+  //     }
+  //   ],
+  //   error: null,
+  //   video: '/Users/janelane/my-app/cypress/videos/login.cy.js.mp4',
+  //   screenshots: [],
+  //   // ...more properties...
+  // }
+  console.log('Finished running', spec.relative)
+})
 ```
 
 :::

--- a/docs/api/plugins/before-run-api.mdx
+++ b/docs/api/plugins/before-run-api.mdx
@@ -46,70 +46,66 @@ awaited before Cypress proceeds running your specs.
 :::cypress-config-plugin-example
 
 ```ts
-module.exports = (on, config) => {
-  on('before:run', (details) => {
-    // details will look something like this when run via `cypress run`:
-    // {
-    //   config: {
-    //     projectId: '12345',
-    //     baseUrl: 'http://example.com/',
-    //     viewportWidth: 1000,
-    //     viewportHeight: 660,
-    //     // ...more properties...
-    //   },
-    //   browser: {
-    //     name: 'electron',
-    //     version: '59.0.3071.115',
-    //     // ...more properties...
-    //   },
-    //   system: {
-    //     osName: 'darwin',
-    //     osVersion: '16.7.0',
-    //   }
-    //   cypressVersion: '6.1.0',
-    //   specs: [
-    //     {
-    //       name: 'login_cy.js',
-    //       relative: 'cypress/e2e/login_cy.js',
-    //       absolute: '/Users/janelane/app/cypress/e2e/login_cy.js',
-    //     },
-    //     // ... more specs
-    //   ],
-    //   specPattern: [
-    //     '**/*.cy.{js,jsx,ts,tsx}'
-    //   ],
-    //   parallel: false,
-    //   group: 'group-1',
-    //   tag: 'tag-1'
-    // }
-
-    // details will look something like this when run via `cypress open`:
-    // {
-    //   config: {
-    //     projectId: '12345',
-    //     baseUrl: 'http://example.com/',
-    //     viewportWidth: 1000,
-    //     viewportHeight: 660,
-    //     // ...more properties...
-    //   },
-    //   system: {
-    //     osName: 'darwin',
-    //     osVersion: '16.7.0',
-    //   }
-    //   cypressVersion: '7.0.0'
-    // }
-
-    if (details.specs && details.browser) {
-      // details.specs and details.browser will be undefined in interactive mode
-      console.log(
-        'Running',
-        details.specs.length,
-        'specs in',
-        details.browser.name
-      )
-    }
-  })
-}
+on('before:run', (details) => {
+  // details will look something like this when run via `cypress run`:
+  // {
+  //   config: {
+  //     projectId: '12345',
+  //     baseUrl: 'http://example.com/',
+  //     viewportWidth: 1000,
+  //     viewportHeight: 660,
+  //     // ...more properties...
+  //   },
+  //   browser: {
+  //     name: 'electron',
+  //     version: '59.0.3071.115',
+  //     // ...more properties...
+  //   },
+  //   system: {
+  //     osName: 'darwin',
+  //     osVersion: '16.7.0',
+  //   }
+  //   cypressVersion: '6.1.0',
+  //   specs: [
+  //     {
+  //       name: 'login_cy.js',
+  //       relative: 'cypress/e2e/login_cy.js',
+  //       absolute: '/Users/janelane/app/cypress/e2e/login_cy.js',
+  //     },
+  //     // ... more specs
+  //   ],
+  //   specPattern: [
+  //     '**/*.cy.{js,jsx,ts,tsx}'
+  //   ],
+  //   parallel: false,
+  //   group: 'group-1',
+  //   tag: 'tag-1'
+  // }
+  // details will look something like this when run via `cypress open`:
+  // {
+  //   config: {
+  //     projectId: '12345',
+  //     baseUrl: 'http://example.com/',
+  //     viewportWidth: 1000,
+  //     viewportHeight: 660,
+  //     // ...more properties...
+  //   },
+  //   system: {
+  //     osName: 'darwin',
+  //     osVersion: '16.7.0',
+  //   }
+  //   cypressVersion: '7.0.0'
+  // }
+  if (details.specs && details.browser) {
+    // details.specs and details.browser will be undefined in interactive mode
+    console.log(
+      'Running',
+      details.specs.length,
+      'specs in',
+      details.browser.name
+    )
+  }
+})
 ```
 
 :::

--- a/docs/api/plugins/before-spec-api.mdx
+++ b/docs/api/plugins/before-spec-api.mdx
@@ -47,18 +47,15 @@ awaited before Cypress proceeds running the spec.
 :::cypress-config-plugin-example
 
 ```ts
-module.exports = (on, config) => {
-  on('before:spec', (spec) => {
-    // spec will look something like this:
-    // {
-    //   name: 'login.cy.js',
-    //   relative: 'cypress/e2e/login.cy.js',
-    //   absolute: '/Users/janelane/app/cypress/e2e/login.cy.js',
-    // }
-
-    console.log('Running', spec.relative)
-  })
-}
+on('before:spec', (spec) => {
+  // spec will look something like this:
+  // {
+  //   name: 'login.cy.js',
+  //   relative: 'cypress/e2e/login.cy.js',
+  //   absolute: '/Users/janelane/app/cypress/e2e/login.cy.js',
+  // }
+  console.log('Running', spec.relative)
+})
 ```
 
 :::


### PR DESCRIPTION
I noticed that some of the Cypress plugin examples are wrapped in unnecessary `module.exports` blocks. So, I've removed them to make the examples valid.

