### PR TITLE
Correct link in Test Retries

### DIFF
--- a/docs/guides/guides/test-retries.mdx
+++ b/docs/guides/guides/test-retries.mdx
@@ -35,7 +35,7 @@ to you.
 
 :::info
 
-You may want to use the [experimental retries](/guides/references/experiments#Experimental-Retries) feature which offers more options for [detecting flaky tests](/guides/cloud/flaky-test-management#Flake-Detection). This experimental feature is available as of Cypress `13.4.0`.
+You may want to use the [experimental test retries](/guides/references/experiments#Experimental-Test-Retries) feature which offers more options for [detecting flaky tests](/guides/cloud/flaky-test-management#Flake-Detection). This experimental feature is available as of Cypress `13.4.0`.
 
 Test retries were originally intended to give failing tests more chances to "pass" (for instance, if CI environments for testing are unreliable), while still being determined as flaky if they do eventually pass. However this may not be the desired result in all cases. Experimental retries give you control over the conditions of the pass or fail result.
 


### PR DESCRIPTION
- This PR addresses a link issue in [Guides > Test Retries](http://localhost:3000/guides/guides/test-retries). Anchor link issues are listed in https://github.com/cypress-io/cypress-documentation/issues/5630.

## Issues

- The target of the anchor link `/guides/references/experiments#Experimental-Retries` does not exist.

## Changes

In [Guides > Test Retries](http://localhost:3000/guides/guides/test-retries) the following link is corrected:

- Link `/guides/references/experiments#Experimental-Retries` is changed to [/guides/references/experiments#Experimental-Test-Retries](https://docs.cypress.io/guides/references/experiments#Experimental-Test-Retries). The link inconsistency was introduced with PR https://github.com/cypress-io/cypress-documentation/pull/5551.