### PR TITLE
Windows uses "type" not "print" for cat

### DIFF
--- a/docs/api/commands/exec.mdx
+++ b/docs/api/commands/exec.mdx
@@ -213,7 +213,7 @@ describe('has data available from database', { execTimeout: 90000 }, () => {
 
 ```javascript
 if (Cypress.platform === 'win32') {
-  cy.exec('print package.json').its('stderr').should('be.empty')
+  cy.exec('type package.json').its('stderr').should('be.empty')
 } else {
   cy.exec('cat package.json').its('stderr').should('be.empty')
 }


### PR DESCRIPTION
For exec command on Windows
------

```
cy.exec('print README.md').then((e) => console.log(e.stdout))
```
output: "**Unable to initialize device PRN**"

```
cy.exec('type README.md').then((e) => console.log(e.stdout))
```
output: "**ACTUAL contents**"