### PR TITLE
Correct anchor link in Configuration

### DIFF
--- a/docs/guides/references/configuration.mdx
+++ b/docs/guides/references/configuration.mdx
@@ -10,7 +10,7 @@ If you are on an older version of Cypress that uses `cypress.json`, please see
 the [legacy configuration](/guides/references/legacy-configuration) guide.
 
 For more info on upgrading configuration to Cypress 10, see the
-[migration guide](/guides/references/migration-guide#Migrating-to-Cypress-version-10-0).
+[migration guide](/guides/references/migration-guide#Migrating-to-Cypress-100).
 
 :::
 


### PR DESCRIPTION
- This PR addresses an anchor link issue in [References > Configuration](https://docs.cypress.io/guides/references/configuration). Link issues are listed in https://github.com/cypress-io/cypress-documentation/issues/5630.

## Issues

- The target of the link `/guides/references/migration-guide#Migrating-to-Cypress-version-10-0` differs.

## Changes

In [References > Configuration](https://docs.cypress.io/guides/references/configuration) the following link is changed:

| Current                                                                | Corrected                                                                                                                                         |
| ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
| `/guides/references/migration-guide#Migrating-to-Cypress-version-10-0` | [/guides/references/migration-guide#Migrating-to-Cypress-100](https://docs.cypress.io/guides/references/migration-guide#Migrating-to-Cypress-100) |
