### PR TITLE
update ci example workflows to use Node.js 20.x LTS

### DIFF
--- a/docs/guides/continuous-integration/aws-codebuild.mdx
+++ b/docs/guides/continuous-integration/aws-codebuild.mdx
@@ -128,7 +128,7 @@ offers a way to specify an image hosted on DockerHub or the
 
 The Cypress team maintains the official
 [Docker Images](https://github.com/cypress-io/cypress-docker-images) for running
-Cypress locally and in CI, which are built with Google Chrome and Firefox. For
+Cypress locally and in CI, which are built with Google Chrome, Firefox and Microsoft Edge. For
 example, this allows us to run the tests in Firefox by passing the
 `--browser firefox` attribute to `cypress run`.
 
@@ -180,13 +180,15 @@ version: 0.2
 
 ## AWS CodeBuild Batch configuration
 ## https://docs.aws.amazon.com/codebuild/latest/userguide/batch-build-buildspec.html
-## Define build to run using the "cypress/browsers:node18.12.0-chrome106-ff106" image from the Cypress Amazon ECR Public Gallery
+## Define build to run using the
+## "cypress/browsers:node-20.9.0-chrome-118.0.5993.88-1-ff-118.0.2-edge-118.0.2088.46-1" image
+## from the Cypress Amazon ECR Public Gallery
 batch:
   fast-fail: false
   build-list:
     - identifier: cypress-e2e-tests
       env:
-        image: public.ecr.aws/cypress-io/cypress/browsers:node18.12.0-chrome106-ff106
+        image: public.ecr.aws/cypress-io/cypress/browsers:node-20.9.0-chrome-118.0.5993.88-1-ff-118.0.2-edge-118.0.2088.46-1
 
 phases:
   install:

--- a/docs/guides/continuous-integration/bitbucket-pipelines.mdx
+++ b/docs/guides/continuous-integration/bitbucket-pipelines.mdx
@@ -61,7 +61,7 @@ example, this allows us to run the tests in Firefox by passing the
 `--browser firefox` attribute to `cypress run`.
 
 ```yaml
-image: cypress/browsers:node18.12.0-chrome106-ff106
+image: cypress/browsers:node-20.9.0-chrome-118.0.5993.88-1-ff-118.0.2-edge-118.0.2088.46-1
 
 pipelines:
   default:
@@ -89,7 +89,7 @@ Artifacts from a job can be defined by providing paths to the `artifacts`
 attribute.
 
 ```yaml
-image: cypress/browsers:node18.12.0-chrome106-ff106
+image: cypress/browsers:node-20.9.0-chrome-118.0.5993.88-1-ff-118.0.2-edge-118.0.2088.46-1
 
 pipelines:
   default:
@@ -153,7 +153,7 @@ recording test results to [Cypress Cloud](/guides/cloud/introduction).
 :::
 
 ```yaml
-image: cypress/base:18.12.1
+image: cypress/base:20.9.0
 
 ## job definition for running E2E tests in parallel
 e2e: &e2e
@@ -212,7 +212,7 @@ definitions:
 The complete `bitbucket-pipelines.yml` is below:
 
 ```yaml
-image: cypress/base:18.12.1
+image: cypress/base:20.9.0
 
 ## job definition for running E2E tests in parallel
 e2e: &e2e

--- a/docs/guides/continuous-integration/github-actions.mdx
+++ b/docs/guides/continuous-integration/github-actions.mdx
@@ -173,7 +173,9 @@ Cypress locally and in CI.
 
 Below we extend the previous example by adding the `container` attribute using a
 [Cypress Docker Image](https://github.com/cypress-io/cypress-docker-images)
-built with Google Chrome `106`. Specifying a browser version allows our tests to
+built with the version of Google Chrome embedded in the tag name of the Docker image
+shown as `chrome-xxx`.
+Specifying a browser version allows our tests to
 execute without any influence from browser version changes in the GitHub runner
 image.
 
@@ -186,7 +188,7 @@ jobs:
   cypress-run:
     runs-on: ubuntu-22.04
     container:
-      image: cypress/browsers:node18.12.0-chrome106-ff106
+      image: cypress/browsers:node-20.9.0-chrome-118.0.5993.88-1-ff-118.0.2-edge-118.0.2088.46-1
       options: --user 1001
     steps:
       - name: Checkout

--- a/docs/guides/continuous-integration/gitlab-ci.mdx
+++ b/docs/guides/continuous-integration/gitlab-ci.mdx
@@ -69,7 +69,7 @@ example project and place the above GitHub Action configuration in
 
 The Cypress team maintains the official
 [Docker Images](https://github.com/cypress-io/cypress-docker-images) for running
-Cypress tests locally and in CI, which are built with Google Chrome and Firefox.
+Cypress tests locally and in CI, which are built with Google Chrome, Firefox and Microsoft Edge.
 For example, this allows us to run the tests in Firefox by passing the
 `--browser firefox` attribute to `cypress run`.
 
@@ -78,7 +78,7 @@ stages:
   - test
 
 test:
-  image: cypress/browsers:node18.12.0-chrome106-ff106
+  image: cypress/browsers:node-20.9.0-chrome-118.0.5993.88-1-ff-118.0.2-edge-118.0.2088.46-1
   stage: test
   script:
     # install dependencies
@@ -109,7 +109,7 @@ cache:
     - .npm/
 
 test:
-  image: cypress/browsers:node18.12.0-chrome106-ff106
+  image: cypress/browsers:node-20.9.0-chrome-118.0.5993.88-1-ff-118.0.2-edge-118.0.2088.46-1
   stage: test
   script:
     # install dependencies
@@ -161,7 +161,8 @@ assign it to the `build` stage.
 stages:
   - build
 
-## Set environment variables for folders in "cache" job settings for npm modules and Cypress binary
+## Set environment variables for folders in "cache" job settings
+## for npm modules and Cypress binary
 variables:
   npm_config_cache: '$CI_PROJECT_DIR/.npm'
   CYPRESS_CACHE_FOLDER: '$CI_PROJECT_DIR/cache/Cypress'
@@ -173,9 +174,9 @@ cache:
     - node_modules
     - build
 
-## Install NPM dependencies and Cypress
+## Install npm dependencies and Cypress
 install:
-  image: cypress/browsers:node18.12.0-chrome106-ff106
+  image: cypress/browsers:node-20.9.0-chrome-118.0.5993.88-1-ff-118.0.2-edge-118.0.2088.46-1
   stage: build
   script:
     - npm ci
@@ -204,7 +205,8 @@ stages:
   - build
   - test
 
-## Set environment variables for folders in "cache" job settings for npm modules and Cypress binary
+## Set environment variables for folders in "cache" job settings
+## for npm modules and Cypress binary
 variables:
   npm_config_cache: '$CI_PROJECT_DIR/.npm'
   CYPRESS_CACHE_FOLDER: '$CI_PROJECT_DIR/cache/Cypress'
@@ -217,15 +219,15 @@ cache:
     - node_modules
     - build
 
-## Install NPM dependencies and Cypress
+## Install npm dependencies and Cypress
 install:
-  image: cypress/browsers:node18.12.0-chrome106-ff106
+  image: cypress/browsers:node-20.9.0-chrome-118.0.5993.88-1-ff-118.0.2-edge-118.0.2088.46-1
   stage: build
   script:
     - npm ci
 
 ui-chrome-tests:
-  image: cypress/browsers:node18.12.0-chrome106-ff106
+  image: cypress/browsers:node-20.9.0-chrome-118.0.5993.88-1-ff-118.0.2-edge-118.0.2088.46-1
   stage: test
   parallel: 5
   script:

--- a/docs/guides/continuous-integration/introduction.mdx
+++ b/docs/guides/continuous-integration/introduction.mdx
@@ -225,7 +225,7 @@ Mounting a project directory with an existing `node_modules` into a
 `cypress/base` docker image **will not work**:
 
 ```shell
-docker run -it -v /app:/app cypress/base:18.12.1 bash -c 'cypress run'
+docker run -it -v /app:/app cypress/base:20.9.0 bash -c 'cypress run'
 Error: the cypress binary is not installed
 ```
 


### PR DESCRIPTION
This PR updates CI example workflow documentation to use Node.js `20.x`, codename 'Iron'. [Node.js v20.9.0](https://nodejs.org/en/blog/release/v20.9.0) became the Active LTS version on Oct 24, 2023.

## Updated pages / sections

- [Continuous Integration > Introduction > Official Cypress Docker Images](https://docs.cypress.io/guides/continuous-integration/introduction#Official-Cypress-Docker-Images)
- [Continuous Integration > AWS CodeBuild > Testing in Chrome and Firefox with Cypress Docker Images](https://docs.cypress.io/guides/continuous-integration/aws-codebuild#Testing-in-Chrome-and-Firefox-with-Cypress-Docker-Images)
- [Continuous Integration > GitHub Actions > Testing with Cypress Docker Images](http://localhost:3000/guides/continuous-integration/github-actions#Testing-with-Cypress-Docker-Images)
- [Continuous Integration > GitLab CI](https://docs.cypress.io/guides/continuous-integration/gitlab-ci)

All current Cypress Docker images in the category [cypress/browsers](https://hub.docker.com/r/cypress/browsers/) have Google Chrome, Mozilla FireFox and Microsoft Edge included, so "Edge" is also added to the text in appropriate places.

Docker images are transitioned to:

- [cypress/base](https://hub.docker.com/r/cypress/base)
    `cypress/base:20.9.0`
- [cypress/browsers](https://hub.docker.com/r/cypress/browsers/)
    `cypress/browsers:node-20.9.0-chrome-118.0.5993.88-1-ff-118.0.2-edge-118.0.2088.46-1`

## Background

Node.js transitioned version `18.x` to LTS maintenance status and version `20.x` to active LTS status on October 24, 2023 (see [Node.js release schedule](https://github.com/nodejs/release#release-schedule) and [Node v20.9.0 (LTS)](https://nodejs.org/en/blog/release/v20.9.0) announcement).
