### PR TITLE
Remove dead anchor link in API cy.origin() to Trade-offs / Multiple tabs

### DIFF
--- a/docs/api/commands/origin.mdx
+++ b/docs/api/commands/origin.mdx
@@ -528,8 +528,7 @@ There are other testing scenarios which are not currently covered by
 
 - It cannot run commands
   [in a different browser window](/guides/references/trade-offs#Multiple-browsers-open-at-the-same-time)
-- It cannot run commands
-  [in a different browser tab](/guides/references/trade-offs#Multiple-tabs)
+- It cannot run commands in a different browser tab
 - It cannot run commands
   [inside an `<iframe>` element](/faq/questions/using-cypress-faq#How-do-I-test-elements-inside-an-iframe)
 


### PR DESCRIPTION
- Closes #5685. This PR corrects an anchor link issue in [API > Other Commands > origin](https://docs.cypress.io/api/commands/origin).  General anchor link issues are listed in https://github.com/cypress-io/cypress-documentation/issues/5630.

## Issue

- The target of the anchor link `/guides/references/trade-offs#Multiple-tabs` does not exist.

## Changes

In [API > Other Commands > origin](https://docs.cypress.io/api/commands/origin) the following change is made:

| Current                                       | Corrected |
| --------------------------------------------- | --------- |
| `/guides/references/trade-offs#Multiple-tabs` | removed   |

- The statement that `cy.origin()` cannot run commands in a different browser tab remains true according to confirmation in https://github.com/cypress-io/cypress-documentation/issues/5685#issuecomment-1957331163, however there is no specific text available on the docs site to explain this.
