### PR TITLE
Correct anchor link to Angular API componentProperties

### DIFF
--- a/docs/guides/component-testing/angular/examples.mdx
+++ b/docs/guides/component-testing/angular/examples.mdx
@@ -21,7 +21,7 @@ it('mounts', () => {
 ### Passing Data to a Component
 
 You can pass inputs and outputs to a component by setting
-[componentProperties](/guides/component-testing/angular/api#ComponentProperties)
+[componentProperties](/guides/component-testing/angular/api#MountConfig)
 in the options:
 
 ```ts


### PR DESCRIPTION
- This PR is a partial fix of https://github.com/cypress-io/cypress-documentation/issues/5630, addressing a bad anchor link in [Component Testing > Angular Component Testing > Angular Examples](https://docs.cypress.io/guides/component-testing/angular/examples) in the section [Passing Data to a Component](https://docs.cypress.io/guides/component-testing/angular/examples#Passing-Data-to-a-Component) to [componentProperties](https://docs.cypress.io/guides/component-testing/angular/api#ComponentProperties).

There is no bookmark [#componentProperties](https://docs.cypress.io/guides/component-testing/angular/api#ComponentProperties) on the page [Component Testing > Angular Component Testing > Angular API](https://docs.cypress.io/guides/component-testing/angular/api). There is however a table entry for `componentProperties` in the section [Interfaces > MountConfig](https://docs.cypress.io/guides/component-testing/angular/api#MountConfig) on the [Angular API](https://docs.cypress.io/guides/component-testing/angular/api) page. This would be a helpful target.

## Changes

The link to `componentProperties` is changed to refer to the [MountConfig](https://docs.cypress.io/guides/component-testing/angular/api#MountConfig) section (which contains a reference to  `componentProperties`).