### PR TITLE
Correct link to config folders / files

### DIFF
--- a/docs/api/commands/fixture.mdx
+++ b/docs/api/commands/fixture.mdx
@@ -29,7 +29,7 @@ cy.fixture('logo.png').then((logo) => {
 <Icon name="angle-right" /> **filePath _(String)_**
 
 A path to a file within the
-[`fixturesFolder`](/guides/references/configuration#Folders-Files) , which
+[`fixturesFolder`](/guides/references/configuration#Folders--Files) , which
 defaults to `cypress/fixtures`.
 
 You can nest fixtures within folders and reference them by defining the path
@@ -89,7 +89,7 @@ cy.fixture('users.json').as('usersData')
 
 When no extension is passed to `cy.fixture()`, Cypress will search for files
 with the specified name within the
-[`fixturesFolder`](/guides/references/configuration#Folders-Files) (which
+[`fixturesFolder`](/guides/references/configuration#Folders--Files) (which
 defaults to `cypress/fixtures`) and resolve the first one.
 
 ```javascript

--- a/docs/api/commands/screenshot.mdx
+++ b/docs/api/commands/screenshot.mdx
@@ -35,7 +35,7 @@ cy.get('.post').screenshot()
 <Icon name="angle-right" /> **fileName _(String)_**
 
 A name for the image file. Will be relative to the
-[screenshots folder](/guides/references/configuration#Folders-Files) and the
+[screenshots folder](/guides/references/configuration#Folders--Files) and the
 path to the spec file. When passed a path, the folder structure will be created.
 See the [Naming conventions](/api/commands/screenshot#Naming-conventions) below
 for more.
@@ -72,7 +72,7 @@ For more details on these options and to set some as defaults across all uses of
 
 The screenshot will be stored in the `cypress/screenshots` folder by default.
 You can change the directory where screenshots are saved in the
-[Cypress configuration](/guides/references/configuration#Folders-Files).
+[Cypress configuration](/guides/references/configuration#Folders--Files).
 
 ### No Args
 

--- a/docs/guides/core-concepts/writing-and-organizing-tests.mdx
+++ b/docs/guides/core-concepts/writing-and-organizing-tests.mdx
@@ -97,7 +97,7 @@ files are located, if you're starting your first project, we recommend you use
 the above structure.
 
 You can modify the folder configuration in your configuration file. See the
-[Cypress configuration](/guides/references/configuration#Folders-Files) for more
+[Cypress configuration](/guides/references/configuration) for more
 detail.
 
 :::info
@@ -119,7 +119,7 @@ these should also be ignored when you check into source control.
 ### Spec files
 
 Test files are located in `cypress/e2e` by default, but can be
-[configured](/guides/references/configuration#Folders-Files) to another
+[configured](/guides/references/configuration#e2e) to another
 directory. Test files may be written as:
 
 - `.js`
@@ -150,7 +150,7 @@ within your `cypress/e2e` folder.
 
 Fixtures are used as external pieces of static data that can be used by your
 tests. Fixture files are located in `cypress/fixtures` by default, but can be
-[configured](/guides/references/configuration#Folders-Files) to another
+[configured](/guides/references/configuration#Folders--Files) to another
 directory.
 
 You would typically use them with the [`cy.fixture()`](/api/commands/fixture)
@@ -273,7 +273,7 @@ other cool things. Read our [plugins guide](/guides/tooling/plugins-guide) for
 more details and examples.
 
 The initial imported plugins file can be
-[configured to another file](/guides/references/configuration#Folders-Files).
+[configured to another file](/guides/references/configuration#Folders--Files).
 
 ### Support file
 
@@ -332,7 +332,7 @@ want applied and available to all of your spec files.
 
 The initial imported support file can be configured to another file or turned
 off completely using the
-[supportFile](/guides/references/configuration#Folders-Files) configuration.
+[supportFile](/guides/references/configuration#Testing-Type-Specific-Options) configuration.
 From your support file you can `import` or `require` other files to keep things
 organized.
 
@@ -985,7 +985,7 @@ The folder, the files within the folder, and all child folders and their files
 :::info
 
 Those folder paths refer to the
-[default folder paths](/guides/references/configuration#Folders-Files). If
+[default folder paths](/guides/references/configuration#Folders--Files). If
 you've configured Cypress to use different folder paths then the folders
 specific to your configuration will be watched.
 

--- a/docs/guides/references/error-messages.mdx
+++ b/docs/guides/references/error-messages.mdx
@@ -55,7 +55,7 @@ The `supportFile` configuration option was removed from the root configutation
 object in Cypress version `10.0.0`. Instead, it must be added within each
 testing type's configuration object as a separate property if you would like to
 use a file other than the default
-[supportFile](/guides/references/configuration#Folders-Files) configuration.
+[supportFile](/guides/references/configuration#Testing-Type-Specific-Options) configuration.
 
 #### Use modules for utility functions
 

--- a/docs/guides/references/migration-guide.mdx
+++ b/docs/guides/references/migration-guide.mdx
@@ -1430,7 +1430,7 @@ recommend doing it manually if you are a Cypress Cloud user.
 ### Generated Files
 
 Generated screenshots and videos will still be created inside their respective
-[folders](/guides/references/configuration#Folders-Files) (`screenshotsFolder`,
+[folders](/guides/references/configuration#Folders--Files) (`screenshotsFolder`,
 `videosFolder`). However, the paths of generated files inside those folders will
 be stripped of any common ancestor paths shared between all spec files found by
 the `specPattern` option (or via the `--spec` command line option or `spec`

--- a/docs/guides/tooling/code-coverage.mdx
+++ b/docs/guides/tooling/code-coverage.mdx
@@ -302,7 +302,7 @@ npm install -D @cypress/code-coverage
 ```
 
 Then add the code below to the
-[supportFile](/guides/references/configuration#Folders-Files) and
+[supportFile](/guides/references/configuration#e2e) and
 [setupNodeEvents](/guides/tooling/plugins-guide#Using-a-plugin) function.
 
 ```js

--- a/docs/guides/tooling/typescript-support.mdx
+++ b/docs/guides/tooling/typescript-support.mdx
@@ -110,7 +110,7 @@ When adding [custom commands](/api/cypress-api/custom-commands) to the `cy`
 object, you can manually add their types to avoid TypeScript errors.
 
 For example if you add the command `cy.dataCy` into your
-[supportFile](/guides/references/configuration#Folders-Files) like this:
+[supportFile](/guides/references/configuration#Testing-Type-Specific-Options) like this:
 
 ```typescript
 // cypress/support/index.ts


### PR DESCRIPTION
- This PR resolves a set of bad links listed in issue https://github.com/cypress-io/cypress-documentation/issues/5630 on various pages and related to Folders / Files configuration options.

## Issue

Multiple pages link to the non-existent bookmark [/guides/references/configuration#Folders-Files](https://docs.cypress.io/guides/references/configuration#Folders-Files).

Using this link opens the correct page at the top and does not show the intended Folders / File section. Users would need to scroll down and search manually.

## Changes

The multiple pages, which link to the non-existent bookmark [/guides/references/configuration#Folders-Files](https://docs.cypress.io/guides/references/configuration#Folders-Files), are changed to link instead to [References > Configuration > Options > Folders / Files](https://docs.cypress.io/guides/references/configuration#Folders--Files) using the relative link [/guides/references/configuration#Folders--Files](https://docs.cypress.io/guides/references/configuration#Folders--Files) (adding a second hyphen to the bookmark).

## 10.x migration changes

In Cypress 10.x and higher, there are separate `supportFile` locations for [e2e](https://docs.cypress.io/guides/references/configuration#e2e) and [component](https://docs.cypress.io/guides/references/configuration#component) testing. Links for the generic `supportFile` to the [References > Configuration](https://docs.cypress.io/guides/references/configuration) page are targeted to the section [References > Configuration > Testing Type-Specific Options](https://docs.cypress.io/guides/references/configuration#Testing-Type-Specific-Options) instead of [References > Configuration > Options > Folders / Files](https://docs.cypress.io/guides/references/configuration#Folders--Files) where `supportFile` is not listed.

References to an E2E test-specific `supportFile` are changed to refer to the [e2e](https://docs.cypress.io/guides/references/configuration#e2e) option table.

## Unresolved 10.x migration issues

- The [Tooling > TypeScript > Types for Custom Commands](https://docs.cypress.io/guides/tooling/typescript-support#Types-for-Custom-Commands) is still using the legacy filename `cypress/support/index.ts`. It is out of scope for this PR to update the TypeScript guidelines for non-legacy usage consistently.  Issue https://github.com/cypress-io/cypress-documentation/issues/5262 was reported in May 2023 and is still open.