### PR TITLE
Correct anchor links in Changelog 0.18.0

### DIFF
--- a/docs/guides/references/changelog.mdx
+++ b/docs/guides/references/changelog.mdx
@@ -11817,8 +11817,8 @@ _Released 11/27/2016_
 **Breaking Changes:**
 
 - Previously, we auto-magically included all files within
-  [`cypress/support`](/guides/core-concepts/writing-and-organizing-tests#Folder-Structure).
-  This has now [gone away](/guides/references/error-messages) and we've
+  [`cypress/support`](/guides/references/legacy-configuration#Folders--Files).
+  This has now [gone away](/guides/references/error-messages#Support-file-missing-or-invalid) and we've
   simplified this to automatically including a single `cypress/support/index.js`
   file. That single file acts as the entry point meaning you should `import` or
   `require` the other support files you'd like to include. Although this is
@@ -11827,7 +11827,7 @@ _Released 11/27/2016_
   the implementation of it has. We will automatically seed a
   `cypress/support/index.js` file for you (even on existing projects). The file
   location of `cypress/support/index.js` can be changed with the new
-  [`supportFile`](/guides/references/configuration#Testing-Type-Specific-Options)
+  [`supportFile`](/guides/references/legacy-configuration#Folders--Files)
   option in your `cypress.json`. This feature can also be turned off by
   specifying `supportFile: false`.
 


### PR DESCRIPTION
- This PR addresses anchor link issues in [References > Changelog > 0.18.0](https://docs.cypress.io/guides/references/changelog#0-18-0). Anchor link issues are listed in https://github.com/cypress-io/cypress-documentation/issues/5630.

## Issues

The target bookmark for the following anchor link does not exist:

- `/guides/core-concepts/writing-and-organizing-tests#Folder-Structure`

## Changes

In [References > Changelog > 0.18.0](https://docs.cypress.io/guides/references/changelog#0-18-0) the following links are changed:

| Current                                                               | Corrected                                                                                                                               |
| --------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
| `/guides/core-concepts/writing-and-organizing-tests#Folder-Structure` | [/guides/references/legacy-configuration#Folders--Files](https://docs.cypress.io/guides/references/legacy-configuration#Folders--Files) |
[gone away](https://docs.cypress.io/guides/references/error-messages) | [/guides/references/error-messages#Support-file-missing-or-invalid](https://docs.cypress.io/guides/references/error-messages#Support-file-missing-or-invalid)
[supportFile](https://docs.cypress.io/guides/references/configuration#Testing-Type-Specific-Options) | [/guides/references/legacy-configuration#Folders--Files](https://docs.cypress.io/guides/references/legacy-configuration#Folders--Files)

## Notes

The Breaking Changes section of the [Changelog 0.18.0](https://docs.cypress.io/guides/references/changelog#0-18-0) describes file configuration for a legacy version of Cypress lower than Cypress `10`. Correcting the link to [Core Concepts > Writing and Organizing Tests > Folder Structure](https://docs.cypress.io/guides/core-concepts/writing-and-organizing-tests#Folder-Structure) would not connect the change log to the right information, since this page describes non-legacy .

Instead, the [Changelog 0.18.0](https://docs.cypress.io/guides/references/changelog#0-18-0) is linked to the [References > Configuration (Legacy) > Folders / Files](https://docs.cypress.io/guides/references/legacy-configuration#Folders--Files) page and section. This guide is for Cypress 9 and below.

Similarly for the link to [supportFile](https://docs.cypress.io/guides/references/configuration#Testing-Type-Specific-Options) which refers to a non-legacy description. This is also changed to link to [References > Configuration (Legacy) > Folders / Files](https://docs.cypress.io/guides/references/legacy-configuration#Folders--Files).

The [gone away](https://docs.cypress.io/guides/references/error-messages) link is changed to specifically refer to [Support file missing or invalid](https://docs.cypress.io/guides/references/error-messages#Support-file-missing-or-invalid), otherwise the meaning is difficult to infer.
