### PR TITLE
Correct anchor link in "Why Cypress?"

### DIFF
--- a/docs/guides/overview/why-cypress.mdx
+++ b/docs/guides/overview/why-cypress.mdx
@@ -225,7 +225,7 @@ it('adds a todo', () => {
 
 Finally, through a large number of [official and 3rd party plugins](/plugins)
 you can write Cypress [a11y](https://github.com/component-driven/cypress-axe),
-[visual](/plugins#Visual%20Testing),
+[visual](/plugins#visual-testing),
 [email](/faq/questions/using-cypress-faq#How-do-I-check-that-an-email-was-sent-out)
 and other types of tests.
 


### PR DESCRIPTION
- This PR addresses a link issue in [Overview > Why Cypress?](https://docs.cypress.io/guides/overview/why-cypress). Anchor link issues are listed in https://github.com/cypress-io/cypress-documentation/issues/5630.

## Issues

- The target of the anchor link `/plugins#Visual%20Testing` does not exist.

## Changes

In [Overview > Why Cypress?](https://docs.cypress.io/guides/overview/why-cypress) the following link is corrected:

- Link `/plugins#Visual%20Testing` is changed to [/plugins#visual-testing](https://docs.cypress.io/plugins#visual-testing). This was caused by https://github.com/cypress-io/cypress-documentation/pull/5299 and fell between the cracks of PR https://github.com/cypress-io/cypress-documentation/pull/5354 and https://github.com/cypress-io/cypress-documentation/pull/5299 intended to correct changed anchor links to bookmarks on the [Plugins](https://docs.cypress.io/plugins) page.

Note that all anchor links to the [Plugins](https://docs.cypress.io/plugins) page are flagged by Docusaurus as broken anchor links. These false positives require separate investigation to see if the check can be ignored or fixed somehow.