### PR TITLE
BREAKING: remove the videoUploadOnPasses configuration option

### DIFF
--- a/docs/guides/guides/module-api.mdx
+++ b/docs/guides/guides/module-api.mdx
@@ -188,7 +188,6 @@ tests results. A typical run could return something like this:
     }],
     "reporter": "spec",
     "reporterStats": {...},
-    "shouldUploadVideo": true,
     "spec": {...},
     "stats": {
       "suites": 1,

--- a/docs/guides/guides/screenshots-and-videos.mdx
+++ b/docs/guides/guides/screenshots-and-videos.mdx
@@ -67,9 +67,9 @@ Videos are stored in the
 When using the `--record` flag while running your tests, videos are processed,
 compressed, and uploaded to [Cypress Cloud](/guides/cloud/introduction) after
 every spec file runs, successful or not. To change this behavior to only process
-videos in the case that tests fail, set the
-[`videoUploadOnPasses`](/guides/references/configuration#Videos) configuration
-option to `false`.
+videos in the case that tests fail, see how to
+[delete videos for specs without failing or retried tests](/guides/guides/screenshots-and-videos#Delete-videos-for-specs-without-failing-or-retried-tests).
+Deleting the video will cause the video to not be uploaded to Cypress Cloud.
 
 Cypress clears any existing videos before a `cypress run`. If you do not want to
 clear your videos folder before a run, you can set
@@ -143,9 +143,9 @@ to Cypress Cloud. Deleting videos after the run can save resource space on the
 machine as well as skip the time used to process, compress, and upload the video
 to [Cypress Cloud](/guides/cloud/introduction).
 
-To only process videos in the case that a test fails, you can set the
-[`videoUploadOnPasses`](/guides/references/configuration#Videos) configuration
-option to `false`.
+To only process videos in the case that a test fails, you can
+[delete videos for specs without failing or retried tests](/guides/guides/screenshots-and-videos#Delete-videos-for-specs-without-failing-or-retried-tests),
+which will not upload the video of passed runs to Cypress Cloud.
 
 For more fine grained control, you can use Cypress's
 [`after:spec`](/api/plugins/after-spec-api) event listener that fires after each

--- a/docs/guides/references/configuration.mdx
+++ b/docs/guides/references/configuration.mdx
@@ -740,6 +740,7 @@ DEBUG=cypress:cli,cypress:server:specs
 
 | Version                                       | Changes                                                                               |
 | --------------------------------------------- | ------------------------------------------------------------------------------------- |
+| [13.0.0](/guides/references/changelog#13-0-0) | Removed `videoUploadOnPasses` option.                                                 |
 | [11.0.0](/guides/references/changelog#11-0-0) | Removed `e2e.experimentalSessionAndOrigin` option.                                    |
 | [10.4.0](/guides/references/changelog#10-4-0) | Added `e2e.testIsolation` option.                                                     |
 | [10.0.0](/guides/references/changelog#10-0-0) | Reworked page to support new `cypress.config.js` and deprecated `cypress.json` files. |

--- a/docs/guides/references/configuration.mdx
+++ b/docs/guides/references/configuration.mdx
@@ -127,7 +127,6 @@ For more options regarding screenshots, view the
 | `videoCompression`      | `false`          | The quality setting for the video compression, in Constant Rate Factor (CRF). The value can be `false` to disable compression or a value between `0` and `51`, where a lower value results in better quality (at the expense of a higher file size).                                                                     |
 | `videosFolder`          | `cypress/videos` | Where Cypress will automatically save the video of the test run when tests run with `cypress run`.                                                                                                                                                                                                                       |
 | `video`                 | `false`          | Whether Cypress will capture a video of the tests run with `cypress run`.                                                                                                                                                                                                                                                |
-| `videoUploadOnPasses`   | `true`           | Whether Cypress will process, compress, and upload videos to [Cypress Cloud](/guides/cloud/introduction) even when all tests in a spec file are passing. This only applies when recording your runs to Cypress Cloud. Turn this off if you'd like to only upload the spec file's video when there are failing tests. |
 
 ### Downloads
 


### PR DESCRIPTION
documentation updates for removing `videoUploadOnPasses` from the documentation for v13. see https://github.com/cypress-io/cypress/pull/27010 for implementation details