### PR TITLE
chore: update changelog for 12.11.0 release

### DIFF
--- a/docs/guides/references/changelog.mdx
+++ b/docs/guides/references/changelog.mdx
@@ -8,7 +8,7 @@ _Released 04/26/2023_
 
 **Features:**
 
-- Adds Component Testing support for Angular 16. Addresses
+- Added Component Testing support for Angular 16. Addresses
   [#26044](https://github.com/cypress-io/cypress/issues/26044).
 - The run navigation component on the
   [Debug page](https://on.cypress.io/debug-page) will now display a warning

--- a/docs/guides/references/changelog.mdx
+++ b/docs/guides/references/changelog.mdx
@@ -2,6 +2,29 @@
 title: Changelog
 ---
 
+## 12.11.0
+
+_Released 04/26/2023_
+
+**Features:**
+
+- Adds Component Testing support for Angular 16. Addresses [#26044](https://github.com/cypress-io/cypress/issues/26044).
+- The run navigation component on the [Debug page](https://on.cypress.io/debug-page) will now display a warning message if there are more relevant runs than can be displayed in the list. Addresses [#26288](https://github.com/cypress-io/cypress/issues/26288).
+
+**Bugfixes:**
+
+- Fixed an issue where setting `videoCompression` to `0` would cause the video output to be broken. `0` is now treated as false. Addresses [#5191](https://github.com/cypress-io/cypress/issues/5191) and [#24595](https://github.com/cypress-io/cypress/issues/24595).
+- Fixed an issue on the [Debug page](https://on.cypress.io/debug-page) where the passing run status would appear even if the Cypress Cloud organization was over its monthly test result limit. Addresses [#26528](https://github.com/cypress-io/cypress/issues/26528).
+
+**Misc:**
+
+- Cleaned up our open telemetry dependencies, reducing the size of the open telemetry modules. Addressed in [#26522](https://github.com/cypress-io/cypress/pull/26522).
+
+**Dependency Updates:**
+
+- Upgraded [`vue`](https://www.npmjs.com/package/vue) from `3.2.31` to `3.2.47`. Addressed in [#26555](https://github.com/cypress-io/cypress/pull/26555).
+
+
 ## 12.10.0
 
 _Released 04/17/2023_

--- a/docs/guides/references/changelog.mdx
+++ b/docs/guides/references/changelog.mdx
@@ -8,22 +8,34 @@ _Released 04/26/2023_
 
 **Features:**
 
-- Adds Component Testing support for Angular 16. Addresses [#26044](https://github.com/cypress-io/cypress/issues/26044).
-- The run navigation component on the [Debug page](https://on.cypress.io/debug-page) will now display a warning message if there are more relevant runs than can be displayed in the list. Addresses [#26288](https://github.com/cypress-io/cypress/issues/26288).
+- Adds Component Testing support for Angular 16. Addresses
+  [#26044](https://github.com/cypress-io/cypress/issues/26044).
+- The run navigation component on the
+  [Debug page](https://on.cypress.io/debug-page) will now display a warning
+  message if there are more relevant runs than can be displayed in the list.
+  Addresses [#26288](https://github.com/cypress-io/cypress/issues/26288).
 
 **Bugfixes:**
 
-- Fixed an issue where setting `videoCompression` to `0` would cause the video output to be broken. `0` is now treated as false. Addresses [#5191](https://github.com/cypress-io/cypress/issues/5191) and [#24595](https://github.com/cypress-io/cypress/issues/24595).
-- Fixed an issue on the [Debug page](https://on.cypress.io/debug-page) where the passing run status would appear even if the Cypress Cloud organization was over its monthly test result limit. Addresses [#26528](https://github.com/cypress-io/cypress/issues/26528).
+- Fixed an issue where setting `videoCompression` to `0` would cause the video
+  output to be broken. `0` is now treated as false. Addresses
+  [#5191](https://github.com/cypress-io/cypress/issues/5191) and
+  [#24595](https://github.com/cypress-io/cypress/issues/24595).
+- Fixed an issue on the [Debug page](https://on.cypress.io/debug-page) where the
+  passing run status would appear even if the Cypress Cloud organization was
+  over its monthly test result limit. Addresses
+  [#26528](https://github.com/cypress-io/cypress/issues/26528).
 
 **Misc:**
 
-- Cleaned up our open telemetry dependencies, reducing the size of the open telemetry modules. Addressed in [#26522](https://github.com/cypress-io/cypress/pull/26522).
+- Cleaned up our open telemetry dependencies, reducing the size of the open
+  telemetry modules. Addressed in
+  [#26522](https://github.com/cypress-io/cypress/pull/26522).
 
 **Dependency Updates:**
 
-- Upgraded [`vue`](https://www.npmjs.com/package/vue) from `3.2.31` to `3.2.47`. Addressed in [#26555](https://github.com/cypress-io/cypress/pull/26555).
-
+- Upgraded [`vue`](https://www.npmjs.com/package/vue) from `3.2.31` to `3.2.47`.
+  Addressed in [#26555](https://github.com/cypress-io/cypress/pull/26555).
 
 ## 12.10.0
 


### PR DESCRIPTION
This PR updates the `CHANGELOG` for the `12.11.0` release