### PR TITLE
Remove AWS CodeBuild links for disabled example

### DIFF
--- a/docs/guides/continuous-integration/ci-provider-examples.mdx
+++ b/docs/guides/continuous-integration/ci-provider-examples.mdx
@@ -83,29 +83,6 @@ Check out the full <Icon name="github" inline="true" callout="RWA GitHub Actions
   url="aws-codebuild"
   callout="AWS CodeBuild Guide"
 />
-<br />
-<Icon
-  name="external-link-alt"
-  color="gray"
-  url="https://cloud.cypress.io/projects/zx15dm"
-  callout="See AWS CodeBuild + Cypress Cloud in action"
-/>
-
-<br />
-<br />
-
-:::info
-
-### <Icon name="graduation-cap" /> Real World Example <Badge type="success">New</Badge>
-
-The Cypress <Icon name="github" inline="true" contentType="rwa" /> uses
-[AWS CodeBuild](https://aws.amazon.com/codebuild) to test over 300 test cases in
-parallel across 25 machines, multiple browsers and multiple device sizes with
-[Cypress Cloud recording](https://cloud.cypress.io/projects/zx15dm).
-
-Check out the full <Icon name="github" inline="true" callout="RWA AWS CodeBuild configuration" url="https://github.com/cypress-io/cypress-realworld-app/blob/develop/buildspec.yml" />.
-
-:::
 
 ### Bitbucket
 


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress-documentation/issues/5538

This PR removes the section in [Continuous Integration > CI Provider Examples > Guides > AWS CodeBuild](https://docs.cypress.io/guides/continuous-integration/ci-provider-examples#AWS-CodeBuild) which refers to the AWS CodeBuild example.

The example's last run was many months ago in July 2023, and according to @jennifer-shehane in https://github.com/cypress-io/cypress-documentation/issues/5538#issuecomment-1939035158 it is not expected for it to be reactivated:

> We don't intend to continue supporting running the AWS CodeBuild

---
**BEFORE**

![AWS CodeBuild before](https://github.com/cypress-io/cypress-documentation/assets/66998419/6d839fd3-8128-4cb4-94f0-3803efb3deed)

---
**AFTER**

![AWS CodeBuild after](https://github.com/cypress-io/cypress-documentation/assets/66998419/e8099aea-3420-48d7-93a8-0365c57155a1)
