### PR TITLE
chore: release 13.5.1

### DIFF
--- a/docs/guides/references/changelog.mdx
+++ b/docs/guides/references/changelog.mdx
@@ -2,6 +2,16 @@
 title: Changelog
 ---
 
+## 13.5.1
+
+_Released 11/14/2023_
+
+**Bugfixes:**
+
+- Fixed a regression in [`13.5.0`](#13-5-0) where requests cached within a given spec may take longer to load than they did previously. Addresses [#28295](https://github.com/cypress-io/cypress/issues/28295).
+- Fixed an issue where pages opened in a new tab were missing response headers, causing them not to load properly. Fixes [#28293](https://github.com/cypress-io/cypress/issues/28293) and [#28303](https://github.com/cypress-io/cypress/issues/28303).
+- We now pass a flag to Chromium browsers to disable default component extensions. This is a common flag passed during browser automation. Fixed in [#28294](https://github.com/cypress-io/cypress/pull/28294).
+
 ## 13.5.0
 
 _Released 11/8/2023_


### PR DESCRIPTION
CHANGELOG entry to `13.5.1` release