### PR TITLE
Correct anchor link in API Cypress.env

### DIFF
--- a/docs/api/cypress-api/env.mdx
+++ b/docs/api/cypress-api/env.mdx
@@ -168,7 +168,7 @@ Cypress.env() // => {foo: 'foo', baz: 'quux', host: 'http://server.dev.local'}
 
 Here's an example that uses `Cypress.env` to access an environment variable
 that's been
-[dynamically set in a plugin](/guides/guides/environment-variables#Option-5-Plugins).
+[dynamically set in a plugin](/guides/tooling/plugins-guide).
 
 Use this approach to grab the value of an environment variable _once_ before any
 of the tests in your spec run.


### PR DESCRIPTION
- This PR addresses an anchor link issue in [API > Cypress API > Cypress.env](https://docs.cypress.io/api/cypress-api/env). Anchor link issues are listed in https://github.com/cypress-io/cypress-documentation/issues/5630.

## Issues

The target bookmark for the following anchor link does not exist:

- `/guides/guides/environment-variables#Option-5-Plugins`

## Changes

In [API > Cypress API > Cypress.env](https://docs.cypress.io/api/cypress-api/env) the following link is changed:

| Current                                       | Corrected                                                                                                               |
| --------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
`/guides/guides/environment-variables#Option-5-Plugins` | [/guides/tooling/plugins-guide](https://docs.cypress.io/guides/tooling/plugins-guide)

## Notes

The text containing the failing bookmark says:

> Here's an example that uses Cypress.env to access an environment variable that's been **dynamically set in a plugin**.

- The target section header `Option #5 Plugins` of `dynamically set in a plugin` was removed from the page [Guides > Environment Variables](https://docs.cypress.io/guides/guides/environment-variables) by PR https://github.com/cypress-io/cypress-documentation/pull/4412. The whole section "`Option #5 Plugins`" was removed without linking to any replacement.

The closest available replacement document is [Tooling > Plugins](https://docs.cypress.io/guides/tooling/plugins-guide) which mentions the following under [Plugins > Use Cases > Configuration](https://docs.cypress.io/guides/tooling/plugins-guide#Configuration):

> With plugins, you can programmatically alter the resolved configuration and environment variables that come from the [Cypress configuration file](https://docs.cypress.io/guides/references/configuration), [`cypress.env.json`](https://docs.cypress.io/guides/guides/environment-variables#Option-2-cypressenvjson), the [command line](https://docs.cypress.io/guides/guides/command-line), or  system environment variables.
