### PR TITLE
docs(gh action): use correct workflow yaml syntax

### DIFF
--- a/docs/guides/continuous-integration/github-actions.mdx
+++ b/docs/guides/continuous-integration/github-actions.mdx
@@ -67,7 +67,7 @@ For Example:
 jobs:
   cypress-run:
     steps:
-      uses: cypress-io/github-action@v6
+      - uses: cypress-io/github-action@v6
 ```
 
 Alternatively, as a mitigation strategy for unforeseen breaks, bind to a


### PR DESCRIPTION
Even though this is a stub, it should have the correct syntax with the dash indicating the mapping for "uses"