### PR TITLE
Replace "irregardless" with "regardless".

### DIFF
--- a/docs/guides/references/experiments.mdx
+++ b/docs/guides/references/experiments.mdx
@@ -124,7 +124,7 @@ modified HTML or JS value.
 
 [Test retries](/guides/guides/test-retries) is a Cypress [Flake Detection](/guides/cloud/flaky-test-management#Flake-Detection) feature that enables you to re-attempt any tests that initially fail. The failure may not be a "true" failure, i.e. flaky. The only way to determine this is to retry the test.
 
-Normally, test retries simply stop on the first passing attempt. And the final test result of any flaky test is always "passing", irregardless of how many prior attempts failed. The following experimental settings for retries give you more control over the retries process.
+Normally, test retries simply stop on the first passing attempt. And the final test result of any flaky test is always "passing", regardless of how many prior attempts failed. The following experimental settings for retries give you more control over the retries process.
 
 There are two strategies for retries:
 


### PR DESCRIPTION
While "irregardless" _is_ a word, it is probably too quirky for international readers, likely used here by mistake.