### PR TITLE
chore: bump circle resources

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,8 @@
 version: 2.1
 
-orbs:
-  cypress: cypress-io/cypress@1.26.0
-
 executors:
   node-executor:
-    resource_class: large
+    resource_class: medium+
     docker:
       - image: cimg/node:18.15.0
   with-chrome-and-firefox:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 
 executors:
   node-executor:
-    resource_class: medium+
+    resource_class: large
     docker:
       - image: cimg/node:18.15.0
   with-chrome-and-firefox:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ orbs:
 
 executors:
   node-executor:
+    resource_class: medium+
     docker:
       - image: cimg/node:18.15.0
   with-chrome-and-firefox:


### PR DESCRIPTION
- bump CirceCI resources to the next tier to help with resource failures
- remove cypress orb for now (nothing custom to test, only docusaurus + markdown content)