### PR TITLE
Update aws-codebuild CI guide - set correct env.image property path

### DIFF
--- a/docs/guides/continuous-integration/aws-codebuild.mdx
+++ b/docs/guides/continuous-integration/aws-codebuild.mdx
@@ -186,8 +186,7 @@ batch:
   build-list:
     - identifier: cypress-e2e-tests
       env:
-        variables:
-          IMAGE: public.ecr.aws/cypress-io/cypress/browsers:node12.14.1-chrome85-ff81
+        image: public.ecr.aws/cypress-io/cypress/browsers:node12.14.1-chrome85-ff81
 
 phases:
   install:


### PR DESCRIPTION
buildspec reference: https://docs.aws.amazon.com/codebuild/latest/userguide/batch-build-buildspec.html

you can see that the image field is in the env prop, not in env.variables