### PR TITLE
remove deprecated browserify-preprocessor plugin references

### DIFF
--- a/docs/api/plugins/preprocessors-api.mdx
+++ b/docs/api/plugins/preprocessors-api.mdx
@@ -15,13 +15,12 @@ them again, and then notifies Cypress to re-run the tests.
 
 ## Examples
 
-We've created three preprocessors as examples for you to look at. These are
-fully functioning preprocessors.
+We've created two preprocessors as examples for you to look at. These are fully
+functioning preprocessors.
 
 The code contains comments that explain how it utilizes the preprocessor API.
 
-- [webpack preprocessor](https://github.com/cypress-io/cypress/tree/develop/npm/webpack-preprocessor)
-- [Browserify preprocessor](https://github.com/cypress-io/cypress-browserify-preprocessor)
+- [webpack preprocessor](https://github.com/cypress-io/cypress/tree/master/npm/webpack-preprocessor)
 - [Watch preprocessor](https://github.com/cypress-io/cypress-watch-preprocessor)
 
 ### See also

--- a/docs/faq/questions/general-questions-faq.mdx
+++ b/docs/faq/questions/general-questions-faq.mdx
@@ -224,9 +224,7 @@ You may also find the following resources helpful when writing end-to-end tests:
 Cypress does _not_ utilize WebDriver for testing, so it does not use or have any
 notion of driver bindings. If your language can be somehow transpiled to
 JavaScript, then you can configure
-[Cypress webpack preprocessor](https://github.com/cypress-io/cypress/tree/develop/npm/webpack-preprocessor)
-or
-[Cypress Browserify preprocessor](https://github.com/cypress-io/cypress-browserify-preprocessor)
+[Cypress webpack preprocessor](https://github.com/cypress-io/cypress/tree/master/npm/webpack-preprocessor)
 to transpile your tests to JavaScript that Cypress can run.
 
 ## <Icon name="angle-right" /> What resources do you recommend to learn JavaScript before writing Cypress tests?


### PR DESCRIPTION
This PR removes the Cypress [browserify-preprocessor](https://github.com/cypress-io/cypress-browserify-preprocessor) plugin from the [Plugins list](https://docs.cypress.io/plugins) and it removes references to it in other places in the documentation.

## Changed pages

- [Plugins list](https://docs.cypress.io/plugins)
- [API > Plugins > Preprocessors API > Examples](https://docs.cypress.io/api/plugins/preprocessors-api#Examples)
- [FAQ > General Questions > Are there driver bindings in my language?](https://docs.cypress.io/faq/questions/general-questions-faq#Are-there-driver-bindings-in-my-language)

## Reason

The [README](https://github.com/cypress-io/cypress-browserify-preprocessor/blob/master/README.md) contains the text:

"Note: This plugin is deprecated and Cypress will not be moving forward with development of the plugin."

## Suggestion

Since the repo [cypress-io/cypress-browserify-preprocessor](https://github.com/cypress-io/cypress-browserify-preprocessor) is archived with a deprecation notice, the npm registry entry https://www.npmjs.com/package/@cypress/browserify-preprocessor should also be deprecated. This can't be handled via PR and it is not possible to add an issue to the repo [cypress-io/cypress-browserify-preprocessor](https://github.com/cypress-io/cypress-browserify-preprocessor) as archived repos do not allow the creation of new issues.
