### PR TITLE
update CI github action upload-artifact to v4

### DIFF
--- a/docs/guides/continuous-integration/github-actions.mdx
+++ b/docs/guides/continuous-integration/github-actions.mdx
@@ -248,7 +248,7 @@ jobs:
           build: npm run build
 
       - name: Save build folder
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build
           if-no-files-found: error
@@ -341,7 +341,7 @@ jobs:
           build: npm run build
 
       - name: Save build folder
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build
           if-no-files-found: error


### PR DESCRIPTION
This PR updates [actions/upload-artifact](https://github.com/actions/upload-artifact) from `v3` to [actions/upload-artifact@v4](https://github.com/actions/upload-artifact/releases/tag/v4.0.0) in 

[Continuous Integration > GitHub Actions > Caching Dependencies and Build Artifacts](https://docs.cypress.io/guides/continuous-integration/github-actions#Caching-Dependencies-and-Build-Artifacts) 

- This aligns with PR https://github.com/cypress-io/github-action/pull/1098

Migrating [actions/upload-artifact](https://github.com/actions/upload-artifact) from `v3` to `v4` avoids deprecation warnings which would otherwise appear if workflows continue to depend on Node.js `16` through `v3` usage.

## Reference

- Blog Dec 14, 2023: [GitHub Actions – Artifacts v4 is now Generally Available](https://github.blog/changelog/2023-12-14-github-actions-artifacts-v4-is-now-generally-available/)