### PR TITLE
Update visual-testing.mdx with breaking lines

### DIFF
--- a/docs/guides/tooling/visual-testing.mdx
+++ b/docs/guides/tooling/visual-testing.mdx
@@ -307,10 +307,11 @@ cy.mySnapshotCommand()
 
 :::tip
 
-&nbsp;<Icon name="check-circle" color="green" /> **Best Practice:** Use
-
-<a href="/api/commands/fixture">cy.fixture()</a> and network mocking to set the application
-state.
+<!-- prettier-ignoring because prettier forces <a> tag into a new line -->
+<!-- prettier-ignore -->
+&nbsp;<Icon name="check-circle" color="green" /> **Best Practice:**
+Use <a href="/api/commands/fixture">cy.fixture()</a> and network mocking to set
+the application state.
 
 :::
 
@@ -341,8 +342,11 @@ breaking tests in other unrelated components.
 
 :::tip
 
-&nbsp;<Icon name="check-circle" color="green" /> **Best Practice:** Use <a href="/plugins"> Component Testing plugins</a> to test the individual components
-functionality in addition to end-to-end and visual tests.
+<!-- prettier-ignoring because prettier forces <a> tag into a new line -->
+<!-- prettier-ignore -->
+&nbsp;<Icon name="check-circle" color="green" /> **Best Practice:** 
+Use <a href="/plugins">Component Testing plugins</a> to test the individual
+components functionality in addition to end-to-end and visual tests.
 
 :::
 

--- a/docs/guides/tooling/visual-testing.mdx
+++ b/docs/guides/tooling/visual-testing.mdx
@@ -341,9 +341,7 @@ breaking tests in other unrelated components.
 
 :::tip
 
-&nbsp;<Icon name="check-circle" color="green" /> **Best Practice:** Use
-
-<a href="/plugins"> Component Testing plugins</a> to test the individual components
+&nbsp;<Icon name="check-circle" color="green" /> **Best Practice:** Use <a href="/plugins"> Component Testing plugins</a> to test the individual components
 functionality in addition to end-to-end and visual tests.
 
 :::

--- a/docs/guides/tooling/visual-testing.mdx
+++ b/docs/guides/tooling/visual-testing.mdx
@@ -339,11 +339,9 @@ breaking tests in other unrelated components.
 
 :::tip
 
-<!-- prettier-ignoring because prettier forces <a> tag into a new line -->
-<!-- prettier-ignore -->
-&nbsp;<Icon name="check-circle" color="green" /> **Best Practice:** 
-Use <a href="/plugins">Component Testing plugins</a> to test the individual
-components functionality in addition to end-to-end and visual tests.
+&nbsp;<Icon name="check-circle" color="green" /> **Best Practice:** Use
+[Component Testing](/guides/component-testing/overview) to test the individual components
+functionality in addition to end-to-end and visual tests.
 
 :::
 

--- a/docs/guides/tooling/visual-testing.mdx
+++ b/docs/guides/tooling/visual-testing.mdx
@@ -307,11 +307,8 @@ cy.mySnapshotCommand()
 
 :::tip
 
-<!-- prettier-ignoring because prettier forces <a> tag into a new line -->
-<!-- prettier-ignore -->
-&nbsp;<Icon name="check-circle" color="green" /> **Best Practice:**
-Use <a href="/api/commands/fixture">cy.fixture()</a> and network mocking to set
-the application state.
+&nbsp;<Icon name="check-circle" color="green" /> **Best Practice:** Use
+[cy.fixture()](/api/commands/fixture) and network mocking to set the application state.
 
 :::
 


### PR DESCRIPTION
Fixes these:

![image](https://github.com/cypress-io/cypress-documentation/assets/5755214/93972dfe-9ab9-4b06-aa8d-4a12aa690091)

![image](https://github.com/cypress-io/cypress-documentation/assets/5755214/a48076c9-63f3-48a7-b293-2934b2bce2ed)



I had to `prettier-ignore` my changes because prettier forces `<a>` tag on a new line. And because there was no config I could add to prettier for these cases, I just `prettier-ignore`d them.