### PR TITLE
Remove incorrectly placed GitHub references in GitLab CI page

### DIFF
--- a/docs/guides/continuous-integration/gitlab-ci.mdx
+++ b/docs/guides/continuous-integration/gitlab-ci.mdx
@@ -43,27 +43,16 @@ test:
     - npm run e2e
 ```
 
-:::tip
-
-<strong>Try it out</strong>
-
-To try out the example above yourself, fork the
-[Cypress Kitchen Sink](https://github.com/cypress-io/cypress-example-kitchensink)
-example project and place the above GitHub Action configuration in
-`.gitlab-ci.yml`.
-
-:::
-
 **How this configuration works:**
 
 - On _push_ to this repository, this job will provision and start GitLab-hosted
-  Linux instance for running the outlined `stages` declared in `script` with in
+  Linux instance for running the outlined `stages` declared in `script` within
   the `test` job section of the configuration.
-- The code is checked out from our GitHub/GitLab repository.
+- The code is checked out from the GitLab repository.
 - Finally, our scripts will:
   - Install npm dependencies
   - Start the project web server (`npm start`)
-  - Run the Cypress tests within our GitHub repository within Electron.
+  - Run the Cypress tests within the GitLab repository using Electron.
 
 ## Testing in Chrome and Firefox with Cypress Docker Images
 


### PR DESCRIPTION
- [Continuous Integration > GitLab CI](https://docs.cypress.io/guides/continuous-integration/gitlab-ci) incorrectly advises to use a GitLab workflow on GitHub. This makes no sense.

The section referring to applying the GitLab workflow to GitHub is removed. Other inapplicable references to GitHub in a GitLab environment are also removed.

There is no equivalent live replacement repo for GitLab.  The original https://gitlab.com/cypress-io/cypress-example-kitchensink/ repo is archived and no longer maintained. Although it is possible that forking the old GitLab repo and applying the workflow to it would still work, there can be no guarantee of this, and it is better to avoid suggesting it, due to uncertain outcomes. (See https://github.com/cypress-io/cypress-example-kitchensink/issues/615#issuecomment-1518538351.)
