### PR TITLE
fix #Nextjs bookmark

### DIFF
--- a/docs/faq/questions/using-cypress-faq.mdx
+++ b/docs/faq/questions/using-cypress-faq.mdx
@@ -1153,7 +1153,7 @@ set good Cypress tests for a Next.js application in this
 [tutorial](https://getstarted.sh/bulletproof-next/e2e-testing-with-cypress).
 
 You can also test Next.js apps in component testing. See the
-[Framework Configuration Guide on Next.js](/guides/component-testing/react/overview#Next-js)
+[Framework Configuration Guide on Next.js](/guides/component-testing/react/overview#Nextjs)
 for more info.
 
 ## <Icon name="angle-right" /> Can I test Gatsby.js sites using Cypress?

--- a/docs/guides/component-testing/overview.mdx
+++ b/docs/guides/component-testing/overview.mdx
@@ -104,7 +104,7 @@ following development servers and frameworks:
 | Framework                                                                                                             | UI Library  | Bundler    |
 | --------------------------------------------------------------------------------------------------------------------- | ----------- | ---------- |
 | [Create React App 4+](/guides/component-testing/react/overview#Create-React-App-CRA)                                  | React 16+   | Webpack 4+ |
-| [Next.js 11+](/guides/component-testing/react/overview#Next-js)                                                       | React 16+   | Webpack 5  |
+| [Next.js 11+](/guides/component-testing/react/overview#Nextjs)                                                        | React 16+   | Webpack 5  |
 | [React with Vite](/guides/component-testing/react/overview#React-with-Vite)                                           | React 16+   | Vite 2+    |
 | [React with Webpack](/guides/component-testing/react/overview#React-with-Webpack)                                     | React 16+   | Webpack 4+ |
 | [Vue CLI](/guides/component-testing/vue/overview#Vue-CLI)                                                             | Vue 2+      | Webpack 4+ |

--- a/docs/guides/component-testing/react/overview.mdx
+++ b/docs/guides/component-testing/react/overview.mdx
@@ -10,7 +10,7 @@ Cypress Component Testing currently supports React 16+ with the following
 frameworks:
 
 - [Create React App](#Create-React-App-CRA)
-- [Next.js](#Next-js)
+- [Next.js](#Nextjs)
 - [React with Vite](#React-with-Vite)
 - [React with Webpack](#React-with-Webpack)
 


### PR DESCRIPTION
This PR fixes references to the bookmark `#Nextjs` referring to the section:

[Component Testing > React Component Testing > React Overview > Next.js](https://docs.cypress.io/guides/component-testing/react/overview#Nextjs)

The currently used bookmark `#Next-js` does not exist. The available bookmark is `#Nextjs`.

The PR corrects links in:

- [FAQ > Using Cypress > Can I test Next.js sites using Cypress?](https://docs.cypress.io/faq/questions/using-cypress-faq#Can-I-test-Nextjs-sites-using-Cypress) (second paragraph)
- List entry for Next.js in [Component Testing > React Component Testing > Framework Support](https://docs.cypress.io/guides/component-testing/react/overview#Framework-Support) (clicking on link has no effect)
- [Component Testing > Overview > Supported Frameworks](https://docs.cypress.io/guides/component-testing/overview#Supported-Frameworks) (table)