### PR TITLE
docs(selectFile): readFile & fixture should use `null` instead of `{ encoding: null }`

### DIFF
--- a/docs/api/actions/selectfile.mdx
+++ b/docs/api/actions/selectfile.mdx
@@ -63,7 +63,7 @@ Either a single file, or an array of files. A file can be:
   [`TypedArray`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray)
   containing binary data, such as `Uint8Array.from('123')`.
   [`Cypress.Buffer`](/api/utilities/buffer) instances, such as those returned by
-  `cy.readFile('file.json', { encoding: null })` or created by
+  `cy.readFile('file.json', null)` or created by
   `Cypress.Buffer.from('foo')` are `TypedArray` instances.
 - An object with a non-null `contents` property, specifying details about the
   file. Eg: `{contents: '@alias', fileName: 'file.json'}`
@@ -144,7 +144,7 @@ though a user would not be able to directly activate the file input.
 ### From a fixture
 
 ```javascript
-cy.fixture('file.json', { encoding: null }).as('myFixture')
+cy.fixture('file.json', null).as('myFixture')
 cy.get('input[type=file]').selectFile('@myFixture')
 ```
 


### PR DESCRIPTION
The `null` should not wrapped in the `{ encoding: null }`, which would cause a type error.

reference: https://docs.cypress.io/api/commands/fixture#Syntax

