### PR TITLE
Remove obsolete libgconf-2-4 from Ubuntu/Debian prerequisites

### DIFF
--- a/docs/guides/continuous-integration/introduction.mdx
+++ b/docs/guides/continuous-integration/introduction.mdx
@@ -319,7 +319,7 @@ has these dependencies installed.
 #### Ubuntu/Debian
 
 ```shell
-apt-get install libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
+apt-get install libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libnss3 libxss1 libasound2 libxtst6 xauth xvfb
 ```
 
 #### CentOS

--- a/docs/guides/getting-started/installing-cypress.mdx
+++ b/docs/guides/getting-started/installing-cypress.mdx
@@ -211,7 +211,7 @@ on your system.
 #### Ubuntu/Debian
 
 ```shell
-apt-get install libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
+apt-get install libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libnss3 libxss1 libasound2 libxtst6 xauth xvfb
 ```
 
 #### Arch

--- a/docs/guides/references/migration-guide.mdx
+++ b/docs/guides/references/migration-guide.mdx
@@ -3188,7 +3188,7 @@ systems, this is available as `libgbm-dev`). To install all required
 dependencies on Ubuntu/Debian, you can run the script below:
 
 ```shell
-apt-get install libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
+apt-get install libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libnss3 libxss1 libasound2 libxtst6 xauth xvfb
 ```
 
 ### TypeScript esModuleInterop


### PR DESCRIPTION
This PR removes the obsolete Ubuntu/Debian `libgconf-2-4` package from the list of recommended prerequisites for Ubuntu/Debian platforms, listed under

- [Getting Started > Installing Cypress > System requirements > Linux Prerequisites > Ubuntu/Debian](https://docs.cypress.io/guides/getting-started/installing-cypress#Linux-Prerequisites) which currently reads:

```bash
apt-get install libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
```

Similarly for

- [Continuous Integration > Introduction > Advanced setup > Dependencies > Linux > Ubuntu/Debian](https://docs.cypress.io/guides/continuous-integration/introduction#Dependencies)

and for

- [References > Migration Guide > Migrating to Cypress 5.0](https://docs.cypress.io/guides/references/migration-guide#Migrating-to-Cypress-50) since  `libgconf-2-4` is not required for Cypress >= version `3.5.0`

## Cypress requirements

Note: `libgconf-2.so.4` is provided by `libgconf-2-4`

- The legacy [Cypress version 3.4.1](https://docs.cypress.io/guides/references/changelog#3-4-1) was the last version to require `libgconf-2-4` (Cypress binary depends on `libgconf-2.so.4`). This version of Cypress was released on July 29, 2019.

    ```text
    ldd ~/.cache/Cypress/3.4.1/Cypress/Cypress | grep gconf
    libgconf-2.so.4 => /lib/x86_64-linux-gnu/libgconf-2.so.4 (0x00007f5a797bc000)
    ```

- [Cypress 3.5.0](https://docs.cypress.io/guides/references/changelog#3-5-0) updated electron from `2.0.18` to `5.0.10`. No dependency is shown by `ldd` on `libgconf-2.so.4` for the Cypress `3.5.0` binary version. This version of Cypress was released on Oct 23, 2019.

## Background

### Ubuntu

[libgconf-2-4](https://packages.ubuntu.com/search?keywords=libgconf-2-4) "GNOME configuration database system (shared libraries)" is available for current Ubuntu releases:
- `20.04` LTS
- `22.04` LTS
- `22.10`
- `23.04`

except for the latest upcoming release:
- `23.10` ([release](https://wiki.ubuntu.com/Releases) planned for Oct 12, 2023) where [libgconf-2-4](https://packages.ubuntu.com/search?keywords=libgconf-2-4)  is not included

    https://answers.launchpad.net/ubuntu/mantic/arm64/libgconf2-dev/3.2.6-8ubuntu1 shows Status: Deleted for `libgconf2` in `mantic` (`23.10`)

### Debian

- https://packages.debian.org/bookworm/gconf2 shows it is still included in Debian `bookworm` (`12` - `stable`)
- https://tracker.debian.org/news/1450621/removed-326-8-from-unstable/ shows it has been removed from future Debian releases (`testing`)

## Verification

```bash
sudo apt -y remove libgconf-2-4
sudo apt-get -y install libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libnss3 libxss1 libasound2 libxtst6 xauth xvfb
sudo apt autoremove
git clone https://github.com/cypress-io/cypress-example-kitchensink
cd cypress-example-kitchensink
n auto
npm ci
npm run local:run
```

Confirmed successful with Cypress `13.2.0` on Ubuntu `23.04` with Node.js `20.8.0` and on Ubuntu `22.04.3` LTS.

## Related

- https://github.com/cypress-io/cypress/issues/1526
- https://github.com/cypress-io/cypress/issues/27972

## References

- [Ubuntu gconf package overview](https://launchpad.net/ubuntu/+source/gconf)
- [Ubuntu wiki > List of releases](https://wiki.ubuntu.com/Releases)
