### PR TITLE
feat: Add documentation for `stripCspDirectives` and CSP information

### DIFF
--- a/docs/guides/guides/content-security-policy.mdx
+++ b/docs/guides/guides/content-security-policy.mdx
@@ -1,0 +1,36 @@
+---
+title: Content Security Policy
+e2eSpecific: true
+---
+
+Content Security Policy (CSP) is a browser security feature that allows you to
+restrict the resources that can be loaded into your application. This can be
+problematic for Cypress, because it needs to inject JavaScript into your
+application in order to run tests and interact with the DOM. This page describes
+how Cypress handles CSP and how to configure it to work with your application.
+
+There are two ways to implement CSP:
+
+- [Meta tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#http-equiv)
+- [HTTP header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy)
+
+The `<meta>` tag implementation is fully supported by Cypress without any
+configuration required. This is because Cypress loads the necessary `<script>`
+tags into your application before any `<meta>` tag is parsed. This prevents any
+CSP directives from being applied to the script loaded by Cypress.
+
+The second implementation requires you to configure Cypress to allow the headers
+to be sent to your application. By default, Cypress will remove any CSP headers
+from the response before it is sent to the browser. This is done to prevent
+Cypress from being blocked by the browser's CSP implementation.
+
+For most application tests, this should not cause any issues. However, if you
+are testing your application's CSP implementation, you will need to configure
+Cypress to allow the headers to be sent to the browser. You can do this by
+setting the
+[`stripCspDirectives`](/guides/references/configuration#stripCspDirectives)
+configuration option.
+
+For more information on CSP, see the
+[Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP)
+documentation on MDN.

--- a/docs/guides/guides/content-security-policy.mdx
+++ b/docs/guides/guides/content-security-policy.mdx
@@ -28,7 +28,7 @@ For most application tests, this should not cause any issues. However, if you
 are testing your application's CSP implementation, you will need to configure
 Cypress to allow the headers to be sent to the browser. You can do this by
 setting the
-[`stripCspDirectives`](/guides/references/configuration#stripCspDirectives)
+[`experimentalCspAllowList`](/guides/references/experiments#Experimental-CSP-Allow-List)
 configuration option.
 
 For more information on CSP, see the

--- a/docs/guides/references/configuration.mdx
+++ b/docs/guides/references/configuration.mdx
@@ -76,6 +76,7 @@ default values.
 | `reporter`             | `spec`                            | The [reporter](/guides/tooling/reporters) used during `cypress run`.                                                                                                                         |
 | `reporterOptions`      | `null`                            | The [reporter options](/guides/tooling/reporters#Reporter-Options) used. Supported options depend on the reporter.                                                                           |
 | `retries`              | `{ "runMode": 0, "openMode": 0 }` | The number of times to retry a failing test. Can be configured to apply to `cypress run` or `cypress open` separately. See [Test Retries](/guides/guides/test-retries) for more information. |
+| `stripCspDirectives`   | `all`                             | Indicates the Content-Security-Policy directives to be stripped during a test run. See [Content-Security-Policy](/guides/guides/content-security-policy) for more information.               |
 | `watchForFileChanges`  | `true`                            | Whether Cypress will watch and restart tests on test file changes.                                                                                                                           |
 
 ### Timeouts
@@ -363,6 +364,7 @@ readonly and cannot be changed at run time.
 - `screenshotOnRunFailure`
 - `scrollBehavior`
 - `slowTestThreshold`
+- `stripCspDirectives`
 - `testIsolation` - this option can only be overridden at the suite-specific
   override level
 - `viewportHeight`
@@ -681,6 +683,47 @@ This function was added in Cypress version `10.0.0` to replace the deprecated
 :::
 
 See the [plugins guide](/guides/tooling/plugins-guide) for more information.
+
+### stripCspDirectives
+
+Cypress will (by default) strip all CSP headers from the response before it is
+sent to the browser. This option allows for more granular control over which CSP
+directives are stripped from the CSP response headers, allowing you to test your
+application with CSP enabled.
+
+#### Strip All CSP Headers
+
+The default value of `stripCspDirectives` is `"all"`. This will remove all CSP
+headers from the response before it is sent to the browser. This option should
+be used if you do not depend on CSP for any tests in your application.
+
+#### Strip Minimum CSP Directives
+
+If you need to test your application with CSP enabled, you can set the
+`stripCspDirectives` option to `"minimum"`. This will allow all CSP headers to
+be sent to the browser _*except*_ those that would prevent Cypress from
+functioning Normally. The following CSP directives are automatically stripped
+from the CSP headers when `stripCspDirectives` is set to `"minimum"`:
+
+| Stripped Directive | Reason                                                                          |
+| ------------------ | ------------------------------------------------------------------------------- |
+| `frame-ancestors`  | This directive prevents Cypress from loading a test application into an iframe. |
+
+#### Strip Specific CSP Directives
+
+If you need to test your application with CSP enabled, but need to strip
+specific CSP directives, you can set the `stripCspDirectives` option to an array
+of directive names. This will allow all CSP directives to be sent to the browser
+_except_ those that are defined in the `stripCspDirectives` array.
+
+:::caution
+
+Defining `stripCspDirectives` _*without*_ including the directives listed in the
+[minimum directives table](#Strip-Minimum-CSP-Directives) will potentially cause
+Cypress to be unable to run tests against your application. This may be desired
+if you are testing against specific CSP directives.
+
+:::
 
 ## Common problems
 

--- a/docs/guides/references/configuration.mdx
+++ b/docs/guides/references/configuration.mdx
@@ -76,7 +76,6 @@ default values.
 | `reporter`             | `spec`                            | The [reporter](/guides/tooling/reporters) used during `cypress run`.                                                                                                                         |
 | `reporterOptions`      | `null`                            | The [reporter options](/guides/tooling/reporters#Reporter-Options) used. Supported options depend on the reporter.                                                                           |
 | `retries`              | `{ "runMode": 0, "openMode": 0 }` | The number of times to retry a failing test. Can be configured to apply to `cypress run` or `cypress open` separately. See [Test Retries](/guides/guides/test-retries) for more information. |
-| `stripCspDirectives`   | `all`                             | Indicates the Content-Security-Policy directives to be stripped during a test run. See [Content-Security-Policy](/guides/guides/content-security-policy) for more information.               |
 | `watchForFileChanges`  | `true`                            | Whether Cypress will watch and restart tests on test file changes.                                                                                                                           |
 
 ### Timeouts
@@ -364,7 +363,6 @@ readonly and cannot be changed at run time.
 - `screenshotOnRunFailure`
 - `scrollBehavior`
 - `slowTestThreshold`
-- `stripCspDirectives`
 - `testIsolation` - this option can only be overridden at the suite-specific
   override level
 - `viewportHeight`
@@ -683,47 +681,6 @@ This function was added in Cypress version `10.0.0` to replace the deprecated
 :::
 
 See the [plugins guide](/guides/tooling/plugins-guide) for more information.
-
-### stripCspDirectives
-
-Cypress will (by default) strip all CSP headers from the response before it is
-sent to the browser. This option allows for more granular control over which CSP
-directives are stripped from the CSP response headers, allowing you to test your
-application with CSP enabled.
-
-#### Strip All CSP Headers
-
-The default value of `stripCspDirectives` is `"all"`. This will remove all CSP
-headers from the response before it is sent to the browser. This option should
-be used if you do not depend on CSP for any tests in your application.
-
-#### Strip Minimum CSP Directives
-
-If you need to test your application with CSP enabled, you can set the
-`stripCspDirectives` option to `"minimum"`. This will allow all CSP headers to
-be sent to the browser _*except*_ those that would prevent Cypress from
-functioning Normally. The following CSP directives are automatically stripped
-from the CSP headers when `stripCspDirectives` is set to `"minimum"`:
-
-| Stripped Directive | Reason                                                                          |
-| ------------------ | ------------------------------------------------------------------------------- |
-| `frame-ancestors`  | This directive prevents Cypress from loading a test application into an iframe. |
-
-#### Strip Specific CSP Directives
-
-If you need to test your application with CSP enabled, but need to strip
-specific CSP directives, you can set the `stripCspDirectives` option to an array
-of directive names. This will allow all CSP directives to be sent to the browser
-_except_ those that are defined in the `stripCspDirectives` array.
-
-:::caution
-
-Defining `stripCspDirectives` _*without*_ including the directives listed in the
-[minimum directives table](#Strip-Minimum-CSP-Directives) will potentially cause
-Cypress to be unable to run tests against your application. This may be desired
-if you are testing against specific CSP directives.
-
-:::
 
 ## Common problems
 

--- a/docs/guides/references/experiments.mdx
+++ b/docs/guides/references/experiments.mdx
@@ -65,7 +65,9 @@ The following CSP directives will always be stripped:
 | Stripped Directive          | Allowable | Reason                                                           |
 | --------------------------- | --------- | ---------------------------------------------------------------- |
 | `frame-ancestors`           | No        | Prevents Cypress from loading a test application into an iframe. |
+| `navigate-to`               | No        | Affects Cypress' ability to navigate to different URLs.          |
 | `require-trusted-types-for` | No        | Might prevent Cypress from rewriting the DOM.                    |
+| `sandbox`                   | No        | Can restrict access to script and iframe functionality.          |
 | `trusted-types`             | No        | Could cause Cypress injections to be marked as untrusted.        |
 
 When `experimentalCspAllowList=true` the following directives are also stripped
@@ -78,8 +80,6 @@ sent to the browser:
 | `default-src`      | Yes       | Conditionally prevents Cypress from loading scripts and running.              |
 | `frame-src`        | Yes       | Could prevent iframes from loading in combination with other Cypress options. |
 | `form-action`      | Yes       | Can prevent Cypress from monitoring form events.                              |
-| `navigate-to`      | Yes       | Affects Cypress' ability to navigate to different URLs.                       |
-| `sandbox`          | Yes       | Can restrict access to script and iframe functionality.                       |
 | `script-src`       | Yes       | Conditionally prevents Cypress from loading scripts and running.              |
 | `script-src-elem`  | Yes       | Conditionally prevents Cypress from loading scripts and running.              |
 

--- a/docs/guides/references/experiments.mdx
+++ b/docs/guides/references/experiments.mdx
@@ -72,14 +72,16 @@ When `experimentalCspAllowList=true` the following directives are also stripped
 in addition to the ones listed above, but can be configured to be allowed to be
 sent to the browser:
 
-| Stripped Directive | Allowable | Reason                                                           |
-| ------------------ | --------- | ---------------------------------------------------------------- |
-| `default-src`      | Yes       | Conditionally prevents Cypress from loading scripts and running. |
-| `sandbox`          | Yes       | Can restrict access to script and iframe functionality.          |
-| `form-action`      | Yes       | Can prevent Cypress from monitoring form events.                 |
-| `navigate-to`      | Yes       | Affects Cypress' ability to navigate to different URLs.          |
-| `script-src`       | Yes       | Conditionally prevents Cypress from loading scripts and running. |
-| `script-src-elem`  | Yes       | Conditionally prevents Cypress from loading scripts and running. |
+| Stripped Directive | Allowable | Reason                                                                        |
+| ------------------ | --------- | ----------------------------------------------------------------------------- |
+| `child-src`        | Yes       | Could prevent iframes from loading in combination with other Cypress options. |
+| `default-src`      | Yes       | Conditionally prevents Cypress from loading scripts and running.              |
+| `frame-src`        | Yes       | Could prevent iframes from loading in combination with other Cypress options. |
+| `form-action`      | Yes       | Can prevent Cypress from monitoring form events.                              |
+| `navigate-to`      | Yes       | Affects Cypress' ability to navigate to different URLs.                       |
+| `sandbox`          | Yes       | Can restrict access to script and iframe functionality.                       |
+| `script-src`       | Yes       | Conditionally prevents Cypress from loading scripts and running.              |
+| `script-src-elem`  | Yes       | Conditionally prevents Cypress from loading scripts and running.              |
 
 #### Allow Specific CSP Directives
 

--- a/docs/guides/references/experiments.mdx
+++ b/docs/guides/references/experiments.mdx
@@ -25,12 +25,94 @@ configuration to Cypress.
 
 | Option                                        | Default | Description                                                                                                                                                                                                                                                                                                                    |
 | --------------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `experimentalCspAllowList`                    | `false` | Indicates the Content-Security-Policy directives to be permitted during a test run. See [Content-Security-Policy](/guides/guides/content-security-policy) for more information.                                                                                                                                                |
 | `experimentalFetchPolyfill`                   | `false` | Automatically replaces `window.fetch` with a polyfill that Cypress can spy on and stub. Note: `experimentalFetchPolyfill` has been deprecated in Cypress 6.0.0 and will be removed in a future release. Consider using [cy.intercept()](/api/commands/intercept) to intercept `fetch` requests instead.                        |
 | `experimentalInteractiveRunEvents`            | `false` | Allows listening to the [`before:run`](/api/plugins/before-run-api), [`after:run`](/api/plugins/after-run-api), [`before:spec`](/api/plugins/before-spec-api), and [`after:spec`](/api/plugins/after-spec-api) events in the [setupNodeEvents](/guides/tooling/plugins-guide#Using-a-plugin) function during interactive mode. |
 | `experimentalMemoryManagement`                | `false` | Enables support for improved memory management within Chromium-based browsers.                                                                                                                                                                                                                                                 |
 | `experimentalModifyObstructiveThirdPartyCode` | `false` | Whether Cypress will search for and replace obstructive code in third party `.js` or `.html` files. NOTE: Setting this flag removes [Subresource Integrity (SRI)](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity).                                                                                |
 | `experimentalSourceRewriting`                 | `false` | Enables AST-based JS/HTML rewriting. This may fix issues caused by the existing regex-based JS/HTML replacement algorithm. See [#5273](https://github.com/cypress-io/cypress/issues/5273) for details.                                                                                                                         |
 | `experimentalWebKitSupport`                   | `false` | Enable experimental support for running tests in WebKit. When set, installs of `playwright-webkit` will be detected and available in Cypress. See [Launching Browsers](/guides/guides/launching-browsers#WebKit-Experimental) for more information.                                                                            |
+
+### Experimental CSP Allow List
+
+Cypress by default strips all CSP headers (`Content-Security-Policy` and
+`Content-Security-Policy-Report-Only`) from the response before it is sent to
+the browser. The `experimentalCspAllowList` option allows for more granular
+control over which CSP directives are stripped from the CSP response headers,
+allowing you to test your application with CSP enabled. Valid values for this
+option are `false` (the default), `true`, or an array of CSP directive names.
+
+| Value                                                 | Example                                                 |
+| ----------------------------------------------------- | ------------------------------------------------------- |
+| [`false` (default)](#Strip-All-CSP-Headers)           | `experimentalCspAllowList=false`                        |
+| [`true`](#Strip-Minimum-CSP-Directives)               | `experimentalCspAllowList=true`                         |
+| [`<CspDirectives>[]`](#Allow-Specific-CSP-Directives) | `experimentalCspAllowList=["default-src","script-src"]` |
+
+#### Strip All CSP Headers
+
+The value `experimentalCspAllowList=false` (default) will remove all CSP headers
+from the response before it is sent to the browser. This option should be used
+if you do not depend on CSP for any tests in your application.
+
+#### Strip Minimum CSP Directives
+
+If you need to test your application with CSP enabled, setting the
+`experimentalCspAllowList` option will allow all CSP headers to be sent to the
+browser _*except*_ those that could prevent Cypress from functioning normally.
+
+The following CSP directives will always be stripped:
+
+| Stripped Directive          | Allowable | Reason                                                           |
+| --------------------------- | --------- | ---------------------------------------------------------------- |
+| `frame-ancestors`           | No        | Prevents Cypress from loading a test application into an iframe. |
+| `require-trusted-types-for` | No        | Might prevent Cypress from rewriting the DOM.                    |
+| `trusted-types`             | No        | Could cause Cypress injections to be marked as untrusted.        |
+
+When `experimentalCspAllowList=true` the following directives are also stripped
+in addition to the ones listed above, but can be configured to be allowed to be
+sent to the browser:
+
+| Stripped Directive | Allowable | Reason                                                           |
+| ------------------ | --------- | ---------------------------------------------------------------- |
+| `default-src`      | Yes       | Conditionally prevents Cypress from loading scripts and running. |
+| `sandbox`          | Yes       | Can restrict access to script and iframe functionality.          |
+| `form-action`      | Yes       | Can prevent Cypress from monitoring form events.                 |
+| `navigate-to`      | Yes       | Affects Cypress' ability to navigate to different URLs.          |
+| `script-src`       | Yes       | Conditionally prevents Cypress from loading scripts and running. |
+| `script-src-elem`  | Yes       | Conditionally prevents Cypress from loading scripts and running. |
+
+#### Allow Specific CSP Directives
+
+Set the `experimentalCspAllowList` option to an array of directive names marked
+as "Allowable" from the list above. This will allow the specified CSP directives
+to be sent to the browser.
+
+The following configuration would allow the `default-src`, `script-src`, and
+`script-src-elem` directives to be sent to the browser:
+
+:::cypress-config-example
+
+```js
+{
+  experimentalCspAllowList: ['default-src', 'script-src', 'script-src-elem']
+}
+```
+
+:::
+
+:::caution
+
+Defining `experimentalCspAllowList` _*may*_ cause Cypress to be unable to run
+tests against your application. If you experience issues, reduce the directives
+specified in your allow list to identify which directive is causing issues.
+
+There is a known issue when using certain directives containing hash algorithm
+values and the `modifyObstructiveCode` and/or `experimentalSourceRewriting`
+options. Using these options in combination with the `experimentalCspAllowList`
+option can cause a mismatch between the original hashed directive value, and the
+modified HTML or JS value.
+
+:::
 
 ## Testing Type-Specific Experiments
 


### PR DESCRIPTION
Documentation for ~~`stripCspDirectives`~~ [`experimentalCspAllowList` feature](https://github.com/cypress-io/cypress/pull/26483)