### PR TITLE
Correct anchor links in Changelog 0.20.0

### DIFF
--- a/docs/guides/references/changelog.mdx
+++ b/docs/guides/references/changelog.mdx
@@ -11028,11 +11028,11 @@ _Released 09/10/2017_
   [#519](https://github.com/cypress-io/cypress/issues/519).
 - Input ranges are now more easily testable using the new
   [.trigger()](/api/commands/trigger) command. See our
-  [new recipe](/examples/recipes#Form-Interactions) for details on how. Fixes
+  [new recipe](/examples/recipes#Testing-the-DOM) for details on how. Fixes
   [#287](https://github.com/cypress-io/cypress/issues/287).
 - Testing drag and drop is now possible using the new
   [.trigger()](/api/commands/trigger) command. See our
-  [new recipe](/examples/recipes#Form-Interactions) for details on how. Fixes
+  [new recipe](/examples/recipes#Testing-the-DOM) for details on how. Fixes
   [#386](https://github.com/cypress-io/cypress/issues/386).
 - Updated [.click()](/api/commands/click) command to accept more position
   arguments. Fixes [#499](https://github.com/cypress-io/cypress/issues/499).
@@ -11077,9 +11077,7 @@ _Released 09/10/2017_
   to
   [check an element's actionability](/guides/core-concepts/interacting-with-elements#Actionability).
   Fixes [#569](https://github.com/cypress-io/cypress/issues/569).
-- Using
-  [Chai.js's `assert` interface](/guides/references/assertions#TDD-Assertions)
-  now works correctly in your specs.
+- Using Chai.js's `assert` interface now works correctly in your specs.
 - Screenshots are now taken during each runnable that fails. Errors in tests
   will happen there. Errors in hooks will also happen there. Previously a
   screenshot would only happen after everything (including hooks) ran. Fixes
@@ -11101,7 +11099,7 @@ _Released 09/10/2017_
   version `2.9.25` to `3.5.0`
 - Updated [chai](/guides/references/bundled-libraries#Chai) from version `1.9.2`
   to `3.5.0`
-- Updated [sinon](/guides/references/bundled-libraries#Sinon-JS) from version
+- Updated [sinon](/guides/references/bundled-libraries#Sinonjs) from version
   `1.x` to `3.2.0`
 - Updated [jQuery](/api/utilities/$) from version `2.1.4` to `2.2.4`.
 - Removed [chai-jQuery](/guides/references/bundled-libraries#Chai-jQuery) and


### PR DESCRIPTION
- This PR addresses anchor link issues in [References > Changelog > 0.20.0](https://docs.cypress.io/guides/references/changelog#0-20-0). Anchor link issues are listed in https://github.com/cypress-io/cypress-documentation/issues/5630.

## Issues

The target bookmarks for the following anchor links do not exist:

- `/examples/recipes#Form-Interactions`
- `/guides/references/assertions#TDD-Assertions`
- `/guides/references/bundled-libraries#Sinon-JS`

## Changes

In [References > Changelog > 0.20.0](https://docs.cypress.io/guides/references/changelog#0-20-0) the following links are changed:

| Current                                         | Corrected                                                                                                           |
| ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
| `/examples/recipes#Form-Interactions`           | [/examples/recipes#Testing-the-DOM](https://docs.cypress.io/examples/recipes#Testing-the-DOM)                       |
| `/guides/references/assertions#TDD-Assertions`  | removed                                                                                                             |
| `/guides/references/bundled-libraries#Sinon-JS` | [/guides/references/bundled-libraries#Sinonjs](https://docs.cypress.io/guides/references/bundled-libraries#Sinonjs) |

## Notes

- The use of input ranges is shown in [Testing the DOM](https://docs.cypress.io/examples/recipes#Testing-the-DOM), example [Form Interactions](https://github.com/cypress-io/cypress-example-recipes/blob/master/examples/testing-dom__form-interactions) "Test form elements like input type range"
- Drag and drop is shown in [Testing the DOM](https://docs.cypress.io/examples/recipes#Testing-the-DOM), example [Drag and Drop](https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/testing-dom__drag-drop) "Use `.trigger()` to test drag and drop"
- The section "TDD Assertions" was removed by PR https://github.com/cypress-io/cypress-documentation/pull/5080, with the remark "Removed the TDD style assertions list. We do not use it anywhere in our own codebase, and we have no tests around it. It also doesn't work with .should() / .and(), which is how we recommend users write tests."
