### PR TITLE
Correct anchor link in Changelog 3.2.0

### DIFF
--- a/docs/guides/references/changelog.mdx
+++ b/docs/guides/references/changelog.mdx
@@ -8754,7 +8754,7 @@ _Released 3/15/2019_
 - The
   [`--browser` argument](/guides/guides/command-line#cypress-run-browser-lt-browser-name-or-path-gt)
   of the [Command Line](/guides/guides/command-line) and the
-  [`browser` argument](/guides/guides/module-api#cypress-run) of the
+  [`browser` argument](/guides/guides/module-api#cypressrun) of the
   [Module API](/guides/guides/module-api) have been updated to allow passing a
   `<path>`. Addresses
   [#1026](https://github.com/cypress-io/cypress/issues/1026).


### PR DESCRIPTION
- This PR addresses an anchor link issue in [References > Changelog > 3.2.0](https://docs.cypress.io/guides/references/changelog#3-2-0). Anchor link issues are listed in https://github.com/cypress-io/cypress-documentation/issues/5630.

## Issues

The target bookmark for the following anchor link does not match exactly:

- `/guides/guides/module-api#cypress-run`

## Changes

In [References > Changelog > 3.2.0](https://docs.cypress.io/guides/references/changelog#3-2-0) the following link is changed:

| Current                                 | Corrected                                                                                           |
| --------------------------------------- | --------------------------------------------------------------------------------------------------- |
| `/guides/guides/module-api#cypress-run` | [/guides/guides/module-api#cypressrun](https://docs.cypress.io/guides/guides/module-api#cypressrun) |