### PR TITLE
fix: correct cy.visit() documentation to include caveat around cy.ori…

### DIFF
--- a/docs/api/commands/visit.mdx
+++ b/docs/api/commands/visit.mdx
@@ -53,7 +53,7 @@ URL or Cypress will attempt to act as your web server. See the
 [prefixes notes](#Prefixes) for more details.
 
 **Note:** visiting a new domain requires the Cypress window to reload. You
-cannot visit different super domains in a single test.
+cannot visit different super domains in a single test without the use of [`cy.origin()`](/api/commands/origin).
 
 **<Icon name="angle-right" /> options** **_(Object)_**
 


### PR DESCRIPTION
…gin for multiple superdomains

Fixes missing information since the release of `cy.origin()` around the `cy.visit()` command.