### PR TITLE
Prevent horizontal scrolling coming from code blocks

### DIFF
--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -266,6 +266,12 @@ div[class^='codeBlockTitle'] {
   box-shadow: inset 0px -6px 0px -4px var(--ifm-code-background-color-light);
 }
 
+@media(min-width: 997px) and (max-width: 1180px) {
+  .tabs-container .tabs {
+    max-width: 36rem;
+  }
+}
+
 .tabs-container .tabs__item {
   margin: 0;
   padding: 0.75rem 1rem;
@@ -319,6 +325,10 @@ div[class^='codeBlockTitle'] {
 /* add some more spacing for main doc container */
 [class^='docItemContainer'] {
   margin: 0 10px;
+}
+
+[class^='docItemContainer'] [class^='codeBlockLines'] {
+  max-width: 0;
 }
 
 /* hides the osano widget */


### PR DESCRIPTION
## What does this do?

- Some articles contain code blocks and tabbed code blocks that create horizontal scrolling in the document. These changes ensure the code block uses its own width (or, in the case of tabs, a max of 36rem in certain viewport sizes).


### Before
https://github.com/cypress-io/cypress-documentation/assets/8979428/df97e9f7-592f-4901-ae8c-c8c4e32cd41f

### After

https://github.com/cypress-io/cypress-documentation/assets/8979428/bbb68b7f-1964-450d-8592-02a0a58694d2


## How to test
- Visit a few articles with code blocks like [this one](http://localhost:3000/guides/references/migration-guide).
- Ensure there's no horizontal scrolling no matter which viewport you view it from.
- Ensure code blocks behave normally (you can scroll, wrap text, copy).
- Ensure code block tabs behave normally (you can switch tabs, you can scroll through them).