### PR TITLE
Remove instructions on running headless tests without Xvfb

### DIFF
--- a/docs/guides/continuous-integration/introduction.mdx
+++ b/docs/guides/continuous-integration/introduction.mdx
@@ -613,30 +613,6 @@ crashing.
 
 :::
 
-### Running headless tests without Xvfb
-
-:::caution
-
-Using the `ELECTRON_RUN_AS_NODE=1` env var is experimental and not fully tested,
-so may not work in all environments.
-
-:::
-
-Chromium based browsers and Firefox can spawn without Xvfb when run via the
-`--headless` flag. If you're testing against either of those browsers using the
-`--browser` flag, you can opt out of Cypress spawning an X11 server by setting
-the environment variable
-[`ELECTRON_RUN_AS_NODE=1`](https://www.electronjs.org/docs/api/environment-variables#electron_run_as_node).
-
-:::caution
-
-Electron cannot be run without an X11 server. Cypress's default browser is
-Electron and won't be able to launch if you set this environment variable.
-Likewise, Cypress's interactive mode (running via `cypress open`) is run via
-Electron and cannot be opened without an X11 server.
-
-:::
-
 ### Colors
 
 If you want colors to be disabled, you can pass the `NO_COLOR` environment


### PR DESCRIPTION
As already written in this bit of the docs, `ELECTRON_RUN_AS_NODE` was never tested.
Having tested it, I'm now sure it _doesn't_ work, and I think removing it from the docs is clearer than having it in there with this note.

Essentially, when `ELECTRON_RUN_AS_NODE` is set to `1`, the `Cypress` binary starts to act as if it's a `node` binary:

![2024-02-19 09_23_19-Window](https://github.com/cypress-io/cypress-documentation/assets/1038428/b5b9dcf8-70b8-4f2e-8dcf-9bd7da7d5582)

When that happens, when cypress tries to call it with set-up params, `node` responds that it does not know those params:

![2024-02-19 09_23_55-Window](https://github.com/cypress-io/cypress-documentation/assets/1038428/19f9eddb-4a06-4364-8d1b-e0a3a05a9750)

Perhaps this used to work in the past, but seeing the 'maybe' in the docs gave me some hope that I would be able to get cypress to run without Xvfb.

Also reported in https://github.com/cypress-io/cypress/issues/23636