### PR TITLE
Correct anchor links to Environment variables

### DIFF
--- a/docs/guides/references/configuration.mdx
+++ b/docs/guides/references/configuration.mdx
@@ -436,9 +436,9 @@ highlighted to show where the value has been set via the following ways:
 - Default value
 - [Cypress configuration file](/guides/references/configuration)
 - The
-  [Cypress environment file](/guides/guides/environment-variables#Option-2-cypress-env-json)
+  [Cypress environment file](/guides/guides/environment-variables#Option-2-cypressenvjson)
 - System
-  [environment variables](/guides/guides/environment-variables#Option-3-CYPRESS)
+  [environment variables](/guides/guides/environment-variables#Option-3-CYPRESS_)
 - [Command Line arguments](/guides/guides/command-line)
 - [setupNodeEvents](#setupNodeEvents)
 

--- a/docs/guides/references/configuration_legacy.mdx
+++ b/docs/guides/references/configuration_legacy.mdx
@@ -452,9 +452,9 @@ value has been set via the following ways:
 - Default value
 - The [configuration file](/guides/references/configuration)
 - The
-  [Cypress environment file](/guides/guides/environment-variables#Option-2-cypress-env-json)
+  [Cypress environment file](/guides/guides/environment-variables#Option-2-cypressenvjson)
 - System
-  [environment variables](/guides/guides/environment-variables#Option-3-CYPRESS)
+  [environment variables](/guides/guides/environment-variables#Option-3-CYPRESS_)
 - [Command Line arguments](/guides/guides/command-line)
 - [Plugins file](/api/plugins/configuration-api)
 

--- a/docs/guides/tooling/plugins-guide.mdx
+++ b/docs/guides/tooling/plugins-guide.mdx
@@ -33,7 +33,7 @@ You can [check out the API docs here](/api/plugins/writing-a-plugin).
 With plugins, you can programmatically alter the resolved configuration and
 environment variables that come from the
 [Cypress configuration file](/guides/references/configuration),
-[`cypress.env.json`](/guides/guides/environment-variables#Option-2-cypress-env-json),
+[`cypress.env.json`](/guides/guides/environment-variables#Option-2-cypressenvjson),
 the [command line](/guides/guides/command-line), or system environment
 variables.
 


### PR DESCRIPTION
- This PR addresses anchor link issues targeting [Guides > Environment Variables](https://docs.cypress.io/guides/guides/environment-variables). The link issues are listed in https://github.com/cypress-io/cypress-documentation/issues/5630.

## Issues

The target of the following links differs slightly:

- `/guides/guides/environment-variables#Option-2-cypress-env-json`
- `/guides/guides/environment-variables#Option-3-CYPRESS`

## Changes

On [Guides > Environment Variables](https://docs.cypress.io/guides/guides/environment-variables) the following links are changed:

| Current                                                          | Corrected                                                                                                                                           |
| ---------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
| `/guides/guides/environment-variables#Option-2-cypress-env-json` | [/guides/guides/environment-variables#Option-2-cypressenvjson](https://docs.cypress.io/guides/guides/environment-variables#Option-2-cypressenvjson) |
| `/guides/guides/environment-variables#Option-3-CYPRESS`          | [/guides/guides/environment-variables#Option-3-CYPRESS_](https://docs.cypress.io/guides/guides/environment-variables#Option-3-CYPRESS_)             |
