### PR TITLE
Correct link to legacy "Test a React Todo App" tutorial

### DIFF
--- a/src/data/courses.json
+++ b/src/data/courses.json
@@ -285,7 +285,7 @@
     },
     {
       "title": "Test a React Todo App",
-      "url": "https://on.cypress.io/tutorials",
+      "url": "/examples/tutorials",
       "author": "Andy van Slaars",
       "authorTwitter": "avanslaars",
       "sourceName": "Cypress.io",


### PR DESCRIPTION
This PR corrects a link to "Test a React Todo App" in the list of [Examples > Media > Courses](https://docs.cypress.io/examples/media/courses-media).

The tutorial is located at https://docs.cypress.io/examples/tutorials#Test-a-React-Todo-App. It is a legacy tutorial using Cypress `3.5.0`.

It should be separately considered whether this tutorial should be kept online considering the old Cypress `3.5.0` version used, and the fact that there is a newer ToDo tutorial on https://github.com/cypress-io/cypress-example-todomvc using Cypress `12.12.0`.
