### PR TITLE
Fix broken links in 9.2.0 and 9.5.4 changelogs

### DIFF
--- a/docs/guides/references/changelog.mdx
+++ b/docs/guides/references/changelog.mdx
@@ -3022,7 +3022,7 @@ _Released 4/11/2022_
   `any` when the correct type is `Cookie`. Fixed in
   [#20513](https://github.com/cypress-io/cypress/pull/20513).
 - Added the missing `Cypress.Command.addAll()` Typescript types. Fixed
-  [#18886](https://github.com/cypress-io/cypress/issue/18886).
+  [#18886](https://github.com/cypress-io/cypress/issues/18886).
 - Fixed an uncommon error observed in `cy.session()` where an error was thrown
   when no cookies had been set for the session and the user clicks the session
   command log to view additional details in the DevTools console. Fixed in
@@ -3354,7 +3354,7 @@ _Released 12/20/2021_
   [#3350](https://github.com/cypress-io/cypress/issues/3350).
 - The default `maxHttpBufferSize` for the internal socket server has been
   increased to
-  [Node's maximum Buffer size](https://nodejs.org/api/buffer#bufferconstantsmax_length)
+  [Node's maximum Buffer size](https://nodejs.org/api/buffer.html#bufferconstantsmax_length)
   (size varies by OS) to allow large file writes with `cy.writeFile()`.
   Addresses [#19140](https://github.com/cypress-io/cypress/issues/19140).
 - Add `CYPRESS_VERIFY_TIMEOUT` environment variable to override the timeout


### PR DESCRIPTION
This PR fixes two broken links in the [Cypress Changelog](https://docs.cypress.io/guides/references/changelog).

From [Cypress `9.5.4`](https://docs.cypress.io/guides/references/changelog#9-5-4)

- https://github.com/cypress-io/cypress/issue/18886 (404 error) should be `https://github.com/cypress-io/cypress/issues/18886` linking to https://github.com/cypress-io/cypress/issues/18886

From [Cypress `9.2.0`](https://docs.cypress.io/guides/references/changelog#9-2-0)

- [Node's maximum Buffer size](https://nodejs.org/api/buffer#bufferconstantsmax_length) https://nodejs.org/api/buffer#bufferconstantsmax_length (404 error) should be https://nodejs.org/api/buffer.html#bufferconstantsmax_length (see [issue #19140](https://github.com/cypress-io/cypress/issues/19140) which contains the correct link).

## Verification

Check links with https://www.deadlinkchecker.com/website-dead-link-checker.asp on the single page https://docs.cypress.io/guides/references/changelog and confirm that no dead links are found.
