### PR TITLE
Correct links to Sinon.JS documentation

### DIFF
--- a/docs/api/commands/spy.mdx
+++ b/docs/api/commands/spy.mdx
@@ -45,7 +45,7 @@ The name of the `method` on the `object` to be wrapped.
 - `cy.spy()` is _synchronous_ and returns a value (the spy) instead of a
   Promise-like chain-able object. It can be aliased.
 - `cy.spy()` returns a
-  [Sinon.js spy](https://sinonjs.org/releases/v6.1.5/spies/). All methods found
+  [Sinon.js spy](https://sinonjs.org/releases/v8/spies/). All methods found
   on Sinon.JS spies are supported.
 
 ## Examples
@@ -115,7 +115,7 @@ You will see the following in the command log:
 #### Automatic reset/restore between tests
 
 `cy.spy()` creates spies in a
-[sandbox](https://sinonjs.org/releases/v6.1.5/sandbox/), so all spies created
+[sandbox](https://sinonjs.org/releases/v8/sandbox/), so all spies created
 are automatically reset/restored between tests without you having to explicitly
 reset/restore them.
 

--- a/docs/api/commands/stub.mdx
+++ b/docs/api/commands/stub.mdx
@@ -191,7 +191,7 @@ You will see the following in the command log:
 #### Automatic reset/restore between tests
 
 `cy.stub()` creates stubs in a
-[sandbox](http://sinonjs.org/releases/v2.0.0/sandbox/), so all stubs created are
+[sandbox](http://sinonjs.org/releases/v8/sandbox/), so all stubs created are
 automatically reset/restored between tests without you having to explicitly
 reset/restore them.
 


### PR DESCRIPTION
- This PR corrects link issues to the documentation for the npm module [sinon](https://www.npmjs.com/package/sinon).

## Issues

The following external links produce a 404 "File not found" error:

In [API > Other Commands > spy](https://docs.cypress.io/api/commands/spy):

- https://sinonjs.org/releases/v6.1.5/spies/
- https://sinonjs.org/releases/v6.1.5/sandbox/

In [API > Other Commands > stub](https://docs.cypress.io/api/commands/stub):

- https://sinonjs.org/releases/v2.0.0/sandbox/

## Changes

`cypress@13.6.4` uses the npm module [sinon](https://www.npmjs.com/package/sinon) version `8.1.1`
https://github.com/cypress-io/cypress/blob/ad99300a5f1a23d336c317600e702a6406fea4a6/packages/driver/package.json#L79

The relevant documentation page is `v8` for the [Sinon.JS v8.1.1](https://sinonjs.org/releases/v8/) release.


In [API > Other Commands > spy](https://docs.cypress.io/api/commands/spy) the following changes are made:

| Current                                      | Corrected                                |
| -------------------------------------------- | ---------------------------------------- |
| https://sinonjs.org/releases/v6.1.5/spies/   | https://sinonjs.org/releases/v8/spies/   |
| https://sinonjs.org/releases/v6.1.5/sandbox/ | https://sinonjs.org/releases/v8/sandbox/ |


In [API > Other Commands > stub](https://docs.cypress.io/api/commands/stub) the following change is made:

| Current                                      | Corrected                                |
| -------------------------------------------- | ---------------------------------------- |
| https://sinonjs.org/releases/v2.0.0/sandbox/ | https://sinonjs.org/releases/v8/sandbox/ |
