### PR TITLE
Correct links in Module API

### DIFF
--- a/docs/guides/guides/module-api.mdx
+++ b/docs/guides/guides/module-api.mdx
@@ -17,7 +17,7 @@ results directly after the run. With this workflow, for example, you can:
 To run Cypress via Node.js in a
 [Yarn Plug'n'Play](https://yarnpkg.com/features/pnp) environment, use
 [yarn node](https://yarnpkg.com/cli/node) instead of
-[node](https://nodejs.dev/en/learn/run-nodejs-scripts-from-the-command-line/).
+[node](https://nodejs.org/en/learn/command-line/run-nodejs-scripts-from-the-command-line).
 
 :::
 
@@ -62,7 +62,7 @@ Just like the [Command Line options](/guides/guides/command-line) for
 | `browser`                 | _string_            | Specify different browser to run tests in, either by name or by filesystem path                                                                                                                          |
 | `ciBuildId`               | _string_            | Specify a unique identifier for a run to enable [grouping](/guides/cloud/smart-orchestration/parallelization#Grouping-test-runs) or [parallelization](/guides/cloud/smart-orchestration/parallelization) |
 | `config`                  | _object_            | Specify [configuration](/guides/references/configuration)                                                                                                                                                |
-| `configFile`              | _string_            | Path to the [configuration file](/guides/references/configuration#Configuration-file) to be used.                                                                                                        |
+| `configFile`              | _string_            | Path to the [configuration file](/guides/references/configuration#Configuration-File) to be used.                                                                                                        |
 | `env`                     | _object_            | Specify [environment variables](/guides/guides/environment-variables)                                                                                                                                    |
 | `group`                   | _string_            | [Group](/guides/cloud/smart-orchestration/parallelization#Grouping-test-runs) recorded tests together under a single run                                                                                 |
 | `headed`                  | _boolean_           | Displays the browser instead of running headlessly                                                                                                                                                       |
@@ -306,7 +306,7 @@ options that modify how Cypress runs.
 | ------------- | --------- | ------------------------------------------------------------------------------------------------- |
 | `browser`     | _string_  | Specify a filesystem path to a custom browser                                                     |
 | `config`      | _object_  | Specify [configuration](/guides/references/configuration)                                         |
-| `configFile`  | _string_  | Path to the [configuration file](/guides/references/configuration#Configuration-file) to be used. |
+| `configFile`  | _string_  | Path to the [configuration file](/guides/references/configuration#Configuration-File) to be used. |
 | `detached`    | _boolean_ | Open Cypress in detached mode                                                                     |
 | `env`         | _object_  | Specify [environment variables](/guides/guides/environment-variables)                             |
 | `global`      | _boolean_ | Run in global mode                                                                                |


### PR DESCRIPTION
- This PR addresses link issues in [Guides > Module API](https://docs.cypress.io/guides/guides/module-api).

## Issues

- A link to https://nodejs.org/en/learn/run-nodejs-scripts-from-the-command-line/ results in a "404 Page could not be found" error.
- The target of the anchor link `/guides/references/configuration#Configuration-file` does not match the auto-generated bookmark exactly. This issue is one of the link issues listed in https://github.com/cypress-io/cypress-documentation/issues/5630.

## Changes

In [Guides > Module API](https://docs.cypress.io/guides/guides/module-api) the following links are corrected:

- Link https://nodejs.org/en/learn/run-nodejs-scripts-from-the-command-line/ is changed to https://nodejs.org/en/learn/command-line/run-nodejs-scripts-from-the-command-line.
- Links `/guides/references/configuration#Configuration-file` are changed to [guides/references/configuration#Configuration-File](https://docs.cypress.io/guides/references/configuration#Configuration-File) (change of case).