### PR TITLE
Updating docs to reflect LayerCI changes to webapp.io

### DIFF
--- a/docs/guides/continuous-integration/ci-provider-examples.mdx
+++ b/docs/guides/continuous-integration/ci-provider-examples.mdx
@@ -179,5 +179,5 @@ and
 
 ### webapp.io
 
-- [cypress-example-layerci](https://github.com/bahmutov/cypress-example-layerci)
-- [Using cypress with webapp.io](https://webapp.io/docs/integrations/cypress)
+- [Basic Example (Layerfile)](https://github.com/webappio/react-e2e-example/blob/master/Layerfile)
+- [Using cypress with webapp.io](https://docs.webapp.io/integrations/cypress)

--- a/docs/guides/continuous-integration/introduction.mdx
+++ b/docs/guides/continuous-integration/introduction.mdx
@@ -454,6 +454,10 @@ to see why the commit information is unavailable.
 DEBUG=commit-info,cypress:server:record
 ```
 
+:::info
+Cypress versions less than 3.15.0 will need to manually provide the CI ENVs to correctly send their SCM to the Cloud
+:::
+
 #### CI Build Information
 
 In some newer CI providers, Cypress can't map the environment variables required


### PR DESCRIPTION
LayerCI rebranded to webapp.io, context here: https://webapp.io/blog/layerci-has-rebranded-to-webapp-io/

This PR does the following:
- Removes the stale example referencing LayerCI
- References the correct documentation for the Cypress example with webapp.io
- Adding a note that Cypress versions less than 3.15.0 will need to manually provide the CI ENVs to correctly send their SCM to the Cloud (Re: https://github.com/cypress-io/cypress/pull/28577#issuecomment-1871298150)