### PR TITLE
update plugin list styles to allow wrapping

### DIFF
--- a/src/components/plugins-list/style.module.css
+++ b/src/components/plugins-list/style.module.css
@@ -43,6 +43,7 @@ ul.pluginsList li {
   padding: 20px;
   border: 1px solid #e8e8e8;
   box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.15);
+  margin: 0 !important;
 }
 
 /* stylelint-disable-next-line at-rule-no-unknown */

--- a/src/components/plugins-list/style.module.css
+++ b/src/components/plugins-list/style.module.css
@@ -31,7 +31,7 @@ h3 {
 
 ul.pluginsList {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
   gap: 1.5rem;
   margin: 0 !important;
   padding: 0;


### PR DESCRIPTION
Quick fix to allow plugin list items to wrap at a mobile breakpoint

| Before | After |
| --- | --- |
| <img width="100%" alt="Screenshot 2023-05-09 at 9 22 54 AM" src="https://github.com/cypress-io/cypress-documentation/assets/1702361/cc4ff4ea-95b4-48ab-9514-9f1bf9988f61"> | <img width="100%" alt="Screenshot 2023-05-09 at 9 23 04 AM" src="https://github.com/cypress-io/cypress-documentation/assets/1702361/c5d96797-a711-4500-919e-335718aca077"> |

_Video_


https://github.com/cypress-io/cypress-documentation/assets/1702361/61bb4f8d-eb40-43ec-8b62-370f134817bb


