### PR TITLE
Correct anchor links in FAQ Using Cypress

### DIFF
--- a/docs/faq/questions/using-cypress-faq.mdx
+++ b/docs/faq/questions/using-cypress-faq.mdx
@@ -223,7 +223,7 @@ a remote page and does not resolve until all of the external resources complete
 their loading phase. Because we expect your applications to observe differing
 load times, this command's default timeout is set to 60000ms. If you visit an
 invalid url or a
-[second unique domain](/guides/guides/web-security#Same-superdomain-per-test),
+[second unique domain](/guides/guides/web-security#Different-superdomain-per-test-requires-cyorigin-command),
 Cypress will log a verbose yet friendly error message.
 
 **_In CI, how do I make sure my server has started?_**
@@ -678,7 +678,7 @@ cover everything.
 ### <Icon name="angle-right" /> Is it possible to catch the promise chain in Cypress?
 
 No. You cannot add a `.catch` error handler to a failed command.
-[Read more about how the Cypress commands are not Promises](/guides/core-concepts/introduction-to-cypress#Commands-Are-Not-Promises)
+[Read more about how the Cypress commands are not Promises](/guides/core-concepts/introduction-to-cypress#The-Cypress-Command-Queue)
 
 ### <Icon name="angle-right" /> Is there a way to modify the screenshots/video resolution?
 


### PR DESCRIPTION
- This PR addresses anchor link issues in [FAQ > Using Cypress](https://docs.cypress.io/faq/questions/using-cypress-faq). Link issues are listed in https://github.com/cypress-io/cypress-documentation/issues/5630.

## Issues

The target of the following links do not exist:

- `/guides/guides/web-security#Same-superdomain-per-test`
- `/guides/core-concepts/introduction-to-cypress#Commands-Are-Not-Promises`

## Changes

In [FAQ > Using Cypress](https://docs.cypress.io/faq/questions/using-cypress-faq) the following links are changed:

| Current                                                                   | Corrected                                                                                                                                                                                           |
| ------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `/guides/guides/web-security#Same-superdomain-per-test`                   | [/guides/guides/web-security#Different-superdomain-per-test-requires-cyorigin-command](https://docs.cypress.io/guides/guides/web-security#Different-superdomain-per-test-requires-cyorigin-command) |
| `/guides/core-concepts/introduction-to-cypress#Commands-Are-Not-Promises` | [/guides/core-concepts/introduction-to-cypress#The-Cypress-Command-Queue](https://docs.cypress.io/guides/core-concepts/introduction-to-cypress#The-Cypress-Command-Queue)                           |


The headings were previously changed by the following 2 PRs respectively:

1. https://github.com/cypress-io/cypress-documentation/pull/4853
2. https://github.com/cypress-io/cypress-documentation/pull/4148

