### PR TITLE
Add cypress-backoff to plugins.json

### DIFF
--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -378,6 +378,13 @@
           "link": "https://github.com/ExpediaGroup/cypress-codegen",
           "keywords": ["commands", "development", "codegen"],
           "badge": "community"
+        },
+        {
+          "name": "cypress-backoff",
+          "description": "A Cypress plugin to apply different timeout strategies to retried tests",
+          "link": "https://github.com/joostvanwollingen/cypress-backoff",
+          "keywords": ["retries", "backoff"],
+          "badge": "community"
         }
       ]
     },


### PR DESCRIPTION
- [X] 🚀 Works with the latest major version of Cypress
- [X] 🛠 Plugin purpose is clearly documented in the [https://github.com/joostvanwollingen/cypress-backoff#readme](README.md)
- [X] 📝 Well-written documentation - https://github.com/joostvanwollingen/cypress-backoff#readme
- [X] 🔬 Tested using Cypress - https://github.com/joostvanwollingen/cypress-backoff/tree/main/cypress/e2e
- [X] 👷‍♀️ CI pipeline that's passing - https://github.com/joostvanwollingen/cypress-backoff/actions/workflows/test.yml