### PR TITLE
Add cypress-solid plugin

### DIFF
--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -392,6 +392,13 @@
           "link": "https://github.com/Zaista/cypress-fixture-faker",
           "keywords": ["fixture", "faker"],
           "badge": "community"
+        },
+        {
+          "name": "cypress-solid",
+          "description": "A Cypress plugin to help you test applications using the Solid Protocol.",
+          "link": "https://github.com/NoelDeMartin/cypress-solid",
+          "keywords": ["solid", "solid-protocol"],
+          "badge": "community"
         }
       ]
     },


### PR DESCRIPTION
I added this under "Development Tools", but I wasn't sure if that's the proper section or I should add it under "Frameworks" (even though Solid is a protocol, not a framework). Let me know if you prefer it under a different category.

The documentation is written in [the README of the repository](https://github.com/NoelDeMartin/cypress-solid#cypress-solid-), and you can find a sample application working with CI here: https://github.com/NoelDeMartin/cypress-solid-sandbox/