### PR TITLE
correct miscellaneous typos in changelog

### DIFF
--- a/docs/guides/references/changelog.mdx
+++ b/docs/guides/references/changelog.mdx
@@ -12,7 +12,7 @@ _Released 08/15/2023_
 
 **Dependency Updates:**
 
-- Upgraded [`webpack`](https://www.npmjs.com/package/webpack) from `v4` to `v5`. This means that we are now bundling your `e2e` tests with webpack 5. We don't anticipate this causing any noticeable changes. However, if you'd like to keep bundling your `e2e` tests with wepback 4 you can use the same process as before by pinning [@cypress/webpack-batteries-included-preprocessor](https://www.npmjs.com/package/@cypress/webpack-batteries-included-preprocessor) to `v2.x.x` and hooking into the [file:preprocessor](/api/plugins/preprocessors-api#Usage) plugin event. This will restore the previous bundling process. Additionally, if you're using [@cypress/webpack-batteries-included-preprocessor](https://www.npmjs.com/package/@cypress/webpack-batteries-included-preprocessor) already, a new version has been published to support webpack `v5`.
+- Upgraded [`webpack`](https://www.npmjs.com/package/webpack) from `v4` to `v5`. This means that we are now bundling your `e2e` tests with webpack 5. We don't anticipate this causing any noticeable changes. However, if you'd like to keep bundling your `e2e` tests with webpack 4 you can use the same process as before by pinning [@cypress/webpack-batteries-included-preprocessor](https://www.npmjs.com/package/@cypress/webpack-batteries-included-preprocessor) to `v2.x.x` and hooking into the [file:preprocessor](/api/plugins/preprocessors-api#Usage) plugin event. This will restore the previous bundling process. Additionally, if you're using [@cypress/webpack-batteries-included-preprocessor](https://www.npmjs.com/package/@cypress/webpack-batteries-included-preprocessor) already, a new version has been published to support webpack `v5`.
 - Upgraded [`tough-cookie`](https://www.npmjs.com/package/tough-cookie) from `4.0` to `4.1.3`, [`@cypress/request`](https://www.npmjs.com/package/@cypress/request) from `2.88.11` to `2.88.12` and [`@cypress/request-promise`](https://www.npmjs.com/package/@cypress/request-promise) from `4.2.6` to `4.2.7` to address a [security vulnerability](https://security.snyk.io/vuln/SNYK-JS-TOUGHCOOKIE-5672873). Fixes [#27261](https://github.com/cypress-io/cypress/issues/27261).
 
 ## 12.17.3
@@ -726,7 +726,7 @@ _Released 1/24/2023_
 
 **Misc**
 
-- Video output link in `cypress run` mode has been added to it's own line to
+- Video output link in `cypress run` mode has been added to its own line to
   make the video output link more easily clickable in the terminal. Addresses
   [#23913](https://github.com/cypress-io/cypress/issues/23913).
 
@@ -2996,7 +2996,7 @@ _Released 1/18/2022_
   passing multiple glob patterns that are separated by commas. Fixes
   [#16102](https://github.com/cypress-io/cypress/issues/16102).
 - Fixed an issue with how the `CYPRESS_VERIFY_TIMEOUT` environment variable was
-  read so it can set in a project's `package.json` or it's `.npmrc`. Fixes
+  read so it can set in a project's `package.json` or its `.npmrc`. Fixes
   [#19559](https://github.com/cypress-io/cypress/issues/19559).
 
 **Dependency Updates:**


### PR DESCRIPTION
- `webpack` was misspelled as `wepback`
- there were two instances where `it's` instead of `its` was written. (See https://www.merriam-webster.com/grammar/when-to-use-its-vs-its)
