### PR TITLE
Plugin: Adds entry for cypress-mailhog email plugin

### DIFF
--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -1227,6 +1227,13 @@
           "link": "https://github.com/mailslurp/cypress-mailslurp",
           "keywords": ["email", "mailslurp", "test", "commands"],
           "badge": "community"
+        },
+        {
+          "name": "cypress-mailhog",
+          "description": "A collection of usefull Cypress commands for testing Emails utilizing the MailHog RestAPI. Comes with TypeScript support.",
+          "link": "https://github.com/SMenigat/cypress-mailhog",
+          "keywords": ["email", "mailhog", "test", "commands"],
+          "badge": "community"
         }
       ]
     },

--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -1230,7 +1230,7 @@
         },
         {
           "name": "cypress-mailhog",
-          "description": "A collection of usefull Cypress commands for testing Emails utilizing the MailHog RestAPI. Comes with TypeScript support.",
+          "description": "A collection of useful Cypress commands for testing Emails utilizing the MailHog RestAPI. Comes with TypeScript support.",
           "link": "https://github.com/SMenigat/cypress-mailhog",
           "keywords": ["email", "mailhog", "test", "commands"],
           "badge": "community"


### PR DESCRIPTION
[cypress-mailhog](https://github.com/SMenigat/cypress-mailhog) is a well maintained command library that allows interaction with the MailHog RestAPI. 

Since the library is already widely used I would be very happy to see it on the official plugin list. 

Please let me know if there are any open todos to get the plugin listed. 