### PR TITLE
Correct anchor links for FAQ "How do I get an element's text context"

### DIFF
--- a/docs/api/queries/contains.mdx
+++ b/docs/api/queries/contains.mdx
@@ -313,7 +313,7 @@ cy.contains('Hello world')
 
 **Tip:** read about assertions against a text with non-breaking space entities
 in
-[How do I get an element's text contents?](/faq/questions/using-cypress-faq#How-do-I-get-an-element-s-text-contents)
+[How do I get an element's text contents?](/faq/questions/using-cypress-faq#How-do-I-get-an-elements-text-contents)
 
 ### Single Element
 

--- a/docs/guides/references/assertions.mdx
+++ b/docs/guides/references/assertions.mdx
@@ -217,7 +217,7 @@ cy.contains('[data-testid="greeting"]', /^Hello/)
 :::info
 
 **Tip:** read about assertions against text with non-breaking space entities in
-[How do I get an element's text contents?](/faq/questions/using-cypress-faq#How-do-I-get-an-element-s-text-contents)
+[How do I get an element's text contents?](/faq/questions/using-cypress-faq#How-do-I-get-an-elements-text-contents)
 
 :::
 


### PR DESCRIPTION
- This PR is a partial fix of https://github.com/cypress-io/cypress-documentation/issues/5630, addressing bad anchor links relating to `/faq/questions/using-cypress-faq#How-do-I-get-an-element-s-text-contents`.

## Changes

- The bad link to `/faq/questions/using-cypress-faq#How-do-I-get-an-element-s-text-contents` is corrected to [/faq/questions/using-cypress-faq#How-do-I-get-an-elements-text-contents](https://docs.cypress.io/faq/questions/using-cypress-faq#How-do-I-get-an-elements-text-contents) (extra hyphen removed).