### PR TITLE
Remove gitlab ci example and update cloud links

### DIFF
--- a/docs/guides/continuous-integration/ci-provider-examples.mdx
+++ b/docs/guides/continuous-integration/ci-provider-examples.mdx
@@ -23,7 +23,7 @@ For the following CI Providers we have in depth guides.
 <Icon
   name="external-link-alt"
   color="gray"
-  url="https://dashboard.cypress.io/projects/7s5okt"
+  url="https://cloud.cypress.io/projects/7s5okt"
   callout="See CircleCI + Cypress Cloud in action"
 />
 
@@ -57,7 +57,7 @@ Check out the full <Icon name="github" inline="true" callout="RWA CircleCI confi
 <Icon
   name="external-link-alt"
   color="gray"
-  url="https://dashboard.cypress.io/projects/tpys4j"
+  url="https://cloud.cypress.io/projects/tpys4j"
   callout="See GitHub Actions + Cypress Cloud in action"
 />
 
@@ -91,7 +91,7 @@ Check out the full <Icon name="github" inline="true" callout="RWA GitHub Actions
 <Icon
   name="external-link-alt"
   color="gray"
-  url="https://dashboard.cypress.io/projects/q1ovwz"
+  url="https://cloud.cypress.io/projects/q1ovwz"
   callout="See BitBucket Pipelines + Cypress Cloud in action"
 />
 
@@ -113,34 +113,6 @@ Check out the full <Icon name="github" inline="true" callout="RWA BitBucket Pipe
 
 :::
 
-### GitLab CI
-
-<Icon name="book" color="gray" url="gitlab-ci" callout="GitLab CI Guide" />
-<br />
-<Icon
-  name="external-link-alt"
-  color="gray"
-  url="https://dashboard.cypress.io/projects/woih1m"
-  callout="See GitLab CI + Cypress Cloud in action"
-/>
-
-<br />
-<br />
-
-:::info
-
-### <Icon name="graduation-cap" /> Real World Example <Badge type="success">New</Badge>
-
-The Cypress <Icon name="github" inline="true" contentType="rwa" /> uses
-[GitLab CI](https://gitlab.com) to test over 300 test cases in parallel across
-25 machines, multiple browsers and multiple device sizes with
-[Cypress Cloud recording](https://cloud.cypress.io/projects/woih1m).
-
-<!-- prettier-ignore -->
-Check out the full <Icon name="github" inline="true" callout="RWA GitLab CI configuration" url="https://github.com/cypress-io/cypress-realworld-app/blob/develop/.gitlab-ci.yml" />.
-
-:::
-
 ### AWS CodeBuild
 
 <Icon
@@ -153,7 +125,7 @@ Check out the full <Icon name="github" inline="true" callout="RWA GitLab CI conf
 <Icon
   name="external-link-alt"
   color="gray"
-  url="https://dashboard.cypress.io/projects/zx15dm"
+  url="https://cloud.cypress.io/projects/zx15dm"
   callout="See AWS CodeBuild + Cypress Cloud in action"
 />
 

--- a/docs/guides/guides/network-requests.mdx
+++ b/docs/guides/guides/network-requests.mdx
@@ -392,7 +392,7 @@ the example:
 
 - <Icon
     name="video"
-    url="https://dashboard.cypress.io/projects/7s5okt/runs/2352/test-results/3bf064fd-6959-441c-bf31-a9f276db0627/video"
+    url="https://cloud.cypress.io/projects/7s5okt/runs/2352/test-results/3bf064fd-6959-441c-bf31-a9f276db0627/video"
     callout="Auto-complete test run video recording"
   /> in Cypress Dashboard.
 


### PR DESCRIPTION
- Addresses #5149



- Removes Gitlab example since that repo is archived and hasn't been run in 5 months
- Updates `dashboard.cypress.io` links to `cloud.cypress.io`