### PR TITLE
Fix links to Linux package prerequisites in WSL section

### DIFF
--- a/docs/guides/references/advanced-installation.mdx
+++ b/docs/guides/references/advanced-installation.mdx
@@ -311,8 +311,8 @@ rely on these being available past 60 days.
 
 ## Windows Subsystem for Linux
 
-First, install the prerequisite packages using the command that relates to your
-linux distribution ([Ubuntu/Debian](#Ubuntu-Debian) or [CentOS](#CentOS)).
+First, install the [prerequisite Linux packages](/guides/getting-started/installing-cypress#Linux-Prerequisites) using the command that relates to your
+Linux distribution ([Ubuntu/Debian](/guides/getting-started/installing-cypress#UbuntuDebian) or [CentOS](/guides/getting-started/installing-cypress#CentOS)).
 
 We need to have an [X-server](https://en.wikipedia.org/wiki/X.Org_Server) to
 display the Cypress UI from the linux subsystem. There are a variety of


### PR DESCRIPTION
This PR fixes dead links in [Guides > References > Advanced Installation > Windows Subsystem for Linux](https://docs.cypress.io/guides/references/advanced-installation#Windows-Subsystem-for-Linux) intended to point to Linux package prerequisites for running Cypress.

Currently, clicking on the links has no effect, since they refer to non-existent bookmarks on the same page. The PR changes the links to refer to the correct page:

- https://docs.cypress.io/guides/getting-started/installing-cypress

and correct bookmark names:

- [#UbuntuDebian](https://docs.cypress.io/guides/getting-started/installing-cypress#UbuntuDebian)
- [#CentOS](https://docs.cypress.io/guides/getting-started/installing-cypress#CentOS)

The generic bookmark:

- [#Linux-Prerequisites](https://docs.cypress.io/guides/getting-started/installing-cypress#Linux-Prerequisites)

is added, since there are other Linux distributions listed other than Ubuntu/Debian and CentOS.

Linux is corrected to mixed case (reference https://www.kernel.org/linux.html).