### PR TITLE
Makes an `intercept`-related comment more readable 

### DIFF
--- a/docs/api/commands/intercept.mdx
+++ b/docs/api/commands/intercept.mdx
@@ -268,7 +268,8 @@ cy.intercept({
 // matches:
 //   PUT /users/1
 //   PATCH /users/1
-//   doesn't match
+//
+// doesn't match:
 //   GET /users
 //   GET /users/1
 


### PR DESCRIPTION
It was a little tricky to read

**Before**

<img width="832" alt="image" src="https://github.com/cypress-io/cypress-documentation/assets/62602854/b2dc340a-cae1-48bc-8991-5a74cd5d9272">


**After**

<img width="860" alt="image" src="https://github.com/cypress-io/cypress-documentation/assets/62602854/8e557311-04a4-4df0-b474-ef584eb8cf95">
