### PR TITLE
fix overflowing plugins title and badge

### DIFF
--- a/src/components/plugins-list/style.module.css
+++ b/src/components/plugins-list/style.module.css
@@ -69,6 +69,7 @@ ul.pluginsList li p {
 @media (min-width: 1280px) {
   .pluginTitle {
     display: flex;
+    flex-direction: column;
     justify-content: space-between;
   }
 


### PR DESCRIPTION
Resubmission of https://github.com/cypress-io/cypress-documentation/pull/5320
Closes https://github.com/cypress-io/cypress-documentation/issues/5305

This PR adds css property `flex-direction: column` for the class `pluginTitle` in [src/components/plugins-list/style.module.css](https://github.com/cypress-io/cypress-documentation/blob/main/src/components/plugins-list/style.module.css), correcting a display issue on https://docs.cypress.io/plugins.

The plugin badge (`official`, `verified`, `community` or `experimental`) is now always displayed below the name of the plugin and it never overflows out of the plugin's box.

It also corrects a potential issue which has not been apparent so far, that an unhyphenated plugin name longer than 24 characters would also overflow. This is a consequence of combining `h3` with `flex`.

## Before

![plugins overlap](https://github.com/cypress-io/cypress-documentation/assets/66998419/8c4561e0-99fc-4976-b4cb-9f2e41dc5553)

## After

![plugins no overflow](https://github.com/cypress-io/cypress-documentation/assets/66998419/46e9bae1-4130-4c76-b7dd-c5f2a58df076)

## Verification

1. Display https://docs.cypress.io/plugins in Google Chrome / Mozilla Firefox and vary the width of the browser. Ensure that all plugin details stay within the plugin's box.

2. Temporarily add a 40 character unhyphenated plugin name (e.g. `A234567890B234567890C234567890D234567890`) and observe that this name stays inside the box independently of the browser's viewport width.

## References

- [MDN: flex-direction](https://developer.mozilla.org/en-US/docs/Web/CSS/flex-direction)

cc: @elylucas 
