### PR TITLE
Fix Google Authentication typo

### DIFF
--- a/docs/guides/end-to-end-testing/testing-strategies/google-authentication.mdx
+++ b/docs/guides/end-to-end-testing/testing-strategies/google-authentication.mdx
@@ -77,7 +77,7 @@ Note the client id and client secret from the previous step and visit the
 [Google OAuth 2.0 Playground](https://developers.google.com/oauthplayground).
 
 Click the `gear` icon in the upper right corner to reveal a
-`OAuth 2.0 configuration` panel. In this panel set the follow:
+`OAuth 2.0 configuration` panel. In this panel set the following:
 
 - OAuth flow: Server-side
 - Access type: Offline


### PR DESCRIPTION
Change "follow" to "following" under "Using the Google OAuth 2.0 Playground to Create Testing Credentials" instruction