### PR TITLE
update to Next.js 13 with TypeScript example

### DIFF
--- a/docs/guides/component-testing/react/overview.mdx
+++ b/docs/guides/component-testing/react/overview.mdx
@@ -127,7 +127,7 @@ Next.js pages and Component Testing for individual components in a Next.js app.
 
 #### Sample Next.js Apps
 
-- [Next.js 12 with TypeScript](https://github.com/cypress-io/cypress-component-testing-apps/tree/main/react-next12-ts)
+- [Next.js 13 with TypeScript](https://github.com/cypress-io/cypress-component-testing-apps/tree/main/react-next13-ts)
 
 ### React with Vite
 


### PR DESCRIPTION
This PR changes the link in the documentation page

[Component Testing > React Component Testing > React Overview > Framework Configuration > Next.js > Sample Next.js Apps](https://docs.cypress.io/guides/component-testing/react/overview#Sample-Nextjs-Apps) to


- [Next.js 13 with TypeScript](https://github.com/cypress-io/cypress-component-testing-apps/tree/main/react-next13-ts)

instead of it using the example of the previous Next.js version 

- [Next.js 12 with TypeScript](https://github.com/cypress-io/cypress-component-testing-apps/tree/main/react-next12-ts).

Next.js `13` is the current version (see [releases](https://github.com/vercel/next.js/releases)).