### PR TITLE
doc(url.mdx): update description

### DIFF
--- a/docs/api/queries/url.mdx
+++ b/docs/api/queries/url.mdx
@@ -24,7 +24,7 @@ cy.url(options)
 **<Icon name="check-circle" color="green" /> Correct Usage**
 
 ```javascript
-cy.url() // Yields the current URL as a string
+cy.url() // Yields a promise that resolves the current url as a string
 ```
 
 ### Arguments

--- a/docs/api/queries/url.mdx
+++ b/docs/api/queries/url.mdx
@@ -24,7 +24,7 @@ cy.url(options)
 **<Icon name="check-circle" color="green" /> Correct Usage**
 
 ```javascript
-cy.url() // Yields a promise that resolves the current url as a string
+cy.url() // Yields a promise-like object that resolves the current url as a string
 ```
 
 ### Arguments


### PR DESCRIPTION
The description on this one is quite confusing. It stated that the command `cy.url()` yields the url as a string which implies that it directly returns the current url as a string. Whereas in reality it returns the Promise like object that actually resolves the url as a string. This confused me and got me stuck for a bit until I found the correct way of doing it from Stackoverflow which is:

```js
cy.url().then(url => {
  // the actual url string
});
```