### PR TITLE
Fix migration guide legacy link @cypress/react/plugins

### DIFF
--- a/docs/guides/references/migration-guide.mdx
+++ b/docs/guides/references/migration-guide.mdx
@@ -2090,7 +2090,7 @@ module.exports = (on, config) => {
 Projects using React may not need to update their plugins file. If your project
 is using a webpack scaffold or boilerplate, it is recommended to use a preset
 plugin imported from
-[`@cypress/react/plugins`](https://github.com/cypress-io/cypress/tree/develop/npm/react/plugins).
+[`@cypress/react/plugins`](https://github.com/cypress-io/cypress/tree/v7.7.0/npm/react/plugins).
 
 **Preset Plugins for React**
 


### PR DESCRIPTION
This PR fixes a dead legacy link [@cypress/react/plugins](https://github.com/cypress-io/cypress/tree/develop/npm/react/plugins) in the migration guide for [Cypress 7.0](https://docs.cypress.io/guides/references/migration-guide#Migrating-to-Cypress-70), in the section [Component Testing > 3. Update plugins file to use dev-server:start](https://docs.cypress.io/guides/references/migration-guide#3-Update-plugins-file-to-use-dev-serverstart) by redirecting it from the default branch to a Cypress legacy branch [v7.7.0](https://github.com/cypress-io/cypress/tree/v7.7.0) where the content is still available.

This involves the legacy [Cypress 7.0](https://docs.cypress.io/guides/references/migration-guide#Migrating-to-Cypress-70) version and a beta release of Component Testing, which was superseded by the GA (Generally Available) version of Component Testing in [Cypress 11](https://docs.cypress.io/guides/references/migration-guide#Migrating-to-Cypress-110). There should no longer be any use of the beta release of Component Testing, so the goal of this PR is to clean up a bad link for historical reading purposes only.

## Issue

The [Migration Guide](https://docs.cypress.io/guides/references/migration-guide) section [Migrating to Cypress 7.0](https://docs.cypress.io/guides/references/migration-guide#Migrating-to-Cypress-70) contains an outdated link to [@cypress/react/plugins](https://github.com/cypress-io/cypress/tree/develop/npm/react/plugins) resulting in a `404 - page not found` error from GitHub.

The `@cypress/react/plugins` was last available in `@cypress/react@5.12.5` and was removed with the release of `@cypress/react@6.0.0` for Cypress `10` compatibility.

## Change

Links in the [Migration Guide](https://docs.cypress.io/guides/references/migration-guide) section [Migrating to Cypress 7.0](https://docs.cypress.io/guides/references/migration-guide#Migrating-to-Cypress-70) to the obsolete directory `@cypress/react/plugins`, no longer available in the default `develop` branch, are replaced with links to the directory [@cypress/react/plugins](https://github.com/cypress-io/cypress/tree/v7.7.0/npm/react/plugins) in the Cypress legacy [v7.7.0](https://github.com/cypress-io/cypress/tree/v7.7.0) branch.