### PR TITLE
Correct anchor links in Social Authentication

### DIFF
--- a/docs/guides/end-to-end-testing/testing-strategies/social-authentication.mdx
+++ b/docs/guides/end-to-end-testing/testing-strategies/social-authentication.mdx
@@ -21,9 +21,9 @@ slug: /guides/end-to-end-testing/social-authentication
 
 Cypress does **not** recommend testing social connection authentication as a
 primary means of application authentication testing. This is due to the
-[challenges](/guides/references/best-practices#Challenges-with-Social-Connection-Authentication)
+[challenges](/guides/references/best-practices#Potential-Challenges-Authenticating-with-Social-Platforms)
 mentioned in our
-[Best Practices Guide](/guides/references/best-practices#Potential-Challenges-Authenticating-with-Social-Platforms).
+[Best Practices Guide](/guides/references/best-practices).
 
 Relying on social authentication in CI will likely result in bot detection and
 in some cases, account suspension due to violating the provider's Terms of


### PR DESCRIPTION
- This PR addresses link issues in [End-to-End Testing > Testing Strategies > Social Authentication](https://docs.cypress.io/guides/end-to-end-testing/social-authentication). A corresponding anchor link issue is listed in https://github.com/cypress-io/cypress-documentation/issues/5630.

## Issue

- The target of the anchor link `/guides/references/best-practices#Challenges-with-Social-Connection-Authentication` does not exist on that page.

## Changes

In [End-to-End Testing > Testing Strategies > Social Authentication](https://docs.cypress.io/guides/end-to-end-testing/social-authentication) the following links are corrected:

- Link `/guides/references/best-practices#Challenges-with-Social-Connection-Authentication` is corrected to [/guides/references/best-practices#Potential-Challenges-Authenticating-with-Social-Platforms](https://docs.cypress.io/guides/references/best-practices#Challenges-with-Social-Connection-Authentication)
- The anchor link from `Best Practices Guide` is removed to target the full page under [/guides/references/best-practices](https://docs.cypress.io/guides/references/best-practices) (otherwise one of the two links would be redundant, since they are both in the same sentence).