### PR TITLE
Update "Replace a method with a function"

### DIFF
--- a/docs/api/commands/stub.mdx
+++ b/docs/api/commands/stub.mdx
@@ -19,7 +19,6 @@ assertion. It is not retryable, chainable, or timeout-able.
 ```javascript
 cy.stub()
 cy.stub(object, method)
-cy.stub(object, method, replacerFn)
 ```
 
 ### Usage
@@ -40,10 +39,6 @@ The `object` that has the `method` to be replaced.
 **<Icon name="angle-right" /> method** **_(String)_**
 
 The name of the `method` on the `object` to be wrapped.
-
-**<Icon name="angle-right" /> replacerFn** **_(Function)_**
-
-The function used to replace the `method` on the `object`.
 
 ### Yields [<Icon name="question-circle"/>](/guides/core-concepts/introduction-to-cypress#Subject-Management) {#Yields}
 
@@ -82,7 +77,7 @@ expect(util.addListeners).to.be.called
 // assume App.start calls util.addListeners
 let listenersAdded = false
 
-cy.stub(util, 'addListeners', () => {
+cy.stub(util, 'addListeners').callsFake(() => {
   listenersAdded = true
 })
 


### PR DESCRIPTION
The `replacerFn` parameter is deprecated, with a recommendation to use `callsFake` instead, but looking for `callsFake` in the docs turns up no information.

I wasn't sure how much to say about `callsFake`. It's not part of the Cypress syntax, and this page doesn't attempt to document every aspect of the underlying Sinon.js stub. I figured an updated example and the existing link to Sinon.js documentation was enough, but I'm happy to revise if needed.
