### PR TITLE
Correct anchor link in Changelog 3.4.1

### DIFF
--- a/docs/guides/references/changelog.mdx
+++ b/docs/guides/references/changelog.mdx
@@ -8069,7 +8069,7 @@ _Released 7/29/2019_
   [GitHub Integration](/guides/cloud/integrations/source-control/github) with
   the Cypress Dashboard.
 - Updated instructions for adding types for custom commands in the
-  [TypeScript Support](/guides/tooling/typescript-support#Types-for-custom-commands)
+  [TypeScript Support](/guides/tooling/typescript-support#Types-for-Custom-Commands)
   doc. Addressed in
   [#1901](https://github.com/cypress-io/cypress-documentation/pull/1901)
 - Added a section about video encoding and how to speed up the encoding time to


### PR DESCRIPTION
- This PR addresses an anchor link issue in [References > Changelog > 3.4.1](https://docs.cypress.io/guides/references/changelog#3-4-1). Anchor link issues are listed in https://github.com/cypress-io/cypress-documentation/issues/5630.

## Issues

The target bookmark for the following anchor link does not match exactly:

- `/guides/tooling/typescript-support#Types-for-custom-commands`

## Changes

In [References > Changelog > 3.4.1](https://docs.cypress.io/guides/references/changelog#3-4-1) the following link is changed:

| Current                                                        | Corrected                                                                                                                                           |
| -------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
| `/guides/tooling/typescript-support#Types-for-custom-commands` | [/guides/tooling/typescript-support#Types-for-Custom-Commands](https://docs.cypress.io/guides/tooling/typescript-support#Types-for-Custom-Commands) |

