### PR TITLE
Change Webkit to WebKit

### DIFF
--- a/docs/faq/questions/cloud-faq.mdx
+++ b/docs/faq/questions/cloud-faq.mdx
@@ -381,7 +381,7 @@ Our aim is to create an impactful debugging experience that covers the most grou
 
 Test Replay leverages [Chrome DevTools Protocol(CDP)](https://chromedevtools.github.io/devtools-protocol/), so currently supports Chromium-based browsers (Chrome, Edge, and Electron) only.
 
-Test Replay would be disabled, with a message that it's only available on Chromium, for tests run in Firefox or Webkit (Safari). You can still record and capture test [artifacts](/guides/cloud/debugging/recorded-runs#Artifacts) (screenshots, videos and CI logs) via other browsers in separate [run groups](/guides/cloud/smart-orchestration/parallelization#Grouping-test-runs).
+Test Replay would be disabled, with a message that it's only available on Chromium, for tests run in Firefox or WebKit (Safari). You can still record and capture test [artifacts](/guides/cloud/debugging/recorded-runs#Artifacts) (screenshots, videos and CI logs) via other browsers in separate [run groups](/guides/cloud/smart-orchestration/parallelization#Grouping-test-runs).
 
 ### <Icon name="angle-right" /> Can I replay tests from historical Cypress Cloud runs?
 

--- a/docs/guides/references/changelog.mdx
+++ b/docs/guides/references/changelog.mdx
@@ -1611,7 +1611,7 @@ _Released 9/13/2022_
 
 **Features:**
 
-- You can now run tests in Webkit, Safari's browser engine, by enabling the
+- You can now run tests in WebKit, Safari's browser engine, by enabling the
   [`experimentalWebKitSupport`](/guides/references/experiments) experiment and
   installing
   [`playwright-webkit`](https://www.npmjs.com/package/playwright-webkit). For


### PR DESCRIPTION
This PR corrects two places where [WebKit](https://www.webkit.org/) (the web browser engine used by Safari) was incorrectly rendered as "Webkit".

## References

- https://www.npmjs.com/package/playwright-webkit
- https://www.webkit.org/