### PR TITLE
In line 853 by mistake someone wrote "xit" instead of "it "so this test…

### DIFF
--- a/docs/guides/core-concepts/writing-and-organizing-tests.mdx
+++ b/docs/guides/core-concepts/writing-and-organizing-tests.mdx
@@ -850,7 +850,7 @@ describe('TodoMVC', () => {
     cy.get('[data-testid="todo-list"] li').should('have.length', 100)
   })
 
-  xit('another test', () => {
+  it('another test', () => {
     expect(false).to.true
   })
 


### PR DESCRIPTION
… example was going to fail

In line 853 by mistake someone wrong "xit" instead of it so this test example was going to fail