### PR TITLE
fix wrong kitchensink script references in GitLab CI example

### DIFF
--- a/docs/guides/continuous-integration/gitlab-ci.mdx
+++ b/docs/guides/continuous-integration/gitlab-ci.mdx
@@ -38,7 +38,7 @@ test:
     # install dependencies
     - npm ci
     # start the server in the background
-    - npm run start:ci &
+    - npm start &
     # run Cypress tests
     - npm run e2e
 ```
@@ -84,7 +84,7 @@ test:
     # install dependencies
     - npm ci
     # start the server in the background
-    - npm run start:ci &
+    - npm start &
     # run Cypress tests
     - npx cypress run --browser firefox
 ```
@@ -115,7 +115,7 @@ test:
     # install dependencies
     - npm ci
     # start the server in the background
-    - npm run start:ci &
+    - npm start &
     # run Cypress tests
     - npx cypress run --browser firefox
   artifacts:
@@ -223,7 +223,7 @@ ui-chrome-tests:
     # install dependencies
     - npm ci
     # start the server in the background
-    - npm run start:ci &
+    - npm start &
     # run Cypress tests in parallel
     - npx cypress run --record --parallel --browser chrome --group "UI - Chrome"
 ```


### PR DESCRIPTION
This PR corrects multiple use of a non-existent script name `start:ci` in code examples in [Continuous Integration > GitLab CI](https://docs.cypress.io/guides/continuous-integration/gitlab-ci) which uses the [cypress-io/cypress-example-kitchensink](https://github.com/cypress-io/cypress-example-kitchensink) repository.

The correct script name is `start` which is already correctly referred to in the explanation text.

![image](https://user-images.githubusercontent.com/66998419/237058057-512f3924-e634-4d25-9a2f-2802582885c7.png)

The command to start the server is [npm start](https://docs.npmjs.com/cli/v9/commands/npm-start). This script is defined in [cypress-io/cypress-example-kitchensink > package.json](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/package.json).