### PR TITLE
Correct links to Node.js require()

### DIFF
--- a/docs/api/commands/origin.mdx
+++ b/docs/api/commands/origin.mdx
@@ -397,11 +397,11 @@ Within the `cy.origin()` callback,
 [`Cypress.require()`](/api/cypress-api/require) can be utilized to include
 [npm](https://www.npmjs.com/) packages and other files. It is functionally the
 same as using
-[CommonJS `require()`](https://nodejs.org/en/knowledge/getting-started/what-is-require/)
+[CommonJS `require()`](https://nodejs.org/api/modules.html#requireid)
 in browser-targeted code.
 
 Note that it is not possible to use
-[CommonJS `require()`](https://nodejs.org/en/knowledge/getting-started/what-is-require/)
+[CommonJS `require()`](https://nodejs.org/api/modules.html#requireid)
 or
 [ES module `import()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#dynamic_imports)
 within the callback.

--- a/docs/api/cypress-api/require.mdx
+++ b/docs/api/cypress-api/require.mdx
@@ -8,7 +8,7 @@ e2eSpecific: true
 modules such as [npm](https://www.npmjs.com/) packages and other local files.
 
 It is functionally the same as using
-[CommonJS `require()`](https://nodejs.org/en/knowledge/getting-started/what-is-require/)
+[CommonJS `require()`](https://nodejs.org/api/modules.html#requireid)
 in browser-targeted code.
 
 ## Syntax


### PR DESCRIPTION
This PR addresses links to the Node.js documentation for `require()` in pages:

- [API > Other Commands > origin](https://docs.cypress.io/api/commands/origin)
- [Cypress API > Cypress.require](https://docs.cypress.io/api/cypress-api/require)

## Issues

- The target of the external link https://nodejs.org/en/knowledge/getting-started/what-is-require/ does not exist.

## Changes

In the following pages:

- [API > Other Commands > origin](https://docs.cypress.io/api/commands/origin)
- [Cypress API > Cypress.require](https://docs.cypress.io/api/cypress-api/require)

the following link is changed:

| Current                                                          | Corrected                                     |
| ---------------------------------------------------------------- | --------------------------------------------- |
| https://nodejs.org/en/knowledge/getting-started/what-is-require/ | https://nodejs.org/api/modules.html#requireid |
