### PR TITLE
Remove links to bitbucket pipelines for mirrored repos that are no longer maintained

### DIFF
--- a/docs/guides/continuous-integration/bitbucket-pipelines.mdx
+++ b/docs/guides/continuous-integration/bitbucket-pipelines.mdx
@@ -41,17 +41,6 @@ pipelines:
           - npm run e2e
 ```
 
-:::info
-
-<strong>Try it out</strong>
-
-To try out the example above yourself, fork the
-[Cypress Kitchen Sink](https://github.com/cypress-io/cypress-example-kitchensink)
-example project and place the above Bitbucket Pipelines configuration in
-`bitbucket-pipelines.yml`.
-
-:::
-
 **How this `bitbucket-pipelines.yml` works:**
 
 - On _push_ to this repository, this job will provision and start Bitbucket
@@ -295,12 +284,3 @@ section, we are leveraging three useful features of
    the example above we use the `--group "UI - Chrome"` flag to organize all UI
    tests for the Chrome browser into a group labeled "UI - Chrome" in the
    [Cypress Cloud](https://on.cypress.io/cloud) report.
-
-## Cypress Real World Example with Bitbucket Pipelines
-
-A complete CI workflow against multiple browsers, viewports and operating
-systems is available in the Cypress Real World App (RWA).
-
-Clone the <Icon name="github" inline="true" contentType="rwa" /> and refer to
-the [bitbucket-pipelines.yml](https://github.com/cypress-io/cypress-realworld-app/blob/develop/bitbucket-pipelines.yml)
-file.


### PR DESCRIPTION
The kitchensink bitbucket pipeline is no longer maintained and run. The realworld app bitbucket pipeline has been failing or 'paused' for more than a year with no active maintenance. 

We don't have a payed plan that will run the pipelines reliably to ensure they're working. We also don't intend to maintain these mirrored bitbucket pipelines moving forward, so removing references to these pipelines. 