### PR TITLE
Correct anchor links in Changelog 3.3.2

### DIFF
--- a/docs/guides/references/changelog.mdx
+++ b/docs/guides/references/changelog.mdx
@@ -8358,11 +8358,11 @@ _Released 6/27/2019_
   teach end-to-end testing with Cypress. Addressed in
   [#1766](https://github.com/cypress-io/cypress-documentation/pull/1766).
 - Added a section about
-  [Hacking on Cypress](/guides/guides/debugging#Hacking-on-Cypress) in the
+  [Hacking on Cypress](/guides/references/troubleshooting#Hacking-on-Cypress) in the
   Debugging doc. Addressed in
   [#1783](https://github.com/cypress-io/cypress-documentation/pull/1783).
 - Added a section on how to
-  [opt out of sending exception data to Cypress](/guides/getting-started/installing-cypress#Opt-out-of-sending-exception-data-to-Cypress)
+  [opt out of sending exception data to Cypress](/guides/references/advanced-installation#Opt-out-of-sending-exception-data-to-Cypress)
   in the Installing Cypress doc.
 
 **Dependency Updates**


### PR DESCRIPTION
- This PR addresses anchor link issues in [References > Changelog > 3.3.2](https://docs.cypress.io/guides/references/changelog#3-3-2). Anchor link issues are listed in https://github.com/cypress-io/cypress-documentation/issues/5630.

## Issues

The target bookmarks for the following anchor links do not exist:

- `/guides/guides/debugging#Hacking-on-Cypress`
- `/guides/getting-started/installing-cypress#Opt-out-of-sending-exception-data-to-Cypress`

## Changes

In [References > Changelog > 3.3.2](https://docs.cypress.io/guides/references/changelog#3-3-2) the following links are changed:

| Current                                                                                   | Corrected                                                                                                                                                                                             |
| ----------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `/guides/guides/debugging#Hacking-on-Cypress`                                             | [/guides/references/troubleshooting#Hacking-on-Cypress](https://docs.cypress.io/guides/references/troubleshooting#Hacking-on-Cypress)                                                                 |
| `/guides/getting-started/installing-cypress#Opt-out-of-sending-exception-data-to-Cypress` | [/guides/references/advanced-installation#Opt-out-of-sending-exception-data-to-Cypress](https://docs.cypress.io/guides/references/advanced-installation#Opt-out-of-sending-exception-data-to-Cypress) |