### PR TITLE
Update visual-testing.mdx anchor to point to #visual-testing

### DIFF
--- a/docs/guides/tooling/visual-testing.mdx
+++ b/docs/guides/tooling/visual-testing.mdx
@@ -123,13 +123,13 @@ mouse hover:
 ## Tooling
 
 There are several published, open source plugins, listed in the
-[Visual Testing plugins](/plugins#Visual%20Testing) section, and several
+[Visual Testing plugins](/plugins#visual-testing) section, and several
 commercial companies have developed visual testing solutions on top of Cypress
 listed below.
 
 ### Open source
 
-Listed in the [Visual Testing plugins](/plugins#Visual%20Testing) section.
+Listed in the [Visual Testing plugins](/plugins#visual-testing) section.
 
 ### Applitools
 
@@ -360,7 +360,7 @@ the
 - [cy.screenshot()](/api/commands/screenshot)
 - [Cypress.Screenshot](/api/cypress-api/screenshot-api)
 - [Plugins](/guides/tooling/plugins-guide)
-- [Visual Testing Plugins](/plugins#Visual%20Testing)
+- [Visual Testing Plugins](/plugins#visual-testing)
 - [Writing a Plugin](/api/plugins/writing-a-plugin)
 - &nbsp;<Icon name="github" contentType="rwa" /> is a full stack example
   application that demonstrates **best practices and scalable strategies with


### PR DESCRIPTION
The link was pointing to `#Visual%20Testing`

![image](https://github.com/cypress-io/cypress-documentation/assets/17337190/0469083b-c539-4336-894d-b2803b7a7d1b)

