### PR TITLE
Correct anchor link in Changelog 3.5.0

### DIFF
--- a/docs/guides/references/changelog.mdx
+++ b/docs/guides/references/changelog.mdx
@@ -7930,7 +7930,7 @@ _Released 10/23/2019_
   doc.
 - Added a section to our Debugging doc about our `cypress-fiddle` plugin used
   for playing around with small test cases.
-- Added a section to our [Debugging](/guides/guides/debugging#Patch-Cypress) doc
+- Added a section to our [Debugging](/guides/references/troubleshooting#Patch-Cypress) doc
   explaining how to patch an installed version of Cypress.
 - Mention not needing to decode portions of the `url` in the `cy.route()` doc.
 - Mention that the `file://` prefix is not supported in the


### PR DESCRIPTION
- This PR addresses an anchor link issue in [References > Changelog > 3.5.0](https://docs.cypress.io/guides/references/changelog#3-5-0). Anchor link issues are listed in https://github.com/cypress-io/cypress-documentation/issues/5630.

## Issues

The target bookmark for the following anchor link does not exist:

- `/guides/guides/debugging#Patch-Cypress`

## Changes

In [References > Changelog > 3.5.0](https://docs.cypress.io/guides/references/changelog#3-5-0) the following link is changed:

| Current                                            | Corrected                                                                                         |
| -------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
| `/guides/guides/debugging#Patch-Cypress` | [/guides/references/troubleshooting#Patch-Cypress](https://docs.cypress.io/guides/references/troubleshooting#Patch-Cypress) |
