### PR TITLE
Correct anchor link in API Cypress.require()

### DIFF
--- a/docs/api/cypress-api/require.mdx
+++ b/docs/api/cypress-api/require.mdx
@@ -46,7 +46,7 @@ cy.origin('cypress.io', async () => {
 ```
 
 See
-[`cy.origin()` Dependencies / Sharing Code](/api/commands/origin#Dependencies-Sharing-Code)
+[`cy.origin()` Dependencies / Sharing Code](/api/commands/origin#Dependencies--Sharing-Code)
 for more example usage.
 
 ## TypeScript


### PR DESCRIPTION
- This PR corrects an anchor link issue in [API > Cypress API > Cypress.require](https://docs.cypress.io/api/cypress-api/require).  Anchor link issues are listed in https://github.com/cypress-io/cypress-documentation/issues/5630.

## Issue

- The anchor link `/api/commands/origin#Dependencies-Sharing-Code` does not match its target exactly.

## Changes

In [API > Cypress API > Cypress.require](https://docs.cypress.io/api/cypress-api/require) the following change is made:

| Current                                          | Corrected                                                                                                                 | Comment      |
| ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------- | ------------ |
| `/api/commands/origin#Dependencies-Sharing-Code` | [/api/commands/origin#Dependencies--Sharing-Code](https://docs.cypress.io/api/commands/origin#Dependencies--Sharing-Code) | Hyphen added |
