### PR TITLE
Remove references to cypress's chromium dls

### DIFF
--- a/docs/guides/guides/launching-browsers.mdx
+++ b/docs/guides/guides/launching-browsers.mdx
@@ -56,9 +56,9 @@ Cypress supports the browser versions below:
 ### Download specific Chrome version
 
 The Chrome browser is evergreen - meaning it will automatically update itself,
-sometimes causing a breaking change in your automated tests. We host
-[chromium.cypress.io](https://chromium.cypress.io) with links to download a
-specific released version of Chrome (dev, Canary and stable) for every platform.
+sometimes causing a breaking change in your automated tests. You can use
+[https://vikyd.github.io/download-chromium-history-version](https://vikyd.github.io/download-chromium-history-version) to download a
+specific released version of Chromium (dev, Canary and stable) for every platform.
 
 ### Electron Browser
 

--- a/docs/guides/guides/launching-browsers.mdx
+++ b/docs/guides/guides/launching-browsers.mdx
@@ -58,7 +58,7 @@ Cypress supports the browser versions below:
 The Chrome browser is evergreen - meaning it will automatically update itself,
 sometimes causing a breaking change in your automated tests. You can use
 [https://vikyd.github.io/download-chromium-history-version](https://vikyd.github.io/download-chromium-history-version) to download a
-specific released version of Chromium (dev, Canary and stable) for every platform.
+specific released version of Chromium for every platform.
 
 ### Electron Browser
 

--- a/docs/guides/references/troubleshooting.mdx
+++ b/docs/guides/references/troubleshooting.mdx
@@ -76,9 +76,9 @@ problem:
 ## Download specific Chrome version
 
 The Chrome browser is evergreen - meaning it will automatically update itself,
-sometimes causing a breaking change in your automated tests. We host
-[chromium.cypress.io](https://chromium.cypress.io) with links to download a
-specific released version of Chrome (dev, Canary and stable) for every platform.
+sometimes causing a breaking change in your automated tests. You can use
+[https://vikyd.github.io/download-chromium-history-version](https://vikyd.github.io/download-chromium-history-version) to download a
+specific released version of Chromium (dev, Canary and stable) for every platform.
 
 ## Clear Cypress cache
 

--- a/docs/guides/references/troubleshooting.mdx
+++ b/docs/guides/references/troubleshooting.mdx
@@ -78,7 +78,7 @@ problem:
 The Chrome browser is evergreen - meaning it will automatically update itself,
 sometimes causing a breaking change in your automated tests. You can use
 [https://vikyd.github.io/download-chromium-history-version](https://vikyd.github.io/download-chromium-history-version) to download a
-specific released version of Chromium (dev, Canary and stable) for every platform.
+specific released version of Chromium for every platform.
 
 ## Clear Cypress cache
 


### PR DESCRIPTION
This service is no longer maintained: https://github.com/cypress-io/chromium-downloads