### PR TITLE
Change anchor links from `Default-Assertions` to `Implicit Assertions`

### DIFF
--- a/docs/api/queries/children.mdx
+++ b/docs/api/queries/children.mdx
@@ -123,14 +123,14 @@ cy.get('ul').children('.active')
 
 - `.children()` will automatically [retry](/guides/core-concepts/retry-ability)
   until the element(s)
-  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Default-Assertions).
+  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Implicit-Assertions).
 - `.children()` will automatically [retry](/guides/core-concepts/retry-ability)
   until all chained assertions have passed.
 
 ### Timeouts [<Icon name="question-circle"/>](/guides/core-concepts/introduction-to-cypress#Timeouts) {#Timeouts}
 
 - `.children()` can time out waiting for the element(s) to
-  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Default-Assertions).
+  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Implicit-Assertions).
 - `.children()` can time out waiting for assertions you've added to pass.
 
 ## Command Log

--- a/docs/api/queries/closest.mdx
+++ b/docs/api/queries/closest.mdx
@@ -75,14 +75,14 @@ cy.get('p.error').closest('.banner')
 
 - `.closest()` will automatically [retry](/guides/core-concepts/retry-ability)
   until the element(s)
-  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Default-Assertions).
+  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Implicit-Assertions).
 - `.closest()` will automatically [retry](/guides/core-concepts/retry-ability)
   until all chained assertions have passed.
 
 ### Timeouts [<Icon name="question-circle"/>](/guides/core-concepts/introduction-to-cypress#Timeouts) {#Timeouts}
 
 - `.closest()` can time out waiting for the element(s) to
-  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Default-Assertions).
+  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Implicit-Assertions).
 - `.closest()` can time out waiting for assertions you've added to pass.
 
 ## Command Log

--- a/docs/api/queries/contains.mdx
+++ b/docs/api/queries/contains.mdx
@@ -459,14 +459,14 @@ cy.contains('Age').find('input').type('29')
 
 - `.contains()` will automatically [retry](/guides/core-concepts/retry-ability)
   until the element(s)
-  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Default-Assertions).
+  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Implicit-Assertions).
 - `.contains()`will automatically [retry](/guides/core-concepts/retry-ability)
   until all chained assertions have passed.
 
 ### Timeouts [<Icon name="question-circle"/>](/guides/core-concepts/introduction-to-cypress#Timeouts) {#Timeouts}
 
 - `.contains()` can time out waiting for the element(s) to
-  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Default-Assertions).
+  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Implicit-Assertions).
 - `.contains()` can time out waiting for assertions you've added to pass.
 
 ## Command Log

--- a/docs/api/queries/eq.mdx
+++ b/docs/api/queries/eq.mdx
@@ -138,14 +138,14 @@ cy.get('li').eq(-2).should('contain', 'sphynx') // true
 
 - `.eq()` will automatically [retry](/guides/core-concepts/retry-ability) until
   the element(s)
-  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Default-Assertions).
+  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Implicit-Assertions).
 - `.eq()` will automatically [retry](/guides/core-concepts/retry-ability) until
   all chained assertions have passed.
 
 ### Timeouts [<Icon name="question-circle"/>](/guides/core-concepts/introduction-to-cypress#Timeouts) {#Timeouts}
 
 - `.eq()` can time out waiting for the element(s) to
-  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Default-Assertions).
+  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Implicit-Assertions).
 - `.eq()` can time out waiting for assertions you've added to pass.
 
 ## Command Log

--- a/docs/api/queries/filter.mdx
+++ b/docs/api/queries/filter.mdx
@@ -132,14 +132,14 @@ cy.get('[data-testid="testattr"]').filter(':contains("Hello\u00a0world")')
 
 - `.filter()` will automatically [retry](/guides/core-concepts/retry-ability)
   until the element(s)
-  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Default-Assertions).
+  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Implicit-Assertions).
 - `.filter()` will automatically [retry](/guides/core-concepts/retry-ability)
   until all chained assertions have passed.
 
 ### Timeouts [<Icon name="question-circle"/>](/guides/core-concepts/introduction-to-cypress#Timeouts) {#Timeouts}
 
 - `.filter()` can time out waiting for the element(s) to
-  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Default-Assertions).
+  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Implicit-Assertions).
 - `.filter()` can time out waiting for assertions you've added to pass.
 
 ## Command Log

--- a/docs/api/queries/find.mdx
+++ b/docs/api/queries/find.mdx
@@ -83,14 +83,14 @@ cy.get('#parent').find('li')
 
 - `.find()` will automatically [retry](/guides/core-concepts/retry-ability)
   until the element(s)
-  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Default-Assertions).
+  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Implicit-Assertions).
 - `.find()` will automatically [retry](/guides/core-concepts/retry-ability)
   until all chained assertions have passed.
 
 ### Timeouts [<Icon name="question-circle"/>](/guides/core-concepts/introduction-to-cypress#Timeouts) {#Timeouts}
 
 - `.find()` can time out waiting for the element(s) to
-  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Default-Assertions).
+  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Implicit-Assertions).
 - `.find()` can time out waiting for assertions you've added to pass.
 
 ## Command Log

--- a/docs/api/queries/first.mdx
+++ b/docs/api/queries/first.mdx
@@ -80,14 +80,14 @@ cy.get('li').first()
 
 - `.first()` will automatically [retry](/guides/core-concepts/retry-ability)
   until the element(s)
-  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Default-Assertions).
+  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Implicit-Assertions).
 - `.first()` will automatically [retry](/guides/core-concepts/retry-ability)
   until all chained assertions have passed.
 
 ### Timeouts [<Icon name="question-circle"/>](/guides/core-concepts/introduction-to-cypress#Timeouts) {#Timeouts}
 
 - `.first()` can time out waiting for the element(s) to
-  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Default-Assertions).
+  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Implicit-Assertions).
 - `.first()` can time out waiting for assertions you've added to pass.
 
 ## Command Log

--- a/docs/api/queries/focused.mdx
+++ b/docs/api/queries/focused.mdx
@@ -71,14 +71,14 @@ cy.focused().should('have.attr', 'name', 'username')
 
 - `cy.focused()` will automatically [retry](/guides/core-concepts/retry-ability)
   until the element(s)
-  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Default-Assertions).
+  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Implicit-Assertions).
 - `cy.focused()` will automatically [retry](/guides/core-concepts/retry-ability)
   until all chained assertions have passed.
 
 ### Timeouts [<Icon name="question-circle"/>](/guides/core-concepts/introduction-to-cypress#Timeouts) {#Timeouts}
 
 - `cy.focused()` can time out waiting for the element(s) to
-  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Default-Assertions).
+  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Implicit-Assertions).
 - `cy.focused()` can time out waiting for assertions you've added to pass.
 
 ## Command Log

--- a/docs/api/queries/get.mdx
+++ b/docs/api/queries/get.mdx
@@ -229,14 +229,14 @@ it('disables on click', () => {
 
 - `cy.get()` will automatically [retry](/guides/core-concepts/retry-ability)
   until the element(s)
-  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Default-Assertions).
+  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Implicit-Assertions).
 - `cy.get()` will automatically [retry](/guides/core-concepts/retry-ability)
   until all chained assertions have passed.
 
 ### Timeouts [<Icon name="question-circle"/>](/guides/core-concepts/introduction-to-cypress#Timeouts) {#Timeouts}
 
 - `cy.get()` can time out waiting for the element(s) to
-  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Default-Assertions).
+  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Implicit-Assertions).
 - `cy.get()` can time out waiting for assertions you've added to pass.
 
 ## Command Log

--- a/docs/api/queries/last.mdx
+++ b/docs/api/queries/last.mdx
@@ -80,14 +80,14 @@ cy.get('li').last()
 
 - `.last()` will automatically [retry](/guides/core-concepts/retry-ability)
   until the element(s)
-  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Default-Assertions).
+  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Implicit-Assertions).
 - `.last()` will automatically [retry](/guides/core-concepts/retry-ability)
   until all chained assertions have passed.
 
 ### Timeouts [<Icon name="question-circle"/>](/guides/core-concepts/introduction-to-cypress#Timeouts) {#Timeouts}
 
 - `.last()` can time out waiting for the element(s) to
-  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Default-Assertions).
+  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Implicit-Assertions).
 - `.last()` can time out waiting for assertions you've added to pass.
 
 ## Command Log

--- a/docs/api/queries/next.mdx
+++ b/docs/api/queries/next.mdx
@@ -125,14 +125,14 @@ cy.get('li').next('.selected')
 
 - `.next()` will automatically [retry](/guides/core-concepts/retry-ability)
   until the element(s)
-  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Default-Assertions).
+  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Implicit-Assertions).
 - `.next()` will automatically [retry](/guides/core-concepts/retry-ability)
   until all chained assertions have passed.
 
 ### Timeouts [<Icon name="question-circle"/>](/guides/core-concepts/introduction-to-cypress#Timeouts) {#Timeouts}
 
 - `.next()` can time out waiting for the element(s) to
-  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Default-Assertions).
+  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Implicit-Assertions).
 - `.next()` can time out waiting for assertions you've added to pass.
 
 ## Command Log

--- a/docs/api/queries/nextall.mdx
+++ b/docs/api/queries/nextall.mdx
@@ -106,14 +106,14 @@ cy.get('li').nextAll('.selected')
 
 - `.nextAll()` will automatically [retry](/guides/core-concepts/retry-ability)
   until the element(s)
-  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Default-Assertions).
+  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Implicit-Assertions).
 - `.nextAll()` will automatically [retry](/guides/core-concepts/retry-ability)
   until all chained assertions have passed.
 
 ### Timeouts [<Icon name="question-circle"/>](/guides/core-concepts/introduction-to-cypress#Timeouts) {#Timeouts}
 
 - `.nextAll()` can time out waiting for the element(s) to
-  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Default-Assertions).
+  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Implicit-Assertions).
 - `.nextAll()` can time out waiting for assertions you've added to pass.
 
 ## Command Log

--- a/docs/api/queries/nextuntil.mdx
+++ b/docs/api/queries/nextuntil.mdx
@@ -106,14 +106,14 @@ cy.get('#veggies').nextUntil('#nuts')
 
 - `.nextUntil()` will automatically [retry](/guides/core-concepts/retry-ability)
   until the element(s)
-  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Default-Assertions).
+  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Implicit-Assertions).
 - `.nextUntil()` will automatically [retry](/guides/core-concepts/retry-ability)
   until all chained assertions have passed.
 
 ### Timeouts [<Icon name="question-circle"/>](/guides/core-concepts/introduction-to-cypress#Timeouts) {#Timeouts}
 
 - `.nextUntil()` can time out waiting for the element(s) to
-  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Default-Assertions).
+  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Implicit-Assertions).
 - `.nextUntil()` can time out waiting for assertions you've added to pass.
 
 ## Command Log

--- a/docs/api/queries/not.mdx
+++ b/docs/api/queries/not.mdx
@@ -90,14 +90,14 @@ cy.get('ul>li').not('.active').should('have.length', 4) // true
 
 - `.not()` will automatically [retry](/guides/core-concepts/retry-ability) until
   the element(s)
-  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Default-Assertions).
+  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Implicit-Assertions).
 - `.not()` will automatically [retry](/guides/core-concepts/retry-ability) until
   all chained assertions have passed.
 
 ### Timeouts [<Icon name="question-circle"/>](/guides/core-concepts/introduction-to-cypress#Timeouts) {#Timeouts}
 
 - `.not()` can time out waiting for the element(s) to
-  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Default-Assertions).
+  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Implicit-Assertions).
 - `.not()` can time out waiting for assertions you've added to pass.
 
 ## Command Log

--- a/docs/api/queries/parent.mdx
+++ b/docs/api/queries/parent.mdx
@@ -117,14 +117,14 @@ cy.get('li').parent('.sub-nav')
 
 - `.parent()` will automatically [retry](/guides/core-concepts/retry-ability)
   until the element(s)
-  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Default-Assertions).
+  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Implicit-Assertions).
 - `.parent()` will automatically [retry](/guides/core-concepts/retry-ability)
   until all chained assertions have passed.
 
 ### Timeouts [<Icon name="question-circle"/>](/guides/core-concepts/introduction-to-cypress#Timeouts) {#Timeouts}
 
 - `.parent()` can time out waiting for the element(s) to
-  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Default-Assertions).
+  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Implicit-Assertions).
 - `.parent()` can time out waiting for assertions you've added to pass.
 
 ## Command Log

--- a/docs/api/queries/parents.mdx
+++ b/docs/api/queries/parents.mdx
@@ -104,14 +104,14 @@ cy.get('li.active').parents('.main-nav')
 
 - `.parents()` will automatically [retry](/guides/core-concepts/retry-ability)
   until the element(s)
-  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Default-Assertions).
+  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Implicit-Assertions).
 - `.parents()` will automatically [retry](/guides/core-concepts/retry-ability)
   until all chained assertions have passed.
 
 ### Timeouts [<Icon name="question-circle"/>](/guides/core-concepts/introduction-to-cypress#Timeouts) {#Timeouts}
 
 - `.parents()` can time out waiting for the element(s) to
-  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Default-Assertions).
+  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Implicit-Assertions).
 - `.parents()` can time out waiting for assertions you've added to pass.
 
 ## Command Log

--- a/docs/api/queries/parentsuntil.mdx
+++ b/docs/api/queries/parentsuntil.mdx
@@ -105,7 +105,7 @@ cy.get('.active').parentsUntil('.nav')
 
 - `.parentsUntil()` will automatically
   [retry](/guides/core-concepts/retry-ability) until the element(s)
-  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Default-Assertions).
+  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Implicit-Assertions).
 - `.parentsUntil()` will automatically
   [retry](/guides/core-concepts/retry-ability) until all chained assertions have
   passed.
@@ -113,7 +113,7 @@ cy.get('.active').parentsUntil('.nav')
 ### Timeouts [<Icon name="question-circle"/>](/guides/core-concepts/introduction-to-cypress#Timeouts) {#Timeouts}
 
 - `.parentsUntil()` can time out waiting for the element(s) to
-  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Default-Assertions).
+  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Implicit-Assertions).
 - `.parentsUntil()` can time out waiting for assertions you've added to pass.
 
 ## Command Log

--- a/docs/api/queries/prev.mdx
+++ b/docs/api/queries/prev.mdx
@@ -106,14 +106,14 @@ cy.get('li').prev('.active')
 
 - `.prev()` will automatically [retry](/guides/core-concepts/retry-ability)
   until the element(s)
-  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Default-Assertions).
+  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Implicit-Assertions).
 - `.prev()` will automatically [retry](/guides/core-concepts/retry-ability)
   until all chained assertions have passed.
 
 ### Timeouts [<Icon name="question-circle"/>](/guides/core-concepts/introduction-to-cypress#Timeouts) {#Timeouts}
 
 - `.prev()` can time out waiting for the element(s) to
-  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Default-Assertions).
+  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Implicit-Assertions).
 - `.prev()` can time out waiting for assertions you've added to pass.
 
 ## Command Log

--- a/docs/api/queries/prevall.mdx
+++ b/docs/api/queries/prevall.mdx
@@ -106,14 +106,14 @@ cy.get('li').prevAll('.selected')
 
 - `.prevAll()` will automatically [retry](/guides/core-concepts/retry-ability)
   until the element(s)
-  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Default-Assertions).
+  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Implicit-Assertions).
 - `.prevAll()` will automatically [retry](/guides/core-concepts/retry-ability)
   until all chained assertions have passed.
 
 ### Timeouts [<Icon name="question-circle"/>](/guides/core-concepts/introduction-to-cypress#Timeouts) {#Timeouts}
 
 - `.prevAll()` can time out waiting for the element(s) to
-  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Default-Assertions).
+  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Implicit-Assertions).
 - `.prevAll()` can time out waiting for assertions you've added to pass.
 
 ## Command Log

--- a/docs/api/queries/prevuntil.mdx
+++ b/docs/api/queries/prevuntil.mdx
@@ -106,14 +106,14 @@ cy.get('#nuts').prevUntil('#veggies')
 
 - `.prevUntil()` will automatically [retry](/guides/core-concepts/retry-ability)
   until the element(s)
-  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Default-Assertions).
+  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Implicit-Assertions).
 - `.prevUntil()` will automatically [retry](/guides/core-concepts/retry-ability)
   until all chained assertions have passed.
 
 ### Timeouts [<Icon name="question-circle"/>](/guides/core-concepts/introduction-to-cypress#Timeouts) {#Timeouts}
 
 - `.prevUntil()` can time out waiting for the element(s) to
-  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Default-Assertions).
+  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Implicit-Assertions).
 - `.prevUntil()` can time out waiting for assertions you've added to pass.
 
 ## Command Log

--- a/docs/api/queries/shadow.mdx
+++ b/docs/api/queries/shadow.mdx
@@ -60,7 +60,7 @@ cy.get('.shadow-host').shadow().find('.my-button').click()
 
 - `.shadow()` will automatically [retry](/guides/core-concepts/retry-ability)
   until the element(s)
-  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Default-Assertions).
+  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Implicit-Assertions).
 - `.shadow()` will automatically [retry](/guides/core-concepts/retry-ability)
   until the element(s) host(s) a shadow root.
 - `.shadow()` will automatically [retry](/guides/core-concepts/retry-ability)
@@ -69,7 +69,7 @@ cy.get('.shadow-host').shadow().find('.my-button').click()
 ### Timeouts [<Icon name="question-circle"/>](/guides/core-concepts/introduction-to-cypress#Timeouts) {#Timeouts}
 
 - `.shadow()` can time out waiting for the element(s) to
-  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Default-Assertions).
+  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Implicit-Assertions).
 - `.shadow()` can time out waiting for the element(s) to host a shadow root.
 - `.shadow()` can time out waiting for assertions you've added to pass.
 

--- a/docs/api/queries/siblings.mdx
+++ b/docs/api/queries/siblings.mdx
@@ -89,14 +89,14 @@ cy.get('li').siblings('.active')
 
 - `.siblings()` will automatically [retry](/guides/core-concepts/retry-ability)
   until the element(s)
-  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Default-Assertions).
+  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Implicit-Assertions).
 - `.siblings()` will automatically [retry](/guides/core-concepts/retry-ability)
   until all chained assertions have passed.
 
 ### Timeouts [<Icon name="question-circle"/>](/guides/core-concepts/introduction-to-cypress#Timeouts) {#Timeouts}
 
 - `.siblings()` can time out waiting for the element(s) to
-  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Default-Assertions).
+  [exist in the DOM](/guides/core-concepts/introduction-to-cypress#Implicit-Assertions).
 - `.siblings()` can time out waiting for assertions you've added to pass.
 
 ## Command Log


### PR DESCRIPTION
- This PR is a partial fix of https://github.com/cypress-io/cypress-documentation/issues/5630, addressing bad anchor links to https://docs.cypress.io/guides/core-concepts/introduction-to-cypress#Default-Assertions.

https://docs.cypress.io/guides/core-concepts/introduction-to-cypress contains no bookmark `Default-Assertions`.

- The bookmark in https://docs.cypress.io/guides/core-concepts/introduction-to-cypress was changed from `Default-Assertions` to [Implicit- Assertions](https://docs.cypress.io/guides/core-concepts/introduction-to-cypress#Implicit-Assertions) in PR https://github.com/cypress-io/cypress-documentation/pull/5315

## Changes

`/guides/core-concepts/introduction-to-cypress#Default-Assertions` is changed to
[/guides/core-concepts/introduction-to-cypress#Implicit-Assertions](https://docs.cypress.io/guides/core-concepts/introduction-to-cypress#Implicit-Assertions)

## Verification

Execute

```shell
npm run build
```

and confirm that there are no reports of bad anchor links to `/guides/core-concepts/introduction-to-cypress#Default-Assertions`.