### PR TITLE
Correct anchor link in Changelog 3.3.0

### DIFF
--- a/docs/guides/references/changelog.mdx
+++ b/docs/guides/references/changelog.mdx
@@ -8669,7 +8669,7 @@ _Released 5/17/2019_
 - Added new options `retryOnStatusCodeFailure` and `retryOnNetworkFailure` to
   [cy.visit()](/api/commands/visit) and [cy.request()](/api/commands/request).
 - Updated
-  [install instructions for Windows](/guides/getting-started/installing-cypress#Download-URLs)
+  [install instructions for Windows](/guides/references/advanced-installation#Download-URLs)
   on how to target 64bit and 32bit infrastructures. Addressed in
   [#1568](https://github.com/cypress-io/cypress-documentation/issues/1568).
 - Updated [.its()](/api/commands/its) and [.invoke()](/api/commands/invoke) docs


### PR DESCRIPTION
- This PR addresses an anchor link issue in [References > Changelog > 3.3.0](https://docs.cypress.io/guides/references/changelog#3-3-0). Anchor link issues are listed in https://github.com/cypress-io/cypress-documentation/issues/5630.

## Issues

The target bookmark for the following anchor link does not exist:

- `/guides/getting-started/installing-cypress#Download-URLs`

## Changes

In [References > Changelog > 3.3.0](https://docs.cypress.io/guides/references/changelog#3-3-0) the following link is changed:

| Current                                                    | Corrected                                                                                                                               |
| ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
| `/guides/getting-started/installing-cypress#Download-URLs` | [/guides/references/advanced-installation#Download-URLs](https://docs.cypress.io/guides/references/advanced-installation#Download-URLs) |