### PR TITLE
remove obsolete TypeScript standalone example pre Cypress 4.4.0

### DIFF
--- a/docs/guides/tooling/typescript-support.mdx
+++ b/docs/guides/tooling/typescript-support.mdx
@@ -214,8 +214,6 @@ As you can see there are generic parameters `<'type', 'element'>` are used:
 
 #### Examples:
 
-- Find
-  [the standalone example](https://github.com/cypress-io/add-cypress-custom-command-in-typescript).
 - See
   [Adding Custom Commands](https://github.com/cypress-io/cypress-example-recipes#fundamentals)
   example recipe.


### PR DESCRIPTION
This PR removes the reference and link to the obsolete TypeScript "find the [standalone example](https://github.com/cypress-io/add-cypress-custom-command-in-typescript)" in [Tooling > TypeScript > Examples](https://docs.cypress.io/guides/tooling/typescript-support#Examples) using Cypress `3.8.3` before native TypeScript support was released with Cypress `4.4.0`.

As stated on the Cypress documentation page [Tooling > TypeScript > History](https://docs.cypress.io/guides/tooling/typescript-support#History):

[4.4.0](https://docs.cypress.io/guides/references/changelog#4-4-0)	Added support for TypeScript without needing your own transpilation through preprocessors.

---

https://github.com/cypress-io/add-cypress-custom-command-in-typescript uses the npm module [@bahmutov/add-typescript-to-cypress](https://www.npmjs.com/package/@bahmutov/add-typescript-to-cypress) which contains the outdated statement in its [README > Why?](https://github.com/bahmutov/add-typescript-to-cypress#why):

"[Cypress](https://www.cypress.io/) is awesome, but does not come with TypeScript support right out of the box. Instead you need to install either [Cypress webpack preprocessor](https://github.com/cypress-io/cypress-webpack-preprocessor) or [Cypress browserify preprocessor](https://github.com/cypress-io/cypress-browserify-preprocessor) and configure them to [transpile TypeScript spec files](https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/preprocessors__typescript-webpack)."

---

## Suggestions

The presence of this example is causing confusion. See https://github.com/cypress-io/add-cypress-custom-command-in-typescript/issues/124.

- The https://github.com/cypress-io/add-cypress-custom-command-in-typescript/blob/master/README.md file should be updated with current information and the repository https://github.com/cypress-io/add-cypress-custom-command-in-typescript should be archived.

- [@bahmutov/add-typescript-to-cypress](https://www.npmjs.com/package/@bahmutov/add-typescript-to-cypress) could also be encouraged to update its README so it reflects Cypress after the release of version [4.4.0](https://docs.cypress.io/guides/references/changelog#4-4-0) on April 13, 2020.
