### PR TITLE
Sync Yarn lockfile after PR #5572

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4360,11 +4360,6 @@ fs.realpath@^1.0.0:
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
-fsevents@~2.3.2:
-  version "2.3.3"
-  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz"
-  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
-
 function-bind@^1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz"


### PR DESCRIPTION
- PR https://github.com/cypress-io/cypress-documentation/pull/5572 caused [yarn.lock](https://github.com/cypress-io/cypress-documentation/blob/main/yarn.lock) to get out of sync.
  
This PR syncs the `yarn.lock` file by running `npm install` and committing the result.

## Verification

Execute

```shell
npm install
```

and ensure that there are no uncommitted changes produced.