### PR TITLE
Recommend using latest version of Cypress in Troubleshooting guide

### DIFF
--- a/docs/guides/references/troubleshooting.mdx
+++ b/docs/guides/references/troubleshooting.mdx
@@ -3,10 +3,15 @@ title: Troubleshooting
 ---
 
 There are times when you will encounter errors or unexpected behavior with
-Cypress itself. In this situation, we recommend checking these support resources
-**first**.
+Cypress itself. This guide recommends some resources and steps to take to troubleshoot those problems.
+
+## Update Cypress 
+
+We always recommend using the latest version of Cypress. If you're not using the latest version, upgrade to the latest version. Your issue may already be resolved. 
 
 ## Support channels
+
+Check these support resources:
 
 - Connect with our community in [Discord](https://discord.gg/cypress)
 - Search existing [GitHub issues](https://github.com/cypress-io/cypress/issues)


### PR DESCRIPTION
Update the first recommendation in our Troubleshooting guide to be to 'update to latest version of Cypress'