### PR TITLE
add changelog, remove node 16 support, and update docker image refere…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,11 +6,11 @@ orbs:
 executors:
   node-executor:
     docker:
-      - image: cimg/node:16.15.1
+      - image: cimg/node:18.15.0
   with-chrome-and-firefox:
     resource_class: medium+
     docker:
-      - image: 'cypress/browsers:node16.13.2-chrome97-ff96'
+      - image: 'cypress/browsers:node18.12.0-chrome106-ff106'
 
 commands:
   docs-build:

--- a/docs/guides/continuous-integration/aws-codebuild.mdx
+++ b/docs/guides/continuous-integration/aws-codebuild.mdx
@@ -186,7 +186,7 @@ batch:
   build-list:
     - identifier: cypress-e2e-tests
       env:
-        image: public.ecr.aws/cypress-io/cypress/browsers:node16.14.2-slim-chrome100-ff99-edge
+        image: public.ecr.aws/cypress-io/cypress/browsers:node18.12.0-chrome106-ff106
 
 phases:
   install:

--- a/docs/guides/continuous-integration/bitbucket-pipelines.mdx
+++ b/docs/guides/continuous-integration/bitbucket-pipelines.mdx
@@ -145,7 +145,7 @@ First, we break the pipeline up into reusable chunks of configuration using a
 `&e2e`. This will be used by the worker jobs.
 
 ```yaml
-image: cypress/base:14.16.0
+image: cypress/base:18.12.1
 
 ## job definition for running E2E tests in parallel
 e2e: &e2e
@@ -204,7 +204,7 @@ definitions:
 The complete `bitbucket-pipelines.yml` is below:
 
 ```yaml
-image: cypress/base:14.16.0
+image: cypress/base:18.12.1
 
 ## job definition for running E2E tests in parallel
 e2e: &e2e

--- a/docs/guides/continuous-integration/github-actions.mdx
+++ b/docs/guides/continuous-integration/github-actions.mdx
@@ -185,7 +185,7 @@ on: push
 jobs:
   cypress-run:
     runs-on: ubuntu-22.04
-    container: cypress/browsers:node16.16.0-chrome107-ff107-edge
+    container: cypress/browsers:node18.12.0-chrome106-ff106
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/docs/guides/continuous-integration/gitlab-ci.mdx
+++ b/docs/guides/continuous-integration/gitlab-ci.mdx
@@ -78,7 +78,7 @@ stages:
   - test
 
 test:
-  image: cypress/browsers:node16.16.0-chrome107-ff107-edge
+  image: cypress/browsers:node18.12.0-chrome106-ff106
   stage: test
   script:
     # install dependencies
@@ -109,7 +109,7 @@ cache:
     - .npm/
 
 test:
-  image: cypress/browsers:node16.16.0-chrome107-ff107-edge
+  image: cypress/browsers:node18.12.0-chrome106-ff106
   stage: test
   script:
     # install dependencies
@@ -175,7 +175,7 @@ cache:
 
 ## Install NPM dependencies and Cypress
 install:
-  image: cypress/browsers:node16.16.0-chrome107-ff107-edge
+  image: cypress/browsers:node18.12.0-chrome106-ff106
   stage: build
   script:
     - npm ci
@@ -211,13 +211,13 @@ cache:
 
 ## Install NPM dependencies and Cypress
 install:
-  image: cypress/browsers:node16.16.0-chrome107-ff107-edge
+  image: cypress/browsers:node18.12.0-chrome106-ff106
   stage: build
   script:
     - npm ci
 
 ui-chrome-tests:
-  image: cypress/browsers:node16.16.0-chrome107-ff107-edge
+  image: cypress/browsers:node18.12.0-chrome106-ff106
   stage: test
   parallel: 5
   script:

--- a/docs/guides/continuous-integration/introduction.mdx
+++ b/docs/guides/continuous-integration/introduction.mdx
@@ -225,7 +225,7 @@ Mounting a project directory with an existing `node_modules` into a
 `cypress/base` docker image **will not work**:
 
 ```shell
-docker run -it -v /app:/app cypress/base:14.16.0 bash -c 'cypress run'
+docker run -it -v /app:/app cypress/base:18.12.1 bash -c 'cypress run'
 Error: the cypress binary is not installed
 ```
 

--- a/docs/guides/getting-started/installing-cypress.mdx
+++ b/docs/guides/getting-started/installing-cypress.mdx
@@ -164,7 +164,6 @@ application supports these operating systems:
 
 If you're using `npm`, `pnpm` or `Yarn` to install Cypress, we support:
 
-- **Node.js** 16.x
 - **Node.js** 18.x
 - **Node.js** 20.x and above
 

--- a/docs/guides/references/changelog.mdx
+++ b/docs/guides/references/changelog.mdx
@@ -17,7 +17,6 @@ _Released 08/29/2023_
 - The properties and values returned by the [Module API](/guides/guides/module-api) and included in the arguments of handlers for the [`after:run`](/api/plugins/after-run-api) and [`after:spec`](/api/plugins/after-spec-api) have been changed to be more consistent. Addresses [#23805](https://github.com/cypress-io/cypress/issues/23805).
 - For Cypress Cloud runs with Test Replay enabled, the Cypress Runner UI is now hidden during the run since the Runner will be visible during Test Replay. As such, if video is recorded (which is now defaulted to `false`) during the run, the Runner will not be visible. In addition, if a runner screenshot (`cy.screenshot({ capture: runner })`) is captured, it will no longer contain the Runner.
 - Node 14 support has been removed and Node 16 support has been deprecated. Node 16 may continue to work with Cypress `v13`, but will not be supported moving forward to closer coincide with [Node 16's end-of-life](https://nodejs.org/en/blog/announcements/nodejs16-eol) schedule. It is recommended that users update to at least Node 18.
-- Due to Node version compatibility, native support for TLS versions `1.0` and `1.1` has been deprecated. If needed. please see this [nodejs issue](https://github.com/nodejs/node/issues/49210) for workarounds and bugfix updates.
 - The minimum supported Typescript version is `4.x`.
 
 ## 12.17.4

--- a/docs/guides/references/changelog.mdx
+++ b/docs/guides/references/changelog.mdx
@@ -2,6 +2,24 @@
 title: Changelog
 ---
 
+## 13.0.0
+
+_Released 08/29/2023_
+
+**Breaking Changes:**
+
+- The [`cy.readFile()`](/api/commands/readfile) command is now retry-able as a [query command](/guides/core-concepts/retry-ability). This should not affect any tests using it; the functionality is unchanged. However, it can no longer be overwritten using [`Cypress.Commands.overwrite()`](/api/cypress-api/custom-commands#Overwrite-Existing-Commands). Addressed in [#25595](https://github.com/cypress-io/cypress/pull/25595).
+- The [`video`](/guides/references/configuration#Videos) configuration option now defaults to `false`. Addresses [#26157](https://github.com/cypress-io/cypress/issues/26157).
+- The [`videoCompression`](/guides/references/configuration#Videos) configuration option now defaults to `false`. Addresses [#26160](https://github.com/cypress-io/cypress/issues/26160).
+- The [`videoUploadOnPasses`](/guides/references/configuration#Videos) configuration option has been removed. Please see our [screenshots & videos guide](/guides/guides/screenshots-and-videos#Delete-videos-for-specs-without-failing-or-retried-tests) on how to accomplish similar functionality. Addresses [#26899](https://github.com/cypress-io/cypress/issues/26899).
+- The current spec path is now passed from the AUT iframe using a query parameter rather than a path segment. This allows for requests for assets at relative paths to be correctly forwarded to the dev server. Fixes [#26725](https://github.com/cypress-io/cypress/issues/26725).
+- The deprecated configuration option, `nodeVersion` has been removed. Addresses [#27016](https://github.com/cypress-io/cypress/issues/27016).
+- The properties and values returned by the [Module API](/guides/guides/module-api) and included in the arguments of handlers for the [`after:run`](/api/plugins/after-run-api) and [`after:spec`](/api/plugins/after-spec-api) have been changed to be more consistent. Addresses [#23805](https://github.com/cypress-io/cypress/issues/23805).
+- For Cypress Cloud runs with Test Replay enabled, the Cypress Runner UI is now hidden during the run since the Runner will be visible during Test Replay. As such, if video is recorded (which is now defaulted to `false`) during the run, the Runner will not be visible. In addition, if a runner screenshot (`cy.screenshot({ capture: runner })`) is captured, it will no longer contain the Runner.
+- Node 14 support has been removed and Node 16 support has been deprecated. Node 16 may continue to work with Cypress `v13`, but will not be supported moving forward to closer coincide with [Node 16's end-of-life](https://nodejs.org/en/blog/announcements/nodejs16-eol) schedule. It is recommended that users update to at least Node 18.
+- Due to Node version compatibility, native support for TLS versions `1.0` and `1.1` has been deprecated. If needed. please see this [nodejs issue](https://github.com/nodejs/node/issues/49210) for workarounds and bugfix updates.
+- The minimum supported Typescript version is `4.x`.
+
 ## 12.17.4
 
 _Released 08/15/2023_


### PR DESCRIPTION
…nce to be on at least node 18

Adds documentation in correspondence with https://github.com/cypress-io/cypress/pull/27642. The changelog for v13 wasn't present yet, so I added it here with what is currently on the branch in cypress-io/cypress.

the bundled version of cypress is still 16.16.0 until the electron update is performed, which at that time we need to update the docs to reflect this