### PR TITLE
Remove 'do it yourself' section from docs on visual testing

### DIFF
--- a/docs/guides/tooling/visual-testing.mdx
+++ b/docs/guides/tooling/visual-testing.mdx
@@ -210,26 +210,6 @@ to see these Percy and Cypress in action.
 | [Blog](https://www.cypress.io/blog/2020/05/27/webcast-recording-keep-your-ui-sharp/) | The companion blog for the Cypress + Happo webinar                                                                                          |
 | [Slides](https://cypress.slides.com/cypress-io/cypress-and-happo)                    | The companion slides for the Cypress + Happo webinar                                                                                        |
 
-### Do It Yourself
-
-Even if you decide to skip using a 3rd party image storage and comparison
-service, you can still perform visual testing. Follow these examples
-
-- [Visual Regression testing with Cypress and cypress-image-snapshot](https://medium.com/norwich-node-user-group/visual-regression-testing-with-cypress-io-and-cypress-image-snapshot-99c520ccc595)
-  tutorial.
-- [Visual testing for React components using open source tools](https://glebbahmutov.com/blog/open-source-visual-testing-of-components/)
-  with companion
-  [videos](https://www.youtube.com/playlist?list=PLP9o9QNnQuAYhotnIDEUQNXuvXL7ZmlyZ).
-
-:::caution
-
-You will want to consider the development costs of implementing a visual testing
-tool yourself versus using an external 3rd party provider. Storing, reviewing
-and analyzing image differences are non-trivial tasks and they can quickly
-become a chore when going with a DIY solution.
-
-:::
-
 ## Best practices
 
 As a general rule there are some best practices when visual testing.


### PR DESCRIPTION
Close https://github.com/cypress-io/cypress-documentation/issues/5580

These links are old and no longer accurately explain visual regression, rolling your own.