### PR TITLE
Correct anchor links to FAQ VPN subdomain IP address question

### DIFF
--- a/docs/guides/cloud/integrations/source-control/github.mdx
+++ b/docs/guides/cloud/integrations/source-control/github.mdx
@@ -302,7 +302,7 @@ installation if you choose **All repositories**.
 :::info
 
 If you are running the tests from within a restrictive VPN, see
-[which subdomains to add to your allowlist for Cypress Cloud and your GitHub Enterprise integration to work properly](/faq/questions/cloud-faq#Im-working-at-a-restrictive-VPN-Which-subdomains-do-I-have-to-allow-on-my-VPN-for-Cypress-Cloud-to-work-properly).
+[which subdomains to add to your allowlist for Cypress Cloud and your GitHub Enterprise integration to work properly](/faq/questions/cloud-faq#Im-working-with-a-restrictive-VPN-Which-subdomains-do-I-have-to-allow-on-my-VPN-for-Cypress-Cloud-to-work-properly).
 
 :::
 

--- a/docs/guides/cloud/integrations/source-control/gitlab.mdx
+++ b/docs/guides/cloud/integrations/source-control/gitlab.mdx
@@ -97,7 +97,7 @@ with more limited access permissions.
 :::warning
 
 If you are running the tests from within a restrictive VPN, see
-[which subdomains to add to your allowlist for Cypress Cloud and your GitLab integration to work properly](/faq/questions/cloud-faq#Im-working-at-a-restrictive-VPN-Which-subdomains-do-I-have-to-allow-on-my-VPN-for-Cypress-Cloud-to-work-properly)
+[which subdomains to add to your allowlist for Cypress Cloud and your GitLab integration to work properly](/faq/questions/cloud-faq#Im-working-with-a-restrictive-VPN-Which-subdomains-do-I-have-to-allow-on-my-VPN-for-Cypress-Cloud-to-work-properly)
 
 :::
 


### PR DESCRIPTION
- This PR is a partial fix of https://github.com/cypress-io/cypress-documentation/issues/5630, addressing bad anchor links to the FAQ bookmark [/faq/questions/cloud-faq#Im-working-at-a-restrictive-VPN-Which-subdomains-do-I-have-to-allow-on-my-VPN-for-Cypress-Cloud-to-work-properly](https://docs.cypress.io/faq/questions/cloud-faq#Im-working-at-a-restrictive-VPN-Which-subdomains-do-I-have-to-allow-on-my-VPN-for-Cypress-Cloud-to-work-properly).

- PR https://github.com/cypress-io/cypress-documentation/pull/5190 changed the title of the FAQ from
  "I'm working **at** a restrictive VPN. Which subdomains do I have to allow on my VPN for Cypress Cloud to work properly?" to
  "I'm working **with** a restrictive VPN. Which subdomains do I have to allow on my VPN for Cypress Cloud to work properly?"
  and added links inconsistently.

## Changes

Bad links to
`/faq/questions/cloud-faq#Im-working-at-a-restrictive-VPN-Which-subdomains-do-I-have-to-allow-on-my-VPN-for-Cypress-Cloud-to-work-properly` are corrected to
[/faq/questions/cloud-faq#Im-working-with-a-restrictive-VPN-Which-subdomains-do-I-have-to-allow-on-my-VPN-for-Cypress-Cloud-to-work-properly](https://docs.cypress.io/faq/questions/cloud-faq#Im-working-with-a-restrictive-VPN-Which-subdomains-do-I-have-to-allow-on-my-VPN-for-Cypress-Cloud-to-work-properly)
