### PR TITLE
Fix link to 'experimentalInteractiveRunEvents'

### DIFF
--- a/docs/api/plugins/before-run-api.mdx
+++ b/docs/api/plugins/before-run-api.mdx
@@ -16,7 +16,7 @@ event will fire once for each machine on which the tests are run.
 :::caution
 
 ⚠️ When running via `cypress open`, the `before:run` event only fires if the
-[experimentalInteractiveRunEvents flag](/guides/references/configuration#Experiments)
+[experimentalInteractiveRunEvents flag](/guides/references/experiments#Configuration)
 is enabled.
 
 :::


### PR DESCRIPTION
The [currently linked page](https://docs.cypress.io/guides/references/configuration#Experiments), does not list any information on the `experimentalInteractiveRunEvents` config value. This flag is explained [here](https://docs.cypress.io/guides/references/experiments#Configuration).

I also find it a bit confusing to have `experiments#Configuration` and `configuration#Experiments`. Maybe one of them should link to the other or something like that?