### PR TITLE
Remove nodeVersion documentation

### DIFF
--- a/docs/guides/references/configuration.mdx
+++ b/docs/guides/references/configuration.mdx
@@ -163,28 +163,6 @@ For more options regarding screenshots, view the
 For more information, see the docs on
 [actionability](/guides/core-concepts/interacting-with-elements#Actionability).
 
-### Node version
-
-:::caution
-
-<Icon name="exclamation-triangle" /> The <code>nodeVersion</code> configuration option is deprecated and will be removed in a
-future version of Cypress. Please remove this option from your configuration
-file.
-
-:::
-
-| Option        | Default  | Description                                                                                                                                                                                                                                                                                                                                 |
-| ------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `nodeVersion` | `system` | Can be `system` or `bundled`. If set to `system`, Cypress will try to use the same Node version that launched Cypress to execute your [plugins](/guides/tooling/plugins-guide). If that can't be determined, Cypress will use the Node version bundled with Cypress. If set to `bundled` Cypress will use the version bundled with Cypress. |
-
-The Node version is used in Cypress to:
-
-- Build files in the
-  [supportFile](#Folders-Files).
-- Execute code in the config file.
-
-<DocsImage src="/img/guides/configuration/test-runner-settings-nodejs-version.jpg" alt="Node version in Settings in Cypress" />
-
 ### Experiments
 
 Configuration might include experimental options currently being tested. See
@@ -236,7 +214,7 @@ object:
 | `supportFile`        | `cypress/support/component.js`           | Path to file to load before spec files load. This file is compiled and bundled. (Pass `false` to disable)                                                                                        |
 | `specPattern`        | <code>\*\*/*.cy.{js,jsx,ts,tsx}</code>                | A glob pattern String or Array of glob pattern Strings of the spec files to load. <br /><br />Note that any files found matching the `e2e.specPattern` value will be automatically **excluded.** |
 | `excludeSpecPattern` | `['/snapshots/*', '/image_snapshots/*']` | A String or Array of glob patterns used to ignore spec files that would otherwise be shown in your list of specs. [Please read the notes on using this.](#excludeSpecPattern)                    |
-`experimentalSingleTabRunMode`                | `false` | Run all specs in a single tab, instead of creating a new tab per spec. This can improve run mode performance, but can impact spec isolation and reliability on large test suites. This experiment currently only applies to Component Testing.     
+`experimentalSingleTabRunMode`                | `false` | Run all specs in a single tab, instead of creating a new tab per spec. This can improve run mode performance, but can impact spec isolation and reliability on large test suites. This experiment currently only applies to Component Testing.
 | `slowTestThreshold`  | `250`                                    | Time, in milliseconds, to consider a test "slow" during `cypress run`. A slow test will display in orange text in the default reporter.                                                          |
 
 

--- a/docs/guides/references/configuration_legacy.mdx
+++ b/docs/guides/references/configuration_legacy.mdx
@@ -144,34 +144,6 @@ For more options regarding screenshots, view the
 For more information, see the docs on
 [actionability](/guides/core-concepts/interacting-with-elements#Actionability).
 
-### Node version
-
-:::caution
-
-The `nodeVersion` configuration option is deprecated and will be removed in a
-future version of Cypress. Please remove this option from your configuration
-file.
-
-:::
-
-| Option        | Default  | Description                                                                                                                                                                                                                                                                                                                                |
-| ------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `nodeVersion` | `system` | Can be `system` or `bundled`. If set to `system`, Cypress will try to use the same Node version that launched Cypress to execute your [plugins](/guides/tooling/plugins-guide). If that can't be determined, Cypress will use the Node version bundled with Cypress. If set to `bundled` Cypress will use the version bundled with Cypress |
-
-The Node version is used in Cypress to:
-
-- Build files in the
-  [integrationFolder](/guides/references/configuration#Folders-Files).
-- Build files in the
-  [supportFile](/guides/references/configuration#Folders-Files).
-- Execute code in the
-  [pluginsFile](/guides/references/configuration#Folders-Files).
-
-<DocsImage
-  src="/img/guides/configuration/test-runner-settings-nodejs-version.jpg"
-  alt="Node version in Settings in Test Runner"
-/>
-
 ### Experiments
 
 Configuration might include experimental options currently being tested. See


### PR DESCRIPTION
Since we are removing the config in v13 we're also removing the documentation.