### PR TITLE
Correct link in Cypress Introduction to routing alias

### DIFF
--- a/docs/guides/core-concepts/introduction-to-cypress.mdx
+++ b/docs/guides/core-concepts/introduction-to-cypress.mdx
@@ -1436,7 +1436,7 @@ For instance:
   timeout is set to `60000ms`.
 - [`cy.wait()`](/api/commands/wait) actually uses 2 different timeouts. When
   waiting for a
-  [routing alias](/guides/core-concepts/variables-and-aliases#Routes), we wait
+  [routing alias](/guides/core-concepts/variables-and-aliases#Intercepts), we wait
   for a matching request for `5000ms`, and then additionally for the server's
   response for `30000ms`. We expect your application to make a matching request
   quickly, but we expect the server's response to potentially take much longer.


### PR DESCRIPTION
- This PR is a partial fix of https://github.com/cypress-io/cypress-documentation/issues/5630, addressing a bad anchor link on the [Core Concepts > Introduction to Cypress](https://docs.cypress.io/guides/core-concepts/introduction-to-cypress) page.

- PR https://github.com/cypress-io/cypress-documentation/pull/3998 modified the heading "Routes" in [Core Concepts > Variables and Aliases](https://docs.cypress.io/guides/core-concepts/variables-and-aliases) to read [Intercepts](https://docs.cypress.io/guides/core-concepts/variables-and-aliases#Intercepts) instead.

## Change

- In [Core Concepts > Introduction to Cypress](https://docs.cypress.io/guides/core-concepts/introduction-to-cypress), change the non-working link
`/guides/core-concepts/variables-and-aliases#Routes` to
[/guides/core-concepts/variables-and-aliases#Intercepts](https://docs.cypress.io/guides/core-concepts/variables-and-aliases#Intercepts).