### PR TITLE
Correct anchor link in Cross Origin Testing

### DIFF
--- a/docs/guides/guides/cross-origin-testing.mdx
+++ b/docs/guides/guides/cross-origin-testing.mdx
@@ -108,7 +108,7 @@ it('navigates to new origin', () => {
 This limitation exists because Cypress switches to the domain under each
 specific test when it runs. For more information on this, please see our Web
 Security page regarding
-[Different superdomain per test requires cy.origin command](/guides/guides/web-security#Different-superdomain-per-test-requires-cy-origin-command).
+[Different superdomain per test requires cy.origin command](/guides/guides/web-security#Different-superdomain-per-test-requires-cyorigin-command).
 
 #### Other workarounds
 


### PR DESCRIPTION
- This PR addresses an anchor link issue in [Guides > Cross Origin Testing](https://docs.cypress.io/guides/guides/cross-origin-testing).

## Issue

- A link to `/guides/guides/web-security#Different-superdomain-per-test-requires-cy-origin-command` does not match the auto-generated bookmark exactly. This issue is one of the link issues listed in https://github.com/cypress-io/cypress-documentation/issues/5630.

## Change

In [Guides > Cross Origin Testing](https://docs.cypress.io/guides/guides/cross-origin-testing) the following link is corrected:

- Link `/guides/guides/web-security#Different-superdomain-per-test-requires-cy-origin-command` is changed to [/guides/guides/web-security#Different-superdomain-per-test-requires-cyorigin-command](https://docs.cypress.io/guides/guides/web-security#Different-superdomain-per-test-requires-cyorigin-command) (one hyphen removed)
