### PR TITLE
Correct anchor link in Changelog 4.11.0

### DIFF
--- a/docs/guides/references/changelog.mdx
+++ b/docs/guides/references/changelog.mdx
@@ -6052,7 +6052,7 @@ _Released 7/21/2020_
   longer throw an `invalid for option "size"` error. Fixes
   [#6099](https://github.com/cypress-io/cypress/issues/6099).
 - Setting `viewportHeight` or `viewportWidth` from within the
-  [test configuration](/guides/core-concepts/writing-and-organizing-tests#test-configuration)
+  [test configuration](/guides/core-concepts/writing-and-organizing-tests#Test-Configuration)
   now properly changes the viewport size for the duration of the suite or test.
 - Setting deep objects and arrays on `config` within the `pluginsFile` now sets
   the values correctly. Fixes


### PR DESCRIPTION
- This PR addresses an anchor link issue in [References > Changelog > 4.11.0](https://docs.cypress.io/guides/references/changelog#4-11-0). Anchor link issues are listed in https://github.com/cypress-io/cypress-documentation/issues/5630.

## Issues

The target bookmark for the following anchor link does not match:

- `/guides/core-concepts/writing-and-organizing-tests#test-configuration`

## Changes

In [References > Changelog > 4.11.0](https://docs.cypress.io/guides/references/changelog#4-11-0) the following link is changed:

| Current                                                     | Corrected                                                                                                                                 |
| ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
| `/guides/core-concepts/writing-and-organizing-tests#test-configuration` | [/guides/core-concepts/writing-and-organizing-tests#Test-Configuration](https://docs.cypress.io/guides/core-concepts/writing-and-organizing-tests#Test-Configuration) |
