### PR TITLE
remove unreachable Cypress Next.js tutorial

### DIFF
--- a/docs/faq/questions/using-cypress-faq.mdx
+++ b/docs/faq/questions/using-cypress-faq.mdx
@@ -1148,9 +1148,7 @@ scenarios, you might be interested in these articles:
 For end-to-end tests, yes, absolutely. See an example in the
 [next-and-cypress-example](https://github.com/bahmutov/next-and-cypress-example)
 repository where we show how to instrument the application's source code to get
-[code coverage](/guides/tooling/code-coverage) from tests. You can learn how to
-set good Cypress tests for a Next.js application in this
-[tutorial](https://getstarted.sh/bulletproof-next/e2e-testing-with-cypress).
+[code coverage](/guides/tooling/code-coverage) from tests.
 
 You can also test Next.js apps in component testing. See the
 [Framework Configuration Guide on Next.js](/guides/component-testing/react/overview#Nextjs)


### PR DESCRIPTION
This PR removes a reference to a Cypress / Next.js tutorial which is a failing link to https://getstarted.sh/bulletproof-next/e2e-testing-with-cypress.

The link was last observed working on April 18, 2021 according to http://web.archive.org/web/20210715000000*/https://getstarted.sh/bulletproof-next/e2e-testing-with-cypress. Since then the site has responded with an HTTP 500 server error.

The link was included in

- [FAQ > Using Cypress > Can I test Next.js sites using Cypress?](https://docs.cypress.io/faq/questions/using-cypress-faq#Can-I-test-Nextjs-sites-using-Cypress) ("You can learn how to set good Cypress tests for a Next.js application in this [tutorial](https://getstarted.sh/bulletproof-next/e2e-testing-with-cypress)")