### PR TITLE
Correct anchor link in Changelog 7.3.0

### DIFF
--- a/docs/guides/references/changelog.mdx
+++ b/docs/guides/references/changelog.mdx
@@ -4207,7 +4207,7 @@ _Released 05/10/2021_
   logs. Addresses [#16236](https://github.com/cypress-io/cypress/issues/16236).
 - Cypress can now use the certificate authority specified in NPM config if
   `CYPRESS_DOWNLOAD_USE_CA` is specified. See
-  ["Using a custom CA"](/guides/getting-started/installing-cypress#Using-a-custom-CA)
+  ["Using a custom CA"](/guides/references/advanced-installation#Using-a-custom-certificate-authority-CA)
   for more information. Addresses
   [#8825](https://github.com/cypress-io/cypress/issues/8825).
 


### PR DESCRIPTION
- This PR addresses an anchor link issue in [References > Changelog > 7.3.0](https://docs.cypress.io/guides/references/changelog#7-3-0). Anchor link issues are listed in https://github.com/cypress-io/cypress-documentation/issues/5630.

## Issues

The following anchor link does not match the corresponding target bookmark:

- `/guides/getting-started/installing-cypress#Using-a-custom-CA`

## Changes

In [References > Changelog > 7.3.0](https://docs.cypress.io/guides/references/changelog#7-3-0) the following link is changed:

| Current                                                     | Corrected                                                                                                                                 |
| ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
| `/guides/getting-started/installing-cypress#Using-a-custom-CA` | [/guides/references/advanced-installation#Using-a-custom-certificate-authority-CA](https://docs.cypress.io/guides/references/advanced-installation#Using-a-custom-certificate-authority-CA) |
