### PR TITLE
Update examples so that they don't visit websites the user wouldn't control

### DIFF
--- a/docs/api/commands/getallcookies.mdx
+++ b/docs/api/commands/getallcookies.mdx
@@ -60,7 +60,7 @@ redirects back to our site, which sets a session cookie.
 
 ```javascript
 cy.contains('Log in').click()
-cy.origin('https://cypress.io', () => {
+cy.origin('https://example.cypress.io', () => {
   cy.get('[type=password]').type('*****')
   cy.contains('Log in').click()
 })

--- a/docs/api/commands/getallcookies.mdx
+++ b/docs/api/commands/getallcookies.mdx
@@ -60,7 +60,7 @@ redirects back to our site, which sets a session cookie.
 
 ```javascript
 cy.contains('Log in').click()
-cy.origin('https://login.site.com', () => {
+cy.origin('https://cypress.io', () => {
   cy.get('[type=password]').type('*****')
   cy.contains('Log in').click()
 })

--- a/docs/api/commands/getalllocalstorage.mdx
+++ b/docs/api/commands/getalllocalstorage.mdx
@@ -64,7 +64,7 @@ cy.visit('/users', {
 
 cy.getAllLocalStorage().then((result) => {
   expect(result).to.deep.equal({
-    '/users': {
+    'http://localhost:8080': {
       key: 'value',
     },
   })

--- a/docs/api/commands/getalllocalstorage.mdx
+++ b/docs/api/commands/getalllocalstorage.mdx
@@ -37,15 +37,15 @@ Pass in an options object to change the default behavior of
 `cy.getAllLocalStorage()` yields an object where the keys are origins and the
 values are key-value pairs of `localStorage` data.
 
-For example, if `key1` is set to `value1` on `https://origin1.com` and `key2` is
-set to `value2` on `https://origin2.com`, `cy.getAllLocalStorage()` will yield:
+For example, if `key1` is set to `value1` on `https://example.cypress.io` and `key2` is
+set to `value2` on `https://www.cypress-dx.com`, `cy.getAllLocalStorage()` will yield:
 
 ```js
 {
-  'https://origin1.com': {
+  'https://example.cypress.io': {
     key1: 'value1',
   },
-  'https://origin2.com': {
+  'https://www.cypress-dx.com': {
     key2: 'value2',
   },
 }

--- a/docs/api/commands/getalllocalstorage.mdx
+++ b/docs/api/commands/getalllocalstorage.mdx
@@ -57,7 +57,7 @@ For example, if `key1` is set to `value1` on `https://example.cypress.io` and
 ### Get all localStorage
 
 ```javascript
-cy.visit('/users', {
+cy.visit('https://example.cypress.io', {
   onBeforeLoad(win) {
     win.localStorage.setItem('key', 'value')
   },

--- a/docs/api/commands/getalllocalstorage.mdx
+++ b/docs/api/commands/getalllocalstorage.mdx
@@ -65,7 +65,7 @@ cy.visit('https://example.cypress.io', {
 
 cy.getAllLocalStorage().then((result) => {
   expect(result).to.deep.equal({
-    'http://localhost:8080': {
+    'https://example.cypress.io': {
       key: 'value',
     },
   })

--- a/docs/api/commands/getalllocalstorage.mdx
+++ b/docs/api/commands/getalllocalstorage.mdx
@@ -37,15 +37,15 @@ Pass in an options object to change the default behavior of
 `cy.getAllLocalStorage()` yields an object where the keys are origins and the
 values are key-value pairs of `localStorage` data.
 
-For example, if `key1` is set to `value1` on `https://example.com` and `key2` is
-set to `value2` on `https://other.com`, `cy.getAllLocalStorage()` will yield:
+For example, if `key1` is set to `value1` on `https://origin1.com` and `key2` is
+set to `value2` on `https://origin2.com`, `cy.getAllLocalStorage()` will yield:
 
 ```js
 {
-  'https://example.com': {
+  'https://origin1.com': {
     key1: 'value1',
   },
-  'https://other.com': {
+  'https://origin2.com': {
     key2: 'value2',
   },
 }
@@ -56,7 +56,7 @@ set to `value2` on `https://other.com`, `cy.getAllLocalStorage()` will yield:
 ### Get all localStorage
 
 ```javascript
-cy.visit('https://example.com', {
+cy.visit('/users', {
   onBeforeLoad(win) {
     win.localStorage.setItem('key', 'value')
   },
@@ -64,7 +64,7 @@ cy.visit('https://example.com', {
 
 cy.getAllLocalStorage().then((result) => {
   expect(result).to.deep.equal({
-    'https://example.com': {
+    '/users': {
       key: 'value',
     },
   })

--- a/docs/api/commands/getalllocalstorage.mdx
+++ b/docs/api/commands/getalllocalstorage.mdx
@@ -37,8 +37,9 @@ Pass in an options object to change the default behavior of
 `cy.getAllLocalStorage()` yields an object where the keys are origins and the
 values are key-value pairs of `localStorage` data.
 
-For example, if `key1` is set to `value1` on `https://example.cypress.io` and `key2` is
-set to `value2` on `https://www.cypress-dx.com`, `cy.getAllLocalStorage()` will yield:
+For example, if `key1` is set to `value1` on `https://example.cypress.io` and
+`key2` is set to `value2` on `https://www.cypress-dx.com`,
+`cy.getAllLocalStorage()` will yield:
 
 ```js
 {

--- a/docs/api/commands/getallsessionstorage.mdx
+++ b/docs/api/commands/getallsessionstorage.mdx
@@ -37,8 +37,9 @@ Pass in an options object to change the default behavior of
 `cy.getAllSessionStorage()` yields an object where the keys are origins and the
 values are key-value pairs of `sessionStorage` data.
 
-For example, if `key1` is set to `value1` on `https://example.cypress.io` and `key2` is
-set to `value2` on `https://www.cypress-dx.com`, `cy.getAllSessionStorage()` will yield:
+For example, if `key1` is set to `value1` on `https://example.cypress.io` and
+`key2` is set to `value2` on `https://www.cypress-dx.com`,
+`cy.getAllSessionStorage()` will yield:
 
 ```js
 {

--- a/docs/api/commands/getallsessionstorage.mdx
+++ b/docs/api/commands/getallsessionstorage.mdx
@@ -65,7 +65,7 @@ cy.visit('/users', {
 
 cy.getAllSessionStorage().then((result) => {
   expect(result).to.deep.equal({
-    '/users': {
+    'http://localhost:8080': {
       key: 'value',
     },
   })

--- a/docs/api/commands/getallsessionstorage.mdx
+++ b/docs/api/commands/getallsessionstorage.mdx
@@ -37,15 +37,15 @@ Pass in an options object to change the default behavior of
 `cy.getAllSessionStorage()` yields an object where the keys are origins and the
 values are key-value pairs of `sessionStorage` data.
 
-For example, if `key1` is set to `value1` on `https://origin1.com` and `key2` is
-set to `value2` on `https://origin2.com`, `cy.getAllSessionStorage()` will yield:
+For example, if `key1` is set to `value1` on `https://example.cypress.io` and `key2` is
+set to `value2` on `https://www.cypress-dx.com`, `cy.getAllSessionStorage()` will yield:
 
 ```js
 {
-  'https://origin1.com': {
+  'https://example.cypress.io': {
     key1: 'value1',
   },
-  'https://origin2.com': {
+  'https://www.cypress-dx.com': {
     key2: 'value2',
   },
 }

--- a/docs/api/commands/getallsessionstorage.mdx
+++ b/docs/api/commands/getallsessionstorage.mdx
@@ -37,15 +37,15 @@ Pass in an options object to change the default behavior of
 `cy.getAllSessionStorage()` yields an object where the keys are origins and the
 values are key-value pairs of `sessionStorage` data.
 
-For example, if `key1` is set to `value1` on `https://example.com` and `key2` is
-set to `value2` on `https://other.com`, `cy.getAllSessionStorage()` will yield:
+For example, if `key1` is set to `value1` on `https://origin1.com` and `key2` is
+set to `value2` on `https://origin2.com`, `cy.getAllSessionStorage()` will yield:
 
 ```js
 {
-  'https://example.com': {
+  'https://origin1.com': {
     key1: 'value1',
   },
-  'https://other.com': {
+  'https://origin2.com': {
     key2: 'value2',
   },
 }
@@ -56,7 +56,7 @@ set to `value2` on `https://other.com`, `cy.getAllSessionStorage()` will yield:
 ### Get all sessionStorage
 
 ```javascript
-cy.visit('https://example.com', {
+cy.visit('/users', {
   onBeforeLoad(win) {
     win.sessionStorage.setItem('key', 'value')
   },
@@ -64,7 +64,7 @@ cy.visit('https://example.com', {
 
 cy.getAllSessionStorage().then((result) => {
   expect(result).to.deep.equal({
-    'https://example.com': {
+    '/users': {
       key: 'value',
     },
   })

--- a/docs/api/commands/origin.mdx
+++ b/docs/api/commands/origin.mdx
@@ -44,8 +44,8 @@ cy.origin(url, options, callbackFn)
 ```js
 const hits = getHits() // Defined elsewhere
 // Run commands in secondary origin, passing in serializable values
-cy.origin('https://www.cypress.io', { args: { hits } }, ({ hits }) => {
-  // Inside callback baseUrl is https://www.cypress.io
+cy.origin('https://example.cypress.io', { args: { hits } }, ({ hits }) => {
+  // Inside callback baseUrl is https://example.cypress.io
   cy.visit('/history/founder')
   // Commands are executed in secondary origin
   cy.get('h1').contains('About our Founder')
@@ -63,10 +63,10 @@ cy.get('h1').contains('My cool site under test')
 
 ```js
 const hits = getHits()
-cy.visit('https://www.cypress.io/history/founder')
+cy.visit('https://example.cypress.io/history/founder')
 // To interact with cross-origin content, move this inside cy.origin() callback
 cy.get('h1').contains('About our Founder')
-// Domain must be a precise match including subdomain, i.e. www.cypress.io
+// Domain must be a precise match including subdomain, i.e. example.cypress.io
 cy.origin('cypress.io', () => {
   cy.visit('/history/founder')
   cy.get('h1').contains('About our Founder')
@@ -170,7 +170,7 @@ will not work:
 **<Icon name="exclamation-triangle" color="red" /> Incorrect Usage**
 
 ```js
-cy.origin('https://www.cypress.io', () => {
+cy.origin('https://example.cypress.io', () => {
   cy.visit('/')
   cy.get('h1') // Yields an element, which can't be serialized...
 }).contains('CYPRESS') // ...so this will fail
@@ -181,7 +181,7 @@ Instead, you must explicitly yield a serializable value:
 **<Icon name="check-circle" color="green" /> Correct Usage**
 
 ```js
-cy.origin('https://www.cypress.io', () => {
+cy.origin('https://example.cypress.io', () => {
   cy.visit('/')
   cy.get('h1').invoke('textContent') // Yields a string...
 }).should('equal', 'CYPRESS') // 👍
@@ -197,8 +197,8 @@ page.
 ```js
 // Do things in primary origin...
 
-cy.origin('www.cypress.io', () => {
-  // Visit https://www.cypress.io/history/founder
+cy.origin('example.cypress.io', () => {
+  // Visit https://example.cypress.io/history/founder
   cy.visit('/history/founder')
   cy.get('h1').contains('About our Founder')
 })
@@ -214,10 +214,10 @@ and the protocol defaults to `https`. When `cy.visit()` is called with the path
 ```js
 // Do things in primary origin...
 
-cy.visit('https://www.cypress.io/history/founder')
+cy.visit('https://example.cypress.io/history/founder')
 
 // The cy.origin block is required to interact with the cross-origin page.
-cy.origin('www.cypress.io', () => {
+cy.origin('example.cypress.io', () => {
   cy.get('h1').contains('About our Founder')
 })
 ```
@@ -247,10 +247,10 @@ Navigating to a secondary origin by clicking a link or button in the primary
 origin is supported.
 
 ```js
-// Button in primary origin goes to https://www.cypress.io
+// Button in primary origin goes to https://example.cypress.io
 cy.contains('button', 'Go').click()
 
-cy.origin('www.cypress.io', () => {
+cy.origin('example.cypress.io', () => {
   // No cy.visit is needed as the button brought us here
   cy.get('h1').contains('CYPRESS')
 })
@@ -262,27 +262,16 @@ Callbacks may **not** themselves contain `cy.origin()` calls, so when visiting
 multiple origins, do so at the top level of the test.
 
 ```js
-cy.origin('origin1.com', () => {
+cy.origin('example.cypress.com', () => {
   cy.visit('/')
-  cy.url().should('contain', 'origin1.com')
+  cy.url().should('contain', 'example.cypress.com')
 })
 
-cy.origin('origin2.com', () => {
+cy.origin('cypress-dx.com', () => {
   cy.visit('/')
-  cy.url().should('contain', 'origin2.com')
-})
-
-cy.origin('origin3.com', () => {
-  cy.visit('/')
-  cy.url().should('contain', 'origin3.com')
+  cy.url().should('contain', 'cypress-dx.com')
 })
 ```
-
-:::info
-
-A future version of Cypress will allow the use of nested `cy.origin()` calls.
-
-:::
 
 ### SSO login custom command
 
@@ -300,7 +289,7 @@ Cypress.Commands.add('login', (username, password) => {
   // Remember to pass in arguments via `args`
   const args = { username, password }
   cy.origin('cypress.io', { args }, ({ username, password }) => {
-    // Go to https://auth-provider.com/login
+    // Go to https://example.cypress.com/login
     cy.visit('/login')
     cy.contains('Username').find('input').type(username)
     cy.contains('Password').find('input').type(password)
@@ -476,13 +465,13 @@ before(() => {
   // makes custom commands available to all subsequent cy.origin('cypress.io)
   // calls in this spec. put it in your support file to make them available to
   // all specs
-  cy.origin('cypress.io, () => {
+  cy.origin('cypress.io', () => {
     Cypress.require('../support/commands')
   })
 })
 
-it('tests cypress.io, () => {
-  cy.origin('cypress.io, () => {
+it('tests cypress.io', () => {
+  cy.origin('cypress.io', () => {
     cy.visit('/page')
     cy.clickLink('Click Me')
   })
@@ -517,7 +506,7 @@ it('also uses cy.origin() + custom command', () => {
     cy.clickLink('Click Me')
   })
 
-  cy.origin('anotherwebsite.com', () => {
+  cy.origin('cypress-dx.com', () => {
     // WARNING: cy.clickLink() will not be available because it is a
     // different origin
   })

--- a/docs/api/commands/origin.mdx
+++ b/docs/api/commands/origin.mdx
@@ -262,19 +262,19 @@ Callbacks may **not** themselves contain `cy.origin()` calls, so when visiting
 multiple origins, do so at the top level of the test.
 
 ```js
-cy.origin('foo.com', () => {
+cy.origin('origin1.com', () => {
   cy.visit('/')
-  cy.url().should('contain', 'foo.com')
+  cy.url().should('contain', 'origin1.com')
 })
 
-cy.origin('bar.com', () => {
+cy.origin('origin2.com', () => {
   cy.visit('/')
-  cy.url().should('contain', 'bar.com')
+  cy.url().should('contain', 'origin2.com')
 })
 
-cy.origin('baz.com', () => {
+cy.origin('origin3.com', () => {
   cy.visit('/')
-  cy.url().should('contain', 'baz.com')
+  cy.url().should('contain', 'origin3.com')
 })
 ```
 
@@ -299,7 +299,7 @@ do this with `cy.origin()`.
 Cypress.Commands.add('login', (username, password) => {
   // Remember to pass in arguments via `args`
   const args = { username, password }
-  cy.origin('my-auth.com', { args }, ({ username, password }) => {
+  cy.origin('cypress.io', { args }, ({ username, password }) => {
     // Go to https://auth-provider.com/login
     cy.visit('/login')
     cy.contains('Username').find('input').type(username)
@@ -331,7 +331,7 @@ Cypress.Commands.add('login', (username, password) => {
     // Username & password can be used as the cache key too
     args,
     () => {
-      cy.origin('my-auth.com', { args }, ({ username, password }) => {
+      cy.origin('cypress.io', { args }, ({ username, password }) => {
         cy.visit('/login')
         cy.contains('Username').find('input').type(username)
         cy.contains('Password').find('input').type(password)
@@ -375,7 +375,7 @@ this will not work:
 
 ```js
 const foo = 1
-cy.origin('somesite.com', () => {
+cy.origin('cypress.io', () => {
   cy.visit('/')
   // This line will throw a ReferenceError because
   // `foo` is not defined in the scope of the callback
@@ -390,7 +390,7 @@ Instead, the variable must be explicitly passed into the callback using the
 
 ```js
 const foo = 1
-cy.origin('somesite.com', { args: { foo } }, ({ foo }) => {
+cy.origin('cypress.io', { args: { foo } }, ({ foo }) => {
   cy.visit('/')
   // Now it will pass
   cy.get('input').type(foo)
@@ -432,7 +432,7 @@ Read more in the [`Cypress.require()` doc](/api/cypress-api/require) itself.
 #### Example
 
 ```js
-cy.origin('somesite.com', () => {
+cy.origin('cypress.io', () => {
   const _ = Cypress.require('lodash')
   const utils = Cypress.require('../support/utils')
 
@@ -473,16 +473,16 @@ beforeEach(() => {
 
 ```js
 before(() => {
-  // makes custom commands available to all subsequent cy.origin('somesite.com')
+  // makes custom commands available to all subsequent cy.origin('cypress.io)
   // calls in this spec. put it in your support file to make them available to
   // all specs
-  cy.origin('somesite.com', () => {
+  cy.origin('cypress.io, () => {
     Cypress.require('../support/commands')
   })
 })
 
-it('tests somesite.com', () => {
-  cy.origin('somesite.com', () => {
+it('tests cypress.io, () => {
+  cy.origin('cypress.io, () => {
     cy.visit('/page')
     cy.clickLink('Click Me')
   })
@@ -497,27 +497,27 @@ successive `cy.origin()` calls.
 
 ```js
 before(() => {
-  cy.origin('somesite.com', () => {
+  cy.origin('cypress.io', () => {
     // makes commands defined in this file available to all callbacks
-    // for somesite.com
+    // for cypress.io
     Cypress.require('../support/commands')
   })
 })
 
 it('uses cy.origin() + custom command', () => {
-  cy.origin('somesite.com', () => {
+  cy.origin('cypress.io', () => {
     cy.visit('/page')
     cy.clickLink('Click Me')
   })
 })
 
 it('also uses cy.origin() + custom command', () => {
-  cy.origin('somesite.com', () => {
+  cy.origin('cypress.io', () => {
     cy.visit('/page')
     cy.clickLink('Click Me')
   })
 
-  cy.origin('differentsite.com', () => {
+  cy.origin('anotherwebsite.com', () => {
     // WARNING: cy.clickLink() will not be available because it is a
     // different origin
   })

--- a/docs/api/commands/origin.mdx
+++ b/docs/api/commands/origin.mdx
@@ -44,16 +44,16 @@ cy.origin(url, options, callbackFn)
 ```js
 const hits = getHits() // Defined elsewhere
 // Run commands in secondary origin, passing in serializable values
-cy.origin('https://www.acme.com', { args: { hits } }, ({ hits }) => {
-  // Inside callback baseUrl is https://www.acme.com
+cy.origin('https://www.cypress.io', { args: { hits } }, ({ hits }) => {
+  // Inside callback baseUrl is https://www.cypress.io
   cy.visit('/history/founder')
   // Commands are executed in secondary origin
-  cy.get('h1').contains('About our Founder, Marvin Acme')
+  cy.get('h1').contains('About our Founder')
   // Passed in values are accessed via callback args
   cy.get('#hitcounter').contains(hits)
 })
 // Even though we're outside the secondary origin block,
-// we're still on acme.com so return to baseUrl
+// we're still on cypress.io so return to baseUrl
 cy.visit('/')
 // Continue running commands on primary origin
 cy.get('h1').contains('My cool site under test')
@@ -63,17 +63,17 @@ cy.get('h1').contains('My cool site under test')
 
 ```js
 const hits = getHits()
-cy.visit('https://www.acme.com/history/founder')
+cy.visit('https://www.cypress.io/history/founder')
 // To interact with cross-origin content, move this inside cy.origin() callback
-cy.get('h1').contains('About our Founder, Marvin Acme')
-// Domain must be a precise match including subdomain, i.e. www.acme.com
-cy.origin('acme.com', () => {
+cy.get('h1').contains('About our Founder')
+// Domain must be a precise match including subdomain, i.e. www.cypress.io
+cy.origin('cypress.io', () => {
   cy.visit('/history/founder')
-  cy.get('h1').contains('About our Founder, Marvin Acme')
+  cy.get('h1').contains('About our Founder')
   // Fails because hits is not passed in via args
   cy.get('#hitcounter').contains(hits)
 })
-// Won't work because still on acme.com
+// Won't work because still on cypress.io
 cy.get('h1').contains('My cool site under test')
 ```
 
@@ -170,10 +170,10 @@ will not work:
 **<Icon name="exclamation-triangle" color="red" /> Incorrect Usage**
 
 ```js
-cy.origin('https://www.acme.com', () => {
+cy.origin('https://www.cypress.io', () => {
   cy.visit('/')
   cy.get('h1') // Yields an element, which can't be serialized...
-}).contains('ACME CORP') // ...so this will fail
+}).contains('CYPRESS') // ...so this will fail
 ```
 
 Instead, you must explicitly yield a serializable value:
@@ -181,10 +181,10 @@ Instead, you must explicitly yield a serializable value:
 **<Icon name="check-circle" color="green" /> Correct Usage**
 
 ```js
-cy.origin('https://www.acme.com', () => {
+cy.origin('https://www.cypress.io', () => {
   cy.visit('/')
   cy.get('h1').invoke('textContent') // Yields a string...
-}).should('equal', 'ACME CORP') // 👍
+}).should('equal', 'CYPRESS') // 👍
 ```
 
 ### Navigating to secondary origin with cy.visit
@@ -197,28 +197,28 @@ page.
 ```js
 // Do things in primary origin...
 
-cy.origin('www.acme.com', () => {
-  // Visit https://www.acme.com/history/founder
+cy.origin('www.cypress.io', () => {
+  // Visit https://www.cypress.io/history/founder
   cy.visit('/history/founder')
-  cy.get('h1').contains('About our Founder, Marvin Acme')
+  cy.get('h1').contains('About our Founder')
 })
 ```
 
-Here the `baseUrl` inside the `cy.origin()` callback is set to `www.acme.com`
+Here the `baseUrl` inside the `cy.origin()` callback is set to `www.cypress.io`
 and the protocol defaults to `https`. When `cy.visit()` is called with the path
 `/history/founder`, the three are concatenated to make
-`https://www.acme.com/history/founder`.
+`https://www.cypress.io/history/founder`.
 
 #### Alternative navigation
 
 ```js
 // Do things in primary origin...
 
-cy.visit('https://www.acme.com/history/founder')
+cy.visit('https://www.cypress.io/history/founder')
 
 // The cy.origin block is required to interact with the cross-origin page.
-cy.origin('www.acme.com', () => {
-  cy.get('h1').contains('About our Founder, Marvin Acme')
+cy.origin('www.cypress.io', () => {
+  cy.get('h1').contains('About our Founder')
 })
 ```
 
@@ -231,15 +231,15 @@ communicate with the cross-origin page
 ```js
 // Do things in primary origin...
 
-cy.visit('https://www.acme.com/history/founder')
+cy.visit('https://www.cypress.io/history/founder')
 
-// This command will fail, it's executed on localhost but the application is at acme.com
+// This command will fail, it's executed on localhost but the application is at cypress.io
 cy.get('h1').contains('About our Founder, Marvin Acme')
 ```
 
 Here `cy.get('h1')` fails because we are trying to interact with a cross-origin
 page outside of the cy.origin block, due to 'same-origin' restrictions, the
-'localhost' javascript context can't communicate with 'acme.com'.
+'localhost' javascript context can't communicate with 'cypress.io'.
 
 ### Navigating to secondary origin with UI
 
@@ -247,12 +247,12 @@ Navigating to a secondary origin by clicking a link or button in the primary
 origin is supported.
 
 ```js
-// Button in primary origin goes to https://www.acme.com
+// Button in primary origin goes to https://www.cypress.io
 cy.contains('button', 'Go').click()
 
-cy.origin('www.acme.com', () => {
+cy.origin('www.cypress.io', () => {
   // No cy.visit is needed as the button brought us here
-  cy.get('h1').contains('ACME CORP')
+  cy.get('h1').contains('CYPRESS')
 })
 ```
 

--- a/docs/api/commands/session.mdx
+++ b/docs/api/commands/session.mdx
@@ -540,7 +540,7 @@ explicitly visit the domain in your login command before calling `cy.session()`.
 ```jsx
 const login = (name) => {
   if (location.hostname !== 'cypress.io') {
-    cy.visit('cypress.io')
+    cy.visit('https://example.cypress.io')
   }
   cy.session(name, () => {
     cy.visit('/login')
@@ -561,7 +561,7 @@ it('t1', () => {
 })
 
 it('t2', () => {
-  cy.visit('anotherexample.com')
+  cy.visit('http://www.cypress-dx.com')
   // do things on anotherexample.com
 })
 

--- a/docs/api/commands/session.mdx
+++ b/docs/api/commands/session.mdx
@@ -539,8 +539,8 @@ explicitly visit the domain in your login command before calling `cy.session()`.
 
 ```jsx
 const login = (name) => {
-  if (location.hostname !== 'example.com') {
-    cy.visit('example.com')
+  if (location.hostname !== 'cypress.io') {
+    cy.visit('cypress.io')
   }
   cy.session(name, () => {
     cy.visit('/login')
@@ -557,7 +557,7 @@ const login = (name) => {
 
 it('t1', () => {
   login('bob')
-  // do things on example.com
+  // do things on cypress.io
 })
 
 it('t2', () => {
@@ -567,7 +567,7 @@ it('t2', () => {
 
 it('t3', () => {
   login('bob')
-  // do things on example.com
+  // do things on cypress.io
 })
 ```
 

--- a/docs/api/commands/task.mdx
+++ b/docs/api/commands/task.mdx
@@ -246,7 +246,7 @@ using `cy.task()` as shown below.
 // in test
 describe('Href visit', () => {
   it('captures href', () => {
-    cy.visit('https://www.mywebapp.com')
+    cy.visit('https://www.cypress.io')
     cy.get('a')
       .invoke('attr', 'href')
       .then((href) => {

--- a/docs/api/commands/task.mdx
+++ b/docs/api/commands/task.mdx
@@ -246,19 +246,19 @@ using `cy.task()` as shown below.
 // in test
 describe('Href visit', () => {
   it('captures href', () => {
-    cy.visit('https://www.cypress.io')
+    cy.visit('https://example.cypress.io')
     cy.get('a')
       .invoke('attr', 'href')
       .then((href) => {
         // href is not same-origin as current url
-        // like https://www.anotherwebapp.com
+        // like https://www.cypress-dx.com
         cy.task('setHref', href)
       })
   })
 
   it('visit href', () => {
     cy.task('getHref').then((href) => {
-      // visit non same-origin url https://www.anotherwebapp.com
+      // visit non same-origin url https://www.cypress-dx.com
       cy.visit(href)
     })
   })

--- a/docs/api/commands/viewport.mdx
+++ b/docs/api/commands/viewport.mdx
@@ -147,7 +147,7 @@ describe('Logo', () => {
         cy.viewport(size)
       }
 
-      -{cy.visit('https://www.cypress.io')::cy.mount(<MyComponent />)}-
+      -{cy.visit('https://example.cypress.io')::cy.mount(<MyComponent />)}-
       cy.get('#logo').should('be.visible')
     })
   })

--- a/docs/api/commands/visit.mdx
+++ b/docs/api/commands/visit.mdx
@@ -132,7 +132,7 @@ requests matching the origin you're testing will have these attached at the
 network level.
 
 ```javascript
-cy.visit('https://www.cypress.io/', {
+cy.visit('https://example.cypress.io/', {
   auth: {
     username: 'wile',
     password: 'coyote',
@@ -144,7 +144,7 @@ You can also provide the username and password directly in the URL.
 
 ```javascript
 // this is the same thing as providing the auth object
-cy.visit('https://wile:coyote@www.cypress.io')
+cy.visit('https://wile:coyote@example.cypress.io')
 ```
 
 :::info
@@ -215,8 +215,8 @@ The parameters passed to `qs` will be merged into existing query parameters on
 the `url`.
 
 ```js
-// visits http://cypress.io/users?page=1&admin=true
-cy.visit('http://cypress.io/users?page=1', {
+// visits https://example.cypress.io/users?page=1&admin=true
+cy.visit('https://example.cypress.io/users?page=1', {
   qs: { admin: true },
 })
 ```
@@ -267,7 +267,7 @@ If you would like to visit a different host when the `baseUrl` has been set,
 provide the fully qualified URL you would like to go to.
 
 ```javascript
-cy.visit('http://cypress.io')
+cy.visit('https://example.cypress.io')
 ```
 
 #### Visit local files

--- a/docs/api/commands/visit.mdx
+++ b/docs/api/commands/visit.mdx
@@ -132,7 +132,7 @@ requests matching the origin you're testing will have these attached at the
 network level.
 
 ```javascript
-cy.visit('https://www.acme.com/', {
+cy.visit('https://www.cypress.io/', {
   auth: {
     username: 'wile',
     password: 'coyote',
@@ -144,7 +144,7 @@ You can also provide the username and password directly in the URL.
 
 ```javascript
 // this is the same thing as providing the auth object
-cy.visit('https://wile:coyote@www.acme.com')
+cy.visit('https://wile:coyote@www.cypress.io')
 ```
 
 :::info
@@ -215,8 +215,8 @@ The parameters passed to `qs` will be merged into existing query parameters on
 the `url`.
 
 ```js
-// visits http://example.com/users?page=1&admin=true
-cy.visit('http://example.com/users?page=1', {
+// visits http://cypress.io/users?page=1&admin=true
+cy.visit('http://cypress.io/users?page=1', {
   qs: { admin: true },
 })
 ```
@@ -267,7 +267,7 @@ If you would like to visit a different host when the `baseUrl` has been set,
 provide the fully qualified URL you would like to go to.
 
 ```javascript
-cy.visit('http://google.com')
+cy.visit('http://cypress.io')
 ```
 
 #### Visit local files

--- a/docs/api/cypress-api/require.mdx
+++ b/docs/api/cypress-api/require.mdx
@@ -56,7 +56,7 @@ There are couple ways to have types inferred for the dependency required.
 ### Casting
 
 ```js
-cy.origin('example.com', async () => {
+cy.origin('cypress.io', async () => {
   const _ = Cypress.require('lodash') as typeof import('lodash')
 
   // lodash methods are properly typed
@@ -71,7 +71,7 @@ cy.origin('example.com', async () => {
 ```js
 import type { LoDashStatic } from 'lodash'
 
-cy.origin('example.com', async () => {
+cy.origin('cypress.io', async () => {
   const _ = Cypress.require < LoDashStatic > 'lodash'
 
   // lodash methods are properly typed

--- a/docs/api/cypress-api/require.mdx
+++ b/docs/api/cypress-api/require.mdx
@@ -22,7 +22,7 @@ Cypress.require(moduleNameOrPath)
 **<Icon name="check-circle" color="green"></Icon> Correct Usage**
 
 ```js
-cy.origin('example.com', () => {
+cy.origin('cypress.io', () => {
   const _ = Cypress.require('lodash')
   const utils = Cypress.require('./utils')
 
@@ -37,7 +37,7 @@ cy.origin('example.com', () => {
 // Use CommonJS `require()` instead
 const _ = Cypress.require('lodash')
 
-cy.origin('example.com', async () => {
+cy.origin('cypress.io', async () => {
   // `require()` and `import()` cannot be used inside the `cy.origin()` callback.
   // Use `Cypress.require()` instead
   const _ = require('lodash')

--- a/docs/guides/core-concepts/conditional-testing.mdx
+++ b/docs/guides/core-concepts/conditional-testing.mdx
@@ -190,15 +190,15 @@ it is.
 ```js
 // tell your back end server which campaign you want sent
 // so you can deterministically know what it is ahead of time
-cy.visit('https://cypress.io?campaign=A')
+cy.visit('https://example.cypress.io?campaign=A')
 
 ...
 
-cy.visit('https://cypress.io?campaign=B')
+cy.visit('https://example.cypress.io?campaign=B')
 
 ...
 
-cy.visit('https://cypress.io?campaign=C')
+cy.visit('https://example.cypress.io?campaign=C')
 ```
 
 Now there is not even a need to do conditional testing since you are able to
@@ -212,11 +212,11 @@ your server to tell you which campaign you are on.
 
 ```js
 // this sends us the session cookies
-cy.visit('https://cypress.io')
+cy.visit('https://example.cypress.io')
 
 // assuming this sends us back
 // the campaign information
-cy.request('https://cypress.io/me')
+cy.request('https://example.cypress.io/me')
   .its('body.campaign')
   .then((campaign) => {
     // runs different cypress test code
@@ -231,7 +231,7 @@ Another way to test this is if your server sent the campaign in a session cookie
 that you could read off.
 
 ```js
-cy.visit('https://cypress.io')
+cy.visit('https://example.cypress.io')
 cy.getCookie('campaign').then((campaign) => {
   return campaigns.test(campaign)
 })
@@ -271,12 +271,12 @@ These patterns are pretty much the same as before:
 
 ```js
 // dont show the wizard
-cy.visit('https://cypress.io?wizard=0')
+cy.visit('https://example.cypress.io?wizard=0')
 ```
 
 ```js
 // show the wizard
-cy.visit('https://cypress.io?wizard=1')
+cy.visit('https://example.cypress.io?wizard=1')
 ```
 
 We would likely need to update our client side code to check whether this query
@@ -289,7 +289,7 @@ In the case where you cannot control it, you can still conditionally dismiss it
 **if** you know whether it is going to be shown.
 
 ```js
-cy.visit('https://cypress.io')
+cy.visit('https://example.cypress.io')
 cy.getCookie('showWizard')
   .then((val) => {
     if (val) {
@@ -310,8 +310,8 @@ If you store and/or persist whether to show the wizard on the server, then ask
 it.
 
 ```js
-cy.visit('https://cypress.io')
-cy.request('https://cypress.io/me')
+cy.visit('https://example.cypress.io')
+cy.request('https://example.cypress.io/me')
   .its('body.showWizard')
   .then((val) => {
     if (val) {

--- a/docs/guides/core-concepts/conditional-testing.mdx
+++ b/docs/guides/core-concepts/conditional-testing.mdx
@@ -190,15 +190,15 @@ it is.
 ```js
 // tell your back end server which campaign you want sent
 // so you can deterministically know what it is ahead of time
-cy.visit('https://app.com?campaign=A')
+cy.visit('https://cypress.io?campaign=A')
 
 ...
 
-cy.visit('https://app.com?campaign=B')
+cy.visit('https://cypress.io?campaign=B')
 
 ...
 
-cy.visit('https://app.com?campaign=C')
+cy.visit('https://cypress.io?campaign=C')
 ```
 
 Now there is not even a need to do conditional testing since you are able to
@@ -212,11 +212,11 @@ your server to tell you which campaign you are on.
 
 ```js
 // this sends us the session cookies
-cy.visit('https://app.com')
+cy.visit('https://cypress.io')
 
 // assuming this sends us back
 // the campaign information
-cy.request('https://app.com/me')
+cy.request('https://cypress.io/me')
   .its('body.campaign')
   .then((campaign) => {
     // runs different cypress test code
@@ -231,7 +231,7 @@ Another way to test this is if your server sent the campaign in a session cookie
 that you could read off.
 
 ```js
-cy.visit('https://app.com')
+cy.visit('https://cypress.io')
 cy.getCookie('campaign').then((campaign) => {
   return campaigns.test(campaign)
 })
@@ -271,12 +271,12 @@ These patterns are pretty much the same as before:
 
 ```js
 // dont show the wizard
-cy.visit('https://app.com?wizard=0')
+cy.visit('https://cypress.io?wizard=0')
 ```
 
 ```js
 // show the wizard
-cy.visit('https://app.com?wizard=1')
+cy.visit('https://cypress.io?wizard=1')
 ```
 
 We would likely need to update our client side code to check whether this query
@@ -289,7 +289,7 @@ In the case where you cannot control it, you can still conditionally dismiss it
 **if** you know whether it is going to be shown.
 
 ```js
-cy.visit('https://app.com')
+cy.visit('https://cypress.io')
 cy.getCookie('showWizard')
   .then((val) => {
     if (val) {
@@ -310,8 +310,8 @@ If you store and/or persist whether to show the wizard on the server, then ask
 it.
 
 ```js
-cy.visit('https://app.com')
-cy.request('https://app.com/me')
+cy.visit('https://cypress.io')
+cy.request('https://cypress.io/me')
   .its('body.showWizard')
   .then((val) => {
     if (val) {

--- a/docs/guides/core-concepts/introduction-to-cypress.mdx
+++ b/docs/guides/core-concepts/introduction-to-cypress.mdx
@@ -644,7 +644,7 @@ immediately, before the `cy.visit()` has executed, so will always evaluate to
 it('test', () => {
   let username = undefined // evaluates immediately as undefined
 
-  cy.visit('https://cypress.io') // Nothing happens yet
+  cy.visit('https://example.cypress.io') // Nothing happens yet
   cy.get('.user-name') // Still, nothing happens yet
     .then(($el) => {
       // Nothing happens yet
@@ -679,7 +679,7 @@ commands run as expected.
 it('test', () => {
   let username = undefined // evaluates immediately as undefined
 
-  cy.visit('https://cypress.io') // Nothing happens yet
+  cy.visit('https://example.cypress.io') // Nothing happens yet
   cy.get('.user-name') // Still, nothing happens yet
     .then(($el) => {
       // Nothing happens yet

--- a/docs/guides/core-concepts/introduction-to-cypress.mdx
+++ b/docs/guides/core-concepts/introduction-to-cypress.mdx
@@ -644,7 +644,7 @@ immediately, before the `cy.visit()` has executed, so will always evaluate to
 it('test', () => {
   let username = undefined // evaluates immediately as undefined
 
-  cy.visit('https://app.com') // Nothing happens yet
+  cy.visit('https://cypress.io') // Nothing happens yet
   cy.get('.user-name') // Still, nothing happens yet
     .then(($el) => {
       // Nothing happens yet
@@ -679,7 +679,7 @@ commands run as expected.
 it('test', () => {
   let username = undefined // evaluates immediately as undefined
 
-  cy.visit('https://app.com') // Nothing happens yet
+  cy.visit('https://cypress.io') // Nothing happens yet
   cy.get('.user-name') // Still, nothing happens yet
     .then(($el) => {
       // Nothing happens yet

--- a/docs/guides/end-to-end-testing/testing-strategies/social-authentication.mdx
+++ b/docs/guides/end-to-end-testing/testing-strategies/social-authentication.mdx
@@ -27,9 +27,9 @@ primary means of application authentication testing. This is due to the
 mentioned in our
 [Best Practices Guide](/guides/references/best-practices#Potential-Challenges-Authenticating-with-Social-Platforms).
 
-Relying on social authentication in
-CI will likely result in bot detection and in some cases, account suspension due
-to violating the provider's Terms of Service.
+Relying on social authentication in CI will likely result in bot detection and
+in some cases, account suspension due to violating the provider's Terms of
+Service.
 
 :::
 

--- a/docs/guides/end-to-end-testing/testing-strategies/social-authentication.mdx
+++ b/docs/guides/end-to-end-testing/testing-strategies/social-authentication.mdx
@@ -27,13 +27,7 @@ primary means of application authentication testing. This is due to the
 mentioned in our
 [Best Practices Guide](/guides/references/best-practices#Potential-Challenges-Authenticating-with-Social-Platforms).
 
-If testing user based authentication flows via social connections is a **must**
-for your application, we recommend testing this in
-[open mode](https://docs.cypress.io/guides/guides/command-line#cypress-open) (or
-[run mode](https://docs.cypress.io/guides/guides/command-line#cypress-run)
-locally and
-[headed](https://docs.cypress.io/guides/guides/command-line#cypress-run-headed))
-to avoid A/B tests or alternate login flows. Relying on social authentication in
+Relying on social authentication in
 CI will likely result in bot detection and in some cases, account suspension due
 to violating the provider's Terms of Service.
 

--- a/docs/guides/guides/cross-origin-testing.mdx
+++ b/docs/guides/guides/cross-origin-testing.mdx
@@ -75,10 +75,10 @@ it('navigates', () => {
 ```
 
 ```javascript
-// this will error because anotherwebsite.com doesn't match the cypress.io superdomain
+// this will error because cypress-dx.com doesn't match the cypress.io superdomain
 it('navigates', () => {
   cy.visit('https://www.cypress.io')
-  cy.visit('https://anotherwebsite.com')
+  cy.visit('https://www.cypress-dx.com')
   cy.get('selector')
 })
 ```
@@ -88,9 +88,9 @@ the sequential command should run against:
 
 ```javascript
 it('navigates', () => {
-  cy.visit('https://www.cypress.io')
-  cy.visit('https://anotherwebsite.com')
-  cy.origin('https://anotherwebsite.com', () => {
+  cy.visit('https://example.cypress.io')
+  cy.visit('https://www.cypress-dx.com')
+  cy.origin('https://www.cypress-dx.com', () => {
     cy.get('selector') // yup all good
   })
 })
@@ -103,7 +103,7 @@ it('navigates', () => {
 
 // split visiting different origin in another test
 it('navigates to new origin', () => {
-  cy.visit('https://anotherwebsite.com')
+  cy.visit('https://cypress-dx.com')
   cy.get('selector') // yup all good
 })
 ```

--- a/docs/guides/guides/cross-origin-testing.mdx
+++ b/docs/guides/guides/cross-origin-testing.mdx
@@ -75,10 +75,10 @@ it('navigates', () => {
 ```
 
 ```javascript
-// this will error because stackoverflow.com doesn't match the cypress.io superdomain
+// this will error because anotherwebsite.com doesn't match the cypress.io superdomain
 it('navigates', () => {
   cy.visit('https://www.cypress.io')
-  cy.visit('https://stackoverflow.com')
+  cy.visit('https://anotherwebsite.com')
   cy.get('selector')
 })
 ```
@@ -89,8 +89,8 @@ the sequential command should run against:
 ```javascript
 it('navigates', () => {
   cy.visit('https://www.cypress.io')
-  cy.visit('https://stackoverflow.com')
-  cy.origin('https://stackoverflow.com', () => {
+  cy.visit('https://anotherwebsite.com')
+  cy.origin('https://anotherwebsite.com', () => {
     cy.get('selector') // yup all good
   })
 })
@@ -103,7 +103,7 @@ it('navigates', () => {
 
 // split visiting different origin in another test
 it('navigates to new origin', () => {
-  cy.visit('https://stackoverflow.com')
+  cy.visit('https://anotherwebsite.com')
   cy.get('selector') // yup all good
 })
 ```

--- a/docs/guides/guides/cross-origin-testing.mdx
+++ b/docs/guides/guides/cross-origin-testing.mdx
@@ -121,11 +121,12 @@ state like `localStorage`, `cookies`, `service workers` and many other APIs are
 not shared between them anyways. Cypress does offer APIs around `localStorage`,
 `sessionStorage`, and `cookies` that are not limited to this restriction.
 
-As a best practice, you should not visit or interact with any website
-not under your control. 
+As a best practice, you should not visit or interact with any website not under
+your control.
 
-If your organization uses Single Sign On (SSO) or OAuth then you might choose to test a 3rd party service other
-than your superdomain, which can be tested with [`cy.origin()`](/api/commands/origin).
+If your organization uses Single Sign On (SSO) or OAuth then you might choose to
+test a 3rd party service other than your superdomain, which can be tested with
+[`cy.origin()`](/api/commands/origin).
 
 We've written several other guides specifically about handling this situation.
 

--- a/docs/guides/guides/cross-origin-testing.mdx
+++ b/docs/guides/guides/cross-origin-testing.mdx
@@ -121,11 +121,11 @@ state like `localStorage`, `cookies`, `service workers` and many other APIs are
 not shared between them anyways. Cypress does offer APIs around `localStorage`,
 `sessionStorage`, and `cookies` that are not limited to this restriction.
 
-As a best practice, you should not visit or interact with a 3rd party service
-not under your control. However, there are exceptions! If your organization uses
-Single Sign On (SSO) or OAuth then you might involve a 3rd party service other
-than your superdomain, which can be safely tested with
-[`cy.origin()`](/api/commands/origin).
+As a best practice, you should not visit or interact with any website
+not under your control. 
+
+If your organization uses Single Sign On (SSO) or OAuth then you might choose to test a 3rd party service other
+than your superdomain, which can be tested with [`cy.origin()`](/api/commands/origin).
 
 We've written several other guides specifically about handling this situation.
 

--- a/docs/guides/guides/web-security.mdx
+++ b/docs/guides/guides/web-security.mdx
@@ -166,8 +166,8 @@ cy.get('a').click() // will fail
 
 Browsers refuse to display insecure content on a secure page. Because Cypress
 initially changed its URL to match `https://example.cypress.io` when the browser
-followed the `href` to `http://example.cypress.io/page2`, the browser will refuse to
-display the contents.
+followed the `href` to `http://example.cypress.io/page2`, the browser will
+refuse to display the contents.
 
 Now you may be thinking, _This sounds like a problem with Cypress because when I
 work with my application outside of Cypress it works just fine._
@@ -241,9 +241,9 @@ cy.origin('https://example.cypress.io', () => {
 })
 ```
 
-If not in control of this superdomain, 
-we recommend you test that the `href` property is correct instead of performing
-the navigation. This will help lead to more deterministic tests.
+If not in control of this superdomain, we recommend you test that the `href`
+property is correct instead of performing the navigation. This will help lead to
+more deterministic tests.
 
 ```javascript
 // this test verifies the behavior and will run considerably faster

--- a/docs/guides/guides/web-security.mdx
+++ b/docs/guides/guides/web-security.mdx
@@ -213,7 +213,7 @@ on an `<a>` that navigates to another superdomain.
 ```html
 <!-- Application code that is served at `localhost:8080` -->
 <html>
-  <a href="https://cypress.io">Stack Overflow</a>
+  <a href="https://example.cypress.io">Cypress</a>
 </html>
 ```
 

--- a/docs/guides/guides/web-security.mdx
+++ b/docs/guides/guides/web-security.mdx
@@ -234,8 +234,8 @@ or by other means, we recommend testing this superdomain with `cy.origin`.
 ```javascript
 // Test code
 cy.visit('http://localhost:8080') // where your web server + HTML is hosted
-cy.get('a').click() // browser navigates to https://cypress.io
-cy.origin('https://cypress.io', () => {
+cy.get('a').click() // browser navigates to https://example.cypress.io
+cy.origin('https://example.cypress.io', () => {
   // declare cy.origin command on expected domain
   cy.get('selector').should('exist') // Yup all good
 })
@@ -248,7 +248,7 @@ the navigation. This will help lead to more deterministic tests.
 ```javascript
 // this test verifies the behavior and will run considerably faster
 cy.visit('http://localhost:8080')
-cy.get('a').should('have.attr', 'href', 'https://cypress.io') // no page load!
+cy.get('a').should('have.attr', 'href', 'https://example.cypress.io') // no page load!
 ```
 
 If for any reason the two above methods cannot be leveraged,
@@ -297,7 +297,7 @@ additional Cypress commands after submitting the form.
 
 app.post('/submit', (req, res) => {
   // redirect the browser to cypress.io
-  res.redirect('https://cypress.io')
+  res.redirect('https://example.cypress.io')
 })
 ```
 
@@ -306,7 +306,7 @@ You can test this with `cy.origin`, which may look like the following test case:
 ```javascript
 cy.visit('http://localhost:8080')
 cy.get('form').submit() // submit the form!
-cy.origin('https://cypress.io', () => {
+cy.origin('cypress.io', () => {
   cy.url().should('contain', 'cypress.io')
 })
 ```
@@ -321,7 +321,7 @@ test these with `cy.origin`.
 ```javascript
 cy.visit('http://localhost:8080')
 cy.get('#login').click() // click a login button, which takes us to our authentication page.
-cy.origin('https://cypress.io', () => {
+cy.origin('cypress.io', () => {
   cy.get('#username').type('User1')
   cy.get('#password').type('Password123')
 
@@ -371,10 +371,10 @@ something like this:
 ```html
 <!-- Application code that is served at `localhost:8080` -->
 <html>
-  <button id="nav">Navigate to cypress.io</button>
+  <button id="nav">Navigate to Cypress example</button>
   <script>
     document.querySelector('#nav').addEventListener('click', () => {
-      window.location.href = 'http://cypress.io'
+      window.location.href = 'https://example.cypress.io'
     })
   </script>
 </html>
@@ -385,7 +385,7 @@ You can test this with `cy.origin`, which may look like the following test case:
 ```javascript
 cy.visit('http://localhost:8080')
 cy.get('#nav').submit() // trigger a javascript redirect!
-cy.origin('http://cypress.io', () => {
+cy.origin('https://example.cypress.io', () => {
   cy.url().should('contain', 'cypress.io')
 })
 ```

--- a/docs/guides/guides/web-security.mdx
+++ b/docs/guides/guides/web-security.mdx
@@ -213,14 +213,14 @@ on an `<a>` that navigates to another superdomain.
 ```html
 <!-- Application code that is served at `localhost:8080` -->
 <html>
-  <a href="https://stackoverflow.com">Stack Overflow</a>
+  <a href="https://cypress.io">Stack Overflow</a>
 </html>
 ```
 
 ```javascript
 // Test code
 cy.visit('http://localhost:8080') // where your web server + HTML is hosted
-cy.get('a').click() // browser navigates to https://stackoverflow.com
+cy.get('a').click() // browser navigates to https://cypress.io
 cy.get('selector').should('exist') // Cypress errors
 ```
 
@@ -234,21 +234,21 @@ or by other means, we recommend testing this superdomain with `cy.origin`.
 ```javascript
 // Test code
 cy.visit('http://localhost:8080') // where your web server + HTML is hosted
-cy.get('a').click() // browser navigates to https://stackoverflow.com
-cy.origin('https://stackoverflow.com', () => {
+cy.get('a').click() // browser navigates to https://cypress.io
+cy.origin('https://cypress.io', () => {
   // declare cy.origin command on expected domain
   cy.get('selector').should('exist') // Yup all good
 })
 ```
 
-If not in control of this superdomain, like in the case of `stackoverflow.com`,
+If not in control of this superdomain, 
 we recommend you test that the `href` property is correct instead of performing
 the navigation. This will help lead to more deterministic tests.
 
 ```javascript
 // this test verifies the behavior and will run considerably faster
 cy.visit('http://localhost:8080')
-cy.get('a').should('have.attr', 'href', 'https://stackoverflow.com') // no page load!
+cy.get('a').should('have.attr', 'href', 'https://cypress.io') // no page load!
 ```
 
 If for any reason the two above methods cannot be leveraged,
@@ -296,8 +296,8 @@ additional Cypress commands after submitting the form.
 // on your localhost:8080 server
 
 app.post('/submit', (req, res) => {
-  // redirect the browser to superduperdomains.com
-  res.redirect('https://superduperdomains.com')
+  // redirect the browser to cypress.io
+  res.redirect('https://cypress.io')
 })
 ```
 
@@ -306,8 +306,8 @@ You can test this with `cy.origin`, which may look like the following test case:
 ```javascript
 cy.visit('http://localhost:8080')
 cy.get('form').submit() // submit the form!
-cy.origin('https://superduperdomains.com', () => {
-  cy.url().should('contain', 'superduperdomains.com')
+cy.origin('https://cypress.io', () => {
+  cy.url().should('contain', 'cypress.io')
 })
 ```
 
@@ -321,7 +321,7 @@ test these with `cy.origin`.
 ```javascript
 cy.visit('http://localhost:8080')
 cy.get('#login').click() // click a login button, which takes us to our authentication page.
-cy.origin('https://my-authentication-instance.com', () => {
+cy.origin('https://cypress.io', () => {
   cy.get('#username').type('User1')
   cy.get('#password').type('Password123')
 
@@ -371,10 +371,10 @@ something like this:
 ```html
 <!-- Application code that is served at `localhost:8080` -->
 <html>
-  <button id="nav">Navigate to some.superdomain.com</button>
+  <button id="nav">Navigate to cypress.io</button>
   <script>
     document.querySelector('#nav').addEventListener('click', () => {
-      window.location.href = 'http://some.superdomain.com'
+      window.location.href = 'http://cypress.io'
     })
   </script>
 </html>
@@ -385,8 +385,8 @@ You can test this with `cy.origin`, which may look like the following test case:
 ```javascript
 cy.visit('http://localhost:8080')
 cy.get('#nav').submit() // trigger a javascript redirect!
-cy.origin('http://some.superdomain.com', () => {
-  cy.url().should('contain', 'some.superdomain.com')
+cy.origin('http://cypress.io', () => {
+  cy.url().should('contain', 'cypress.io')
 })
 ```
 

--- a/docs/guides/guides/web-security.mdx
+++ b/docs/guides/guides/web-security.mdx
@@ -142,7 +142,7 @@ application.
 
 ```javascript
 // Test code
-cy.visit('https://app.corp.com')
+cy.visit('https://example.cypress.io')
 ```
 
 In your application code, you set `cookies` and store a session on the browser.
@@ -152,7 +152,7 @@ your application code.
 ```html
 <!-- Application code -->
 <html>
-  <a href="http://app.corp.com/page2">Page 2</a>
+  <a href="http://example.cypress.io/page2">Page 2</a>
 </html>
 ```
 
@@ -160,13 +160,13 @@ Cypress will immediately fail with the following test code:
 
 ```javascript
 // Test code
-cy.visit('https://app.corp.com')
+cy.visit('https://example.cypress.io')
 cy.get('a').click() // will fail
 ```
 
 Browsers refuse to display insecure content on a secure page. Because Cypress
-initially changed its URL to match `https://app.corp.com` when the browser
-followed the `href` to `http://app.corp.com/page2`, the browser will refuse to
+initially changed its URL to match `https://example.cypress.io` when the browser
+followed the `href` to `http://example.cypress.io/page2`, the browser will refuse to
 display the contents.
 
 Now you may be thinking, _This sounds like a problem with Cypress because when I

--- a/docs/guides/overview/why-cypress.mdx
+++ b/docs/guides/overview/why-cypress.mdx
@@ -177,7 +177,7 @@ performs actions via the UI just like a real user would.
 
 ```js
 it('adds todos', () => {
-  cy.visit('https://todo.app.com')
+  cy.visit('https://example.cypress.io/')
   cy.get('[data-testid="new-todo"]')
     .type('write code{enter}')
     .type('write tests{enter}')

--- a/docs/guides/references/best-practices.mdx
+++ b/docs/guides/references/best-practices.mdx
@@ -302,7 +302,7 @@ to visit or interact with sites or servers you do not control.
 :::tip
 
 &#8239;<Icon name="check-circle" color="green" /> **Best Practice:** Only test
-what you control. Try to avoid requiring a 3rd party server. When necessary, use
+websites that you control. Try to avoid visiting or requiring a 3rd party server. If you choose, you may use
 [`cy.request()`](/api/commands/request) to talk to 3rd party servers via their
 APIs. If possible, cache results via [`cy.session()`](/api/commands/session) to
 avoid repeat visits.
@@ -318,7 +318,7 @@ You may want to access 3rd party services in several situations:
 2. Verifying your server updates a 3rd party server.
 3. Checking your email to see if your server sent a "forgot password" email.
 
-Most of the time, these situations can be safely tested with
+If you choose, these situations can be tested with
 [`cy.visit()`](/api/commands/visit) and [`cy.origin()`](/api/commands/origin).
 However, you will only want to utilize these commands for resources in your
 control, either by controlling the domain or hosted instance. These use cases
@@ -334,10 +334,10 @@ are common for:
 #### Potential Challenges Authenticating with Social Platforms
 
 Other services, such as social logins through popular media providers, are not
-recommended. Social logins will likely work, especially if run locally. However,
+recommended. Testing social logins may work, especially if run locally. However,
 we consider this a bad practice and do not recommend it because:
 
-- It is incredibly time consuming and slows down your tests (unless using
+- It's incredibly time consuming and slows down your tests (unless using
   [`cy.session()`](/api/commands/session)).
 - The 3rd party site may have changed or updated its content.
 - The 3rd party site may be having issues outside of your control.
@@ -366,7 +366,7 @@ Additionally, testing through an OAuth provider is mutable - you will first need
 a real user on their service and then modifying anything on that user might
 affect other tests downstream.
 
-**Here are potential solutions to alleviate these problems:**
+**Here are solutions you may choose to use to alleviate these problems:**
 
 1. Use another platform that you control to log in with username and password
    via [`cy.origin()`](/api/commands/origin). This likely guarantees that you

--- a/docs/guides/references/best-practices.mdx
+++ b/docs/guides/references/best-practices.mdx
@@ -302,10 +302,10 @@ to visit or interact with sites or servers you do not control.
 :::tip
 
 &#8239;<Icon name="check-circle" color="green" /> **Best Practice:** Only test
-websites that you control. Try to avoid visiting or requiring a 3rd party server. If you choose, you may use
-[`cy.request()`](/api/commands/request) to talk to 3rd party servers via their
-APIs. If possible, cache results via [`cy.session()`](/api/commands/session) to
-avoid repeat visits.
+websites that you control. Try to avoid visiting or requiring a 3rd party
+server. If you choose, you may use [`cy.request()`](/api/commands/request) to
+talk to 3rd party servers via their APIs. If possible, cache results via
+[`cy.session()`](/api/commands/session) to avoid repeat visits.
 
 :::
 

--- a/docs/guides/references/changelog.mdx
+++ b/docs/guides/references/changelog.mdx
@@ -11778,7 +11778,7 @@ _Released 08/30/2016_
 
 - You cannot [`cy.visit()`](/api/commands/visit) two different super domains
   within a single test. Example:
-  `cy.visit('https://google.com').visit('https://apple.com')`. There shouldn't
+  `cy.visit('https://cypress.io').visit('https://anotherwebsite.com')`. There shouldn't
   be any reason you ever need to do this in a single test, if you do, you should
   make these two separate tests.
 

--- a/docs/guides/references/changelog.mdx
+++ b/docs/guides/references/changelog.mdx
@@ -11778,9 +11778,9 @@ _Released 08/30/2016_
 
 - You cannot [`cy.visit()`](/api/commands/visit) two different super domains
   within a single test. Example:
-  `cy.visit('https://cypress.io').visit('https://anotherwebsite.com')`. There shouldn't
-  be any reason you ever need to do this in a single test, if you do, you should
-  make these two separate tests.
+  `cy.visit('https://cypress.io').visit('https://anotherwebsite.com')`. There
+  shouldn't be any reason you ever need to do this in a single test, if you do,
+  you should make these two separate tests.
 
 **Features:**
 

--- a/docs/guides/references/error-messages.mdx
+++ b/docs/guides/references/error-messages.mdx
@@ -523,10 +523,10 @@ In order to fix this, our `cy.get()` command **must** be wrapped with the
 [`cy.origin()`](/api/commands/origin) command, like so:
 
 ```javascript
-it('navigates to docs.cypress.io and runs additional commands', () => {
+it('navigates to example.cypress.io and runs additional commands', () => {
   cy.visit('http://localhost:3000')
-  cy.visit('https://docs.cypress.io') // visit a different superdomain
-  cy.origin('https://docs.cypress.io', () => {
+  cy.visit('https://example.cypress.io') // visit a different superdomain
+  cy.origin('https://example.cypress.io', () => {
     cy.get('h1').should('contain', 'Why Cypress?') // now succeeds!
   })
 })

--- a/docs/guides/references/migration-guide.mdx
+++ b/docs/guides/references/migration-guide.mdx
@@ -61,7 +61,7 @@ Here's a simplified example of such a test strategy.
 
 ```js
 it('logs in', () => {
-  cy.visit('https://cypress.io')
+  cy.visit('https://example.cypress.io')
   cy.get('input#password').type('Password123!')
   cy.get('button#submit').click()
 })
@@ -94,12 +94,12 @@ all reside in a single test, like the following.
 ```js
 it('securely edits content', () => {
   cy.origin('cypress.io', () => {
-    cy.visit('https://cypress.io')
+    cy.visit('https://example.cypress.io')
     cy.get('input#password').type('Password123!')
     cy.get('button#submit').click()
   })
 
-  cy.origin('anotherwebsite.com', () => {
+  cy.origin('cypress-dx.com', () => {
     cy.url().should('contain', 'cms')
     cy.get('#current-user').contains('logged in')
     cy.get('button#edit-1').click()
@@ -144,7 +144,7 @@ nor deterministic:
 ```js
 describe('workflow', { testIsolation: false }, () => {
   it('logs in', () => {
-    cy.visit('cypress.io/log-in)
+    cy.visit('https://example.cypress.io/log-in')
     cy.get('username').type('User1')
     cy.get('password').type(Cypress.env('User1_password'))
     cy.get('button#login').click()
@@ -152,7 +152,7 @@ describe('workflow', { testIsolation: false }, () => {
   })
 
   it('clicks user profile', () => {
-    cy.get('User1').find('#profile_avatar).click()
+    cy.get('User1').find('#profile_avatar').click()
     cy.contains('Email Preferences')
   })
 

--- a/docs/guides/references/migration-guide.mdx
+++ b/docs/guides/references/migration-guide.mdx
@@ -99,7 +99,7 @@ it('securely edits content', () => {
     cy.get('button#submit').click()
   })
 
-  cy.origin('mycms.com', () => {
+  cy.origin('anotherwebsite.com', () => {
     cy.url().should('contain', 'cms')
     cy.get('#current-user').contains('logged in')
     cy.get('button#edit-1').click()

--- a/docs/guides/references/migration-guide.mdx
+++ b/docs/guides/references/migration-guide.mdx
@@ -61,7 +61,7 @@ Here's a simplified example of such a test strategy.
 
 ```js
 it('logs in', () => {
-  cy.visit('https://supersecurelogons.com')
+  cy.visit('https://cypress.io')
   cy.get('input#password').type('Password123!')
   cy.get('button#submit').click()
 })
@@ -93,8 +93,8 @@ all reside in a single test, like the following.
 
 ```js
 it('securely edits content', () => {
-  cy.origin('supersecurelogons.com', () => {
-    cy.visit('https://supersecurelogons.com')
+  cy.origin('cypress.io', () => {
+    cy.visit('https://cypress.io')
     cy.get('input#password').type('Password123!')
     cy.get('button#submit').click()
   })
@@ -144,7 +144,7 @@ nor deterministic:
 ```js
 describe('workflow', { testIsolation: false }, () => {
   it('logs in', () => {
-    cy.visit('my-app.com/log-in)
+    cy.visit('cypress.io/log-in)
     cy.get('username').type('User1')
     cy.get('password').type(Cypress.env('User1_password'))
     cy.get('button#login').click()


### PR DESCRIPTION
- Update visit/origin examples to not visit external sites
- Ensure wording of docs are that Cypress discourages testing sites not under your control.