### PR TITLE
Correct anchor links to "Setting a Global baseUrl"

### DIFF
--- a/docs/api/commands/visit.mdx
+++ b/docs/api/commands/visit.mdx
@@ -12,7 +12,7 @@ Visit a remote URL.
 We recommend setting a `baseUrl` when using `cy.visit()`.
 
 Read about
-[best practices](/guides/references/best-practices#Setting-a-global-baseUrl)
+[best practices](/guides/references/best-practices#Setting-a-Global-baseUrl)
 here.
 
 :::

--- a/docs/api/queries/url.mdx
+++ b/docs/api/queries/url.mdx
@@ -110,7 +110,7 @@ return them the full current URL. We almost never refer to the URL as an `href`.
 Instead of hard-coding the URL used in the assertion, we recommend you define a
 `baseUrl` in your [Cypress configuration](/guides/references/configuration). For
 more details on why, see our Best Practices guide on
-[setting a global `baseUrl`](/guides/references/best-practices#Setting-a-global-baseUrl).
+[setting a global `baseUrl`](/guides/references/best-practices#Setting-a-Global-baseUrl).
 
 Given the remote URL, `http://localhost:8000/index.html`, and the baseUrl,
 `http://localhost:8000`, these assertions are the same.


### PR DESCRIPTION
- This PR addresses anchor link issues targeting `/guides/references/best-practices#Setting-a-global-baseUrl`. Anchor link issues are listed in https://github.com/cypress-io/cypress-documentation/issues/5630.

## Issue

In

- [API > Other Queries > url](https://docs.cypress.io/api/commands/url)
- [API > Other Commands > visit](https://docs.cypress.io/api/commands/visit)

the following link

- `/guides/references/best-practices#Setting-a-global-baseUrl` does not match its target exactly.

## Changes

In

- [API > Other Queries > url](https://docs.cypress.io/api/commands/url)
- [API > Other Commands > visit](https://docs.cypress.io/api/commands/visit)

the following change is made:

| Current                                                      | Corrected                                                                                                                                       | Comment     |
| ------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
| `/guides/references/best-practices#Setting-a-global-baseUrl` | [/guides/references/best-practices#Setting-a-Global-baseUrl](https://docs.cypress.io/guides/references/best-practices#Setting-a-Global-baseUrl) | Case change |
