### PR TITLE
docs: update master branch links to develop branch

### DIFF
--- a/docs/api/plugins/preprocessors-api.mdx
+++ b/docs/api/plugins/preprocessors-api.mdx
@@ -20,7 +20,7 @@ fully functioning preprocessors.
 
 The code contains comments that explain how it utilizes the preprocessor API.
 
-- [webpack preprocessor](https://github.com/cypress-io/cypress/tree/master/npm/webpack-preprocessor)
+- [webpack preprocessor](https://github.com/cypress-io/cypress/tree/develop/npm/webpack-preprocessor)
 - [Browserify preprocessor](https://github.com/cypress-io/cypress-browserify-preprocessor)
 - [Watch preprocessor](https://github.com/cypress-io/cypress-watch-preprocessor)
 
@@ -50,11 +50,11 @@ Are you looking to change the **default options** for webpack?
 
 If you already use webpack in your project, you can pass in your webpack config
 as
-[shown here](https://github.com/cypress-io/cypress/tree/master/npm/webpack-preprocessor#options).
+[shown here](https://github.com/cypress-io/cypress/tree/develop/npm/webpack-preprocessor#options).
 
 If you don't use webpack in your project or would like to keep the majority of
 the default options, you can
-[modify the default options](https://github.com/cypress-io/cypress/tree/master/npm/webpack-preprocessor#modifying-default-options).
+[modify the default options](https://github.com/cypress-io/cypress/tree/develop/npm/webpack-preprocessor#modifying-default-options).
 Editing the options allows you to do things like:
 
 - Add your own Babel plugins

--- a/docs/faq/questions/general-questions-faq.mdx
+++ b/docs/faq/questions/general-questions-faq.mdx
@@ -224,7 +224,7 @@ You may also find the following resources helpful when writing end-to-end tests:
 Cypress does _not_ utilize WebDriver for testing, so it does not use or have any
 notion of driver bindings. If your language can be somehow transpiled to
 JavaScript, then you can configure
-[Cypress webpack preprocessor](https://github.com/cypress-io/cypress/tree/master/npm/webpack-preprocessor)
+[Cypress webpack preprocessor](https://github.com/cypress-io/cypress/tree/develop/npm/webpack-preprocessor)
 or
 [Cypress Browserify preprocessor](https://github.com/cypress-io/cypress-browserify-preprocessor)
 to transpile your tests to JavaScript that Cypress can run.

--- a/docs/guides/core-concepts/retry-ability.mdx
+++ b/docs/guides/core-concepts/retry-ability.mdx
@@ -320,7 +320,7 @@ particular, you should rarely need this pattern.
 
 As another example, when confirming that the button component invokes the
 `click` prop testing with the
-[cypress/react](https://github.com/cypress-io/cypress/tree/master/npm/react)
+[cypress/react](https://github.com/cypress-io/cypress/tree/develop/npm/react)
 mounting library, the following test might or might not work:
 
 #### <Icon name="exclamation-triangle" color="red" /> Incorrectly checking if the stub was called

--- a/docs/guides/core-concepts/writing-and-organizing-tests.mdx
+++ b/docs/guides/core-concepts/writing-and-organizing-tests.mdx
@@ -1021,7 +1021,7 @@ The `watchForFileChanges` property is only in effect when running Cypress using
 :::
 
 The component responsible for the file-watching behavior in Cypress is the
-[`webpack-preprocessor`](https://github.com/cypress-io/cypress/tree/master/npm/webpack-preprocessor).
+[`webpack-preprocessor`](https://github.com/cypress-io/cypress/tree/develop/npm/webpack-preprocessor).
 This is the default file-watcher packaged with Cypress.
 
 If you need further control of the file-watching behavior you can configure this
@@ -1033,4 +1033,4 @@ Cypress also ships other [file-watching preprocessors](/plugins#Preprocessors);
 you'll have to configure these explicitly if you want to use them.
 
 - [Cypress Watch Preprocessor](https://github.com/cypress-io/cypress-watch-preprocessor)
-- [Cypress webpack Preprocessor](https://github.com/cypress-io/cypress/tree/master/npm/webpack-preprocessor)
+- [Cypress webpack Preprocessor](https://github.com/cypress-io/cypress/tree/develop/npm/webpack-preprocessor)

--- a/docs/guides/end-to-end-testing/migration/protractor-to-cypress.mdx
+++ b/docs/guides/end-to-end-testing/migration/protractor-to-cypress.mdx
@@ -316,7 +316,7 @@ yarn run cy:open
 It will start up Cypress and our Angular app at the same time.
 
 Again, we highly recommend using our
-[Angular Schematic](https://github.com/cypress-io/cypress/tree/master/npm/cypress-schematic)
+[Angular Schematic](https://github.com/cypress-io/cypress/tree/develop/npm/cypress-schematic)
 to install Cypress, and we plan on adding new capabilities to it over time.
 
 ## Working with the DOM
@@ -1118,7 +1118,7 @@ For more information, check out our
 ## Angular Schematic Configuration
 
 The
-[Cypress Angular Schematic](https://github.com/cypress-io/cypress/tree/master/npm/cypress-schematic#readme)
+[Cypress Angular Schematic](https://github.com/cypress-io/cypress/tree/develop/npm/cypress-schematic#readme)
 has many configurable options to fit the needs of your project.
 
 ### Running the builder with a specific browser

--- a/docs/guides/guides/debugging.mdx
+++ b/docs/guides/guides/debugging.mdx
@@ -201,7 +201,7 @@ By default, Cypress will include an inline source map in your spec file, so you
 will get the most out of the error experience. If you
 [modify the preprocessor](/api/plugins/preprocessors-api), ensure that inline
 source maps are enabled to get the same experience. With webpack and the
-[webpack preprocessor](https://github.com/cypress-io/cypress/tree/master/npm/webpack-preprocessor),
+[webpack preprocessor](https://github.com/cypress-io/cypress/tree/develop/npm/webpack-preprocessor),
 for example, set
 [the `devtool` option](https://webpack.js.org/configuration/devtool/) to
 `inline-source-map`.


### PR DESCRIPTION
- closes #5273

This PR updates links which are intended to point to the default branch of the [cypress-io/cypress](https://github.com/cypress-io/cypress) repository.

Previously the default branch was the [master branch](https://github.com/cypress-io/cypress/tree/master), which has been changed to be the [develop branch](https://github.com/cypress-io/cypress/tree/develop).

So links to
- https://github.com/cypress-io/cypress/tree/master are changed to
- https://github.com/cypress-io/cypress/tree/develop

## Affected links

(Currently 1006 commits behind `develop`.)

- https://github.com/cypress-io/cypress/tree/master/npm/webpack-preprocessor
- https://github.com/cypress-io/cypress/tree/master/npm/react
- https://github.com/cypress-io/cypress/tree/master/npm/cypress-schematic

**No** changes are made to the [changelog.mdx](https://github.com/cypress-io/cypress-documentation/blob/main/docs/guides/references/changelog.mdx), since the links to the `master` branch for changes in older versions are historically correct.