### PR TITLE
Correct Changelog anchor links for installing Cypress

### DIFF
--- a/docs/guides/references/changelog.mdx
+++ b/docs/guides/references/changelog.mdx
@@ -9218,7 +9218,7 @@ _Released 11/2/2018_
   The [following flags](https://nodejs.org/api/fs.html#fs_file_system_flags) are
   available. Fixes [#1249](https://github.com/cypress-io/cypress/issues/1249).
 - There is a new
-  [CYPRESS_DOWNLOAD_MIRROR](/guides/getting-started/installing-cypress#Mirroring)
+  [CYPRESS_DOWNLOAD_MIRROR](/guides/references/advanced-installation#Mirroring)
   environment variable for installing Cypress at a mirror url. Fixes
   [#2609](https://github.com/cypress-io/cypress/pull/2609).
 - The [Module API](/guides/guides/module-api) now returns the `runUrl` from
@@ -9325,7 +9325,7 @@ _Released 11/2/2018_
 - Added `runUrl` to returned run in [Module API doc](/guides/guides/module-api).
 - Documented new `CYPRESS_DOWNLOAD_MIRROR` flag and rewrote advanced install
   instructions to be clearer in
-  [Installing Cypress doc](/guides/getting-started/installing-cypress#Advanced).
+  [Installing Cypress doc](/guides/references/advanced-installation).
 
 **Dependency Updates**
 
@@ -10696,7 +10696,7 @@ _Released 10/29/2017_
 - The branch name is now properly collected when recording in Buildkite CI.
   Fixes [#777](https://github.com/cypress-io/cypress/issues/777).
 - You can install the Cypress binary from any URL or file path using the
-  [`CYPRESS_BINARY_VERSION` environment variable](/guides/getting-started/installing-cypress#Advanced).
+  [`CYPRESS_BINARY_VERSION` environment variable](/guides/references/advanced-installation).
   Closes [#701](https://github.com/cypress-io/cypress/issues/701).
 
 **Documentation Changes:**


### PR DESCRIPTION
- This PR addresses anchor link issues in [References > Changelog](https://docs.cypress.io/guides/references/changelog) referring to installing Cypress moved content. Anchor link issues are listed in https://github.com/cypress-io/cypress-documentation/issues/5630.

## Issues

The target bookmarks for the following anchor links do not exist:

- `/guides/getting-started/installing-cypress#Mirroring`
- `/guides/getting-started/installing-cypress#Advanced`


## Changes

In
- [References > Changelog > 3.1.1](https://docs.cypress.io/guides/references/changelog#3-1-1)
- [References > Changelog > 1.0.3](https://docs.cypress.io/guides/references/changelog#1-0-3)

the following links are changed:

| Current                                                | Corrected                                                                                                                       |
| ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------- |
| `/guides/getting-started/installing-cypress#Mirroring` | [/guides/references/advanced-installation#Mirroring](https://docs.cypress.io/guides/references/advanced-installation#Mirroring) |
| `/guides/getting-started/installing-cypress#Advanced`  | [/guides/references/advanced-installation](https://docs.cypress.io/guides/references/advanced-installation)                     |