### PR TITLE
update CI github action download-artifact to v4

### DIFF
--- a/docs/guides/continuous-integration/github-actions.mdx
+++ b/docs/guides/continuous-integration/github-actions.mdx
@@ -262,7 +262,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download the build folder
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build
           path: build
@@ -379,7 +379,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download the build folder
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build
 


### PR DESCRIPTION
This PR updates [actions/download-artifact](https://github.com/actions/download-artifact) from `v3` to [actions/download-download@v4](https://github.com/actions/download-artifact/releases/tag/v4.0.0) in

[Continuous Integration > GitHub Actions > Caching Dependencies and Build Artifacts](https://docs.cypress.io/guides/continuous-integration/github-actions#Caching-Dependencies-and-Build-Artifacts)

- PR https://github.com/cypress-io/cypress-documentation/pull/5579 only covered `upload-artifact` and it is important that upload and download both use the same version as `v4` is not cross-compatible with `v3`.

## Reference

- Blog Dec 14, 2023: [GitHub Actions – Artifacts v4 is now Generally Available](https://github.blog/changelog/2023-12-14-github-actions-artifacts-v4-is-now-generally-available/)