### PR TITLE
chore: update some text for clarity

### DIFF
--- a/docs/guides/guides/command-line.mdx
+++ b/docs/guides/guides/command-line.mdx
@@ -530,19 +530,19 @@ By passing `--browser` and `--e2e` or `--component` when launching a project,
 you can open Cypress and launch the browser at the same time. Otherwise, you
 will be guided through selecting a browser, project, and/or testing type.
 
-| Option                | Description                                                                                                                   |
-| --------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| Option                | Description                                                                                                                                                                         |
+| --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--browser`, `-b`     | [Run Cypress in the browser with the given name. If a filesystem path is supplied, Cypress will attempt to use the browser at that path.](#cypress-open-browser-lt-browser-path-gt) |
-| `--component`         | [Open in component testing mode](/guides/core-concepts/testing-types#What-is-Component-Testing)                                          |
-| `--config`, `-c`      | [Specify configuration](#cypress-open-config-lt-config-gt)                                                                    |
-| `--config-file`, `-C` | [Specify configuration file](#cypress-open-config-file-lt-configuration-file-gt)                                              |
-| `--detached`, `-d`    | Open Cypress in detached mode                                                                                                 |
-| `--e2e`               | Open in end to end testing mode (default)                                                                                                |
-| `--env`, `-e`         | [Specify environment variables](#cypress-open-env-lt-env-gt)                                                                  |
-| `--global`            | [Open in global mode](#cypress-open-global)                                                                                    |
-| `--help`, `-h`        | Output usage information                                                                                                      |
-| `--port`, `-p`        | [Override default port](#cypress-open-port-lt-port-gt)                                                                        |
-| `--project`, `-P`     | [Path to a specific project](#cypress-open-project-lt-project-path-gt)                                                        |
+| `--component`         | [Open in component testing mode](/guides/core-concepts/testing-types#What-is-Component-Testing)                                                                                     |
+| `--config`, `-c`      | [Specify configuration](#cypress-open-config-lt-config-gt)                                                                                                                          |
+| `--config-file`, `-C` | [Specify configuration file](#cypress-open-config-file-lt-configuration-file-gt)                                                                                                    |
+| `--detached`, `-d`    | Open Cypress in detached mode                                                                                                                                                       |
+| `--e2e`               | Open in end to end testing mode (default)                                                                                                                                           |
+| `--env`, `-e`         | [Specify environment variables](#cypress-open-env-lt-env-gt)                                                                                                                        |
+| `--global`            | [Open in global mode](#cypress-open-global)                                                                                                                                         |
+| `--help`, `-h`        | Output usage information                                                                                                                                                            |
+| `--port`, `-p`        | [Override default port](#cypress-open-port-lt-port-gt)                                                                                                                              |
+| `--project`, `-P`     | [Path to a specific project](#cypress-open-project-lt-project-path-gt)                                                                                                              |
 
 #### `cypress open --browser <browser-path>` {#cypress-open-browser-lt-browser-path-gt}
 

--- a/docs/guides/guides/command-line.mdx
+++ b/docs/guides/guides/command-line.mdx
@@ -532,14 +532,14 @@ will be guided through selecting a browser, project, and/or testing type.
 
 | Option                | Description                                                                                                                   |
 | --------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `--browser`, `-b`     | [Path to a custom browser to be added to the list of available browsers in Cypress](#cypress-open-browser-lt-browser-path-gt) |
-| `--component`         | [Run component tests](/guides/core-concepts/testing-types#What-is-Component-Testing)                                          |
+| `--browser`, `-b`     | [Run Cypress in the browser with the given name. If a filesystem path is supplied, Cypress will attempt to use the browser at that path.](#cypress-open-browser-lt-browser-path-gt) |
+| `--component`         | [Open in component testing mode](/guides/core-concepts/testing-types#What-is-Component-Testing)                                          |
 | `--config`, `-c`      | [Specify configuration](#cypress-open-config-lt-config-gt)                                                                    |
 | `--config-file`, `-C` | [Specify configuration file](#cypress-open-config-file-lt-configuration-file-gt)                                              |
 | `--detached`, `-d`    | Open Cypress in detached mode                                                                                                 |
-| `--e2e`               | Run end to end tests (default)                                                                                                |
+| `--e2e`               | Open in end to end testing mode (default)                                                                                                |
 | `--env`, `-e`         | [Specify environment variables](#cypress-open-env-lt-env-gt)                                                                  |
-| `--global`            | [Run in global mode](#cypress-open-global)                                                                                    |
+| `--global`            | [Open in global mode](#cypress-open-global)                                                                                    |
 | `--help`, `-h`        | Output usage information                                                                                                      |
 | `--port`, `-p`        | [Override default port](#cypress-open-port-lt-port-gt)                                                                        |
 | `--project`, `-P`     | [Path to a specific project](#cypress-open-project-lt-project-path-gt)                                                        |


### PR DESCRIPTION
Noticed the description of the function of the the `--browser` flag was incorrect for `cypress open`. Tweaked a couple other things (mostly "open" vs "run").