### PR TITLE
Corrected doc for mount API for vue 2

### DIFF
--- a/docs/api/commands/mount.mdx
+++ b/docs/api/commands/mount.mdx
@@ -61,14 +61,14 @@ Cypress.Commands.add('mount', (component, options = {}) => {
   options.extensions.components = options.extensions.components || {}
 
   /* Add any global plugins */
-  // options.global.plugins.push({
+  // options.extensions.plugins.push({
   //   install(app) {
   //     app.use(MyPlugin);
   //   },
   // });
 
   /* Add any global components */
-  // options.global.components['Button'] = Button;
+  // options.extensions.components['Button'] = Button;
 
   return mount(component, options)
 })


### PR DESCRIPTION
For vue 3 tab item, the documentation contains `options.global`. However, for vue 2 tab item, the documentation should say `options.extensions` instead of `options.global`. 