### PR TITLE
Correct anchor links to CI Provider Examples

### DIFF
--- a/docs/faq/questions/cloud-faq.mdx
+++ b/docs/faq/questions/cloud-faq.mdx
@@ -246,7 +246,7 @@ savings.
 ### <Icon name="angle-right" /> My CI setup is based on Docker, but is very custom. How can I load balance my test runs?
 
 Even if your CI setup is very different from the
-[CI examples we have](/guides/continuous-integration/introduction#Examples) and
+[CI examples we have](/guides/continuous-integration/ci-provider-examples) and
 [run with our sample projects](https://github.com/cypress-io/cypress-example-kitchensink#ci-status),
 you can still take advantage of the test load balancing using Cypress Cloud.
 Find a variable across your containers that is the same for all of them, but is

--- a/docs/guides/references/error-messages.mdx
+++ b/docs/guides/references/error-messages.mdx
@@ -704,7 +704,7 @@ not automatically determine or generate a `ciBuildId`.
 In order to use either of these parameters a `ciBuildId` must be determined.
 
 The `ciBuildId` is automatically detected if you are running Cypress in most
-[CI providers](/guides/continuous-integration/introduction#Examples). Please
+[CI providers](/guides/continuous-integration/ci-provider-examples). Please
 review the
 [natively recognized environment variables](/guides/cloud/smart-orchestration/parallelization#CI-Build-ID-environment-variables-by-provider)
 for your CI provider.


### PR DESCRIPTION
- This PR addresses anchor link issues targeting [Continuous Integration > CI Provider Examples](https://docs.cypress.io/guides/continuous-integration/ci-provider-examples). Link issues are listed in https://github.com/cypress-io/cypress-documentation/issues/5630.

## Issue

In
- [References > Error Messages](https://docs.cypress.io/guides/references/error-messages)
- [FAQ > Cypress Cloud](https://docs.cypress.io/faq/questions/cloud-faq)

the target of the link

- `/guides/continuous-integration/introduction#Examples` does not exist.

## Changes

In
- [References > Error Messages](https://docs.cypress.io/guides/references/error-messages)
- [FAQ > Cypress Cloud](https://docs.cypress.io/faq/questions/cloud-faq)

the following link is changed:

| Current                                                | Corrected                                                                                                                         |
| ------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------- |
| `/guides/continuous-integration/introduction#Examples` | [/guides/continuous-integration/ci-provider-examples](https://docs.cypress.io/guides/continuous-integration/ci-provider-examples) |
