### PR TITLE
Correct links in "Writing and Organizing Tests"

### DIFF
--- a/docs/guides/core-concepts/writing-and-organizing-tests.mdx
+++ b/docs/guides/core-concepts/writing-and-organizing-tests.mdx
@@ -111,7 +111,7 @@ screenshots and videos taken during the testing of your application. Many users
 will opt to add these folders to their `.gitignore` file. Additionally, if you
 are storing sensitive environment variables in your
 [Cypress configuration](/guides/references/configuration) or
-[`cypress.env.json`](/guides/guides/environment-variables#Option-2-cypress-env-json),
+[`cypress.env.json`](/guides/guides/environment-variables#Option-2-cypressenvjson),
 these should also be ignored when you check into source control.
 
 :::
@@ -521,7 +521,7 @@ describe('Hooks', () => {
 :::danger
 
 🚨 Before writing `after()` or `afterEach()` hooks, please see our
-[thoughts on the anti-pattern of cleaning up state with `after()` or `afterEach()`](/guides/references/best-practices#Using-after-or-afterEach-hooks).
+[thoughts on the anti-pattern of cleaning up state with `after()` or `afterEach()`](/guides/references/best-practices#Using-after-Or-afterEach-Hooks).
 
 :::
 
@@ -639,7 +639,7 @@ specify(name, config, fn)
 
 **Note:** Some configuration values are readonly and cannot be changed via test
 configuration. Be sure to review the list of
-[test configuration options](/guides/references/configuration##Test-Configuration).
+[test configuration options](/guides/references/configuration#Test-Configuration).
 
 :::
 


### PR DESCRIPTION
- This PR is related to issue https://github.com/cypress-io/cypress-documentation/issues/5630. It resolves issues with anchor links in the page [Core Concepts > Writing and Organizing Tests](https://docs.cypress.io/guides/core-concepts/writing-and-organizing-tests), in addition to those proposed for correction in https://github.com/cypress-io/cypress-documentation/issues/5630.

## Changes

1. The bad link to [/guides/guides/environment-variables#Option-2-cypress-env-json](https://docs.cypress.io/guides/guides/environment-variables#Option-2-cypress-env-json) is corrected to [/guides/guides/environment-variables#Option-2-cypressenvjson](https://docs.cypress.io/guides/guides/environment-variables#Option-2-cypressenvjson) (extraneous hyphens `-` removed).

2. The bad link to [/guides/references/best-practices#Using-after-or-afterEach-hooks](https://docs.cypress.io/guides/references/best-practices#Using-after-or-afterEach-hooks) is corrected to [/guides/references/best-practices#Using-after-Or-afterEach-Hooks](https://docs.cypress.io/guides/references/best-practices#Using-after-Or-afterEach-Hooks) (case correction).

3. The bad link to [/guides/references/configuration##Test-Configuration](https://docs.cypress.io/guides/references/configuration##Test-Configuration) is corrected to [https://docs.cypress.io/guides/references/configuration#Test-Configuration](https://docs.cypress.io/guides/references/configuration#Test-Configuration) (extraneous `#` removed).