### PR TITLE
Correct anchor link in Changelog 1.2.0

### DIFF
--- a/docs/guides/references/changelog.mdx
+++ b/docs/guides/references/changelog.mdx
@@ -10447,7 +10447,7 @@ _Released 12/14/2017_
 
 - Renamed `environmentVariables` to `env` in the Desktop GUI. Fixes
   [#1052](https://github.com/cypress-io/cypress/issues/1052).
-- [Cypress.config()](/guides/references/configuration#Cypress-config) now
+- [Cypress.config()](/api/cypress-api/config) now
   returns a complete set of configuration values. Fixes
   [#509](https://github.com/cypress-io/cypress/issues/509).
 - Added TypeScript typings for bundled Cypress tools like `$`, `_`, etc. Fixes


### PR DESCRIPTION
- This PR addresses an anchor link issue in [References > Changelog > 1.2.0](https://docs.cypress.io/guides/references/changelog#1-2-0). Anchor link issues are listed in https://github.com/cypress-io/cypress-documentation/issues/5630.

## Issues

The target bookmark for the following anchor link referring to `Cypress.config()` does not exist:

- `/guides/references/configuration#Cypress-config`

## Changes

In [References > Changelog > 1.2.0](https://docs.cypress.io/guides/references/changelog#1-2-0) the following link is changed:

| Current                                           | Corrected                                                                 |
| ------------------------------------------------- | ------------------------------------------------------------------------- |
| `/guides/references/configuration#Cypress-config` | [/api/cypress-api/config](https://docs.cypress.io/api/cypress-api/config) |
