### PR TITLE
address deprecated xpath plugin references

### DIFF
--- a/docs/api/cypress-api/custom-commands.mdx
+++ b/docs/api/cypress-api/custom-commands.mdx
@@ -912,8 +912,5 @@ repository for a working example.
   and
   [How to Publish Custom Cypress Command on NPM](https://glebbahmutov.com/blog/publishing-cypress-command/).
 - [Plugins using custom commands](/plugins#Custom%20Commands)
-- [`cypress-xpath`](https://github.com/cypress-io/cypress-xpath) adds a
-  `cy.xpath()` command and shows best practices for writing custom commands:
-  retries, logging, and TypeScript definition.
 - [Cypress.log()](/api/cypress-api/cypress-log)
 - [Recipe: Logging In](/examples/recipes)

--- a/docs/guides/end-to-end-testing/migration/protractor-to-cypress.mdx
+++ b/docs/guides/end-to-end-testing/migration/protractor-to-cypress.mdx
@@ -399,15 +399,6 @@ cy.get('.my-class').contains('text')
 cy.contains('text')
 ```
 
-:::info
-
-While Protractor also allows for selection by XPath, Cypress doesn't support
-this out of the box. However, you can add the
-[cypress-xpath plugin](https://www.npmjs.com/package/cypress-xpath) to easily
-enable it.
-
-:::
-
 #### Getting multiple elements on a page
 
 When you want to get access to more than one element on the page, you would need

--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -1239,6 +1239,13 @@
           "link": "https://github.com/cypress-io/cypress-browserify-preprocessor",
           "keywords": ["browserify"],
           "badge": "official"
+        },
+        {
+          "name": "cypress-xpath",
+          "description": "Adds XPath command. This repo is also a good example of using custom commands to do retries, provide TypeScript definitions, etc.",
+          "link": "https://github.com/cypress-io/cypress/tree/develop/npm/xpath",
+          "keywords": ["xpath", "commands"],
+          "badge": "official"
         }
       ]
     }

--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -393,13 +393,6 @@
       "description": " Read the <a target=\"_blank\" href=\"/api/plugins/preprocessors-api\">Custom Commands</a> and <a target=\"_blank\" href=\"/api/plugins/preprocessors-api\">Custom Query</a> documentation to learn more.",
       "plugins": [
         {
-          "name": "cypress-xpath",
-          "description": "Adds XPath command. This repo is also a good example of using custom commands to do retries, provide TypeScript definitions, etc.",
-          "link": "https://github.com/cypress-io/cypress/tree/develop/npm/xpath",
-          "keywords": ["xpath", "commands"],
-          "badge": "official"
-        },
-        {
           "name": "cypress-testing-library",
           "description": "🐅 Simple and complete custom Cypress commands and utilities that encourage good testing practices.",
           "link": "https://github.com/kentcdodds/cypress-testing-library",


### PR DESCRIPTION
This PR moves the [xpath](https://github.com/cypress-io/cypress/tree/develop/npm/xpath) plugin reference in the [Plugins list](https://docs.cypress.io/plugins) to the [Legacy](https://docs.cypress.io/plugins#Legacy) section.

Links to [cypress-io/cypress-xpath](https://github.com/cypress-io/cypress-xpath) on other pages are removed.

## Changed pages

- [Plugins list](https://docs.cypress.io/plugins)
- [API > Custom Commands > See also](https://docs.cypress.io/api/cypress-api/custom-commands#See-also)
- [End-to-End Testing > Migrating from Other Frameworks > Migrating from Protractor to Cypress > Working with the DOM](https://docs.cypress.io/guides/end-to-end-testing/protractor-to-cypress#Working-with-the-DOM)

## Reasons

[xpath](https://github.com/cypress-io/cypress/tree/develop/npm/xpath) shows the README text "@cypress/xpath has been deprecated and is no longer supported." so for consistency with this message it should no longer be advertised in the main part of the [Plugins list](https://docs.cypress.io/plugins).

The repository [cypress-io/cypress-xpath](https://github.com/cypress-io/cypress-xpath) is deprecated and refers instead to https://github.com/cypress-io/cypress/tree/develop/npm/xpath and to https://www.npmjs.com/package/@cypress/xpath, both of which carry deprecation notices.
