### PR TITLE
update actions/checkout to v4 for GitHub Actions

### DIFF
--- a/docs/guides/continuous-integration/github-actions.mdx
+++ b/docs/guides/continuous-integration/github-actions.mdx
@@ -96,7 +96,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       # Install NPM dependencies, cache them correctly
       # and run all Cypress tests
       - name: Cypress run
@@ -190,7 +190,7 @@ jobs:
       options: --user 1001
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Cypress run
         uses: cypress-io/github-action@v6
         with:
@@ -236,7 +236,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Cypress install
         uses: cypress-io/github-action@v6
@@ -257,7 +257,7 @@ jobs:
     needs: install
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Download the build folder
         uses: actions/download-artifact@v3
@@ -329,7 +329,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Cypress install
         uses: cypress-io/github-action@v6
@@ -374,7 +374,7 @@ jobs:
         containers: [1, 2, 3, 4, 5]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Download the build folder
         uses: actions/download-artifact@v3
@@ -495,7 +495,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Cypress run
         uses: cypress-io/github-action@v6
@@ -522,7 +522,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Cypress run
         uses: cypress-io/github-action@v6


### PR DESCRIPTION
Update all workflow examples in [Continuous Integration > GitHub Actions](https://docs.cypress.io/guides/continuous-integration/github-actions)  to use JavaScript action [actions/checkout](https://github.com/actions/checkout) `v4`.

- The previously used `v3` runs under `node16` with [end-of-life](https://nodejs.org/en/blog/announcements/nodejs16-eol) today, Sep 11, 2023
- `v4` is the latest version, which runs under `node20`, and is under active support