### PR TITLE
docs: add community frameworks support

### DIFF
--- a/docs/guides/component-testing/overview.mdx
+++ b/docs/guides/component-testing/overview.mdx
@@ -117,12 +117,11 @@ following development servers and frameworks:
 
 ## Community Supported Frameworks
 
-The following integrations are built and maintained by Cypress community members. 
+The following integrations are built and maintained by Cypress community members.
 
-| Framework                                                                                                             | UI Library  | Bundler    |
-| --------------------------------------------------------------------------------------------------------------------- | ----------- | ---------- |
-| [Qwik](https://github.com/qwikifiers/cypress-qwik) <Badge type="info">Community</Badge>                               | Qwik        |    Vite    |
-
+| Framework                                                                               | UI Library | Bundler |
+| --------------------------------------------------------------------------------------- | ---------- | ------- |
+| [Qwik](https://github.com/qwikifiers/cypress-qwik) <Badge type="info">Community</Badge> | Qwik       | Vite    |
 
 ## Component Testing vs. End-to-End Testing
 

--- a/docs/guides/component-testing/overview.mdx
+++ b/docs/guides/component-testing/overview.mdx
@@ -115,6 +115,15 @@ following development servers and frameworks:
 | [Svelte with Vite](/guides/component-testing/svelte/overview#Svelte-with-Vite) <Badge type="info">Alpha</Badge>       | Svelte 3+   | Vite 2+    |
 | [Svelte with Webpack](/guides/component-testing/svelte/overview#Svelte-with-Webpack) <Badge type="info">Alpha</Badge> | Svelte 3+   | Webpack 4+ |
 
+## Community Supported Frameworks
+
+The following integrations are built and maintained by Cypress community members. 
+
+| Framework                                                                                                             | UI Library  | Bundler    |
+| --------------------------------------------------------------------------------------------------------------------- | ----------- | ---------- |
+| [Qwik](https://github.com/qwikifiers/cypress-qwik) <Badge type="info">Community</Badge>                               | Qwik        |    Vite    |
+
+
 ## Component Testing vs. End-to-End Testing
 
 We cover the differences between component and end-to-end testing in-depth in

--- a/docs/guides/component-testing/third-party-definitions.mdx
+++ b/docs/guides/component-testing/third-party-definitions.mdx
@@ -302,9 +302,9 @@ Adapters, both of which have extensive test suites.
 
 That's it! Publish your Framework Definition on npm and start using it.
 
-## List of Framework Definitions
+## Available Framework Definitions
 
-Once your Framework Definition is published and ready for use we would be
-delighted to mention it in our documentation so other Cypress users on the same
-framework can find it.
-[Submit a Pull Request](https://github.com/cypress-io/cypress-documentation/blob/main/CONTRIBUTING.md)!
+You can find a list of available Framework Definitions [here](/guides/component-testing/overview#Community-Supported-Frameworks).
+
+If you have created a Framework Definition we would be delighted to mention it in our documentation
+so other Cypress users on the same framework can find it. [Please submit a Pull Request](https://github.com/cypress-io/cypress-documentation/blob/main/CONTRIBUTING.md)!

--- a/docs/guides/guides/command-line.mdx
+++ b/docs/guides/guides/command-line.mdx
@@ -246,7 +246,7 @@ You can specify a path to a file where
 cypress run --config-file tests/cypress.config.js
 ```
 
-#### `cypress run --env <env>` {#cypress-run-config-file-lt-configuration-file-gt}
+#### `cypress run --env <env>` {#cypress-run-env-lt-env-gt}
 
 Set Cypress [environment variables](/guides/guides/environment-variables).
 


### PR DESCRIPTION
Wanted to add Qwik as a possible framework to use with component testing
figured it'll be nice to have a place where community supported framework integrations could be listed in

Thanks!