### PR TITLE
Add caution against using cypress as name of script

### DIFF
--- a/docs/guides/getting-started/opening-the-app.mdx
+++ b/docs/guides/getting-started/opening-the-app.mdx
@@ -53,6 +53,17 @@ npm run cypress:open
 
 ...and Cypress will open right up for you.
 
+:::caution
+
+<strong>Best Practice</strong>
+
+Don't use `cypress` as the exact name of a script, especially if you use Yarn as package manager.
+Yarn will select the script in preference to the Cypress binary of the same name and
+Cypress CLI commands may not work as expected.
+Use instead a descriptive and non-ambiguous script name such as `cypress:open` or `cypress:run`.
+
+:::
+
 ### CLI tools
 
 By installing Cypress through `npm` you also get access to many other CLI

--- a/docs/guides/getting-started/opening-the-app.mdx
+++ b/docs/guides/getting-started/opening-the-app.mdx
@@ -58,8 +58,8 @@ npm run cypress:open
 <strong>Best Practice</strong>
 
 Don't use `cypress` as the exact name of a script, especially if you use Yarn as package manager.
-Yarn will select the script in preference to the Cypress binary of the same name and
-Cypress CLI commands may not work as expected.
+When running commands on the Cypress binary (e.g `yarn cypress verify`), Yarn will reference the
+script of the same name instead and [Cypress CLI commands](/guides/guides/command-line) may not work as expected.
 Use instead a descriptive and non-ambiguous script name such as `cypress:open` or `cypress:run`.
 
 :::


### PR DESCRIPTION
This PR adds a caution / Best Practice message to [Getting Started > Opening the App > Adding npm Scripts](https://docs.cypress.io/guides/getting-started/opening-the-app#Adding-npm-Scripts) to suggest **not** to use `cypress` as a literal script name due to its interference with the Yarn / Cypress CLI.

## Background

Defining a script in `package.json` with the name `cypress` causes ambiguity for Yarn users and should be avoided.

For instance, with the following definition

```json
  "scripts": {
    "cypress": "cypress open"
  }
```

executing

```bash
yarn run cypress verify
```

will be executed instead as

```bash
yarn run cypress open
```

When there is a script and a binary with the same name `yarn run` (Yarn Classic and Modern) selects the script. Yarn Modern offers the `--binaries-only` option to make the choice deterministic. Yarn Classic does not offer this option.

The following command overrides the script definition for Yarn Modern only.

```bash
yarn run --binaries-only cypress verify
```

- This "gotcha" caused https://github.com/cypress-io/github-action/issues/941 in June 2023.
