### PR TITLE
Correct anchor link in Changelog 13.4.0

### DIFF
--- a/docs/guides/references/changelog.mdx
+++ b/docs/guides/references/changelog.mdx
@@ -182,7 +182,7 @@ _Released 10/30/2023_
 
 **Features:**
 
-- Introduced experimental configuration options for advanced retry logic: adds `experimentalStrategy` and `experimentalOptions` keys to the `retry` configuration key. See [Experimental Flake Detection Features](/guides/references/experiments/#Experimental-Flake-Detection-Features) for more information. Addressed in [#27930](https://github.com/cypress-io/cypress/pull/27930).
+- Introduced experimental configuration options for advanced retry logic: adds `experimentalStrategy` and `experimentalOptions` keys to the `retry` configuration key. See [Experimental Flake Detection Features](/guides/references/experiments#Experimental-Flake-Detection-Features) for more information. Addressed in [#27930](https://github.com/cypress-io/cypress/pull/27930).
 
 **Bugfixes:**
 


### PR DESCRIPTION
- This PR addresses an anchor link issue in [References > Changelog > 13.4.0](https://docs.cypress.io/guides/references/changelog#13-4-0). Anchor link issues are listed in https://github.com/cypress-io/cypress-documentation/issues/5630.

## Issues

The target bookmark for the following anchor link was flagged as an anchor link error by Docusaurus, although in practice the link works:

- [/guides/references/experiments/#Experimental-Flake-Detection-Features](https://docs.cypress.io/guides/references/experiments/#Experimental-Flake-Detection-Features)

## Changes

In [References > Changelog > 13.4.0](https://docs.cypress.io/guides/references/changelog#13-4-0) the following link is changed:

| Current                                                                                                                                                               | Corrected                                                                                                                                                           |
| --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| [/guides/references/experiments/#Experimental-Flake-Detection-Features](https://docs.cypress.io/guides/references/experiments/#Experimental-Flake-Detection-Features) | [/guides/references/experiments#Experimental-Flake-Detection-Features](https://docs.cypress.io/guides/references/experiments#Experimental-Flake-Detection-Features) |


The `/` before the HTML fragment is removed.

## Verification

```shell
npm run build
```

Ensure that Docusaurus no longer reports `#Experimental-Flake-Detection-Features` as an anchor link error.
