### PR TITLE
docs: remove deprecated links to extend configuration

### DIFF
--- a/docs/guides/references/configuration.mdx
+++ b/docs/guides/references/configuration.mdx
@@ -764,9 +764,5 @@ DEBUG=cypress:cli,cypress:server:specs
   [Cypress.env()](/api/cypress-api/env)
 - [Environment variables](/guides/guides/environment-variables)
 - [Environment Variables recipe](/examples/recipes#Fundamentals)
-- [Extending the Cypress Configuration File](https://www.cypress.io/blog/2020/06/18/extending-the-cypress-config-file/)
-  blog post and
-  [@bahmutov/cypress-extends](https://github.com/bahmutov/cypress-extends)
-  package.
 - Blog post
   [Keep passwords secret in E2E tests](https://glebbahmutov.com/blog/keep-passwords-secret-in-e2e-tests/)


### PR DESCRIPTION
Extending configuration with [@bahmutov/cypress-extends](https://github.com/bahmutov/cypress-extends) package is deprecated since Cypress 10.0