### PR TITLE
Fix MIME type for favicon.svg

### DIFF
--- a/plugins/fav-icon.js
+++ b/plugins/fav-icon.js
@@ -17,7 +17,7 @@ module.exports = async function favIcon(context) {
             tagName: 'link',
             attributes: {
               rel: 'icon',
-              type: 'image/sv+xml',
+              type: 'image/svg+xml',
               href: '/favicon.svg',
             },
           },


### PR DESCRIPTION
- This follows on from PR https://github.com/cypress-io/cypress-documentation/pull/5426 submitted by @wolfgang42 which was not merged due to legal / administrative reasons.

## Issue

https://docs.cypress.io/guides/overview/why-cypress shows the following source code relating to `favicon`:

```html
<link rel="icon" type="image/x-icon" href="/favicon.ico" sizes="any">
<link rel="icon" type="image/sv+xml" href="/favicon.svg">
```

The MIME type `image/sv+xml` is incorrect, as pointed out by @wolfgang42. The correct MIME type for `.svg` files using Scalable Vector Graphics (SVG) is `image/svg+xml`.

All browsers support `favicon.ico` so due to the incorrect MIME type for `favicon.svg`, the svg version is never displayed.

## Change

Correct `type: 'image/sv+xml',` to read instead `type: 'image/svg+xml',`.

## Local Verification

```bash
npm ci
npm run build
```

Rename `/dist/favicon.ico` to `/dist/favicon-disable.ico`

```bash
npm run serve
```

Check that the favicon appears in a web browser such as Google Chrome.

![favicon](https://github.com/cypress-io/cypress-documentation/assets/66998419/e1f8173e-a76d-424e-8a2c-0916a5083d9d)

## Reference

- [Definitive edition of "How to Favicon" in 2023](https://dev.to/masakudamatsu/favicon-nightmare-how-to-maintain-sanity-3al7)
- [mdn web docs > Common MIME types](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types)
- [SVG favicons](https://caniuse.com/link-icon-svg)
