### PR TITLE
Add cypress-log-filter plugin

### DIFF
--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -324,6 +324,13 @@
           "badge": "community"
         },
         {
+          "name": "cypress-log-filter",
+          "description": "Easily filter Cypress command logs based on different log levels",
+          "link": "https://github.com/Brugui7/cypress-log-filter",
+          "keywords": ["log", "command", "filter"],
+          "badge": "community"
+        },
+        {
           "name": "cy-search",
           "description": "Search Cypress documentation from the terminal.",
           "link": "https://github.com/bahmutov/cy-search",


### PR DESCRIPTION
Plugin link: [cypress-log-filter](https://github.com/Brugui7/cypress-log-filter)

Before submitting your plugin, please check to see if it fulfills these requirements:

- [X] :rocket: Works with the latest major version of Cypress
- [X] :hammer_and_wrench: Plugin purpose is clearly documented (in a README or docs website)
- [X] :memo: Well-written documentation - A great example ([link](https://github.com/Brugui7/cypress-log-filter#readme))
- [X] :microscope: Tested using Cypress - tests using Cypress can act as both example usage and test coverage
- [X] :construction_worker_woman: CI pipeline that's passing (CircleCI and [Github Actions](https://github.com/cypress-io/cypress-tutorial-build-todo/blob/main/.github/workflows) are both free for Open Source)

If you have reason to believe your plugin does not need to meet certain requirements, please feel free to provide justification below:

- This plugin adds a dropdown in the Cypress UI that may not follow Cypress design style guidelines

- This plugin has a test that fails intentionally to log an error in the command logs.