### PR TITLE
Correct anchor link in Changelog 0.16.0

### DIFF
--- a/docs/guides/references/changelog.mdx
+++ b/docs/guides/references/changelog.mdx
@@ -12675,7 +12675,7 @@ _Released 05/17/2016_
   you'll want to reinstall them. You only have to install them once and they
   will persist.
 - The `whitelist` callback function of
-  [`Cypress.Cookies.defaults()`](/api/cypress-api/cookies#Defaults) now receives
+  [`Cypress.Cookies.defaults()`](/api/cypress-api/cookies#History) now receives
   a `cookie object` instead of just the `cookies name` as a string.
 
 **Features:**


### PR DESCRIPTION
- This PR addresses an anchor link issue in [References > Changelog > 0.16.0](https://docs.cypress.io/guides/references/changelog#0-16-0). Anchor link issues are listed in https://github.com/cypress-io/cypress-documentation/issues/5630.

## Issues

The target bookmark for the following anchor link does not exist:

- `/api/cypress-api/cookies#Defaults`

## Changes

In [References > Changelog > 0.16.0](https://docs.cypress.io/guides/references/changelog#0-16-0) the following link is changed:

| Current                             | Corrected                                                                                     |
| ----------------------------------- | --------------------------------------------------------------------------------------------- |
| `/api/cypress-api/cookies#Defaults` | [/api/cypress-api/cookies#History](https://docs.cypress.io/api/cypress-api/cookies#History) |

## Notes

The [Changelog  9.7.0](https://docs.cypress.io/guides/references/changelog#9-7-0) Deprecations section says:

> The `Cypress.Cookies.preserveOnce()` and `Cypress.Cookies.defaults()` Cypress  APIs have been deprecated. In a future release, support for  `Cypress.Cookies.preserveOnce()` and `Cypress.Cookies.defaults()` will be  removed. Consider using the experimental   [`cy.session()`](https://docs.cypress.io/api/commands/session) command instead to cache and restore  cookies and other sessions details between tests.

The [API > Cypress API > Cypress.Cookies](https://docs.cypress.io/api/cypress-api/cookies) page, section [History](https://docs.cypress.io/api/cypress-api/cookies#History) documents the deprecation and later removal of `Cypress.Cookies.default()`.
