### PR TITLE
Update variables-and-aliases.mdx

### DIFF
--- a/docs/guides/core-concepts/variables-and-aliases.mdx
+++ b/docs/guides/core-concepts/variables-and-aliases.mdx
@@ -438,7 +438,7 @@ cy.get('@favoriteColor').then(function (aliasValue) {
 ```
 
 In the second `.then()` block, `cy.get('@favoriteColor')` runs
-`cy.wrap(favorites).its('color')` fresh each time, but `this.color` was set when
+`cy.wrap(favorites).its('color')` fresh each time, but `this.favoriteColor` was set when
 the alias was first stored, back when our favorite color was blue.
 
 ### Elements

--- a/docs/guides/core-concepts/variables-and-aliases.mdx
+++ b/docs/guides/core-concepts/variables-and-aliases.mdx
@@ -433,7 +433,7 @@ cy.then(function () {
 cy.get('@favoriteColor').then(function (aliasValue) {
   expect(aliasValue).to.eql('red')
 
-  expect(this.color).to.eql('blue')
+  expect(this.favoriteColor).to.eql('blue')
 })
 ```
 


### PR DESCRIPTION
I assume `this.color` should have been `this.favoriteColor` considering `as('favoriteColor')`