### PR TITLE
fix: Set prose-wrap to preserve

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -2,5 +2,5 @@
   "semi": false,
   "singleQuote": true,
   "printWidth": 80,
-  "proseWrap": "always"
+  "proseWrap": "preserve"
 }

--- a/docs/api/commands/intercept.mdx
+++ b/docs/api/commands/intercept.mdx
@@ -1636,6 +1636,5 @@ information about the request and response to the console:
 [match-url]: #Matching-url
 [glob-match-url]: #Glob-Pattern-Matching-URLs
 [arg-method]: #method-String
-[arg-routehandler]:
-  #routeHandler-lt-code-gtstring-object-Function-StaticResponselt-code-gt
+[arg-routehandler]: #routeHandler-lt-code-gtstring-object-Function-StaticResponselt-code-gt
 [arg-routematcher]: #routeMatcher-RouteMatcher

--- a/docs/guides/continuous-integration/circleci.mdx
+++ b/docs/guides/continuous-integration/circleci.mdx
@@ -65,8 +65,7 @@ workflows:
     jobs:
       - cypress/run:
           start-command: 'npm run start'
-          cypress-command:
-            'npx cypress run --parallel --record --group all tests'
+          cypress-command: 'npx cypress run --parallel --record --group all tests'
           parallelism: 4
 ```
 

--- a/docs/guides/guides/cross-browser-testing.mdx
+++ b/docs/guides/guides/cross-browser-testing.mdx
@@ -178,13 +178,11 @@ workflows:
           name: Chrome
           start-command: 'npm start'
           install-browsers: true
-          cypress-command:
-            'npx cypress run --browser chrome --record --group chrome'
+          cypress-command: 'npx cypress run --browser chrome --record --group chrome'
       - cypress/run:
           name: Firefox
           start-command: 'npm start'
-          cypress-command:
-            'npx cypress run --browser firefox --record --group
+          cypress-command: 'npx cypress run --browser firefox --record --group
             firefox-critical-path --spec
             cypress/e2e/signup.cy.js,cypress/e2e/login.cy.js'
 ```
@@ -215,8 +213,7 @@ workflows:
     jobs:
       - cypress/run:
           name: Chrome
-          cypress-command:
-            'npx cypress run --record --parallel --group chrome --browser chrome'
+          cypress-command: 'npx cypress run --record --parallel --group chrome --browser chrome'
           start-command: 'npm start'
           parallelism: 4
           install-browsers: true

--- a/docs/guides/references/migration-guide.mdx
+++ b/docs/guides/references/migration-guide.mdx
@@ -3616,8 +3616,7 @@ module.exports = (on) => {
 ```
 
 [intercept]: /api/commands/intercept
-[npmcypresswebpackdevserver]:
-  https://www.npmjs.org/package/@cypress/webpack-dev-server
+[npmcypresswebpackdevserver]: https://www.npmjs.org/package/@cypress/webpack-dev-server
 [npmcypressreact]: https://www.npmjs.org/package/@cypress/react
 [npmcypressvue]: https://www.npmjs.org/package/@cypress/vue
 [npmreact]: https://www.npmjs.org/package/react


### PR DESCRIPTION
Set prose-wrap to the default value of preserve to allow for markdown lines greater than 80 characters.

https://prettier.io/docs/en/options.html#prose-wrap