### PR TITLE
update github-action description in plugins list to include pnpm and Yarn

### DIFF
--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -116,7 +116,7 @@
         },
         {
           "name": "Cypress Github Actions",
-          "description": "GitHub Action for running Cypress end-to-end and component tests. Includes NPM installation, custom caching and lots of configuration options.",
+          "description": "GitHub Action for running Cypress end-to-end and component tests. Includes npm, pnpm and Yarn installation, custom caching and lots of configuration options.",
           "link": "https://github.com/cypress-io/github-action",
           "keywords": ["continuous-integration", "github-actions"],
           "badge": "official"


### PR DESCRIPTION
This PR modifies the entry in the [Plugins > Development Tools](https://docs.cypress.io/plugins#Development%20Tools) list for the GitHub JavaScript action [github-action](https://github.com/cypress-io/github-action).

The definitive description of the action is taken from the top of its [README](https://github.com/cypress-io/github-action/blob/master/README.md) file (as it is published to GitHub's Marketplace as [cypress-io/github-action](https://github.com/marketplace/actions/cypress-io#cypress-iogithub-action--) and npm's JavaScript Package Registry as [@cypress/github-action](https://www.npmjs.com/package/@cypress/)github-action):

"[GitHub Action](https://docs.github.com/en/actions) for running [Cypress](https://www.cypress.io) end-to-end and component tests. Includes npm, pnpm and Yarn installation, custom caching and lots of configuration options."
