### PR TITLE
use individual article urls in examples/media blogs page

### DIFF
--- a/src/components/blogs-list/index.tsx
+++ b/src/components/blogs-list/index.tsx
@@ -29,7 +29,7 @@ export default function blogsList(): BlogsProps {
                 <div key={index} className="mediaColumn">
                   <div className="mediaTitleContainer">
                     <a
-                       href={blog.sourceUrl}
+                       href={blog.url}
                        target="_blank"
                        rel="noopener noreferer"
                     >
@@ -37,7 +37,7 @@ export default function blogsList(): BlogsProps {
                     </a>
                   </div>
                   {blog.img && (
-                      <a href={blog.sourceUrl}
+                      <a href={blog.url}
                          target="_blank"
                          rel="noopener noreferer"
                       >


### PR DESCRIPTION
This PR adds the blog article links to entries in [Examples > Media > Blogs](https://docs.cypress.io/examples/media/blogs-media). Previously only the links to the site hosting each blog article were being used.

## Verification

Open [Examples > Media > Blogs](https://docs.cypress.io/examples/media/blogs-media)

1. Click on the title of a blog article and confirm that the article itself is opened.
2. Click on the graphic of a blog article and again confirm that the article itself is opened.
3. Click on the link underneath the blog article and confirm that the site hosting the blog article is opened.