### PR TITLE
fix blog deeplinks

### DIFF
--- a/src/components/blogs-list/index.tsx
+++ b/src/components/blogs-list/index.tsx
@@ -14,7 +14,7 @@ export default function blogsList(): BlogsProps {
               {blogsJSON.small.map((blog, index) => (
                 <li key={index}>
                   <a
-                    href={`${blog.sourceUrl}`}
+                    href={`${blog.url}`}
                     target="_blank"
                     rel="noopener noreferer"
                   >
@@ -29,7 +29,7 @@ export default function blogsList(): BlogsProps {
                 <div key={index} className="mediaColumn">
                   <div className="mediaTitleContainer">
                     <a
-                       href={blog.sourceUrl}
+                       href={blog.url}
                        target="_blank"
                        rel="noopener noreferer"
                     >
@@ -37,7 +37,7 @@ export default function blogsList(): BlogsProps {
                     </a>
                   </div>
                   {blog.img && (
-                      <a href={blog.sourceUrl}
+                      <a href={blog.url}
                          target="_blank"
                          rel="noopener noreferer"
                       >


### PR DESCRIPTION
Blog posts are set up to deeplink to the noted content but also the root source as a credit within "Published on...". This fixes both areas pointing only to the root source. 