### PR TITLE
Correct anchor links in API cy.intercept()

### DIFF
--- a/docs/api/commands/intercept.mdx
+++ b/docs/api/commands/intercept.mdx
@@ -26,9 +26,9 @@ cy.intercept(method, url)
 cy.intercept(routeMatcher)
 ```
 
-See arguments [url](/api/commands/intercept#url-String-Glob-RegExp),
-[method](/api/commands/intercept#method-String) and
-[routeMatcher](/api/commands/intercept#routeMatcher-RouteMatcher)
+See arguments [url](#url-String-Glob-RegExp),
+[method](#method-String) and
+[routeMatcher](#routeMatcher-RouteMatcher)
 
 ```js
 // spying and response stubbing
@@ -39,7 +39,7 @@ cy.intercept(url, routeMatcher, staticResponse)
 ```
 
 See
-[staticResponse](/api/commands/intercept#staticResponse-lt-code-gtStaticResponselt-code-gt)
+[staticResponse](#staticResponse-StaticResponse)
 argument
 
 ```js
@@ -51,7 +51,7 @@ cy.intercept(url, routeMatcher, routeHandler)
 ```
 
 See
-[routeHandler](/api/commands/intercept#routeHandler-lt-code-gtFunctionlt-code-gt)
+[routeHandler](#routeHandler-Function)
 argument
 
 ### Usage
@@ -155,7 +155,7 @@ access to the entire request-response where you can modify the outgoing request,
 send a response, access the real response, and more.
 
 See ["Intercepted requests"][req] and
-[Request/Response Modification with `routeHandler`](#Request-Response-Modification-with-routeHandler).
+[Request/Response Modification with `routeHandler`](#RequestResponse-Modification-with-routeHandler).
 
 ### Yields [<Icon name="question-circle"/>](/guides/core-concepts/introduction-to-cypress#Subject-Management) {#Yields}
 
@@ -171,7 +171,7 @@ See ["Intercepted requests"][req] and
 :::info
 
 `cy.intercept` can be used solely for spying: to passively listen for matching
-routes and apply [aliases](#Aliasing-a-Route) to them without manipulating the
+routes and apply [aliases](#Aliasing-an-intercepted-route) to them without manipulating the
 request or its response in any way. This alone is powerful as it allows you to
 [wait](#Waiting-on-a-request) for these requests, resulting in more reliable
 tests.
@@ -319,7 +319,7 @@ For more guidance around aliasing requests with GraphQL, see
 ### Waiting on a request
 
 Use [cy.wait()](/api/commands/wait) with
-[aliasing an intercepted route](#aliasing-an-intercepted-route) to wait for the
+[aliasing an intercepted route](#Aliasing-an-intercepted-route) to wait for the
 request/response cycle to complete.
 
 #### With URL
@@ -863,7 +863,7 @@ Lifecycle][lifecycle].
 :::
 
 See also
-[Providing a stub response with `req.reply()`](#Providing-a-stub-response-with-req-reply)
+[Providing a stub response with `req.reply()`](#Providing-a-stub-response-with-reqreply)
 
 Modifying the real response (`continue`):
 
@@ -1351,7 +1351,7 @@ The following properties are available on `StaticResponse`.
 You can supply a `StaticResponse` to Cypress in 3 ways:
 
 - To `cy.intercept()` as
-  [`an argument`](#staticResponse-lt-code-gtStaticResponselt-code-gt), to stub a
+  [`an argument`](#staticResponse-StaticResponse), to stub a
   response to a route: `cy.intercept('/url', staticResponse)`
 - To [`req.reply()`][req-reply], to stub a response from a request handler:
   `req.reply(staticResponse)`
@@ -1393,7 +1393,7 @@ The following steps are used to handle the request phase.
    information on the `req` object.
    - If [`req.reply()`][req-reply] is called, immediately end the request phase
      with the provided response. See
-     ["Providing a stub response with `req.reply()`"](#Providing-a-stub-response-with-req-reply).
+     ["Providing a stub response with `req.reply()`"](#Providing-a-stub-response-with-reqreply).
    - If [`req.continue()`][req-continue] is called, immediately end the request
      phase, and send the request to the destination server. If a callback is
      provided to [`req.continue()`][req-continue], it will be called during the
@@ -1628,9 +1628,9 @@ information about the request and response to the console:
 [req-continue]: #Controlling-the-outbound-request-with-reqcontinue
 [req-reply]: #Providing-a-stub-response-with-reqreply
 [res]: #Intercepted-responses
-[res-send]: #Ending-the-response-with-res-send
+[res-send]: #Ending-the-response-with-ressend
 [match-url]: #Matching-url
 [glob-match-url]: #Glob-Pattern-Matching-URLs
 [arg-method]: #method-String
-[arg-routehandler]: #routeHandler-lt-code-gtstring-object-Function-StaticResponselt-code-gt
+[arg-routehandler]: #routeHandler-Function
 [arg-routematcher]: #routeMatcher-RouteMatcher


### PR DESCRIPTION
- This PR addresses multiple anchor link issues in [API > Other Commands > intercept](https://docs.cypress.io/api/commands/intercept).  Anchor link issues are listed in https://github.com/cypress-io/cypress-documentation/issues/5630.

## Issues

- `/api/commands/intercept#staticResponse-lt-code-gtStaticResponselt-code-gt` does not match target
- `/api/commands/intercept#routeHandler-lt-code-gtFunctionlt-code-gt` does not match target
- `/api/commands/intercept#Request-Response-Modification-with-routeHandler` does not match target exactly
- `/api/commands/intercept#Aliasing-a-Route` has no matching target
- `/api/commands/intercept#aliasing-an-intercepted-route` does not match target exactly
- `/api/commands/intercept#routeHandler-lt-code-gtstring-object-Function-StaticResponselt-code-gt` has no matching target
- `/api/commands/intercept#Providing-a-stub-response-with-req-reply` does not match target exactly
- `/api/commands/intercept#Ending-the-response-with-res-send` does not match target exactly

## Changes

In [API > Other Commands > intercept](https://docs.cypress.io/api/commands/intercept) the following changes are made:

| Current                                                                                          | Corrected                                                                                                                                        |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ |
| `/api/commands/intercept#staticResponse-lt-code-gtStaticResponselt-code-gt`                      | [#staticResponse-StaticResponse](https://docs.cypress.io/api/commands/intercept#staticResponse-StaticResponse)                                   |
| `/api/commands/intercept#routeHandler-lt-code-gtFunctionlt-code-gt`                              | [#routeHandler-Function](https://docs.cypress.io/api/commands/intercept#routeHandler-Function)                                                   |
| `/api/commands/intercept#Request-Response-Modification-with-routeHandler`                        | [#RequestResponse-Modification-with-routeHandler](https://docs.cypress.io/api/commands/intercept#RequestResponse-Modification-with-routeHandler) |
| `/api/commands/intercept#Aliasing-a-Route`                                                       | [#Aliasing-an-intercepted-route](https://docs.cypress.io/api/commands/intercept#Aliasing-an-intercepted-route)                                   |
| `/api/commands/intercept#aliasing-an-intercepted-route`                                          | [#Aliasing-an-intercepted-route](https://docs.cypress.io/api/commands/intercept#Aliasing-an-intercepted-route)                                   |
| `/api/commands/intercept#routeHandler-lt-code-gtstring-object-Function-StaticResponselt-code-gt` | [#routeHandler-Function](https://docs.cypress.io/api/commands/intercept#routeHandler-Function)                                                   |
| `/api/commands/intercept#Providing-a-stub-response-with-req-reply`                               | [#Providing-a-stub-response-with-reqreply](https://docs.cypress.io/api/commands/intercept#Providing-a-stub-response-with-reqreply)               |
| `/api/commands/intercept#Ending-the-response-with-res-send`                                      | [#Ending-the-response-with-ressend](https://docs.cypress.io/api/commands/intercept#Ending-the-response-with-ressend)                             |

### Refactor

Additionally `/api/commands/intercept` is removed from links pointing to the same page, leaving only the necessary `#` fragment of the link. This makes the `.mdx` source easier to read and less prone to errors.