### PR TITLE
Add support link to footer

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -232,6 +232,10 @@ const config = {
                 label: 'Careers',
                 href: 'https://www.cypress.io/careers',
               },
+              {
+                label: 'Support',
+                href: 'https://www.cypress.io/support',
+              },
             ],
           },
         ],


### PR DESCRIPTION
Replaces https://github.com/cypress-io/cypress-documentation/pull/5331

This PR adds a link

https://www.cypress.io/support/

to the footer of https://docs.cypress.io/ under the **Company** heading.

The site https://www.cypress.io/ already contains a link to [Support](https://www.cypress.io/support/) under the footer **Company** heading, so adding the same link to the https://docs.cypress.io/ footer is consistent.

---
BEFORE

![image](https://github.com/cypress-io/cypress-documentation/assets/66998419/f401fe85-f8a4-4981-8512-64388fe9f653)

---
AFTER

![Support link added](https://github.com/cypress-io/cypress-documentation/assets/66998419/d39c53d3-7346-43a9-9304-dc2c7eddc507)