### PR TITLE
Add Discord badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Cypress Documentation [![first-timers-only](http://img.shields.io/badge/first--timers--only-friendly-blue.svg)](https://github.com/cypress-io/cypress-documentation/labels/first-timers-only)
+# Cypress Documentation [![Discord chat](https://img.shields.io/badge/chat-on%20Discord-brightgreen)](https://on.cypress.io/discord) [![first-timers-only](http://img.shields.io/badge/first--timers--only-friendly-blue.svg)](https://github.com/cypress-io/cypress-documentation/labels/first-timers-only)
 
 The code for Cypress Documentation including Guides, API, Examples, Cypress
 Cloud & FAQ found at https://docs.cypress.io.


### PR DESCRIPTION
This PR adds the "chat on Discord" badge to the top of this ([cypress-io/cypress-documentation](https://github.com/cypress-io/cypress-documentation)) repo's [README.md](https://github.com/cypress-io/cypress-documentation/blob/main/README.md) file, linking to https://on.cypress.io/discord.

[![Discord chat](https://img.shields.io/badge/chat-on%20Discord-brightgreen)](https://on.cypress.io/discord)

This gives it the same functionality as the link in the [cypress-io/cypress](https://github.com/cypress-io/cypress) repo's [README.md](https://github.com/cypress-io/cypress/blob/main/README.md) file.

- Related to PR https://github.com/cypress-io/cypress-documentation/pull/5311
cc: @nagash77 @emilyrohrbough 

New
---
![image](https://github.com/cypress-io/cypress-documentation/assets/66998419/d8a60265-c59a-4221-8192-e9a07fd0bf13)