### PR TITLE
Update operating system minimum version to Ubuntu 20.04

### DIFF
--- a/docs/guides/getting-started/installing-cypress.mdx
+++ b/docs/guides/getting-started/installing-cypress.mdx
@@ -155,7 +155,7 @@ Cypress is a desktop application that is installed on your computer. The desktop
 application supports these operating systems:
 
 - **macOS** 10.9 and above _(Intel or Apple Silicon 64-bit (x64 or arm64))_
-- **Linux** Ubuntu 12.04 and above, Fedora 21 and Debian 8 _(x86_64 or Arm
+- **Linux** Ubuntu 20.04 and above, Fedora 21 and Debian 8 _(x86_64 or Arm
   64-bit (x64 or arm64))_ (see [Linux Prerequisites](#Linux-Prerequisites) down
   below)
 - **Windows** 7 and above _(64-bit only)_


### PR DESCRIPTION
- relates to issue #5444

This PR updates the Ubuntu version in the list of supported operating systems under the section [Getting Started > Installing Cypress > System requirements > Operating System](https://docs.cypress.io/guides/getting-started/installing-cypress#Operating-System)

from

- Ubuntu `12.04` and above

to

- Ubuntu `20.04` and above

## Background

[Getting Started > Installing Cypress > System requirements > Node.js](https://docs.cypress.io/guides/getting-started/installing-cypress#Nodejs) lists Node.js `18`, `20` and above as being supported.

The [Node.js 18 announcement](https://nodejs.org/en/blog/announcements/v18-release-announce) provides detailed information in the [Toolchain and Compiler Upgrades](https://nodejs.org/en/blog/announcements/v18-release-announce#toolchain-and-compiler-upgrades) section which lists:
> Prebuilt binaries for Linux are now built on Red Hat Enterprise Linux (RHEL) 8 and are compatible with Linux distributions based on glibc 2.28 or later, for example, Debian 10, RHEL 8, Ubuntu 20.04.

additionally it states:
> Node.js does not support running on operating systems that are no longer supported by their vendor.

[Node.js 18 > BUILDING.md](https://github.com/nodejs/node/blob/v18.x/BUILDING.md#supported-platforms) lists more detailed information.

The release notes of [Ubuntu 18.04.6 LTS (Bionic Beaver)](https://wiki.ubuntu.com/BionicBeaver/ReleaseNotes) include the text "WARNING: Release reached End of Life".

[Ubuntu 20.04 LTS (Focal Fossa)](https://wiki.ubuntu.com/FocalFossa/ReleaseNotes) is therefore the earliest version which is supported by Node.js `18` and is compatible with the prebuilt binaries of Node.js `18`.

Attempting to run `node` or `npm` from Node.js `18.18.0` LTS on Ubuntu `18.04.6` LTS (Bionic Beaver) fails with the fatal error message:
> node: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found (required by node)