### PR TITLE
Correct link in Plugins Guide

### DIFF
--- a/docs/guides/tooling/plugins-guide.mdx
+++ b/docs/guides/tooling/plugins-guide.mdx
@@ -186,7 +186,7 @@ on('task', {
 :::note
 
 _<Icon name="github" /> Source:
-[cypress/plugins/index.ts](https://github.com/cypress-io/cypress-realworld-app/blob/develop/cypress/plugins/index.ts)_
+[Real World App > cypress.config.ts](https://github.com/cypress-io/cypress-realworld-app/blob/develop/cypress.config.ts)_
 
 :::
 


### PR DESCRIPTION
This PR addresses a link issue in [Tooling > Plugins](https://docs.cypress.io/guides/tooling/plugins-guide).

## Issues

The target of the following link does not exist:

- https://github.com/cypress-io/cypress-realworld-app/blob/develop/cypress/plugins/index.ts

## Changes

In [Tooling > Plugins](https://docs.cypress.io/guides/tooling/plugins-guide) the following link is changed:

| Current                                                                                   | Corrected                                                                                                                                  |
| ----------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
| https://github.com/cypress-io/cypress-realworld-app/blob/develop/cypress/plugins/index.ts | [cypress-io/cypress-realworld-app > cypress.config.ts](https://github.com/cypress-io/cypress-realworld-app/blob/develop/cypress.config.ts) |

- The plugins file was deleted by https://github.com/cypress-io/cypress-realworld-app/pull/1104/files as part of the migration to Cypress `10`, moving the content into `cypress.config.js` which was subsequently converted to `cypress.config.ts` in PR https://github.com/cypress-io/cypress-realworld-app/pull/1381.

