### PR TITLE
Update then.mdx

### DIFF
--- a/docs/api/commands/then.mdx
+++ b/docs/api/commands/then.mdx
@@ -137,6 +137,11 @@ cy.wrap(1)
     cy.wrap(num).should('equal', 1) // true
 
     return 2
+    cy.wrap(num)
+      .should("equal", 1) // true
+      .then(() => {
+        return 2
+      })
   })
   .should('equal', 2) // true
 ```


### PR DESCRIPTION
fix error:
cy.then() failed because you are mixing up async and sync code.