### PR TITLE
Correct anchor link to GitLab status checks

### DIFF
--- a/docs/guides/cloud/integrations/source-control/gitlab.mdx
+++ b/docs/guides/cloud/integrations/source-control/gitlab.mdx
@@ -5,7 +5,7 @@ sidebar_label: GitLab
 ---
 
 [Cypress Cloud](https://on.cypress.io/cloud) can integrate your Cypress tests
-with your GitLab workflow via [commit statuses](#Commit-statuses) and
+with your GitLab workflow via [status checks](#Status-checks) and
 [merge request comments](#Merge-Request-comments). A project first needs to be
 [set up to record](/guides/cloud/account-management/projects) to Cypress Cloud
 to use GitLab integration.


### PR DESCRIPTION
- This PR is a partial fix of https://github.com/cypress-io/cypress-documentation/issues/5630, addressing an outdated and bad anchor link in [Cypress Cloud > Integrations > Source Control > GitLab](https://docs.cypress.io/guides/cloud/integrations/source-control/gitlab) to the section [commit statuses](https://docs.cypress.io/guides/cloud/integrations/source-control/gitlab#Commit-statuses) on the same page.

- PR https://github.com/cypress-io/cypress-documentation/pull/5077 changed the section heading `Commit statuses` to [Status checks](https://docs.cypress.io/guides/cloud/integrations/source-control/gitlab#Status-checks).

## Changes

The outdated reference and link to [commit statuses](https://docs.cypress.io/guides/cloud/integrations/source-control/gitlab#Commit-statuses) is changed to [status checks](https://docs.cypress.io/guides/cloud/integrations/source-control/gitlab#Status-checks) to match the section lower down on the page.