### PR TITLE
Add Yarn Plug'n'Play note to Module API guide

### DIFF
--- a/docs/guides/guides/module-api.mdx
+++ b/docs/guides/guides/module-api.mdx
@@ -10,6 +10,17 @@ results directly after the run. With this workflow, for example, you can:
 - Rerun a single failing spec file
 - Kick off other builds or scripts
 
+:::info
+
+<strong>Yarn Plug'n'Play</strong>
+
+To run Cypress via Node.js in a
+[Yarn Plug'n'Play](https://yarnpkg.com/features/pnp) environment, use
+[yarn node](https://yarnpkg.com/cli/node) instead of
+[node](https://nodejs.dev/en/learn/run-nodejs-scripts-from-the-command-line/).
+
+:::
+
 ## `cypress.run()`
 
 Runs Cypress tests via Node.js and resolve with all test results. See the


### PR DESCRIPTION
- Closes #5248

This PR resolves https://github.com/cypress-io/cypress-documentation/issues/5248. It adds a note for [Yarn Plug'n'Play](https://yarnpkg.com/features/pnp) to use [yarn node](https://yarnpkg.com/cli/node) instead of [node](https://nodejs.dev/en/learn/run-nodejs-scripts-from-the-command-line/) in the

[Module API](https://docs.cypress.io/guides/guides/module-api) Guide

## Verification

To verify that the instructions are correct:

- Use cypress@12.9.0 to avoid issue https://github.com/cypress-io/cypress/issues/26567 and https://github.com/cypress-io/cypress/issues/26676.

Execute:

```bash
mkdir cy-module-api-pnp
cd cy-module-api-pnp
git init
yarn set version berry
yarn init -y
yarn add cypress@12.9.0 -D -E
yarn cypress open
```
- Ignore error `ERROR:node_bindings.cc(279)` (see issue https://github.com/cypress-io/cypress/issues/19229).

Click on E2E Testing
Click on Continue
Select Electron
Click on Start E2E Testing in Electron
Click Create New Spec
Click Create Spec
Click Okay, run the spec
Exit the Cypress App

Create `e2e-run-tests.js` in root directory of project:

```js
// e2e-run-tests.js
const cypress = require('cypress')

cypress.run()
```

Execute the following incorrect instruction: `node e2e-run-tests.js`
note the failure "Error: Cannot find module 'cypress' "

Now execute the correct instruction for Yarn Plug'n'Play:

`yarn node e2e-run-tests.js`

Cypress completes successfully with "All specs passed!"
