### PR TITLE
Correct anchor link in Preprocessors API

### DIFF
--- a/docs/api/plugins/preprocessors-api.mdx
+++ b/docs/api/plugins/preprocessors-api.mdx
@@ -4,7 +4,7 @@ title: Preprocessors API
 
 A preprocessor is the plugin responsible for preparing a
 [support file](/guides/core-concepts/writing-and-organizing-tests#Support-file)
-or a [test file](/guides/core-concepts/writing-and-organizing-tests#Test-files)
+or a [spec file](/guides/core-concepts/writing-and-organizing-tests#Spec-files)
 for the browser.
 
 A preprocessor could transpile your file from another language (CoffeeScript or


### PR DESCRIPTION
- This PR corrects an anchor link issue in [API > Plugins > Preprocessors](https://docs.cypress.io/api/plugins/preprocessors-api).  Anchor link issues are listed in https://github.com/cypress-io/cypress-documentation/issues/5630.

## Issue

- The anchor link `/guides/core-concepts/writing-and-organizing-tests#Test-files` does not exist

## Changes

In [API > Plugins > Preprocessors](https://docs.cypress.io/api/plugins/preprocessors-api) the following change is made:

| Current                                                         | Corrected                                                                                                                                             |
| --------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
| `/guides/core-concepts/writing-and-organizing-tests#Test-files` | [/guides/core-concepts/writing-and-organizing-tests#Spec-files](https://docs.cypress.io/guides/core-concepts/writing-and-organizing-tests#Spec-files) |

- PR https://github.com/cypress-io/cypress-documentation/pull/4412 changed the name of the heading from "Test files" to "Spec files".
