### PR TITLE
chore: add changelog from 13.6.3

### DIFF
--- a/docs/guides/references/changelog.mdx
+++ b/docs/guides/references/changelog.mdx
@@ -2,6 +2,41 @@
 title: Changelog
 ---
 
+## 13.6.3
+
+_Released 1/16/2024_
+
+**Bugfixes:**
+
+- Force `moduleResolution` to `node` when `typescript` projects are detected to correctly run Cypress. This change should not have a large impact as `commonjs` is already forced when `ts-node` is registered. This fix does not impact the ESM Typescript configuration loader. Fixes [#27731](https://github.com/cypress-io/cypress/issues/27731).
+- No longer wait for additional frames when recording a video for a spec that was skipped by the Cloud due to Auto Cancellation. Fixes [#27898](https://github.com/cypress-io/cypress/issues/27898).
+- Now `node_modules` will not be ignored if a project path or a provided path to spec files contains it. Fixes [#23616](https://github.com/cypress-io/cypress/issues/23616).
+- Updated display of assertions and commands with a URL argument to escape markdown formatting so that values are displayed as is and assertion values display as bold. Fixes [#24960](https://github.com/cypress-io/cypress/issues/24960) and [#28100](https://github.com/cypress-io/cypress/issues/28100).
+- When generating assertions via Cypress Studio, the preview of the generated assertions now correctly displays the past tense of 'expected' instead of 'expect'. Fixed in [#28593](https://github.com/cypress-io/cypress/pull/28593).
+- Fixed a regression in [`13.6.2`](/guides/references/changelog#13.6.2) where the `body` element was not highlighted correctly in Test Replay. Fixed in [#28627](https://github.com/cypress-io/cypress/pull/28627).
+- Correctly sync `Cypress.currentRetry` with secondary origin so test retries that leverage [`cy.origin()`](/api/commands/origin) render logs as expected. Fixes [#28574](https://github.com/cypress-io/cypress/issues/28574).
+- Fixed an issue where some cross-origin logs, like assertions or cy.clock(), were getting too many dom snapshots. Fixes [#28609](https://github.com/cypress-io/cypress/issues/28609).
+- Fixed asset capture for Test Replay for requests that are routed through service workers. This addresses an issue where styles were not being applied properly in Test Replay and [`cy.intercept()`](/api/commands/intercept) was not working properly for requests in this scenario. Fixes [#28516](https://github.com/cypress-io/cypress/issues/28516).
+- Fixed an issue where visiting an `http://` site would result in an infinite reload/redirect loop in Chrome 114+. Fixes [#25891](https://github.com/cypress-io/cypress/issues/25891).
+- Fixed an issue where requests made from extra tabs do not include their original headers. Fixes [#28641](https://github.com/cypress-io/cypress/issues/28641).
+- Fixed an issue where [`cy.wait()`](/api/commands/wait) would sometimes throw an error reading a property of undefined when returning responses. Fixes [#28233](https://github.com/cypress-io/cypress/issues/28233).
+
+**Performance:**
+
+- Fixed a performance regression from [`13.3.2`](/guides/references/changelog#13.3.2) where requests may not correlate correctly when test isolation is off. Fixes [#28545](https://github.com/cypress-io/cypress/issues/28545).
+
+**Dependency Updates:**
+
+- Remove dependency on `@types/node` package. Addresses [#28473](https://github.com/cypress-io/cypress/issues/28473).
+- Updated [`@cypress/unique-selector`](https://www.npmjs.com/package/@cypress/unique-selector) to include a performance optimization. It's possible this could improve performance of the selector playground. Addressed in [#28571](https://github.com/cypress-io/cypress/pull/28571).
+- Replace [`CircularJSON`](https://www.npmjs.com/package/circular-json) with its successor [`flatted`](https://www.npmjs.com/package/flatted) version `3.2.9`. This resolves decoding issues observed in complex objects sent from the browser. Addressed in [#28683](https://github.com/cypress-io/cypress/pull/28683).
+- Updated [`better-sqlite3`](https://www.npmjs.com/package/better-sqlite3) from `8.7.0` to `9.2.2` to fix macOS Catalina issues. Addresses [#28697](https://github.com/cypress-io/cypress/issues/28697).
+
+**Misc:**
+
+- Improved accessibility of some areas of the Cypress App. Addressed in [#28628](https://github.com/cypress-io/cypress/pull/28628).
+- Updated some documentation links to go through on.cypress.io. Addressed in [#28623](https://github.com/cypress-io/cypress/pull/28623).
+
 ## 13.6.2
 
 _Released 12/26/2023_

--- a/docs/guides/tooling/typescript-support.mdx
+++ b/docs/guides/tooling/typescript-support.mdx
@@ -73,13 +73,11 @@ If that does not work, try restarting the IDE.
 
 ### Processing your Cypress configuration and plugins
 
-Cypress needs to be able to transpile your Cypress configuration and plugins written in TypeScript in order to make them executable within Cypress' Node.js runtime.
-To do this, Cypress will attempt to read the user's TypeScript and project configuration to apply the correct TypeScript loader to Cypress' Node.js runtime.
+Cypress needs to be able to transpile your Cypress configuration and plugins written in TypeScript in order to make them executable within Cypress's Node.js runtime. To do this, Cypress will attempt to read the user's TypeScript and project configuration to apply the correct TypeScript loader to Cypress's Node.js runtime.
 
-If your project is an `ESM` package (short for [ECMAScript Module](https://nodejs.org/api/esm.html#modules-ecmascript-modules)), Cypress attempts
-to apply the [ts-node/esm](https://github.com/TypeStrong/ts-node?tab=readme-ov-file#esm) Node.js loader to resolve the Cypress configuration and plugins. `ESM` is determined by Cypress if you have the `type: "module"` key-value pair present inside your project's `package.json`.
+If your project is an `ESM` package (short for [ECMAScript Module](https://nodejs.org/api/esm.html#modules-ecmascript-modules)), Cypress attempts to apply the [ts-node/esm](https://github.com/TypeStrong/ts-node?tab=readme-ov-file#esm) Node.js loader to resolve the Cypress configuration and plugins. `ESM` is determined by Cypress if you have the `type: "module"` key-value pair present inside your project's `package.json`.
 
-Otherwise, regular [ts-node](https://github.com/TypeStrong/ts-node?tab=readme-ov-file#node-flags-and-other-tools) is required into Cypress' Node.js runtime.
+Otherwise, regular [ts-node](https://github.com/TypeStrong/ts-node?tab=readme-ov-file#node-flags-and-other-tools) is required into Cypress's Node.js runtime.
 Since Node.js by itself can only interpret CommonJS files, Cypress attempts to make your TypeScript configuration compatable with Cypress' Node.js runtime.
 To do this, Cypress overrides the following configuration values found inside your project's `tsconfig.json`:
 

--- a/docs/guides/tooling/typescript-support.mdx
+++ b/docs/guides/tooling/typescript-support.mdx
@@ -9,7 +9,7 @@ tests in TypeScript.
 
 ### Install TypeScript
 
-To use TypeScript with Cypress, you will need TypeScript 3.4+. If you do not
+To use TypeScript with Cypress, you will need TypeScript 4.0+. If you do not
 already have TypeScript installed as a part of your framework, you will need to
 install it:
 
@@ -70,6 +70,28 @@ VS Code (within a .ts or .js file):
 If that does not work, try restarting the IDE.
 
 :::
+
+### Processing your Cypress configuration and plugins
+
+Cypress needs to be able to transpile your Cypress configuration and plugins written in TypeScript in order to make them executable within Cypress' Node.js runtime.
+To do this, Cypress will attempt to read the user's TypeScript and project configuration to apply the correct TypeScript loader to Cypress' Node.js runtime.
+
+If your project is an `ESM` package (short for [ECMAScript Module](https://nodejs.org/api/esm.html#modules-ecmascript-modules)), Cypress attempts
+to apply the [ts-node/esm](https://github.com/TypeStrong/ts-node?tab=readme-ov-file#esm) Node.js loader to resolve the Cypress configuration and plugins. `ESM` is determined by Cypress if you have the `type: "module"` key-value pair present inside your project's `package.json`.
+
+Otherwise, regular [ts-node](https://github.com/TypeStrong/ts-node?tab=readme-ov-file#node-flags-and-other-tools) is required into Cypress' Node.js runtime.
+Since Node.js by itself can only interpret CommonJS files, Cypress attempts to make your TypeScript configuration compatable with Cypress' Node.js runtime.
+To do this, Cypress overrides the following configuration values found inside your project's `tsconfig.json`:
+
+```json
+{
+  "module": "commonjs",
+  "moduleResolution": "node",
+  "preserveValueImports": false
+}
+```
+
+This does not have an impact on your project or its TypeScript configuration settings. This override only happens within the context of the Cypress runtime.
 
 ### Clashing Types with Jest
 
@@ -354,6 +376,7 @@ Both Jest and Expect (bundled inside Cypress) provide the clashing types for the
 
 | Version                                       | Changes                                                                                    |
 | --------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| [13.0.0](/guides/references/changelog#13-0-0) | Raised minimum required TypeScript version from 3.4+ to 4.0+                               |
 | [10.0.0](/guides/references/changelog#10-0-0) | Update guide to cover TypeScript setup for component testing                               |
 | [5.0.0](/guides/references/changelog#5-0-0)   | Raised minimum required TypeScript version from 2.9+ to 3.4+                               |
 | [4.4.0](/guides/references/changelog#4-4-0)   | Added support for TypeScript without needing your own transpilation through preprocessors. |


### PR DESCRIPTION
- adds the `13.6.3` changelog from the app.
- contains merged in https://github.com/cypress-io/cypress-documentation/pull/5604