### PR TITLE
docs: update Docker image examples to supported Node.js 18

### DIFF
--- a/docs/guides/continuous-integration/aws-codebuild.mdx
+++ b/docs/guides/continuous-integration/aws-codebuild.mdx
@@ -180,7 +180,7 @@ version: 0.2
 
 ## AWS CodeBuild Batch configuration
 ## https://docs.aws.amazon.com/codebuild/latest/userguide/batch-build-buildspec.html
-## Define build to run using the "cypress/browsers:node12.14.1-chrome85-ff81" image from the Cypress Amazon ECR Public Gallery
+## Define build to run using the "cypress/browsers:node18.12.0-chrome106-ff106" image from the Cypress Amazon ECR Public Gallery
 batch:
   fast-fail: false
   build-list:

--- a/docs/guides/continuous-integration/bitbucket-pipelines.mdx
+++ b/docs/guides/continuous-integration/bitbucket-pipelines.mdx
@@ -61,7 +61,7 @@ example, this allows us to run the tests in Firefox by passing the
 `--browser firefox` attribute to `cypress run`.
 
 ```yaml
-image: cypress/browsers:node12.14.1-chrome85-ff81
+image: cypress/browsers:node18.12.0-chrome106-ff106
 
 pipelines:
   default:
@@ -89,7 +89,7 @@ Artifacts from a job can be defined by providing paths to the `artifacts`
 attribute.
 
 ```yaml
-image: cypress/browsers:node12.14.1-chrome85-ff81
+image: cypress/browsers:node18.12.0-chrome106-ff106
 
 pipelines:
   default:

--- a/docs/guides/getting-started/installing-cypress.mdx
+++ b/docs/guides/getting-started/installing-cypress.mdx
@@ -238,7 +238,7 @@ container with the Node.js process.
   ui:
     image: cypress/base:latest
     # if targeting a specific node version, use e.g.
-    # image: cypress/base:14
+    # image: cypress/base:18.12.1
 ```
 
 `cypress/base` is a drop-in replacement for


### PR DESCRIPTION
Node.js `18` and `20 and above` are the only versions currently supported by Cypress according to [Getting Started > Installing Cypress > System requirements > Node.js](https://docs.cypress.io/guides/getting-started/installing-cypress#Nodejs) therefore examples and templates should only use these versions.

Out of range examples Node.js `12` or `14` are updated to align with existing examples using Node.js `18.x`.

## Changes

### cypress/base

- Update `cypress/base:14` to `cypress/base:18.12.1`
  - in [Getting Started > Installing Cypress > Docker](https://docs.cypress.io/guides/getting-started/installing-cypress#Docker)

- (Leave references to `cypress/base:18.12.1` as they are.)

### cypress/browsers

- Update `cypress/browsers:node12.14.1-chrome85-ff81` to `cypress/browsers:node18.12.0-chrome106-ff106`
  - in [Continuous Integration > Bitbucket Pipelines](https://docs.cypress.io/guides/continuous-integration/bitbucket-pipelines)
  - in [Continuous Integration > AWS CodeBuild](https://docs.cypress.io/guides/continuous-integration/aws-codebuild)

- (Leave references to `cypress/browsers:node18.12.0-chrome106-ff106` as they are.)


### cypress/included

- (No examples use `cypress/included` with a version reference, so no changes needed.)

## Outlook

According to the [Node.js Release schedule](https://github.com/nodejs/release#release-schedule) Node.js `18` enters end-of-life on April 30, 2025, so the Docker versions used in the examples are good for the next year and a half. It would however also be worthwhile optionally considering updating to Node.js `20` when this version takes on the `LTS` role next month on Oct 24, 2023. In this case the CI templates on Cypress Cloud (which are currently partially out-of-date) should also be updated to Node.js `20`.
