### PR TITLE
fix: plugin PickleJs text display

### DIFF
--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -746,7 +746,7 @@
         },
         {
           "name": "PickleJS",
-          "description": "An addition to the Cucumber plugin, featuring a collection of phrases you can use for common actions (ex: \"I click on an <Element>\", \"I should see an <Element>\").",
+          "description": "An addition to the Cucumber plugin, featuring a collection of phrases you can use for common actions (ex: \"I click on an &lt;Element&gt;\", \"I should see an &lt;Element&gt;\").",
           "link": "https://picklejs.com",
           "keywords": ["cucumber", "collection", "actions", "commands"],
           "badge": "community"


### PR DESCRIPTION
This PR fixes the text display for the plugin entry of [PickleJS](https://picklejs.com/) in the [Plugins list](https://docs.cypress.io/plugins), section "Extending other testing frameworks".

The characters `<` and `>` in the description text for the `PickleJS` plugin are replaced by their HTML character entities `&lt;`and `&gt;` respectively.

Before | After
--- | ---
![PickleJS before](https://github.com/cypress-io/cypress-documentation/assets/66998419/43b6d826-b94a-445d-81e0-edde6e4d0e2a) | ![PickleJS after](https://github.com/cypress-io/cypress-documentation/assets/66998419/30e3e980-9bd9-49ef-a434-6ab2bc369b1a)


## Issue

The text is incomplete. Where it was intended for `<element>` to appear, nothing is displayed.

"An addition to the Cucumber plugin, featuring a collection of phrases you can use for common actions (ex: "I click on an ", "I should see an ")."