### PR TITLE
docs: lock webkit version

### DIFF
--- a/docs/guides/guides/launching-browsers.mdx
+++ b/docs/guides/guides/launching-browsers.mdx
@@ -178,7 +178,7 @@ these steps:
 1. Add `experimentalWebKitSupport: true` to your
    [configuration](/guides/references/configuration) to enable the experiment.
 2. Install the `playwright-webkit` NPM package in your repo to acquire WebKit
-   itself: `npm install --save-dev playwright-webkit`.
+   itself: `npm install --save-dev playwright-webkit@1.34`.
    - We built this experiment on top of the Playwright WebKit browser as a
      stepping stone towards creating a better UX with Cypress-provided browsers
      in the future. Thank you, Playwright contributors.


### PR DESCRIPTION
Issue https://github.com/cypress-io/cypress/issues/27141

Newer versions do not work properly with Cypress.