### PR TITLE
Correct anchor link in Changelog 12.0.0

### DIFF
--- a/docs/guides/references/changelog.mdx
+++ b/docs/guides/references/changelog.mdx
@@ -1311,7 +1311,7 @@ Read more about 12.0 in
   disabled, this changes how Cypress cleans up the browser context before each
   test and you may experience test errors with this upgrade. To better
   understand the full impact of this change, please review the
-  [migration guide](/guides/references/migration-guide#test-isolation).
+  [migration guide](/guides/references/migration-guide#Test-Isolation).
   - In Cypress v12, the `testIsolation` configuration values have changed from
     `on` or `off` to `true` or `false`. Addressed in
     [#24935](https://github.com/cypress-io/cypress/pull/24935).


### PR DESCRIPTION
- This PR addresses an anchor link issue in [References > Changelog > 12.0.0](https://docs.cypress.io/guides/references/changelog#12-0-0). Anchor link issues are listed in https://github.com/cypress-io/cypress-documentation/issues/5630.

## Issues

- The anchor link `/guides/references/migration-guide#test-isolation)` does not match the case of the target bookmark.

## Changes

In [References > Changelog > 12.0.0](https://docs.cypress.io/guides/references/changelog#12-0-0) the following link is changed:

| Current                                              | Corrected                                                                                                                     |
| ---------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
| `/guides/references/migration-guide#test-isolation)` | [/guides/references/migration-guide#Test-Isolation](https://docs.cypress.io/guides/references/migration-guide#Test-Isolation) |
