### PR TITLE
chore: add link to Best Practices - Selectors

### DIFF
--- a/docs/guides/references/best-practices.mdx
+++ b/docs/guides/references/best-practices.mdx
@@ -221,7 +221,7 @@ package to use the familiar testing library methods (like `findByRole`,
 `findByLabelText`, etc...) to select elements in Cypress specs.
 
 In particular, if you're looking for more resources to understand how we
-recommend you approach testing your components, look to:
+recommend you approach testing your components, look to: [Cypress Component Testing](/guides/component-testing/overview).
 
 ## <Icon name="angle-right" /> Assigning Return Values
 


### PR DESCRIPTION
Added missing link to the Selecting Elements section of the Best Practices guide.