### PR TITLE
Correct anchor link in Changelog 9.5.2

### DIFF
--- a/docs/guides/references/changelog.mdx
+++ b/docs/guides/references/changelog.mdx
@@ -3130,7 +3130,7 @@ _Released 3/14/2022_
   browser. Fixes [#20496](https://github.com/cypress-io/cypress/issues/20496).
 - Updates were made to the pre-release build setup such that Cypress will use a
   unique cache folder for each
-  [pre-release installation](/guides/getting-started/installing-cypress#Install-pre-release-version)
+  [pre-release installation](/guides/references/advanced-installation#Install-pre-release-version)
   on a machine. This removes the need to run `cypress clear cache` before
   installing a new pre-release version of Cypress or before installing a new
   released version of Cypress after a pre-release version had been installed.


### PR DESCRIPTION
- This PR addresses an anchor link issue in [References > Changelog > 9.5.2](https://docs.cypress.io/guides/references/changelog#9-5-2). Anchor link issues are listed in https://github.com/cypress-io/cypress-documentation/issues/5630.

## Issues

The following anchor link does not match the corresponding target bookmark:

- `/guides/getting-started/installing-cypress#Install-pre-release-version`

## Changes

In [References > Changelog > 9.5.2](https://docs.cypress.io/guides/references/changelog#9-5-2) the following links are changed:

| Current                                                                  | Corrected                                                                                                                                                           |
| ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `/guides/getting-started/installing-cypress#Install-pre-release-version` | [/guides/references/advanced-installation#Install-pre-release-version](https://docs.cypress.io/guides/references/advanced-installation#Install-pre-release-version) |
