### PR TITLE
Correct anchor link in Changelog 3.8.1

### DIFF
--- a/docs/guides/references/changelog.mdx
+++ b/docs/guides/references/changelog.mdx
@@ -7269,7 +7269,7 @@ _Released 12/26/2019_
 **Bugfixes:**
 
 - We fixed a bug where
-  [cypress run --headless](/guides/guides/command-line#cypress-run-headless)
+  [cypress run --headless](/guides/guides/command-line#Options)
   would not run Chrome-family browsers headlessly. Fixes
   [#5949](https://github.com/cypress-io/cypress/issues/5949).
 - We fixed an issue where, on some systems with IPv4 and IPv6 enabled, Cypress


### PR DESCRIPTION
- This PR addresses an anchor link issue in [References > Changelog > 3.8.1](https://docs.cypress.io/guides/references/changelog#3-8-1). Anchor link issues are listed in https://github.com/cypress-io/cypress-documentation/issues/5630.

## Issues

The target bookmark for the following anchor link does not exist:

- `/guides/guides/command-line#cypress-run-headless`

## Changes

In [References > Changelog > 3.8.1](https://docs.cypress.io/guides/references/changelog#3-8-1) the following link is changed:

| Current                                            | Corrected                                                                                         |
| -------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
| `/guides/guides/command-line#cypress-run-headless` | [/guides/guides/command-line#Options](https://docs.cypress.io/guides/guides/command-line#Options) |

- Headless is the default run mode since [Cypress 8.0.0](https://docs.cypress.io/guides/references/changelog#8-0-0) and the specific example heading `cypress run --headless` was removed by PR https://github.com/cypress-io/cypress-documentation/pull/4012.
