### PR TITLE
Add non-root user `1001` for Firefox in Cypress GHA with Docker

### DIFF
--- a/docs/guides/continuous-integration/github-actions.mdx
+++ b/docs/guides/continuous-integration/github-actions.mdx
@@ -173,7 +173,7 @@ Cypress locally and in CI.
 
 Below we extend the previous example by adding the `container` attribute using a
 [Cypress Docker Image](https://github.com/cypress-io/cypress-docker-images)
-built with Google Chrome `107`. Specifying a browser version allows our tests to
+built with Google Chrome `106`. Specifying a browser version allows our tests to
 execute without any influence from browser version changes in the GitHub runner
 image.
 
@@ -185,7 +185,9 @@ on: push
 jobs:
   cypress-run:
     runs-on: ubuntu-22.04
-    container: cypress/browsers:node18.12.0-chrome106-ff106
+    container:
+      image: cypress/browsers:node18.12.0-chrome106-ff106
+      options: --user 1001
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -196,6 +198,12 @@ jobs:
           start: npm start
           browser: chrome
 ```
+
+:::caution
+
+If you are testing with Firefox, you must specify the non-root user `1001` as above. Refer to [Firefox not found](https://github.com/cypress-io/cypress-docker-images#firefox-not-found) for more information.
+
+:::
 
 ## Caching Dependencies and Build Artifacts
 


### PR DESCRIPTION
The non-root user `1001` is added to the example in [Continuous Integration > GitHub Actions > Testing with Cypress Docker Images](https://docs.cypress.io/guides/continuous-integration/github-actions#Testing-with-Cypress-Docker-Images). This aligns the example with the Cypress GitHub Action's [README > Docker image](https://github.com/cypress-io/github-action#docker-image) section.

A `caution` paragraph is also added, which refers to more detailed information in the README of the Docker repo under [Firefox not found](https://github.com/cypress-io/cypress-docker-images#firefox-not-found).

---

If this advice is not followed, then

```bash
firefox -v
```

outputs the message

> Running Firefox as root in a regular user's session is not supported.

when

```bash
id
```

shows
> uid=0(root) gid=0(root) groups=0(root)