### PR TITLE
Correct anchor link in Changelog 0.17.11

### DIFF
--- a/docs/guides/references/changelog.mdx
+++ b/docs/guides/references/changelog.mdx
@@ -11892,8 +11892,8 @@ _Released 11/16/2016_
 
 **Roadmap:**
 
-- The changes in version [`0.17.11`](#01711-11162016) below are in preparation
-  for Cypress ￢ﾀﾙ platform service: a portal where screenshots, videos, config,
+- The changes in version `0.17.11` below are in preparation
+  for Cypress platform service: a portal where screenshots, videos, config,
   and logs of your builds are accessible.
 
 **Overview:**


### PR DESCRIPTION
- This PR addresses an anchor link issue in [References > Changelog > 0.17.11](https://docs.cypress.io/guides/references/changelog#0-17-11). Anchor link issues are listed in https://github.com/cypress-io/cypress-documentation/issues/5630.

## Issues

The target bookmark for the following anchor link does not exist:

- `#01711-11162016`

There are some scrambled characters in the paragraph

> The changes in version 0.17.11 below are in preparation for Cypress ￢ﾀﾙ platform service: a portal where screenshots, videos, config, and logs of your builds are accessible.

## Changes

The bad anchor link `#01711-11162016` is removed. It is unnecessary since the paragraph is already part of the the [References > Changelog > 0.17.11](https://docs.cypress.io/guides/references/changelog#0-17-11) it is apparently attempting to link to.

The unreadable characters are also removed.
