### PR TITLE
Typo in "session" documentation.mdx

### DIFF
--- a/docs/api/commands/session.mdx
+++ b/docs/api/commands/session.mdx
@@ -622,7 +622,7 @@ In order to reduce development time, when running Cypress in "open" mode,
 sessions will be cached _for spec file reruns_.
 
 To persist a session across multiple specs, use the option
-`cacheAcrossSpecs=true`.
+`cacheAcrossSpecs: true`.
 
 ### Explicitly clearing sessions
 


### PR DESCRIPTION
Typo in "cacheAcrossSpecs" description and tutorial