### PR TITLE
Remove "Run filtered specs" anchor link from Changelog 4.12.0

### DIFF
--- a/docs/guides/references/changelog.mdx
+++ b/docs/guides/references/changelog.mdx
@@ -5955,7 +5955,7 @@ _Released 8/3/2020_
   allow plugins to better target specific Cypress versions. Addresses
   [#6352](https://github.com/cypress-io/cypress/issues/6352).
 - During `cypress open`, you can now run a subset of all specs by
-  [entering a text search filter and clicking 'Run n tests'](/guides/core-concepts/writing-and-organizing-tests#Run-filtered-specs).
+  entering a text search filter and clicking 'Run n tests'
   Addresses [#6581](https://github.com/cypress-io/cypress/issues/6581).
 
 **Bugfixes:**


### PR DESCRIPTION
- This PR addresses an anchor link issue in the [References > Changelog > 4.12.0](https://docs.cypress.io/guides/references/changelog#4-12-0) section which refers to "Run filtered specs". This functionality was introduced and later withdrawn. Anchor link issues are listed in https://github.com/cypress-io/cypress-documentation/issues/5630.

## Issues

In the [References > Changelog > 4.12.0](https://docs.cypress.io/guides/references/changelog#4-12-0) section, the target bookmark for the following anchor link does not exist:

- `/guides/core-concepts/writing-and-organizing-tests#Run-filtered-specs`


## Changes

In [References > Changelog > 4.12.0](https://docs.cypress.io/guides/references/changelog#4-12-0) the following link is removed:

| Current                                                               | Corrected |
| --------------------------------------------------------------------- | --------- |
| /guides/core-concepts/writing-and-organizing-tests#Run-filtered-specs | removed   |

Filtered "Run n tests" are not currently available.

The [experimental E2E](https://docs.cypress.io/guides/references/experiments#End-to-End-Testing) option `experimentalRunAllSpecs` does not offer a filter functionality.