### PR TITLE
Remove `./node_modules/.bin/cypress open`

### DIFF
--- a/docs/guides/getting-started/opening-the-app.mdx
+++ b/docs/guides/getting-started/opening-the-app.mdx
@@ -15,7 +15,7 @@ title: Opening the App
 
 ## `cypress open`
 
-Now you can open Cypress from your **project root** one of the following ways:
+You can open Cypress from your **project root** one of the following ways:
 
 **Using `npx`**
 
@@ -27,12 +27,6 @@ npx cypress open
 
 ```shell
 yarn run cypress open
-```
-
-**The long way with the full path**
-
-```shell
-./node_modules/.bin/cypress open
 ```
 
 After a moment, the Cypress Launchpad will open.

--- a/docs/guides/guides/command-line.mdx
+++ b/docs/guides/guides/command-line.mdx
@@ -45,12 +45,6 @@ npx cypress run
 yarn cypress run
 ```
 
-...or...
-
-```
-./node_modules/.bin/cypress run
-```
-
 You may find it easier to add the cypress command to the `scripts` object in
 your `package.json` file and call it from an
 [`npm run` script](https://docs.npmjs.com/cli/run-script.html).


### PR DESCRIPTION
- Closes #5382

`./node_modules/.bin/cypress open` is no longer necessary in order to open the Cypress app. It is replaced by the simpler `npx cypress open`.

For Yarn Modern configurations `./node_modules/.bin/cypress open` only works with the backwards compatible `node-modules` option, not with `pnp` or `pnpm`.

## Changes

The following two pages are changed:

- [Guides > Getting Started > Opening the App > `cypress open`](https://docs.cypress.io/guides/getting-started/opening-the-app#cypress-open)
- [Guides > Command Line > How to run commands](https://docs.cypress.io/guides/guides/command-line#How-to-run-commands)

## Background

- Prior to [npm 5.2.0](https://github.com/npm/cli/blob/v5.2.0/CHANGELOG.md) there was no command in `npm` to invoke Cypress directly and `./node_modules/.bin/cypress open` was one option which was used.
- [npm 5.2.0](https://github.com/npm/cli/blob/v5.2.0/CHANGELOG.md), released in July 2017, provided `npx` integrated into `npm` which allowed the long-form `./node_modules/.bin/cypress open` to be replaced by the short-form `npx cypress open`.
- The earliest [currently supported version of Node.js](https://github.com/nodejs/release#release-schedule) is now `16.x`. [Node.js 16.0.0](https://nodejs.org/en/blog/release/v16.0.0) shipped with [npm 7.10.0](https://github.com/npm/cli/blob/v7.10.0/CHANGELOG.md), so all such supported versions have `npx` built in.
- The dependency data structure for Yarn Modern Plug'n'Play (`pnp`) and Yarn Modern (`pnpm`) is not compatible with calling Cypress via `./node_modules/.bin/cypress`
