### PR TITLE
Update IDE-integration.mdx

### DIFF
--- a/docs/guides/tooling/IDE-integration.mdx
+++ b/docs/guides/tooling/IDE-integration.mdx
@@ -51,7 +51,7 @@ with Cypress.
 - [Cypress Fixture-IntelliSense](https://marketplace.visualstudio.com/items?itemName=JosefBiehler.cypress-fixture-intellisense):
   Supports your [cy.fixture()](/api/commands/fixture) by providing intellisense
   for existing fixtures.
-- [Cypress Helper](https://marketplace.visualstudio.com/items?itemName=Shelex.vscode-cy-helper):
+- [Cypress Helper](https://marketplace.visualstudio.com/items?itemName=shevtsov.vscode-cy-helper):
   Various helpers and commands for integration with Cypress.
 - [Cypress Snippets](https://marketplace.visualstudio.com/items?itemName=andrew-codes.cypress-snippets):
   Useful Cypress code snippets.


### PR DESCRIPTION
Update the extension link of Cypress Helper (Visual Studio Code) to the new extension version Cypress Helper (latest).
```
Name: Cypress Helper (latest)
Id: shevtsov.vscode-cy-helper
Description: Extension for cypress.io testing tool
Version: 3.5.0
Publisher: shevtsov
VS Marketplace Link: https://marketplace.visualstudio.com/items?itemName=shevtsov.vscode-cy-helper
```