### PR TITLE
Update why-cypress to remove nutshell video.mdx

### DIFF
--- a/docs/guides/overview/why-cypress.mdx
+++ b/docs/guides/overview/why-cypress.mdx
@@ -14,11 +14,6 @@ sidebar_position: 10
 
 :::
 
-<DocsVideo
-  title="Cypress in a Nutshell"
-  src="https://youtube.com/embed/LcGHiFnBh3Y"
-/>
-
 ## In a nutshell
 
 Cypress is a next generation front end testing tool built for the modern web. We


### PR DESCRIPTION
Removing outdated "Cypress in a Nutshell" video from the page. I'll also be archiving the video on YouTube and removing other references to it.