### PR TITLE
chore: release 13.6.2 changelog

### DIFF
--- a/docs/guides/references/changelog.mdx
+++ b/docs/guides/references/changelog.mdx
@@ -2,6 +2,23 @@
 title: Changelog
 ---
 
+## 13.6.2
+
+_Released 12/26/2023_
+
+**Bugfixes:**
+
+- Fixed a regression in [`13.6.1`](/guides/references/changelog#13-6-1) where a malformed URI would crash Cypress. Fixes [#28521](https://github.com/cypress-io/cypress/issues/28521).
+- Fixed a regression in [`12.4.0`](/guides/references/changelog#12-4-0) where erroneous `<br>` tags were displaying in error messages in the Command Log making them less readable. Fixes [#28452](https://github.com/cypress-io/cypress/issues/28452).
+
+**Performance:**
+
+- Improved performance when finding unique selectors for command log snapshots for Test Replay. Addressed in [#28536](https://github.com/cypress-io/cypress/pull/28536).
+
+**Dependency Updates:**
+
+- Updated ts-node from `10.9.1` to `10.9.2`. Cypress will longer error during `cypress run` or `cypress open` when using Typescript 5.3.2+ with `extends` in `tsconfig.json`. Addresses [#28385](https://github.com/cypress-io/cypress/issues/28385).
+
 ## 13.6.1
 
 _Released 12/5/2023_


### PR DESCRIPTION
Updates `CHANGELOG` for release `13.6.2`