### PR TITLE
Remove references to stand-alone npx

### DIFF
--- a/docs/guides/getting-started/opening-the-app.mdx
+++ b/docs/guides/getting-started/opening-the-app.mdx
@@ -19,9 +19,6 @@ Now you can open Cypress from your **project root** one of the following ways:
 
 **Using `npx`**
 
-**Note**: [npx](https://www.npmjs.com/package/npx) is included with `npm > v5.2`
-or can be installed separately.
-
 ```shell
 npx cypress open
 ```

--- a/docs/guides/guides/command-line.mdx
+++ b/docs/guides/guides/command-line.mdx
@@ -35,8 +35,6 @@ command's documentation.
 To run a command, you'll need to prefix each command in order to properly locate
 the cypress executable.
 
-(requires npm@5.2.0 or greater)
-
 ```
 npx cypress run
 ```
@@ -82,7 +80,7 @@ Cypress Cloud, the command should be:
 npm run cy:run -- --record --spec "cypress/e2e/my-spec.cy.js"
 ```
 
-If you are using the [npx](https://github.com/zkat/npx) tool, you can invoke the
+You can also invoke the
 locally installed Cypress tool directly:
 
 ```shell


### PR DESCRIPTION
All currently supported versions of `npm` include `npx` integrated, so `npx` can be treated as a command which is available to all users of `npm` package management.

Historical references to the stand-alone version of `npx` and the release of `npx` integrated into `npm`, which took place 6 years ago, are removed.

The following two pages are changed:

- [Guides > Getting Started > Opening the App > `cypress open`](https://docs.cypress.io/guides/getting-started/opening-the-app#cypress-open)
- [Guides > Command Line > How to run commands](https://docs.cypress.io/guides/guides/command-line#How-to-run-commands)

## Background

- [npm 5.2.0](https://github.com/npm/cli/blob/v5.2.0/CHANGELOG.md) was the first version to include `npx` integrated into `npm`. It was released in July 2017, which is now 6 years ago.
- The earliest currently supported version of Node.js is now `16.x`. [Node.js 16.0.0](https://nodejs.org/en/blog/release/v16.0.0) shipped with [npm 7.10.0](https://github.com/npm/cli/blob/v7.10.0/CHANGELOG.md)
- The now-unsupported version Node.js `14.x`. [Node.js 14.0.0](https://nodejs.org/en/blog/release/v14.0.0) shipped with [npm 6.14.4](https://github.com/npm/cli/blob/v6.14.4/CHANGELOG.md)
- https://github.com/zkat/npx, which forwards to https://github.com/npm/npx, was archived in July 2019.
- https://github.com/npm/npx was archived in April 2021.
- The stand-alone `npm` module [`npx`](https://github.com/npm/npx) is deprecated.
