### PR TITLE
Correct anchor link in Changelog 7.0.0

### DIFF
--- a/docs/guides/references/changelog.mdx
+++ b/docs/guides/references/changelog.mdx
@@ -4504,7 +4504,7 @@ to Cypress 7.0.**
   [#8714](https://github.com/cypress-io/cypress/issues/8714).
 - The bundled Node.js version was upgraded from `12.18.3` to `14.16.0`. This
   could change the behavior of code within the `pluginsFile` when using the
-  [bundled Node.js version](/guides/references/configuration#Node-version) of
+  [bundled Node.js version](/guides/references/legacy-configuration#Node-version) of
   Cypress. Addressed in
   [#15292](https://github.com/cypress-io/cypress/pull/15292).
 - Installing Cypress on your system now requires Node.js 12+. Addresses


### PR DESCRIPTION
- This PR addresses an anchor link issue in [References > Changelog > 7.0.0](https://docs.cypress.io/guides/references/changelog#7-0-0). Anchor link issues are listed in https://github.com/cypress-io/cypress-documentation/issues/5630.

## Issues

The target bookmark for the following anchor link does not exist:

- `/guides/references/configuration#Node-version`

## Changes

In [References > Changelog > 7.0.0](https://docs.cypress.io/guides/references/changelog#7-0-0) the following link is changed:

| Current                                                     | Corrected                                                                                                                                 |
| ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
| `/guides/references/configuration#Node-version` | [/guides/references/legacy-configuration#Node-version](https://docs.cypress.io/guides/references/legacy-configuration#Node-version) |