### PR TITLE
docs: add missed asterisks before the words to make them bold

### DIFF
--- a/docs/api/commands/each.mdx
+++ b/docs/api/commands/each.mdx
@@ -23,7 +23,7 @@ cy.get('ul>li').each(() => {...}) // Iterate through each 'li'
 cy.getCookies().each(() => {...}) // Iterate through each cookie
 ```
 
-<Icon name="exclamation-triangle" color="red" /> Incorrect Usage**
+<Icon name="exclamation-triangle" color="red" /> **Incorrect Usage**
 
 ```javascript
 

--- a/docs/api/commands/end.mdx
+++ b/docs/api/commands/end.mdx
@@ -18,7 +18,7 @@ End a chain of commands.
 cy.contains('ul').end() // Yield 'null' instead of 'ul' element
 ```
 
-<Icon name="exclamation-triangle" color="red" /> Incorrect Usage**
+<Icon name="exclamation-triangle" color="red" /> **Incorrect Usage**
 
 ```javascript
 cy.end()

--- a/docs/api/commands/focus.mdx
+++ b/docs/api/commands/focus.mdx
@@ -22,7 +22,7 @@ chain further commands that rely on the subject after `.focus()`.
 cy.get('input').first().focus() // Focus on the first input
 ```
 
-<Icon name="exclamation-triangle" color="red" /> Incorrect Usage**
+<Icon name="exclamation-triangle" color="red" /> **Incorrect Usage**
 
 ```javascript
 cy.focus('#search') // Errors, cannot be chained off 'cy'

--- a/docs/api/commands/origin.mdx
+++ b/docs/api/commands/origin.mdx
@@ -57,7 +57,7 @@ cy.visit('/')
 cy.get('h1').contains('My cool site under test')
 ```
 
-<Icon name="exclamation-triangle" color="red" /> Incorrect Usage**
+<Icon name="exclamation-triangle" color="red" /> **Incorrect Usage**
 
 ```js
 const hits = getHits()
@@ -165,7 +165,7 @@ Values returned or yielded from the callback function **must** be serializable
 or they will not be returned to the primary origin. For example, the following
 will not work:
 
-<Icon name="exclamation-triangle" color="red" /> Incorrect Usage**
+<Icon name="exclamation-triangle" color="red" /> **Incorrect Usage**
 
 ```js
 cy.origin('https://example.cypress.io', () => {
@@ -280,7 +280,7 @@ this functionality in a `login`
 duplicate this login code in every test. Here's an idealized example of how to
 do this with `cy.origin()`.
 
-<Icon name="exclamation-triangle" color="#f0ad4e" /> Inefficient Usage**
+<Icon name="exclamation-triangle" color="#f0ad4e" /> **Inefficient Usage**
 
 ```js
 Cypress.Commands.add('login', (username, password) => {
@@ -358,7 +358,7 @@ for transmission. It is very important to understand that variables **inside**
 the callback are not shared with the scope **outside** the callback. For example
 this will not work:
 
-<Icon name="exclamation-triangle" color="red" /> Incorrect Usage**
+<Icon name="exclamation-triangle" color="red" /> **Incorrect Usage**
 
 ```js
 const foo = 1

--- a/docs/api/commands/session.mdx
+++ b/docs/api/commands/session.mdx
@@ -48,7 +48,7 @@ cy.session(username, () => {
 })
 ```
 
-<Icon name="exclamation-triangle" color="red" /> Incorrect Usage**
+<Icon name="exclamation-triangle" color="red" /> **Incorrect Usage**
 
 ```javascript
 // visiting before calling cy.session() is redundant, it needs to
@@ -692,7 +692,7 @@ const login = (name, email) => {
 }
 ```
 
-<Icon name="exclamation-triangle" color="red" /> Incorrect Usage**
+<Icon name="exclamation-triangle" color="red" /> **Incorrect Usage**
 
 If you have custom `login` code that uses multiple parameters (in this example,
 a name, a token, and a password), in order to be able to log in many different

--- a/docs/api/commands/spread.mdx
+++ b/docs/api/commands/spread.mdx
@@ -26,7 +26,7 @@ structure as its subject.
 cy.getCookies().spread(() => {}) // Yield all cookies
 ```
 
-<Icon name="exclamation-triangle" color="red" /> Incorrect Usage**
+<Icon name="exclamation-triangle" color="red" /> **Incorrect Usage**
 
 ```javascript
 cy.spread(() => {}) // Errors, cannot be chained off 'cy'

--- a/docs/api/commands/submit.mdx
+++ b/docs/api/commands/submit.mdx
@@ -29,7 +29,7 @@ must be a `<form>`.
 cy.get('form').submit() // Submit a form
 ```
 
-<Icon name="exclamation-triangle" color="red" /> Incorrect Usage**
+<Icon name="exclamation-triangle" color="red" /> **Incorrect Usage**
 
 ```javascript
 cy.submit() // Errors, cannot be chained off 'cy'

--- a/docs/api/commands/within.mdx
+++ b/docs/api/commands/within.mdx
@@ -25,7 +25,7 @@ cy.get('.list')
   .within(($list) => {}) // Yield the first `.list` and scope all commands within it
 ```
 
-<Icon name="exclamation-triangle" color="red" /> Incorrect Usage**
+<Icon name="exclamation-triangle" color="red" /> **Incorrect Usage**
 
 ```javascript
 cy.within(() => {}) // Errors, cannot be chained off 'cy'

--- a/docs/api/cypress-api/require.mdx
+++ b/docs/api/cypress-api/require.mdx
@@ -30,7 +30,7 @@ cy.origin('cypress.io', () => {
 })
 ```
 
-<Icon name="exclamation-triangle" color="red"></Icon> Incorrect Usage**
+<Icon name="exclamation-triangle" color="red"></Icon> **Incorrect Usage**
 
 ```js
 // `Cypress.require()` cannot be used outside the `cy.origin()` callback.

--- a/docs/api/queries/as.mdx
+++ b/docs/api/queries/as.mdx
@@ -33,7 +33,7 @@ cy.stub(api, 'onUnauth').as('unauth') // Alias stub as @unauth
 cy.spy(win, 'fetch').as('winFetch') // Alias spy as @winFetch
 ```
 
-<Icon name="exclamation-triangle" color="red" /> Incorrect Usage**
+<Icon name="exclamation-triangle" color="red" /> **Incorrect Usage**
 
 ```javascript
 cy.as('foo') // Errors, cannot be chained off 'cy'

--- a/docs/api/queries/children.mdx
+++ b/docs/api/queries/children.mdx
@@ -29,7 +29,7 @@ The querying behavior of this command matches exactly how
 cy.get('nav').children() // Yield children of nav
 ```
 
-<Icon name="exclamation-triangle" color="red" /> Incorrect Usage**
+<Icon name="exclamation-triangle" color="red" /> **Incorrect Usage**
 
 ```javascript
 cy.children() // Errors, cannot be chained off 'cy'

--- a/docs/api/queries/closest.mdx
+++ b/docs/api/queries/closest.mdx
@@ -28,7 +28,7 @@ The querying behavior of this command matches exactly how
 cy.get('td').closest('.filled') // Yield closest el with class '.filled'
 ```
 
-<Icon name="exclamation-triangle" color="red" /> Incorrect Usage**
+<Icon name="exclamation-triangle" color="red" /> **Incorrect Usage**
 
 ```javascript
 cy.closest('.active') // Errors, cannot be chained off 'cy'

--- a/docs/api/queries/contains.mdx
+++ b/docs/api/queries/contains.mdx
@@ -32,7 +32,7 @@ cy.get('.nav').contains('About') // Yield el in .nav containing 'About'
 cy.contains('Hello') // Yield first el in document containing 'Hello'
 ```
 
-<Icon name="exclamation-triangle" color="red" /> Incorrect Usage**
+<Icon name="exclamation-triangle" color="red" /> **Incorrect Usage**
 
 ```javascript
 cy.title().contains('My App') // Errors, 'title' does not yield DOM element

--- a/docs/api/queries/eq.mdx
+++ b/docs/api/queries/eq.mdx
@@ -30,7 +30,7 @@ cy.get('tbody>tr').eq(0) // Yield first 'tr' in 'tbody'
 cy.get('ul>li').eq(4) // Yield fifth 'li' in 'ul'
 ```
 
-<Icon name="exclamation-triangle" color="red" /> Incorrect Usage**
+<Icon name="exclamation-triangle" color="red" /> **Incorrect Usage**
 
 ```javascript
 cy.eq(0) // Errors, cannot be chained off 'cy'

--- a/docs/api/queries/filter.mdx
+++ b/docs/api/queries/filter.mdx
@@ -33,7 +33,7 @@ The querying behavior of this command matches exactly how
 cy.get('td').filter('.users') // Yield all el's with class '.users'
 ```
 
-<Icon name="exclamation-triangle" color="red" /> Incorrect Usage**
+<Icon name="exclamation-triangle" color="red" /> **Incorrect Usage**
 
 ```javascript
 cy.filter('.animated') // Errors, cannot be chained off 'cy'

--- a/docs/api/queries/find.mdx
+++ b/docs/api/queries/find.mdx
@@ -27,7 +27,7 @@ The querying behavior of this command matches exactly how
 cy.get('.article').find('footer') // Yield 'footer' within '.article'
 ```
 
-<Icon name="exclamation-triangle" color="red" /> Incorrect Usage**
+<Icon name="exclamation-triangle" color="red" /> **Incorrect Usage**
 
 ```javascript
 cy.find('.progress') // Errors, cannot be chained off 'cy'

--- a/docs/api/queries/first.mdx
+++ b/docs/api/queries/first.mdx
@@ -27,7 +27,7 @@ The querying behavior of this command matches exactly how
 cy.get('nav a').first() // Yield first link in nav
 ```
 
-<Icon name="exclamation-triangle" color="red" /> Incorrect Usage**
+<Icon name="exclamation-triangle" color="red" /> **Incorrect Usage**
 
 ```javascript
 cy.first() // Errors, cannot be chained off 'cy'

--- a/docs/api/queries/invoke.mdx
+++ b/docs/api/queries/invoke.mdx
@@ -40,7 +40,7 @@ cy.get('.modal').invoke('show') // Invoke the jQuery 'show' function
 cy.wrap({ animate: fn }).invoke('animate') // Invoke the 'animate' function
 ```
 
-<Icon name="exclamation-triangle" color="red" /> Incorrect Usage**
+<Icon name="exclamation-triangle" color="red" /> **Incorrect Usage**
 
 ```javascript
 cy.invoke('convert') // Errors, cannot be chained off 'cy'

--- a/docs/api/queries/its.mdx
+++ b/docs/api/queries/its.mdx
@@ -28,7 +28,7 @@ cy.wrap({ width: '50' }).its('width') // Get the 'width' property
 cy.window().its('sessionStorage') // Get the 'sessionStorage' property
 ```
 
-<Icon name="exclamation-triangle" color="red" /> Incorrect Usage**
+<Icon name="exclamation-triangle" color="red" /> **Incorrect Usage**
 
 ```javascript
 cy.its('window') // Errors, cannot be chained off 'cy'

--- a/docs/api/queries/last.mdx
+++ b/docs/api/queries/last.mdx
@@ -27,7 +27,7 @@ The querying behavior of this command matches exactly how
 cy.get('nav a').last() // Yield last link in nav
 ```
 
-<Icon name="exclamation-triangle" color="red" /> Incorrect Usage**
+<Icon name="exclamation-triangle" color="red" /> **Incorrect Usage**
 
 ```javascript
 cy.last() // Errors, cannot be chained off 'cy'

--- a/docs/api/queries/next.mdx
+++ b/docs/api/queries/next.mdx
@@ -30,7 +30,7 @@ The querying behavior of this command matches exactly how
 cy.get('nav a:first').next() // Yield next link in nav
 ```
 
-<Icon name="exclamation-triangle" color="red" /> Incorrect Usage**
+<Icon name="exclamation-triangle" color="red" /> **Incorrect Usage**
 
 ```javascript
 cy.next() // Errors, cannot be chained off 'cy'

--- a/docs/api/queries/nextall.mdx
+++ b/docs/api/queries/nextall.mdx
@@ -29,7 +29,7 @@ The querying behavior of this command matches exactly how
 cy.get('.active').nextAll() // Yield all links next to `.active`
 ```
 
-<Icon name="exclamation-triangle" color="red" /> Incorrect Usage**
+<Icon name="exclamation-triangle" color="red" /> **Incorrect Usage**
 
 ```javascript
 cy.nextAll() // Errors, cannot be chained off 'cy'

--- a/docs/api/queries/nextuntil.mdx
+++ b/docs/api/queries/nextuntil.mdx
@@ -32,7 +32,7 @@ The querying behavior of this command matches exactly how
 cy.get('div').nextUntil('.warning') // Yield siblings after 'div' until '.warning'
 ```
 
-<Icon name="exclamation-triangle" color="red" /> Incorrect Usage**
+<Icon name="exclamation-triangle" color="red" /> **Incorrect Usage**
 
 ```javascript
 cy.nextUntil() // Errors, cannot be chained off 'cy'

--- a/docs/api/queries/not.mdx
+++ b/docs/api/queries/not.mdx
@@ -33,7 +33,7 @@ The querying behavior of this command matches exactly how
 cy.get('input').not('.required') // Yield all inputs without class '.required'
 ```
 
-<Icon name="exclamation-triangle" color="red" /> Incorrect Usage**
+<Icon name="exclamation-triangle" color="red" /> **Incorrect Usage**
 
 ```javascript
 cy.not('.icon') // Errors, cannot be chained off 'cy'

--- a/docs/api/queries/parent.mdx
+++ b/docs/api/queries/parent.mdx
@@ -32,7 +32,7 @@ The querying behavior of this command matches exactly how
 cy.get('header').parent() // Yield parent el of `header`
 ```
 
-<Icon name="exclamation-triangle" color="red" /> Incorrect Usage**
+<Icon name="exclamation-triangle" color="red" /> **Incorrect Usage**
 
 ```javascript
 cy.parent() // Errors, cannot be chained off 'cy'

--- a/docs/api/queries/parents.mdx
+++ b/docs/api/queries/parents.mdx
@@ -33,7 +33,7 @@ The querying behavior of this command matches exactly how
 cy.get('aside').parents() // Yield parents of aside
 ```
 
-<Icon name="exclamation-triangle" color="red" /> Incorrect Usage**
+<Icon name="exclamation-triangle" color="red" /> **Incorrect Usage**
 
 ```javascript
 cy.parents() // Errors, cannot be chained off 'cy'

--- a/docs/api/queries/parentsuntil.mdx
+++ b/docs/api/queries/parentsuntil.mdx
@@ -32,7 +32,7 @@ The querying behavior of this command matches exactly how
 cy.get('p').parentsUntil('.article') // Yield parents of 'p' until '.article'
 ```
 
-<Icon name="exclamation-triangle" color="red" /> Incorrect Usage**
+<Icon name="exclamation-triangle" color="red" /> **Incorrect Usage**
 
 ```javascript
 cy.parentsUntil() // Errors, cannot be chained off 'cy'

--- a/docs/api/queries/prev.mdx
+++ b/docs/api/queries/prev.mdx
@@ -29,7 +29,7 @@ The querying behavior of this command matches exactly how
 cy.get('tr.highlight').prev() // Yield previous 'tr'
 ```
 
-<Icon name="exclamation-triangle" color="red" /> Incorrect Usage**
+<Icon name="exclamation-triangle" color="red" /> **Incorrect Usage**
 
 ```javascript
 cy.prev() // Errors, cannot be chained off 'cy'

--- a/docs/api/queries/prevall.mdx
+++ b/docs/api/queries/prevall.mdx
@@ -29,7 +29,7 @@ The querying behavior of this command matches exactly how
 cy.get('.active').prevAll() // Yield all links previous to `.active`
 ```
 
-<Icon name="exclamation-triangle" color="red" /> Incorrect Usage**
+<Icon name="exclamation-triangle" color="red" /> **Incorrect Usage**
 
 ```javascript
 cy.prevAll() // Errors, cannot be chained off 'cy'

--- a/docs/api/queries/prevuntil.mdx
+++ b/docs/api/queries/prevuntil.mdx
@@ -32,7 +32,7 @@ The querying behavior of this command matches exactly how
 cy.get('p').prevUntil('.intro') // Yield siblings before 'p' until '.intro'
 ```
 
-<Icon name="exclamation-triangle" color="red" /> Incorrect Usage**
+<Icon name="exclamation-triangle" color="red" /> **Incorrect Usage**
 
 ```javascript
 cy.prevUntil() // Errors, cannot be chained off 'cy'

--- a/docs/api/queries/shadow.mdx
+++ b/docs/api/queries/shadow.mdx
@@ -20,7 +20,7 @@ Traverse into the shadow DOM of an element.
 cy.get('.shadow-host').shadow()
 ```
 
-<Icon name="exclamation-triangle" color="red" /> Incorrect Usage**
+<Icon name="exclamation-triangle" color="red" /> **Incorrect Usage**
 
 ```javascript
 cy.shadow() // Errors, cannot be chained off 'cy'

--- a/docs/api/queries/siblings.mdx
+++ b/docs/api/queries/siblings.mdx
@@ -23,7 +23,7 @@ cy.get('td').siblings() // Yield all td's siblings
 cy.get('li').siblings('.active') // Yield all li's siblings with class '.active'
 ```
 
-<Icon name="exclamation-triangle" color="red" /> Incorrect Usage**
+<Icon name="exclamation-triangle" color="red" /> **Incorrect Usage**
 
 ```javascript
 cy.siblings('.error') // Errors, cannot be chained off 'cy'

--- a/docs/api/utilities/$.mdx
+++ b/docs/api/utilities/$.mdx
@@ -31,7 +31,7 @@ Cypress.$.post
 Cypress.$('p')
 ```
 
-<Icon name="exclamation-triangle" color="red" /> Incorrect Usage**
+<Icon name="exclamation-triangle" color="red" /> **Incorrect Usage**
 
 ```javascript
 cy.$('p') // Errors, cannot be chained off 'cy'

--- a/docs/api/utilities/blob.mdx
+++ b/docs/api/utilities/blob.mdx
@@ -23,7 +23,7 @@ Cypress.Blob.method()
 Cypress.Blob.method()
 ```
 
-<Icon name="exclamation-triangle" color="red" /> Incorrect Usage**
+<Icon name="exclamation-triangle" color="red" /> **Incorrect Usage**
 
 ```javascript
 cy.Blob.method() // Errors, cannot be chained off 'cy'

--- a/docs/api/utilities/buffer.mdx
+++ b/docs/api/utilities/buffer.mdx
@@ -25,7 +25,7 @@ Cypress.Buffer.method()
 Cypress.Buffer.method()
 ```
 
-<Icon name="exclamation-triangle" color="red" /> Incorrect Usage**
+<Icon name="exclamation-triangle" color="red" /> **Incorrect Usage**
 
 ```javascript
 cy.Buffer.method() // Errors, cannot be chained off 'cy'

--- a/docs/api/utilities/lodash.mdx
+++ b/docs/api/utilities/lodash.mdx
@@ -20,7 +20,7 @@ Cypress._.method()
 Cypress._.keys(obj)
 ```
 
-<Icon name="exclamation-triangle" color="red" /> Incorrect Usage**
+<Icon name="exclamation-triangle" color="red" /> **Incorrect Usage**
 
 ```javascript
 cy._.keys(obj) // Errors, cannot be chained off 'cy'

--- a/docs/api/utilities/minimatch.mdx
+++ b/docs/api/utilities/minimatch.mdx
@@ -23,7 +23,7 @@ Cypress.minimatch('/users/1/comments/2', '/users/*/comments', {
 })
 ```
 
-<Icon name="exclamation-triangle" color="red" /> Incorrect Usage**
+<Icon name="exclamation-triangle" color="red" /> **Incorrect Usage**
 
 ```javascript
 cy.minimatch() // Errors, cannot be chained off 'cy'

--- a/docs/api/utilities/promise.mdx
+++ b/docs/api/utilities/promise.mdx
@@ -22,7 +22,7 @@ new Cypress.Promise(fn)
 new Cypress.Promise((resolve, reject) => { ... })
 ```
 
-<Icon name="exclamation-triangle" color="red" /> Incorrect Usage**
+<Icon name="exclamation-triangle" color="red" /> **Incorrect Usage**
 
 ```javascript
 new cy.Promise(...)  // Errors, cannot be chained off 'cy'

--- a/docs/api/utilities/sinon.mdx
+++ b/docs/api/utilities/sinon.mdx
@@ -23,7 +23,7 @@ Cypress.sinon.match.<matcher name>
 Cypress.sinon.match.string
 ```
 
-<Icon name="exclamation-triangle" color="red" /> Incorrect Usage**
+<Icon name="exclamation-triangle" color="red" /> **Incorrect Usage**
 
 ```javascript
 cy.sinon.match.string // Errors, cannot be chained off 'cy'

--- a/docs/guides/tooling/visual-testing.mdx
+++ b/docs/guides/tooling/visual-testing.mdx
@@ -239,7 +239,7 @@ you confirm the page is done changing.
 
 For example, if the snapshot command is `cy.mySnapshotCommand`:
 
-<Icon name="exclamation-triangle" color="red" /> Incorrect Usage**
+<Icon name="exclamation-triangle" color="red" /> **Incorrect Usage**
 
 ```js
 // the web application takes time to add the new item,


### PR DESCRIPTION
Most of the `Incorrect Usage` are missed asterisks before. So, I've added them.

**Before:**
<img width="1792" alt="image" src="https://github.com/cypress-io/cypress-documentation/assets/29764053/911b3e9b-0a5e-4c89-abbb-3d9153e8a468">



**After:**
<img width="1792" alt="image" src="https://github.com/cypress-io/cypress-documentation/assets/29764053/7dc8de63-ad05-404c-bb84-f61ab77fa56a">
