### PR TITLE
Note `Cypress.Commands.add()` error

### DIFF
--- a/docs/api/cypress-api/custom-commands.mdx
+++ b/docs/api/cypress-api/custom-commands.mdx
@@ -315,6 +315,17 @@ Log? Read more about [Command Logging](#Command-Logging).
 
 :::
 
+:::caution
+
+Note that `Cypress.Commands.add()` will throw an error when trying to add a
+custom command with the same name as an existing built-in Cypress command or
+reserved internal function. In order to override the behavior of an existing
+command, `Cypress.Commands.overwrite()` should be used instead. For more
+information, read the section
+[Overwrite Existing Commands](#Overwrite-Existing-Commands).
+
+:::
+
 ### Child Commands
 
 Child commands are always chained off of a **parent** command, or another


### PR DESCRIPTION
This is a reimplementation in the new site of an [older PR](https://github.com/cypress-io/cypress-documentation/pull/4178) that never made it in.

