### PR TITLE
chore: remove json string syntax

### DIFF
--- a/docs/guides/guides/test-retries.mdx
+++ b/docs/guides/guides/test-retries.mdx
@@ -117,13 +117,13 @@ by passing the `retries` option an object with the following options:
 
 ```jsx
 {
-  "retries": {
+  retries: {
     // Configure retry attempts for `cypress run`
     // Default is 0
-    "runMode": 2,
+    runMode: 2,
     // Configure retry attempts for `cypress open`
     // Default is 0
-    "openMode": 0
+    openMode: 0
   }
 }
 ```
@@ -137,7 +137,7 @@ by defining the `retries` property and setting the desired number of retries.
 
 ```jsx
 {
-  "retries": 1
+  retries: 1
 }
 ```
 


### PR DESCRIPTION
The retries example code blocks were still using the pre-v10 `.json` syntax with strings as keys. 

This better aligns with the `.js/.ts` object notation. 