### PR TITLE
fix GHA caching dependencies and build artifacts example

### DIFF
--- a/docs/guides/continuous-integration/github-actions.mdx
+++ b/docs/guides/continuous-integration/github-actions.mdx
@@ -189,36 +189,44 @@ jobs:
 
 ## Caching Dependencies and Build Artifacts
 
-The Cypress team maintains the official
-[Cypress GitHub Action](https://github.com/marketplace/actions/cypress-io) for
-running Cypress tests. This action provides npm installation, custom caching,
-additional configuration options and simplifies setting up advanced workflows
-with Cypress in the GitHub Actions platform.
-
 :::info
 
 Caching of dependencies and build artifacts between installation and worker jobs
-can be accomplished with the
+can be accomplished by combining the
+[Cypress GitHub Action](https://github.com/marketplace/actions/cypress-io) with
+the GitHub
 [Upload/Download Artifact Actions](https://docs.github.com/en/actions/guides/storing-workflow-data-as-artifacts).
 
 :::
 
 The `install` job below uses the
 [upload-artifact](https://github.com/marketplace/actions/upload-a-build-artifact)
-action and will save the state of the `build` directory for the worker jobs.
+action and saves the state of the `build` directory for the `cypress-run` worker
+job.
+
+The
+[download-artifact](https://github.com/marketplace/actions/download-a-build-artifact)
+action retrieves the `build` directory saved in the `install` job, as seen below
+in the `cypress-run` worker job.
 
 ```yaml
-name: Cypress Tests with installation job
+name: Cypress Tests with Dependency and Artifact Caching
 
 on: push
 
 jobs:
   install:
     runs-on: ubuntu-22.04
-    container: cypress/browsers:node12.18.3-chrome87-ff82
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Cypress install
+        uses: cypress-io/github-action@v5
+        with:
+          # Disable running of tests within install job
+          runTests: false
+          build: npm run build
 
       - name: Save build folder
         uses: actions/upload-artifact@v3
@@ -227,48 +235,24 @@ jobs:
           if-no-files-found: error
           path: build
 
-      - name: Cypress install
-        uses: cypress-io/github-action@v5
-        with:
-          # Disable running of tests within install job
-          runTests: false
-          build: yarn build
-```
-
-The
-[download-artifact](https://github.com/marketplace/actions/download-a-build-artifact)
-action will retrieve the `build` directory saved in the install job, as seen
-below in a worker job.
-
-```yaml
-name: Cypress Tests with Dependency and Artifact Caching
-
-on: push
-
-jobs:
-  # install:
-  # ....
   cypress-run:
     runs-on: ubuntu-22.04
-    container: cypress/browsers:node12.18.3-chrome87-ff82
+    needs: install
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Download the build folders
+      - name: Download the build folder
         uses: actions/download-artifact@v3
         with:
           name: build
           path: build
 
-      # Install NPM dependencies, cache them correctly
-      # and run all Cypress tests
       - name: Cypress run
         uses: cypress-io/github-action@v5
         with:
-          # Specify Browser since container image is compiled with Firefox
-          browser: firefox
-          build: yarn build
+          start: npm start
+          browser: chrome
 ```
 
 ## Parallelization


### PR DESCRIPTION
This PR fixes and updates the example in [Guides > Continuous Integration > Github Actions](https://docs.cypress.io/guides/continuous-integration/github-actions) with the section heading [Caching Dependencies and Build Artifacts](https://docs.cypress.io/guides/continuous-integration/github-actions#Caching-Dependencies-and-Build-Artifacts).

## Issue

The example is faulty.

The example `install` job shows the steps in the wrong order. It uploads the `build` folder before this has been created.

The example `cypress-run` job downloads the `build` folder, but then overwrites it with a `yarn build` command. It should not re-build.

The [needs:](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds) key is missing, so there is no guarantee that the download of artifacts will take place *after* they have been uploaded.

## Changes

- The duplicate and out-of-date introduction about the purpose of the action is removed. This is already included in [Cypress GitHub Action](https://docs.cypress.io/guides/continuous-integration/github-actions#Cypress-GitHub-Action) at the top of the document.

- The order of `build` and `upload` in the `install` job is corrected.

- For consistency with the previous examples `npm run build` is used instead of `yarn build`.

- The incorrect `yarn build` instruction in the `cypress-run` job is removed.

- The two example snippets are merged together and linked by a `needs:` clause.
