### PR TITLE
Fixed electron example link

### DIFF
--- a/docs/faq/questions/using-cypress-faq.mdx
+++ b/docs/faq/questions/using-cypress-faq.mdx
@@ -971,7 +971,7 @@ anything that runs in a browser and Electron is a browser + Node.
 That being said, we use Cypress to test our own Desktop app's front end - by
 stubbing events from Electron. These tests are open source so you can check them
 out
-[here](https://github.com/cypress-io/cypress/tree/develop/packages/desktop-gui/cypress/integration).
+[here](https://github.com/cypress-io/cypress/tree/develop/packages/launchpad/cypress/e2e).
 
 ## <Icon name="angle-right" /> I found a bug! What do I do?
 


### PR DESCRIPTION
Fixes Issue #5131 & #5282.

Changed the Broken link to "https://github.com/cypress-io/cypress/tree/develop/packages/launchpad/cypress/e2e" as suggested by @MikeMcC399 