### PR TITLE
update TypeScript documentation

### DIFF
--- a/docs/guides/tooling/typescript-support.mdx
+++ b/docs/guides/tooling/typescript-support.mdx
@@ -9,7 +9,7 @@ tests in TypeScript.
 
 ### Install TypeScript
 
-To use TypeScript with Cypress, you will need TypeScript 3.4+. If you do not
+To use TypeScript with Cypress, you will need TypeScript 4.0+. If you do not
 already have TypeScript installed as a part of your framework, you will need to
 install it:
 
@@ -70,6 +70,28 @@ VS Code (within a .ts or .js file):
 If that does not work, try restarting the IDE.
 
 :::
+
+### Processing your Cypress configuration and plugins
+
+Cypress needs to be able to transpile your Cypress configuration and plugins written in TypeScript in order to make them executable within Cypress' Node.js runtime.
+To do this, Cypress will attempt to read the user's TypeScript and project configuration to apply the correct TypeScript loader to Cypress' Node.js runtime.
+
+If your project is an `ESM` package (short for [ECMAScript Module](https://nodejs.org/api/esm.html#modules-ecmascript-modules)), Cypress attempts
+to apply the [ts-node/esm](https://github.com/TypeStrong/ts-node?tab=readme-ov-file#esm) Node.js loader to resolve the Cypress configuration and plugins. `ESM` is determined by Cypress if you have the `type: "module"` key-value pair present inside your project's `package.json`.
+
+Otherwise, regular [ts-node](https://github.com/TypeStrong/ts-node?tab=readme-ov-file#node-flags-and-other-tools) is required into Cypress' Node.js runtime.
+Since Node.js by itself can only interpret CommonJS files, Cypress attempts to make your TypeScript configuration compatable with Cypress' Node.js runtime.
+To do this, Cypress overrides the following configuration values found inside your project's `tsconfig.json`:
+
+```json
+{
+  "module": "commonjs",
+  "moduleResolution": "node",
+  "preserveValueImports": false
+}
+```
+
+This does not have an impact on your project or its TypeScript configuration settings. This override only happens within the context of the Cypress runtime.
 
 ### Clashing Types with Jest
 
@@ -354,6 +376,7 @@ Both Jest and Expect (bundled inside Cypress) provide the clashing types for the
 
 | Version                                       | Changes                                                                                    |
 | --------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| [13.0.0](/guides/references/changelog#13-0-0) | Raised minimum required TypeScript version from 3.4+ to 4.0+                               |
 | [10.0.0](/guides/references/changelog#10-0-0) | Update guide to cover TypeScript setup for component testing                               |
 | [5.0.0](/guides/references/changelog#5-0-0)   | Raised minimum required TypeScript version from 2.9+ to 3.4+                               |
 | [4.4.0](/guides/references/changelog#4-4-0)   | Added support for TypeScript without needing your own transpilation through preprocessors. |


### PR DESCRIPTION
updatesTypeScript documentation to display new minimum version set inCypress v13 and update changelog entry.

 Also add entry on values being overridden in the users `tsconfig.json` in order to make their typescript files executable inside the Cypress Node.js runtime