### PR TITLE
Correct link in Retry-ability to BDD Assertions

### DIFF
--- a/docs/guides/core-concepts/retry-ability.mdx
+++ b/docs/guides/core-concepts/retry-ability.mdx
@@ -144,7 +144,7 @@ For example, the following test has [`.should()`](/api/commands/should) and
 [`.and()`](/api/commands/and) assertions. `.and()` is an alias of the
 `.should()` command, so the second assertion is really a custom callback
 assertion in the form of the [`.should(cb)`](/api/commands/should#Function)
-function with 2 [`expect`](/guides/references/assertions#BDD-Assertions)
+function with 2 [`expect`](/guides/references/assertions#Chai)
 assertions inside of it.
 
 ```javascript


### PR DESCRIPTION
- This PR is a partial fix of https://github.com/cypress-io/cypress-documentation/issues/5630, addressing a bad anchor link on the [Core Concepts > Retry-ability](https://docs.cypress.io/guides/core-concepts/retry-ability) page.

- PR https://github.com/cypress-io/cypress-documentation/pull/5080 removed the section header `BDD Assertions` from the page [References > Assertions](https://docs.cypress.io/guides/references/assertions). A few lines above, the relevant section header is now [Chai](https://docs.cypress.io/guides/references/assertions#Chai).

## Change

- In [Core Concepts > Retry-ability](https://docs.cypress.io/guides/core-concepts/retry-ability), change the non-working link
`/guides/references/assertions#BDD-Assertions` to
[/guides/references/assertions#Chai](https://docs.cypress.io/guides/references/assertions#Chai).