### PR TITLE
Fix bold markdown in retry-ability.mdx

### DIFF
--- a/docs/guides/core-concepts/retry-ability.mdx
+++ b/docs/guides/core-concepts/retry-ability.mdx
@@ -33,7 +33,7 @@ While all methods you chain off of `cy` in your Cypress tests are commands, it's
 important to understand the different rules by which they operate.
 
 - **Queries** link up, retrying the entire chain together.
-- ** Assertions** are a type of query that's specially displayed in the command
+- **Assertions** are a type of query that's specially displayed in the command
   log.
 - **Non-queries** only execute once.
 


### PR DESCRIPTION
URL: https://docs.cypress.io/guides/core-concepts/

<img width="867" alt="image" src="https://github.com/cypress-io/cypress-documentation/assets/4522927/c8183be1-9b91-402d-bdb8-8a4e06ebf18f">

I just noticed some text that is not probably in bold on the live website, this is a minor PR to fix that.

I'm not sure if this fix is already in a separate branch. This is my first time contributing, so forgive me if I am missing any steps here.