### PR TITLE
Correct anchor link in Changelog 6.0.0

### DIFF
--- a/docs/guides/references/changelog.mdx
+++ b/docs/guides/references/changelog.mdx
@@ -5173,7 +5173,7 @@ Cypress now offers full network stubbing support with the introduction of the
 [cy.intercept()](/api/commands/intercept) command (previously `cy.route2()`).
 With [cy.intercept()](/api/commands/intercept) your tests can intercept, modify
 and wait on any type of HTTP request originating from your app. See our guide on
-[Migrating `cy.route()` to `cy.intercept()`](/guides/references/migration-guide#Migrating-cy-route-to-cy-intercept).
+[Migrating `cy.route()` to `cy.intercept()`](/guides/references/migration-guide#Migrating-cyroute-to-cyintercept).
 
 **Breaking Changes:**
 
@@ -5226,7 +5226,7 @@ deprecations.
 - `cy.server()` and `cy.route()` have been deprecated. In a future release,
   support for `cy.server()` and `cy.route()` will be removed. We encourage you
   to use [cy.intercept()](/api/commands/intercept) instead. See our guide on
-  [Migrating `cy.route()` to `cy.intercept()`](/guides/references/migration-guide#Migrating-cy-route-to-cy-intercept).
+  [Migrating `cy.route()` to `cy.intercept()`](/guides/references/migration-guide#Migrating-cyroute-to-cyintercept).
   Addressed in [#9185](https://github.com/cypress-io/cypress/pull/9185).
 - `experimentalFetchPolyfill` has been deprecated. We encourage you to use
   [cy.intercept()](/api/commands/intercept) to intercept requests using the


### PR DESCRIPTION
- This PR addresses an anchor link issue in [References > Changelog > 6.0.0](https://docs.cypress.io/guides/references/changelog#6-0-0). Anchor link issues are listed in https://github.com/cypress-io/cypress-documentation/issues/5630.

## Issues

The target bookmark for the following anchor link does not match:

- `/guides/references/migration-guide#Migrating-cy-route-to-cy-intercept`

## Changes

In [References > Changelog > 6.0.0](https://docs.cypress.io/guides/references/changelog#6-0-0) the following link is changed:

| Current                                                     | Corrected                                                                                                                                 |
| ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
| `/guides/references/migration-guide#Migrating-cy-route-to-cy-intercept` | [/guides/references/migration-guide#Migrating-cyroute-to-cyintercept](https://docs.cypress.io/guides/references/migration-guide#Migrating-cyroute-to-cyintercept) |
