### PR TITLE
Correct anchor link to Testing Types / "What is E2E Testing?"

### DIFF
--- a/docs/guides/core-concepts/cypress-app.mdx
+++ b/docs/guides/core-concepts/cypress-app.mdx
@@ -402,7 +402,7 @@ Under Test is rendered.
 ### Application Under Test <E2EOnlyBadge />
 
 In
-[E2E Testing](/guides/core-concepts/testing-types#What-is-End-to-end-Testing),
+[E2E Testing](/guides/core-concepts/testing-types#What-is-E2E-Testing),
 the right-hand side of the Test Runner is used to display the Application Under
 Test (AUT): the application that was navigated to using a
 [`cy.visit()`](/api/commands/visit) or any subsequent routing calls made from


### PR DESCRIPTION
- This PR is a partial fix of https://github.com/cypress-io/cypress-documentation/issues/5630, addressing a bad anchor link in [Core Concepts > Cypress App](https://docs.cypress.io/guides/core-concepts/cypress-app) in the section [Preview pane > Application Under Test](https://docs.cypress.io/guides/core-concepts/cypress-app#Application-Under-Test) to [E2E Testing](https://docs.cypress.io/guides/core-concepts/testing-types#What-is-End-to-end-Testing).

- PR https://github.com/cypress-io/cypress-documentation/pull/4527 changed the section header in [Core Concepts > Testing Types](https://docs.cypress.io/guides/core-concepts/testing-types) from "What is End-to-end Testing?" to [What is E2E Testing?](https://docs.cypress.io/guides/core-concepts/testing-types#What-is-E2E-Testing), changing the autogenerated bookmark accordingly.

## Changes

The link to `E2E Testing` is changed to refer to the [What is E2E Testing?](https://docs.cypress.io/guides/core-concepts/testing-types#What-is-E2E-Testing) section.