### PR TITLE
Correct anchor links to Folder structure

### DIFF
--- a/docs/guides/tooling/IDE-integration.mdx
+++ b/docs/guides/tooling/IDE-integration.mdx
@@ -179,7 +179,7 @@ regular JavaScript spec files.
 Adding a
 [`tsconfig.json`](http://www.typescriptlang.org/docs/handbook/tsconfig-json.html)
 inside your
-[`cypress` folder](/guides/core-concepts/writing-and-organizing-tests#Folder-Structure)
+[`cypress` folder](/guides/core-concepts/writing-and-organizing-tests#Folder-structure)
 with the following configuration should get intelligent code completion working.
 
 ```json

--- a/docs/guides/tooling/typescript-support.mdx
+++ b/docs/guides/tooling/typescript-support.mdx
@@ -35,7 +35,7 @@ yarn add --dev typescript
 We recommend creating a
 [`tsconfig.json`](http://www.typescriptlang.org/docs/handbook/tsconfig-json.html)
 inside your
-[`cypress` folder](/guides/core-concepts/writing-and-organizing-tests#Folder-Structure)
+[`cypress` folder](/guides/core-concepts/writing-and-organizing-tests#Folder-structure)
 with the following configuration:
 
 ```json


### PR DESCRIPTION
- This PR addresses anchor link issues targeting [Core Concepts > Writing and Organizing Tests > Folder structure](https://docs.cypress.io/guides/core-concepts/writing-and-organizing-tests#Folder-structure). Link issues are listed in https://github.com/cypress-io/cypress-documentation/issues/5630.

## Issue

The target of the link `/guides/core-concepts/writing-and-organizing-tests#Folder-Structure` uses different case on the following pages:

- [Tooling > IDE Integration](https://docs.cypress.io/guides/tooling/IDE-integration)
- [Tooling > TypeScript](https://docs.cypress.io/guides/tooling/typescript-support)

## Changes

In

- [Tooling > IDE Integration](https://docs.cypress.io/guides/tooling/IDE-integration)
- [Tooling > TypeScript](https://docs.cypress.io/guides/tooling/typescript-support)

the following link is changed:

| Current                                                               | Corrected                                                                                                                                                         | Comment        |
| --------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
| `/guides/core-concepts/writing-and-organizing-tests#Folder-Structure` | [/guides/core-concepts/writing-and-organizing-tests#Folder-structure](https://docs.cypress.io/guides/core-concepts/writing-and-organizing-tests#Folder-structure) | Change in case |

- The case of the section heading was previously changed in PR https://github.com/cypress-io/cypress-documentation/pull/3896.
