### PR TITLE
Remove specific Docusaurus 2 version from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Cloud & FAQ found at https://docs.cypress.io.
 
 [![Netlify Status](https://api.netlify.com/api/v1/badges/dbf22ada-b50c-49b0-a933-bf02e87d25d1/deploy-status)](https://app.netlify.com/sites/cypress-docs/deploys)
 
-Our docs are built using [Docusaurus 2](https://docusaurus.io/).
+Our docs are built using [Docusaurus](https://docusaurus.io/).
 
 ### Installation
 


### PR DESCRIPTION
In the [README](https://github.com/cypress-io/cypress-documentation/blob/main/README.md) the tool reference is changed from the outdated "Docusaurus 2" to the version-neutral name "Docusaurus". This corresponds to the documentation link https://docusaurus.io/ which does not specify any version.

- PR https://github.com/cypress-io/cypress-documentation/pull/5601 configured the repo to update from Docusaurus `^2.4.1` to Docusaurus `^3.1.0` already. The repo is currently using  [@docusaurus/core@3.1.1](https://github.com/facebook/docusaurus/releases/tag/v3.1.1).