### PR TITLE
Extend docs on how to write a custom devServer

### DIFF
--- a/docs/guides/component-testing/component-framework-configuration.mdx
+++ b/docs/guides/component-testing/component-framework-configuration.mdx
@@ -71,11 +71,14 @@ interface DevServerOptions {
 :::
 
 Any requests triggered during a test using the `devServerPublicPathRoute` as
-defined in the `cypressConfig` will be forwarded to your server. The
-cypress-runner will trigger a request for an index.html when a test is started.
-Your server needs to send the custom index.html file after injecting a script to
-load the actual test. If you do not bundle your support file along with the
-tests, you need to add a separate import statement for the support file.
+defined in the `cypressConfig` will be forwarded to your server. Cypress will
+trigger a request for `component-index.html` when a test is started. Your server
+needs to reply with a custom `index.html` file as specified via
+`cypressConfig.indexHtmlFile` after injecting a script to load the actual test.
+An example of this can bee seen in
+[this loader](https://github.com/cypress-io/cypress/blob/466155c2125476374d9f9549530f67d0c6354a41/npm/vite-dev-server/src/plugins/cypress.ts#L82-L92)
+used by the vite-devserver. If you do not bundle your support file along with
+the tests, you need to add a separate import statement for the support file.
 
 ```ts
 const CypressInstance = (window.Cypress = parent.Cypress)
@@ -93,9 +96,12 @@ CypressInstance.onSpecWindow(window, [
 CypressInstance.action('app:window:before:load', window)
 ```
 
+For a more complete example you can check out the
+[kickstart script used in the vite-devserver.](https://github.com/cypress-io/cypress/blob/develop/npm/vite-dev-server/client/initCypressTests.js)
+
 The `devServerEvents` event emitter should be used to notify cypress about
-finished builds by emitting the `dev-server:compile:success`-event and to listen
-for the `dev-server:specs:changed`-event that will notify you about changed
+finished builds by emitting a `dev-server:compile:success` event and to listen
+for the `dev-server:specs:changed` event that will notify you about changed
 entry points.
 
 ## Spec Pattern for Component Tests

--- a/docs/guides/component-testing/component-framework-configuration.mdx
+++ b/docs/guides/component-testing/component-framework-configuration.mdx
@@ -117,7 +117,7 @@ function createServer(cypressConfig, bundleDir, port = 1234) {
 
 For a real-world example, you can refer to
 [this loader](https://github.com/cypress-io/cypress/blob/466155c2125476374d9f9549530f67d0c6354a41/npm/vite-dev-server/src/plugins/cypress.ts#L82-L92)
-used by the vite-devserver.
+used by the Vite Dev Server.
 
 The client script must retrieve information on the currently active test from
 the Cypress instance of the parent frame and load the corresponding bundle. If a
@@ -145,7 +145,7 @@ if (supportFilePath) {
   )
 }
 
-// load the testfile - you can extend the load function to also load css
+// load the spec - you can extend the load function to also load css
 const { relative } = CypressInstance.spec
 importPromise = importPromise.then(
   () => import(`${devServerPublicPathRoute}/${relative}`)

--- a/docs/guides/component-testing/component-framework-configuration.mdx
+++ b/docs/guides/component-testing/component-framework-configuration.mdx
@@ -128,34 +128,29 @@ const devServerPublicPathRoute = CypressInstance.config(
   'devServerPublicPathRoute'
 )
 
-const imports = []
+let importPromise = Promise.resolve()
 
 // If you do not bundle your support file along with the tests,
 // you need to add a separate import statement for the support file.
-if (CypressInstance.config('supportFile')) {
-  const absolute = CypressInstance.config('supportFile')
-  const relative = absolute.replace(CypressInstance.config('projectRoot'), '')
-  const relativeUrl = `${devServerPublicPathRoute}${relative}`
-  imports.push({
-    absolute,
-    relative,
-    relativeUrl,
-    load: () => import(relativeUrl),
-  })
+const supportFilePath = CypressInstance.config('supportFile')
+if (supportFilePath) {
+  const relative = supportFilePath.replace(
+    CypressInstance.config('projectRoot'),
+    ''
+  )
+  importPromise = importPromise.then(
+    () => import(`${devServerPublicPathRoute}${relative}`)
+  )
 }
 
 // load the testfile - you can extend the load function to also load css
-const { absolute, relative } = CypressInstance.spec
-const relativeUrl = `${devServerPublicPathRoute}/${relative}`
-imports.push({
-  absolute,
-  relative,
-  relativeUrl,
-  load: () => import(relativeUrl),
-})
+const { relative } = CypressInstance.spec
+importPromise = importPromise.then(
+  () => import(`${devServerPublicPathRoute}/${relative}`)
+)
 
 // trigger loading the imports
-CypressInstance.onSpecWindow(window, imports)
+CypressInstance.onSpecWindow(window, importPromise)
 
 // then start the test process
 CypressInstance.action('app:window:before:load', window)

--- a/docs/guides/component-testing/component-framework-configuration.mdx
+++ b/docs/guides/component-testing/component-framework-configuration.mdx
@@ -14,37 +14,6 @@ guide for a list of supported development servers and how they are configured.
 Below are more advanced configuration options you can customize to fit your
 project.
 
-## Custom Dev Server
-
-A custom function can be passed into the `devServer` option, which allows the
-use of other dev servers not provided by Cypress out of the box. These can be
-from the Cypress community, preview builds not included with the app, or a
-custom one you create.
-
-The function's signature takes in a
-[Cypress Configuration](/guides/references/configuration) object as its only
-parameter and returns either an instance of a `devServer` or a promise that
-resolves to a `devServer` instance.
-
-:::cypress-config-example
-
-```ts
-{
-  component: {
-    devServer(cypressConfig: CypressConfiguration) {
-      // return devServer instance or a promise that resolves to
-      // a dev server here
-      return {
-        port: 1234,
-        close: () => {},
-      }
-    },
-  },
-}
-```
-
-:::
-
 ## Custom Index File
 
 By default, Cypress renders your components into an HTML file located at
@@ -64,6 +33,69 @@ in the [component config](/guides/references/configuration#component) options:
   }
 }
 ```
+
+## Custom Dev Server
+
+A custom function can be passed into the `devServer` option, which allows the
+use of build systems not provided by Cypress out of the box. These can be
+from the Cypress community, preview builds not included with the app, or a
+custom one you create.
+
+The function's signature takes in a object with the following properties as its only
+parameter and needs to resolve an object containing the port of your dev server.
+
+```ts
+interface DevServerOptions {
+  specs: Cypress.Spec[]
+  cypressConfig: Cypress.PluginConfigOptions
+  devServerEvents: NodeJS.EventEmitter
+}
+```
+
+:::cypress-config-example
+
+```ts
+{
+  component: {
+    async devServer({specs, cypressConfig, devServerEvents}: DevServerOptions) {
+      const port = await startDevServer(specs, cypressConfig, devServerEvents)
+      return {
+        port: port
+      }
+    },
+  },
+}
+```
+
+:::
+
+Any requests triggered during a test using the `devServerPublicPathRoute` as defined
+in the `cypressConfig` will be forwarded to your server. The cypress-runner will
+trigger a request for an index.html when a test is started. Your server needs to send
+the custom index.html file after injecting a script to load the actual test.
+If you do not bundle your support file along with the tests, you need to add a separate
+import statement for the support file.
+
+```ts
+const CypressInstance = (window.Cypress = parent.Cypress)
+const { absolute, relative } = CypressInstance.spec
+const relativeUrl = `${CypressInstance.config('devServerPublicPathRoute')}/${relative}`
+
+// load the testfile - you can extend the load function to also load css
+CypressInstance.onSpecWindow(
+  window,
+  [{ absolute, relative, relativeUrl, load: () => import(relativeUrl) }]
+)
+
+// then start the test process
+CypressInstance.action('app:window:before:load', window)
+```
+
+The `devServerEvents` event emitter should be used to notify cypress about 
+finished builds by emitting the `dev-server:compile:success`-event and to
+listen for the `dev-server:specs:changed`-event that will notify you about
+changed entry points.
+
 
 ## Spec Pattern for Component Tests
 

--- a/docs/guides/component-testing/component-framework-configuration.mdx
+++ b/docs/guides/component-testing/component-framework-configuration.mdx
@@ -43,7 +43,7 @@ you create.
 
 The function's signature takes in a object with the following properties as its
 only parameter and needs to resolve an object containing the port of your dev
-server.
+server and a callback to shut it down.
 
 ```ts
 interface DevServerOptions {
@@ -59,9 +59,11 @@ interface DevServerOptions {
 {
   component: {
     async devServer({specs, cypressConfig, devServerEvents}: DevServerOptions) {
-      const port = await startDevServer(specs, cypressConfig, devServerEvents)
+      const {port, close} = await startDevServer(specs, cypressConfig, devServerEvents)
+
       return {
-        port: port
+        port,
+        close 
       }
     },
   },

--- a/docs/guides/component-testing/component-framework-configuration.mdx
+++ b/docs/guides/component-testing/component-framework-configuration.mdx
@@ -72,25 +72,90 @@ interface DevServerOptions {
 
 Any requests triggered during a test using the `devServerPublicPathRoute` as
 defined in the `cypressConfig` will be forwarded to your server. Cypress will
-trigger a request for `component-index.html` when a test is started. Your server
-needs to reply with a custom `index.html` file as specified via
-`cypressConfig.indexHtmlFile` after injecting a script to load the actual test.
-An example of this can bee seen in
+trigger a request for `[devServerPublicPathRoute]/index.html` when a test is
+started. Your server needs to reply with the html-file referenced in
+`cypressConfig.indexHtmlFile` and inject a script to load the support files and
+the actual test.
+
+```ts
+function createServer(cypressConfig, bundleDir, port = 1234) {
+  const app = express()
+
+  // read kickstart script - see below for an example
+  const clientScript = readFileSync(
+    path.join(__dirname, './client-script.js'),
+    'utf8'
+  )
+
+  app.get(
+    cypressConfig.devServerPublicPathRoute + '/index.html',
+    async (_req, res) => {
+      // read custom index.html file
+      const html = await fs.readFile(
+        path.join(cypressConfig.repoRoot, cypressConfig.indexHtmlFile),
+        { encoding: 'utf8' }
+      )
+
+      // inject kickstart-script
+      const output = html.replace(
+        '</head>',
+        `<script type="module">${clientScript}</script></head>`
+      )
+      res.send(output)
+    }
+  )
+
+  // you need to establish some url-to-path-mapping, if your bundler outputs
+  // the full directory structure you can map this one to one
+  app.use(cypressConfig.devServerPublicPathRoute, express.static(bundleDir))
+
+  app.listen(port)
+}
+```
+
+For a real-world example, you can refer to
 [this loader](https://github.com/cypress-io/cypress/blob/466155c2125476374d9f9549530f67d0c6354a41/npm/vite-dev-server/src/plugins/cypress.ts#L82-L92)
-used by the vite-devserver. If you do not bundle your support file along with
-the tests, you need to add a separate import statement for the support file.
+used by the vite-devserver.
+
+The client script must retrieve information on the currently active test from
+the Cypress instance of the parent frame and load the corresponding bundle. If a
+support file is defined, it should be injected at the top of your test bundle or
+loaded before the test script.
 
 ```ts
 const CypressInstance = (window.Cypress = parent.Cypress)
-const { absolute, relative } = CypressInstance.spec
-const relativeUrl = `${CypressInstance.config(
+const devServerPublicPathRoute = CypressInstance.config(
   'devServerPublicPathRoute'
-)}/${relative}`
+)
+
+const imports = []
+
+// If you do not bundle your support file along with the tests,
+// you need to add a separate import statement for the support file.
+if (CypressInstance.config('supportFile')) {
+  const absolute = CypressInstance.config('supportFile')
+  const relative = absolute.replace(CypressInstance.config('projectRoot'), '')
+  const relativeUrl = `${devServerPublicPathRoute}${relative}`
+  imports.push({
+    absolute,
+    relative,
+    relativeUrl,
+    load: () => import(relativeUrl),
+  })
+}
 
 // load the testfile - you can extend the load function to also load css
-CypressInstance.onSpecWindow(window, [
-  { absolute, relative, relativeUrl, load: () => import(relativeUrl) },
-])
+const { absolute, relative } = CypressInstance.spec
+const relativeUrl = `${devServerPublicPathRoute}/${relative}`
+imports.push({
+  absolute,
+  relative,
+  relativeUrl,
+  load: () => import(relativeUrl),
+})
+
+// trigger loading the imports
+CypressInstance.onSpecWindow(window, imports)
 
 // then start the test process
 CypressInstance.action('app:window:before:load', window)

--- a/docs/guides/component-testing/component-framework-configuration.mdx
+++ b/docs/guides/component-testing/component-framework-configuration.mdx
@@ -63,7 +63,7 @@ interface DevServerOptions {
 
       return {
         port,
-        close 
+        close
       }
     },
   },

--- a/docs/guides/component-testing/component-framework-configuration.mdx
+++ b/docs/guides/component-testing/component-framework-configuration.mdx
@@ -37,12 +37,13 @@ in the [component config](/guides/references/configuration#component) options:
 ## Custom Dev Server
 
 A custom function can be passed into the `devServer` option, which allows the
-use of build systems not provided by Cypress out of the box. These can be
-from the Cypress community, preview builds not included with the app, or a
-custom one you create.
+use of build systems not provided by Cypress out of the box. These can be from
+the Cypress community, preview builds not included with the app, or a custom one
+you create.
 
-The function's signature takes in a object with the following properties as its only
-parameter and needs to resolve an object containing the port of your dev server.
+The function's signature takes in a object with the following properties as its
+only parameter and needs to resolve an object containing the port of your dev
+server.
 
 ```ts
 interface DevServerOptions {
@@ -69,33 +70,33 @@ interface DevServerOptions {
 
 :::
 
-Any requests triggered during a test using the `devServerPublicPathRoute` as defined
-in the `cypressConfig` will be forwarded to your server. The cypress-runner will
-trigger a request for an index.html when a test is started. Your server needs to send
-the custom index.html file after injecting a script to load the actual test.
-If you do not bundle your support file along with the tests, you need to add a separate
-import statement for the support file.
+Any requests triggered during a test using the `devServerPublicPathRoute` as
+defined in the `cypressConfig` will be forwarded to your server. The
+cypress-runner will trigger a request for an index.html when a test is started.
+Your server needs to send the custom index.html file after injecting a script to
+load the actual test. If you do not bundle your support file along with the
+tests, you need to add a separate import statement for the support file.
 
 ```ts
 const CypressInstance = (window.Cypress = parent.Cypress)
 const { absolute, relative } = CypressInstance.spec
-const relativeUrl = `${CypressInstance.config('devServerPublicPathRoute')}/${relative}`
+const relativeUrl = `${CypressInstance.config(
+  'devServerPublicPathRoute'
+)}/${relative}`
 
 // load the testfile - you can extend the load function to also load css
-CypressInstance.onSpecWindow(
-  window,
-  [{ absolute, relative, relativeUrl, load: () => import(relativeUrl) }]
-)
+CypressInstance.onSpecWindow(window, [
+  { absolute, relative, relativeUrl, load: () => import(relativeUrl) },
+])
 
 // then start the test process
 CypressInstance.action('app:window:before:load', window)
 ```
 
-The `devServerEvents` event emitter should be used to notify cypress about 
-finished builds by emitting the `dev-server:compile:success`-event and to
-listen for the `dev-server:specs:changed`-event that will notify you about
-changed entry points.
-
+The `devServerEvents` event emitter should be used to notify cypress about
+finished builds by emitting the `dev-server:compile:success`-event and to listen
+for the `dev-server:specs:changed`-event that will notify you about changed
+entry points.
 
 ## Spec Pattern for Component Tests
 

--- a/docs/guides/component-testing/component-framework-configuration.mdx
+++ b/docs/guides/component-testing/component-framework-configuration.mdx
@@ -41,7 +41,7 @@ use of build systems not provided by Cypress out of the box. These can be from
 the Cypress community, preview builds not included with the app, or a custom one
 you create.
 
-The function's signature takes in a object with the following properties as its
+The function's signature takes in an object with the following properties as its
 only parameter and needs to resolve an object containing the port of your dev
 server and a callback to shut it down.
 


### PR DESCRIPTION
* switch section on custom index html file and dev server, so it's already explained when mentioning it in the dev-server-section
* add a minimal example for the test-kickstart-script
* update documentation of the parameters
* add some explanation on the role of the dev-server