### PR TITLE
Correct anchor link in Changelog 0.13.4

### DIFF
--- a/docs/guides/references/changelog.mdx
+++ b/docs/guides/references/changelog.mdx
@@ -13306,7 +13306,7 @@ _Released 12/31/2015_
 **Features:**
 
 - Added `waitForAnimations` and `animationDistanceThreshold`
-  [configuration options](/guides/references/configuration#Animations).
+  [configuration options](/guides/references/configuration#Actionability).
 - Cypress now automatically detects and waits for an element which is animating
   to stop animating. The threshold that Cypress considers _animating_ is set to
   a distance of `5px` per `60fps`. In other words, if your element is moving too


### PR DESCRIPTION
- This PR addresses an anchor link issue in [References > Changelog > 0.13.4](https://docs.cypress.io/guides/references/changelog#0-13-4). Anchor link issues are listed in https://github.com/cypress-io/cypress-documentation/issues/5630.

## Issues

The target bookmark for the following anchor link does not exist:

- `/guides/references/configuration#Animations`

## Changes

In [References > Changelog > 0.13.4](https://docs.cypress.io/guides/references/changelog#0-13-4) the following link is changed:

| Current                                       | Corrected                                                                                                               |
| --------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
| `/guides/references/configuration#Animations` | [/guides/references/configuration#Actionability](https://docs.cypress.io/guides/references/configuration#Actionability) |
