### PR TITLE
Remove very old examples from Docker examples page

### DIFF
--- a/docs/examples/docker.mdx
+++ b/docs/examples/docker.mdx
@@ -9,7 +9,7 @@ sidebar_position: 40
 
 This repo holds various Docker images for running Cypress locally and in CI.
 
-There are Docker images:
+The Docker images:
 
 - `cypress/base:<Node version>` has the operating system dependencies required
   to run Cypress.
@@ -18,25 +18,6 @@ There are Docker images:
   pre-installed Cypress versions.
 - `cypress/factory:<tag>` is a docker image that can be used with docker args to
   generate a docker container with specific versions of node, yarn, chrome,
-  firefox, edge and cypress. It is used to create the above docker images and
+  firefox, edge and cypress. It's used to create the above docker images and
   can be used by you to create a custom docker image with versions of your
   choice.
-
-## Examples
-
-| Name                                                                                                                                    | Description                                                                                              |
-| --------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
-| <Icon name="github" /> [GitLab](https://gitlab.com/cypress-io/cypress-example-docker-gitlab)                                            | Run Cypress tests in Docker on [GitLab](https://gitlab.com/)                                             |
-| <Icon name="github" /> [CircleCI 2.0](https://github.com/cypress-io/cypress-example-docker-circle)                                      | Run Cypress tests in Docker on [Circle 2.0](https://circleci.com)                                        |
-| <Icon name="github" /> [CircleCI Workflows](https://github.com/cypress-io/cypress-example-docker-circle-workflows)                      | Run Multiple Cypress tests in parallel with [Circle Workflows](https://circleci.com/docs/2.0/workflows/) |
-| <Icon name="github" /> [Codeship Pro](https://github.com/cypress-io/cypress-example-docker-codeship)                                    | Run Cypress tests in Docker on [Codeship Pro](https://codeship.com/)                                     |
-| <Icon name="github" /> [demo-docker-cypress-included](https://github.com/bahmutov/demo-docker-cypress-included)                         | Demo running the complete Docker image `cypress/included`                                                |
-| <Icon name="github" /> [cypress-example-docker-compose](https://github.com/cypress-io/cypress-example-docker-compose)                   | Run Cypress tests using docker-compose on [CircleCI](https://circleci.com/)                              |
-| <Icon name="github" /> [cypress-open-from-docker-compose](https://github.com/bahmutov/cypress-open-from-docker-compose)                 | Demo running application and Cypress tests using docker-compose                                          |
-| <Icon name="github" /> [cypress-tests-apache-in-docker](https://github.com/bahmutov/cypress-tests-apache-in-docker)                     | Run local Cypress tests against Apache running inside a Docker container                                 |
-| <Icon name="github" /> [cypress-example-docker-compose-included](https://github.com/cypress-io/cypress-example-docker-compose-included) | Cypress example with docker-compose and `cypress/included` image                                         |
-| <Icon name="github" /> [cypress-desktop](https://github.com/piopi/cypress-desktop)                                                      | Run Cypress with a desktop environment and noVNC in Docker                                               |
-
-## See also
-
-- ["Run Cypress with a single Docker command"](https://www.cypress.io/blog/2019/05/02/run-cypress-with-a-single-docker-command/)

--- a/docs/examples/docker.mdx
+++ b/docs/examples/docker.mdx
@@ -18,6 +18,5 @@ The Docker images:
   pre-installed Cypress versions.
 - `cypress/factory:<tag>` is a docker image that can be used with docker args to
   generate a docker container with specific versions of node, yarn, chrome,
-  firefox, edge and cypress. It's used to create the above docker images and
-  can be used by you to create a custom docker image with versions of your
-  choice.
+  firefox, edge and cypress. It's used to create the above docker images and can
+  be used by you to create a custom docker image with versions of your choice.


### PR DESCRIPTION
There is a large set of examples in the Docker examples page that are out of date or archived. We shouldn't be referencing out of date examples on our docs. We should refer everyone to the docker-images GitHub repo which has the most up to date examples in its Readme.

This PR removes all of the examples on the Docker examples page.

Likely there should be improvements on where information around docker images lives in the docs overall.