### PR TITLE
Correct anchor links to Cloud projects Identification

### DIFF
--- a/docs/guides/cloud/getting-started.mdx
+++ b/docs/guides/cloud/getting-started.mdx
@@ -85,12 +85,12 @@ recording!
      alt="Record Instructions"
    />
 9. After setting up your project, Cypress inserts a unique
-   [projectId](#Identification) into your Cypress configuration file. If you're
+   [projectId](/guides/cloud/account-management/projects#Project-ID) into your Cypress configuration file. If you're
    using source control, we recommend that you check your configuration file,
    including the `projectId`, into source control.
 10. Within [Continuous Integration](/guides/continuous-integration/introduction)
     or from your local computer's terminal, pass the displayed
-    [Record Key](#Identification) while running the
+    [Record Key](/guides/cloud/account-management/projects#Record-key) while running the
     [cypress run](/guides/guides/command-line#cypress-run) command.
 
     Provide record key directly:


### PR DESCRIPTION
- This PR is a partial fix of https://github.com/cypress-io/cypress-documentation/issues/5630, addressing bad anchor links on [Cypress Cloud > Getting Started](https://docs.cypress.io/guides/cloud/getting-started) to the bookmark [#Identification](https://docs.cypress.io/guides/cloud/getting-started#Identification).

- PR https://github.com/cypress-io/cypress-documentation/pull/5173 moved the Identification section from [Cypress Cloud > Getting Started](https://docs.cypress.io/guides/cloud/getting-started) to a separate new page [Cypress Cloud > Account Management > Projects](https://docs.cypress.io/guides/cloud/account-management/projects#Identification).

## Changes

The bad links to `#Identification` are corrected to 
 
- [/guides/cloud/account-management/projects#Project-ID](https://docs.cypress.io/guides/cloud/account-management/projects#Project-ID)
- [/guides/cloud/account-management/projects#Record-key](https://docs.cypress.io/guides/cloud/account-management/projects#Record-key)

for the references in the [Cypress Cloud > Getting Started > Setup > Set up a project to record](http://localhost:3000/guides/cloud/getting-started#Set-up-a-project-to-record) to `projectId` and `Record Key` respectively.
