### PR TITLE
fix cli example with project and spec options

### DIFF
--- a/docs/guides/guides/command-line.mdx
+++ b/docs/guides/guides/command-line.mdx
@@ -438,15 +438,15 @@ app/
     unit/
     e2e/
       cypress/
-        integration/
-          spec.js
+        e2e/
+          spec.cy.js
       cypress.config.js
 ```
 
 If we are in the `app` folder, we can run the specs using the following command
 
 ```shell
-cypress run --project tests/e2e --spec ./tests/e2e/cypress/e2e/spec.js
+cypress run --project tests/e2e --spec ./tests/e2e/cypress/e2e/spec.cy.js
 ```
 
 #### `cypress run --tag <tag>` {#cypress-run-tag-lt-tag-gt}


### PR DESCRIPTION
- This PR follows on from the abandoned PR https://github.com/cypress-io/cypress-documentation/pull/5467.

## Issue

The example showing the combination of the `--project` and `--spec` option in [Guides > Command Line > Commands](https://docs.cypress.io/guides/guides/command-line#Commands) was inconsistently updated in the transition to Cypress `10.x`:

```shell
cypress run --project tests/e2e --spec ./tests/e2e/cypress/e2e/spec.js
```

![project-spec](https://github.com/cypress-io/cypress-documentation/assets/66998419/e7716349-51b3-4cd8-8a6f-8d4f429a18ea)


The example is not aligned to the default [e2e tests specPattern](https://docs.cypress.io/guides/references/configuration#e2e) `cypress/e2e/**/*.cy.{js,jsx,ts,tsx}` for current versions of Cypress (`.cy` is missing in the filename) and the directory tree structure preceding the command uses the legacy directory `cypress/integration` instead of `cypress/e2e`.

## Resolution

1. Change the directory name in the directory tree from `cypress/integration` to `cypress/e2e`
2. Change the test spec filename to `spec.cy.js`
