### PR TITLE
Remove link for disabled Bitbucket recording to Cypress Cloud

### DIFF
--- a/docs/guides/continuous-integration/ci-provider-examples.mdx
+++ b/docs/guides/continuous-integration/ci-provider-examples.mdx
@@ -112,22 +112,14 @@ Check out the full <Icon name="github" inline="true" callout="RWA AWS CodeBuild 
 
 :::
 
-### BitBucket
+### Bitbucket
 
 <Icon
   name="book"
   color="gray"
   url="bitbucket-pipelines"
-  callout="BitBucket Pipelines Guide"
+  callout="Bitbucket Pipelines Guide"
 />
-<br />
-<Icon
-  name="external-link-alt"
-  color="gray"
-  url="https://cloud.cypress.io/projects/q1ovwz"
-  callout="See BitBucket Pipelines + Cypress Cloud in action"
-/>
-
 <br />
 
 ## Examples


### PR DESCRIPTION
## Issue

[Continuous Integration > CI Provider Examples > BitBucket](https://docs.cypress.io/guides/continuous-integration/ci-provider-examples#BitBucket) (sic) lists the link

> [See BitBucket Pipelines + Cypress Cloud in action](https://cloud.cypress.io/projects/q1ovwz).

This links to Cypress Cloud project [`q1ovwz`](https://cloud.cypress.io/projects/q1ovwz) with the name `cypress-realworld-app-bitbucket`.

- https://github.com/cypress-io/cypress-realworld-app/pull/1376 removed the Bitbucket workflow from the [cypress-io/cypress-realworld-app](https://github.com/cypress-io/cypress-realworld-app) repo on Jul 6, 2023.

- https://github.com/cypress-io/cypress-documentation/pull/5360 from @jennifer-shehane on Jul 5, 2023 noted that references to Bitbucket pipelines should be removed, however the link listed
above has not yet been removed. This should now be done.

## Change

- Remove the link to the disabled Bitbucket project [`q1ovwz`](https://cloud.cypress.io/projects/q1ovwz) on Cypress Cloud https://cloud.cypress.io/projects/q1ovwz from [Continuous Integration > CI Provider Examples > BitBucket](https://docs.cypress.io/guides/continuous-integration/ci-provider-examples#BitBucket).

- Correct the spelling to use "Bitbucket" instead of "BitBucket".

## Reference

- https://support.atlassian.com/bitbucket-cloud/docs/get-started-with-bitbucket-pipelines/ shows the name is written as "Bitbucket Pipelines"

## Additional suggestion

Delete the obsolete project [`q1ovwz`](https://cloud.cypress.io/projects/q1ovwz) from Cypress Cloud. (Not something which I can do.)
