### PR TITLE
Remove references to `npm bin`; removed since npm 9.x

### DIFF
--- a/docs/guides/continuous-integration/introduction.mdx
+++ b/docs/guides/continuous-integration/introduction.mdx
@@ -215,7 +215,7 @@ Dockerfile would look like this:
 ```text
 FROM cypress/base
 RUN npm install
-RUN $(npm bin)/cypress run
+RUN npx cypress run
 ```
 
 :::caution

--- a/docs/guides/getting-started/opening-the-app.mdx
+++ b/docs/guides/getting-started/opening-the-app.mdx
@@ -35,12 +35,6 @@ yarn run cypress open
 ./node_modules/.bin/cypress open
 ```
 
-**Or with the shortcut using `npm bin`**
-
-```shell
-$(npm bin)/cypress open
-```
-
 After a moment, the Cypress Launchpad will open.
 
 ### Adding npm Scripts

--- a/docs/guides/guides/command-line.mdx
+++ b/docs/guides/guides/command-line.mdx
@@ -48,12 +48,6 @@ yarn cypress run
 ...or...
 
 ```
-$(npm bin)/cypress run
-```
-
-...or...
-
-```
 ./node_modules/.bin/cypress run
 ```
 


### PR DESCRIPTION
- Closes #5381 

## Changes

References to `$(npm bin)/cypress open` as a way of opening the Cypress app are removed or replaced with `npx cypress open`.

`$(npm bin)/cypress open` works with Node.js `16` and no longer works with Node.js `18` and `20`.

The following pages are affected:

- [Guides > Getting Started > Opening the App > `cypress open`](https://docs.cypress.io/guides/getting-started/opening-the-app#cypress-open)
- [Guides > Command Line > How to run commands](https://docs.cypress.io/guides/guides/command-line#How-to-run-commands)
- [Continuous Integration > Introduction > Official Cypress Docker Images](https://docs.cypress.io/guides/continuous-integration/introduction#Official-Cypress-Docker-Images)

## Background

- For `npm` version 9.x or higher, the command `npm bin` has been removed (see [npm v9.0.0 released](https://github.blog/changelog/2022-10-24-npm-v9-0-0-released/) Oct 24, 2022).
- Node.js `16` is the last supported version which includes `npm` version `8` with `npm bin` availability.
- Node.js `18` (current LTS version) and Node.js `20` are based on `npm` version `9` with no `npm bin` included.
- The replacement for `npm bin` is `npx` and `npm exec` to execute binaries.
- [npm 5.2.0](https://github.com/npm/cli/blob/v5.2.0/CHANGELOG.md) was the first version to include `npx` integrated into `npm`. It was released in July 2017.
