### PR TITLE
Update parallelization containers to Node.js 16

### DIFF
--- a/docs/guides/continuous-integration/github-actions.mdx
+++ b/docs/guides/continuous-integration/github-actions.mdx
@@ -302,7 +302,7 @@ on: push
 jobs:
   install:
     runs-on: ubuntu-22.04
-    container: cypress/browsers:node12.18.3-chrome87-ff82
+    container: cypress/browsers:node16.16.0-chrome105-ff104-edge
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -353,7 +353,7 @@ jobs:
 
   ui-chrome-tests:
     runs-on: ubuntu-22.04
-    container: cypress/browsers:node12.18.3-chrome87-ff82
+    container: cypress/browsers:node16.16.0-chrome105-ff104-edge
     needs: install
     strategy:
       fail-fast: false
@@ -427,7 +427,7 @@ the configuration that was used in the install job.
 #...
 ui-chrome-tests:
   runs-on: ubuntu-22.04
-  container: cypress/browsers:node12.18.3-chrome87-ff82
+  container: cypress/browsers:node16.16.0-chrome105-ff104-edge
   needs: install
   strategy:
     fail-fast: false


### PR DESCRIPTION
This PR updates the example in [Guides > Continuous Integration > Github Actions](https://docs.cypress.io/guides/continuous-integration/github-actions) with the section heading [Parallelization](https://docs.cypress.io/guides/continuous-integration/github-actions#Parallelization).

The container is updated from:

- `container: cypress/browsers:node12.18.3-chrome87-ff82`to
- `container: cypress/browsers:node16.16.0-chrome105-ff104-edge`

to match the workflow [cypress-io/cypress-realworld-app (RWA): .github/workflows/main.yml](https://github.com/cypress-io/cypress-realworld-app/blob/develop/.github/workflows/main.yml).

## Background

The [YouTube video](https://youtu.be/96Yn_IiQUJI) at the beginning of the section introduces parallelization on the [cypress-io/cypress-realworld-app (RWA)](https://github.com/cypress-io/cypress-realworld-app) with reference to the workflow [.github/workflows/main.yml](https://github.com/cypress-io/cypress-realworld-app/blob/develop/.github/workflows/main.yml).

The workflow structure which the video describes is correct. The version references are however out of date. I don't think that matters as it can't be expected to record a new video for every version change.

The [RWA](https://github.com/cypress-io/cypress-realworld-app) is currently tied to using Node.js `16.16.0`, according to [.node-version](https://github.com/cypress-io/cypress-realworld-app/blob/develop/.node-version).

The workflow [.github/workflows/main.yml](https://github.com/cypress-io/cypress-realworld-app/blob/develop/.github/workflows/main.yml) uses:

- `image: cypress/browsers:node16.16.0-chrome105-ff104-edge`
- `uses: cypress-io/github-action@v5`
- `actions/setup-node@v3` with `node-version: '16'` (on Windows)

For consistency the documentation example should also use `image: cypress/browsers:node16.16.0-chrome105-ff104-edge`.
