### PR TITLE
Correct anchor link in Changelog 10.9.0

### DIFF
--- a/docs/guides/references/changelog.mdx
+++ b/docs/guides/references/changelog.mdx
@@ -1794,7 +1794,7 @@ _Released 9/27/2022_
 
 - Added support for requiring dependencies within the
   [`cy.origin()`](/api/commands/origin) callback. See the
-  [`cy.origin()`](/api/commands/origin#Dependencies-Sharing-Code) docs for more
+  [`cy.origin()`](/api/commands/origin#Dependencies--Sharing-Code) docs for more
   information.
 - Added support for visiting cross-origin pages outside of a
   [`cy.origin()`](/api/commands/origin) callback. See the


### PR DESCRIPTION
- This PR addresses an anchor link issue in [References > Changelog > 10.9.0](https://docs.cypress.io/guides/references/changelog#10.9.0). Anchor link issues are listed in https://github.com/cypress-io/cypress-documentation/issues/5630.

## Issues

The following anchor link does not match the corresponding target bookmark:

- `/api/commands/origin#Dependencies-Sharing-Code`

## Changes

In [References > Changelog > 10.9.0](https://docs.cypress.io/guides/references/changelog#10.9.0) the following link is changed:

| Current                                          | Corrected                                                                                                                 |
| ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------- |
| `/api/commands/origin#Dependencies-Sharing-Code` | [/api/commands/origin#Dependencies--Sharing-Code](https://docs.cypress.io/api/commands/origin#Dependencies--Sharing-Code) |
