### PR TITLE
Correct anchor link in Configuration (Legacy)

### DIFF
--- a/docs/guides/references/configuration_legacy.mdx
+++ b/docs/guides/references/configuration_legacy.mdx
@@ -26,7 +26,7 @@ results to [Cypress Cloud](https://on.cypress.io/cloud-introduction) the
 
 You can change the configuration file or turn off the use of a configuration
 file by using the
-[`--config-file` flag](/guides/guides/command-line#cypress-open-config-file-lt-config-file-gt).
+[`--config-file` flag](/guides/guides/command-line#cypress-open-config-file-lt-configuration-file-gt).
 
 :::
 


### PR DESCRIPTION
- This PR addresses an anchor link issue in [References > Configuration (Legacy)](https://docs.cypress.io/guides/references/legacy-configuration). Link issues are listed in https://github.com/cypress-io/cypress-documentation/issues/5630.

## Issues

- The target of the link `/guides/guides/command-line#cypress-open-config-file-lt-config-file-gt` differs.

## Changes

In [References > Configuration (Legacy)](https://docs.cypress.io/guides/references/legacy-configuration) the following link is changed:

| Current                                                                  | Corrected                                                                                                                                                                             |
| ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `/guides/guides/command-line#cypress-open-config-file-lt-config-file-gt` | [/guides/guides/command-line#cypress-open-config-file-lt-configuration-file-gt](https://docs.cypress.io/guides/guides/command-line#cypress-open-config-file-lt-configuration-file-gt) |
