### PR TITLE
chore: update with guidance about how to disable --headless=new

### DIFF
--- a/docs/api/plugins/browser-launch-api.mdx
+++ b/docs/api/plugins/browser-launch-api.mdx
@@ -383,6 +383,31 @@ on('before:browser:launch', (browser, options) => {
 
 :::
 
+### Disable `--headless=new` for Chrome
+
+Starting in Chrome version 112, Cypress now will now launch Chrome with the with
+[the new `--headless=new` flag](https://developer.chrome.com/articles/new-headless/).
+
+If this new option causes issues with your tests it can easily be reverted with
+the following example so long as Chrome supports the old version of
+`--headless`.
+
+```ts
+on('before:browser:launch', (browser = {}, launchOptions) => {
+  if (browser.name === 'chrome' && browser.isHeadless) {
+    launchOptions.args = launchOptions.args.map((arg) => {
+      if (arg === '--headless=new') {
+        return '--headless'
+      }
+
+      return arg
+    })
+  }
+
+  return launchOptions
+})
+```
+
 ### Set a Firefox flag
 
 If we need to set a particular Firefox flag, like `browser.send_pings` we can do

--- a/docs/api/plugins/browser-launch-api.mdx
+++ b/docs/api/plugins/browser-launch-api.mdx
@@ -385,12 +385,7 @@ on('before:browser:launch', (browser, options) => {
 
 ### Disable `--headless=new` for Chrome
 
-Starting in Cypress 12.15.0 for Chrome version 112, Cypress now will now launch Chrome with the with
-[the new `--headless=new` flag](https://developer.chrome.com/articles/new-headless/).
-
-If this new option causes issues with your tests it can easily be reverted with
-the following example so long as Chrome supports the old version of
-`--headless`.
+Starting in Chrome 112, you can change the value of the `--headless` flag to the old value before the `--headless=new` flag was introduced.
 
 ```ts
 on('before:browser:launch', (browser = {}, launchOptions) => {

--- a/docs/api/plugins/browser-launch-api.mdx
+++ b/docs/api/plugins/browser-launch-api.mdx
@@ -385,7 +385,7 @@ on('before:browser:launch', (browser, options) => {
 
 ### Disable `--headless=new` for Chrome
 
-Starting in Chrome version 112, Cypress now will now launch Chrome with the with
+Starting in Cypress 12.15.0 for Chrome version 112, Cypress now will now launch Chrome with the with
 [the new `--headless=new` flag](https://developer.chrome.com/articles/new-headless/).
 
 If this new option causes issues with your tests it can easily be reverted with

--- a/docs/api/plugins/browser-launch-api.mdx
+++ b/docs/api/plugins/browser-launch-api.mdx
@@ -385,7 +385,8 @@ on('before:browser:launch', (browser, options) => {
 
 ### Disable `--headless=new` for Chrome
 
-Starting in Chrome 112, you can change the value of the `--headless` flag to the old value before the `--headless=new` flag was introduced.
+Starting in Chrome 112, you can change the value of the `--headless` flag to the
+old value before the `--headless=new` flag was introduced.
 
 ```ts
 on('before:browser:launch', (browser = {}, launchOptions) => {


### PR DESCRIPTION
This adds a blurb about how to disable --headless=new if someone runs into issues with it.