### PR TITLE
Correct anchor link in Changelog 9.3.0

### DIFF
--- a/docs/guides/references/changelog.mdx
+++ b/docs/guides/references/changelog.mdx
@@ -3307,7 +3307,7 @@ _Released 1/18/2022_
   This environment variable is useful for users who are downloading the Cypress
   binary from a proxy that is not one-to-one with the Cypress's default download
   url. More information can be found in the
-  [Install Binary](/guides/getting-started/installing-cypress#Install-binary)
+  [Install Binary](/guides/references/advanced-installation#Install-binary)
   documentation. Fixes
   [#15697](https://github.com/cypress-io/cypress/issues/15697).
 


### PR DESCRIPTION
- This PR addresses an anchor link issue in [References > Changelog > 9.3.0](https://docs.cypress.io/guides/references/changelog#9-3-0). Anchor link issues are listed in https://github.com/cypress-io/cypress-documentation/issues/5630.

## Issues

The following anchor link does not match the corresponding target bookmark:

- `/guides/getting-started/installing-cypress#Install-binary`

## Changes

In [References > Changelog > 9.3.0](https://docs.cypress.io/guides/references/changelog#9-3-0) the following link is changed:

| Current                                                     | Corrected                                                                                                                                 |
| ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
| `/guides/getting-started/installing-cypress#Install-binary` | [/guides/references/advanced-installation#Install-binary](https://docs.cypress.io/guides/references/advanced-installation#Install-binary) |
