### PR TITLE
Update intercept.mdx pattern matching example

### DIFF
--- a/docs/api/commands/intercept.mdx
+++ b/docs/api/commands/intercept.mdx
@@ -274,7 +274,7 @@ cy.intercept({
 
 // same as above, but using regex
 cy.intercept({
-  method: '/PUT|PATCH/',
+  method: /PUT|PATCH/,
   url: '**/users/*',
 })
 ```


### PR DESCRIPTION
The second example for pattern matching in the docs for `cy.intercept()` doesn't actually use regex for the `method` field. When using this example in a test, the intended behaviour (`PUT` or `PATCH` requests being intercepted) doesn't happen.

This PR makes a slight alteration to the docs to provide an accurate and working example. From a quick glance this seems to be the only occurrence in this file, but happy to have others added if found!