### PR TITLE
fix: plugins section id no whitespace

### DIFF
--- a/src/components/plugins-list/index.tsx
+++ b/src/components/plugins-list/index.tsx
@@ -16,7 +16,7 @@ export default function PluginsList() {
           key={plugin.name}
           data-cy={`plugin-${plugin.name}`}
         >
-          <h2 id={plugin.name}>{plugin.name}</h2>
+          <h2 id={plugin.name.replaceAll(' ', '-').toLowerCase()}>{plugin.name}</h2>
 
           {plugin.description && (
             <p


### PR DESCRIPTION
This PR ensures that `h2` section ids generated for the [Plugins list](https://docs.cypress.io/plugins) conform to HTML rules which disallow whitespace in an `id` attribute.

For instance, the Section "Development Tools" was generated as `<h2 id="Development Tools">`, which is illegal due to the embedded whitespace between the two words.

`h2` section ids are now generated by replacing space with hyphen "-" and converting to lower case.

## Verification

1. Execute `npm run build`
2. View the generated HTML `dist/plugins/index.html`
3. Search for `<h2 id="` strings and confirm that ids are lower case and contain no whitespace.

## Reference

- https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/id
