### PR TITLE
Update operating system minimum version to Windows 10

### DIFF
--- a/docs/guides/getting-started/installing-cypress.mdx
+++ b/docs/guides/getting-started/installing-cypress.mdx
@@ -158,7 +158,7 @@ application supports these operating systems:
 - **Linux** Ubuntu 12.04 and above, Fedora 21 and Debian 8 _(x86_64 or Arm
   64-bit (x64 or arm64))_ (see [Linux Prerequisites](#Linux-Prerequisites) down
   below)
-- **Windows** 7 and above _(64-bit only)_
+- **Windows** 10 and above _(64-bit only)_
 
 ### Node.js
 


### PR DESCRIPTION
- relates to issue #5444

This PR updates the Windows version in the list of supported operating systems under the section [Getting Started > Installing Cypress > System requirements > Operating System](https://docs.cypress.io/guides/getting-started/installing-cypress#Operating-System)

from

- Windows 7 and above (64-bit only)

to

- Windows 10 and above (64-bit only)

## Background

[Getting Started > Installing Cypress > System requirements > Node.js](https://docs.cypress.io/guides/getting-started/installing-cypress#Nodejs) lists Node.js `18`, `20` and above as being supported.

The [Node.js 18 announcement](https://nodejs.org/en/blog/announcements/v18-release-announce) provides detailed information in the [Toolchain and Compiler Upgrades](https://nodejs.org/en/blog/announcements/v18-release-announce#toolchain-and-compiler-upgrades) section which states:

> Node.js does not support running on operating systems that are no longer supported by their vendor. For operating systems where their vendor has planned to end support earlier than April 2025, such as Windows 8.1 (January 2023) and Windows Server 2012 R2 (October 2023), support for Node.js 18 will end at the earlier date.

[Node.js 18 > BUILDING.md](https://github.com/nodejs/node/blob/v18.x/BUILDING.md#supported-platforms) lists more detailed information.

Refer to [Lifecycle FAQ - Windows](https://learn.microsoft.com/en-us/lifecycle/faq/windows) for detailed information on Microsoft Windows products.

Support for [Microsoft Windows 7](https://learn.microsoft.com/en-us/lifecycle/products/windows-7) ended in Jan 2023.

Support for [Microsoft Windows 8](https://learn.microsoft.com/en-us/lifecycle/products/windows-8) ended in Jan 2016.

Support for [Microsoft Windows 8.1](https://support.microsoft.com/en-gb/windows/windows-8-1-support-ended-on-january-10-2023-3cfd4cde-f611-496a-8057-923fba401e93) ended on Jan 10, 2023.