### PR TITLE
Correct links in Amazon Cognito Authentication

### DIFF
--- a/docs/guides/end-to-end-testing/testing-strategies/amazon-cognito-authentication.mdx
+++ b/docs/guides/end-to-end-testing/testing-strategies/amazon-cognito-authentication.mdx
@@ -90,7 +90,7 @@ the
 
 Clone the
 [Cypress Real World App](https://github.com/cypress-io/cypress-realworld-app)
-and install the [AWS Amazon Amplify CLI](https://docs.amplify.aws/CLI) as
+and install the [AWS Amazon Amplify CLI](https://docs.amplify.aws/cli) as
 follows:
 
 ```jsx
@@ -103,7 +103,7 @@ configured with an optional [Amazon Cognito](https://aws.amazon.com/cognito)
 instance via the
 [AWS Amplify Framework Authentication Library](https://aws-amplify.github.io/amplify-js/api/classes/authclass.html).
 
-The [AWS Amazon Amplify CLI](https://docs.amplify.aws/CLI) is used to provision
+The [AWS Amazon Amplify CLI](https://docs.amplify.aws/cli) is used to provision
 the [Amazon Web Services (AWS)](https://aws.amazon.com) infrastructure needed to
 configure your environment and cloud resources.
 
@@ -141,7 +141,7 @@ Use the `yarn dev:cognito` command when starting the
 First, we need to configure Cypress to use the
 [AWS Cognito](https://aws.amazon.com/cognito) environment variables set in the
 `.env` file. In addition, we are using the `aws-exports.js` supplied during the
-[AWS Amplify CLI](https://docs.amplify.aws/CLI) build process.
+[AWS Amplify CLI](https://docs.amplify.aws/cli) build process.
 
 :::cypress-config-example
 
@@ -168,7 +168,7 @@ const awsConfig = require('./aws-exports-es5.js')
 
 There are two ways you can authenticate to AWS Cognito:
 
-- [Login with `cy.origin()`](/guides/end-to-end-testing/amazon-cognito-authentication#Login-with-cy-origin)
+- [Login with `cy.origin()`](/guides/end-to-end-testing/amazon-cognito-authentication#Login-with-cyorigin)
 - [Programmatic Access](/guides/end-to-end-testing/amazon-cognito-authentication#Programmatic-Login)
 
 ### Login with [`cy.origin()`](/api/commands/origin)


### PR DESCRIPTION
- This PR is a partial fix of https://github.com/cypress-io/cypress-documentation/issues/5630, addressing two bad links on the [End-to-End Testing > Testing Strategies > Amazon Cognito Authentication](https://docs.cypress.io/guides/end-to-end-testing/amazon-cognito-authentication) page.

## Issues

- The link to https://docs.amplify.aws/CLI returns a 404 not found error. (This is not covered in issue #5630, since it is not an anchor link. It is addressed and bundled here additionally.)
- Hardly noticeable `/guides/end-to-end-testing/amazon-cognito-authentication#Login-with-cy-origin` , which attempts to link to a bookmark just underneath it, does not match the auto-generated bookmark exactly.

## Change

In [End-to-End Testing > Testing Strategies > Amazon Cognito Authentication](https://docs.cypress.io/guides/end-to-end-testing/amazon-cognito-authentication) the following links are corrected:

- Link https://docs.amplify.aws/CLI is changed to https://docs.amplify.aws/cli (change of case)
- Link `/guides/end-to-end-testing/amazon-cognito-authentication#Login-with-cy-origin` is changed to [/guides/end-to-end-testing/amazon-cognito-authentication#Login-with-cyorigin](https://docs.cypress.io/guides/end-to-end-testing/amazon-cognito-authentication#Login-with-cyorigin) (one hyphen removed)