### PR TITLE
Correct anchor links to Changelog versions

### DIFF
--- a/docs/api/commands/spread.mdx
+++ b/docs/api/commands/spread.mdx
@@ -107,7 +107,7 @@ cy.getCookies().spread((cookie1, cookie2, cookie3) => {
 
 | Version                                     | Changes                   |
 | ------------------------------------------- | ------------------------- |
-| [0.5.9](/guides/references/changelog#0-5.9) | `.spread()` command added |
+| [0.5.9](/guides/references/changelog#0-5-9) | `.spread()` command added |
 
 ## See also
 

--- a/docs/api/commands/spy.mdx
+++ b/docs/api/commands/spy.mdx
@@ -171,7 +171,7 @@ the following:
 
 | Version                                       | Changes                   |
 | --------------------------------------------- | ------------------------- |
-| [0.20.0](/guides/references/changelog#0-20.0) | Added `.log(bool)` method |
+| [0.20.0](/guides/references/changelog#0-20-0) | Added `.log(bool)` method |
 | [0.18.8](/guides/references/changelog#0-18-8) | `cy.spy()` command added  |
 
 ## See also

--- a/docs/api/commands/stub.mdx
+++ b/docs/api/commands/stub.mdx
@@ -235,7 +235,7 @@ outputs the following:
 
 | Version                                       | Changes                   |
 | --------------------------------------------- | ------------------------- |
-| [0.20.0](/guides/references/changelog#0-20.0) | Added `.log(bool)` method |
+| [0.20.0](/guides/references/changelog#0-20-0) | Added `.log(bool)` method |
 | [0.18.8](/guides/references/changelog#0-18-8) | `cy.stub()` command added |
 
 ## See also

--- a/docs/api/commands/visit.mdx
+++ b/docs/api/commands/visit.mdx
@@ -460,7 +460,7 @@ following:
 | [0.17.0](/guides/references/changelog#0-17-0) | Cannot `cy.visit()` two different super domains in a single test                 |
 | [0.6.8](/guides/references/changelog#0-6-8)   | Added option `log`                                                               |
 | [0.4.3](/guides/references/changelog#0-4-3)   | Added option `onBeforeLoad`                                                      |
-| [< 0.3.3](/guides/references/changelog#0-3.3) | `cy.visit()` command added                                                       |
+| [< 0.3.3](/guides/references/changelog#0-3-3) | `cy.visit()` command added                                                       |
 
 ## See also
 


### PR DESCRIPTION
This PR addresses anchor link issues targeting versions in the [References > Changelog](https://docs.cypress.io/guides/references/changelog) document from the following pages:

- [API > Other Commands > spread](https://docs.cypress.io/api/commands/spread)
- [API > Other Commands > spy](https://docs.cypress.io/api/commands/spy)
- [API > Other Commands > stub](https://docs.cypress.io/api/commands/stub)
- [API > Other Commands > stub](https://docs.cypress.io/api/commands/visit)

Link issues are listed in https://github.com/cypress-io/cypress-documentation/issues/5630.

## Issues

The target of the following links do not exist exactly:

- `/guides/references/changelog#0-5.9`
- `/guides/references/changelog#0-20.0`
- `/guides/references/changelog#0-3.3`


## Changes

On the pages:

- [API > Other Commands > spread](https://docs.cypress.io/api/commands/spread)
- [API > Other Commands > spy](https://docs.cypress.io/api/commands/spy)
- [API > Other Commands > stub](https://docs.cypress.io/api/commands/stub)
- [API > Other Commands > stub](https://docs.cypress.io/api/commands/visit)

the following links are corrected:

| Current                               | Corrected                                                                                         |
| ------------------------------------- | ------------------------------------------------------------------------------------------------- |
| `/guides/references/changelog#0-5.9`  | [/guides/references/changelog#0-5-9](https://docs.cypress.io/guides/references/changelog#0-5-9)   |
| `/guides/references/changelog#0-20.0` | [/guides/references/changelog#0-20-0](https://docs.cypress.io/guides/references/changelog#0-20-0) |
| `/guides/references/changelog#0-3.3`  | [/guides/references/changelog#0-3-3](https://docs.cypress.io/guides/references/changelog#0-3-3)   |

