### PR TITLE
Fix invalid port number in web-security.mdx

### DIFF
--- a/docs/guides/guides/web-security.mdx
+++ b/docs/guides/guides/web-security.mdx
@@ -28,7 +28,7 @@ and we are _mostly_ able to do this.
 - Uses the browser's internal APIs for network level traffic.
 
 When Cypress first loads, the internal Cypress web application is hosted on a
-random port: something like `http://localhost:65874/__/`.
+random port: something like `http://localhost:64874/__/`.
 
 After the first [`cy.visit()`](/api/commands/visit) command is issued in a test,
 Cypress changes its URL to match the origin of your remote application, thereby


### PR DESCRIPTION
According to [RFC 6335 - 6. Port Number Ranges](https://www.rfc-editor.org/rfc/rfc6335.html#section-6)

"the Dynamic Ports, also known as the Private or Ephemeral Ports,
from 49152-65535 (never assigned)"

so the value 65874 would be outside the permitted range.