### PR TITLE
chore: Remove Vite 4.2 warning

### DIFF
--- a/docs/guides/component-testing/react/quickstart.mdx
+++ b/docs/guides/component-testing/react/quickstart.mdx
@@ -33,20 +33,6 @@ cd my-awesome-app
 npm install
 ```
 
-:::caution
-
-We are currently investigating an issue with Vite 4.2 and Cypress. We recommend
-manually installing Vite 4.1 in the project until the issue is resolved.
-
-```bash
-npm i vite@4.1
-```
-
-View the status of
-[issue 26138 here](https://github.com/cypress-io/cypress/issues/26138)
-
-:::
-
 > You can also download a Git repo with a fully working copy of this tutorial
 > [here](https://github.com/cypress-io/component-testing-quickstart-apps/tree/main/react).
 

--- a/docs/guides/component-testing/vue/quickstart.mdx
+++ b/docs/guides/component-testing/vue/quickstart.mdx
@@ -33,20 +33,6 @@ cd my-awesome-app
 npm install
 ```
 
-:::caution
-
-We are currently investigating an issue with Vite 4.2 and Cypress. We recommend
-manually installing Vite 4.1 in the project until the issue is resolved.
-
-```bash
-npm i vite@4.1
-```
-
-View the status of
-[issue 26138 here](https://github.com/cypress-io/cypress/issues/26138)
-
-:::
-
 > You can also download a Git repo with a fully working copy of this tutorial
 > [here](https://github.com/cypress-io/component-testing-quickstart-apps/tree/main/vue).
 


### PR DESCRIPTION
Vite 4.2 issue has been resolved as of Cypress v12.9.0 (see cypress-io/cypress#26139)