### PR TITLE
Add Cypress-SignalR-Mock plugin

### DIFF
--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -580,6 +580,13 @@
           "badge": "community"
         },
         {
+          "name": "Cypress-SignalR-Mock",
+          "description": "Easy way to publish messages from and to your SignalR hubs in Cypress E2E tests.",
+          "link": "https://github.com/JasonLandbridge/Cypress-SignalR-Mock",
+          "keywords": ["commands", "signalr", "mock", "websocket"],
+          "badge": "community"
+        },
+        {
           "name": "cypress-websocket-testing",
           "description": "Test WebSocket connections with Cypress",
           "link": "https://github.com/lensesio/cypress-websocket-testing",


### PR DESCRIPTION
<!-- PLUGIN PULL REQUEST TEMPLATE -->
<!-- 👋 Hello and thank you for your contribution! -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

This is attempt 2: https://github.com/cypress-io/cypress-documentation/pull/5231

I have ensured the Cypress runs as part of the CI with a Cypress test that displays the plugin working

Plugin link: [Cypress-SignalR-Mock](https://github.com/JasonLandbridge/Cypress-SignalR-Mock)

Before submitting your plugin, please check to see if it fulfills these requirements:

- [X] 🚀 Works with the latest major version of Cypress
- [X] 🛠 Plugin purpose is clearly documented (in a README or docs website)
- [X] 📝 Well-written documentation - A great example ([link](https://github.com/Fredx87/cypress-keycloak-commands#cypress-keycloak-commands))
- [X] 🔬 Tested using Cypress - tests using Cypress can act as both example usage _and_ test coverage
- [X] 👷‍♀️ CI pipeline that's passing (CircleCI and [Github Actions](https://github.com/cypress-io/cypress-tutorial-build-todo/blob/main/.github/workflows) are both free for Open Source)

If you have reason to believe your plugin does not need to meet certain requirements, please feel free to provide justification below: