### PR TITLE
Add component test devserver plugins

### DIFF
--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -975,6 +975,20 @@
           "link": "https://github.com/bahmutov/cypress-svelte-unit-test",
           "keywords": ["component", "svelte"],
           "badge": "experimental"
+        },
+        {
+          "name": "cypress-ct-custom-devserver",
+          "description": "Simplified API for creating custom dev servers for Cypress.",
+          "link": "https://github.com/fochlac/cypress-ct-custom-devserver",
+          "keywords": ["component", "buildtool", "devserver"],
+          "badge": "community"
+        },
+        {
+          "name": "cypress-devserver-esbuild",
+          "description": "Build Cypress Component Tests using esbuild.",
+          "link": "https://github.com/fochlac/cypress-devserver-esbuild",
+          "keywords": ["component", "esbuild", "devserver"],
+          "badge": "community"
         }
       ]
     },


### PR DESCRIPTION
 * add helper that significatly simplifies the dev-server api (cypress-ct-custom-devserver)
 * add esbuild-dev-server plugins (cypress-devserver-esbuild)