### PR TITLE
Remove notice about the npm package and the cypress binary versions

### DIFF
--- a/docs/guides/getting-started/installing-cypress.mdx
+++ b/docs/guides/getting-started/installing-cypress.mdx
@@ -43,11 +43,6 @@ in the correct directory.
 
 :::info
 
-Notice that the Cypress `npm` package is a wrapper around the Cypress binary.
-The version of the `npm` package determines the version of the binary
-downloaded. As of version `3.0`, the binary is downloaded to a global cache
-directory to be used across projects.
-
 System proxy properties `http_proxy`, `https_proxy` and `no_proxy` are respected
 for the download of the Cypress binary. You can also use the npm properties
 `npm_config_proxy` and `npm_config_https_proxy`. Those have lower priority, so


### PR DESCRIPTION
I can't imagine this info being relevant to anyone. This seems like a throwback notice to the time when we had a different npm package version than the binary? What's the value in a user knowing this at the time they install? Maybe someone else's view differs and I'm missing the point of this section - welcome to feedback. 