### PR TITLE
Remove Xvfb anchor link in Changelog 8.0.0

### DIFF
--- a/docs/guides/references/changelog.mdx
+++ b/docs/guides/references/changelog.mdx
@@ -3975,9 +3975,7 @@ to Cypress 8.0.**
   option. See [Client certificates](/guides/references/client-certificates) for
   more detail.
 - Setting the environment variable `ELECTRON_RUN_AS_NODE` now starts Cypress as
-  a normal Node.js process rather than an Electron process. See
-  [Running headless tests without Xvfb](/guides/continuous-integration/introduction#Running-headless-tests-without-Xvfb)
-  for more details. Addresses
+  a normal Node.js process rather than an Electron process. Addresses
   [#16505](https://github.com/cypress-io/cypress/issues/16505).
 
 **Bugfixes:**


### PR DESCRIPTION
- This PR addresses an anchor link issue in [References > Changelog > 8.0.0](https://docs.cypress.io/guides/references/changelog#8-0-0). Anchor link issues are listed in https://github.com/cypress-io/cypress-documentation/issues/5630.

## Issues

The target bookmark for the following anchor link does not exist:

- `/guides/continuous-integration/introduction#Running-headless-tests-without-Xvfb`

## Changes

In [References > Changelog > 8.0.0](https://docs.cypress.io/guides/references/changelog#8-0-0) the following sentence containing the obsolete link is removed:

"See Running headless tests without Xvfb for more details."

## Notes

- PR https://github.com/cypress-io/cypress-documentation/pull/5666 left a dangling anchor link to https://docs.cypress.io/guides/continuous-integration/introduction#Running-headless-tests-without-Xvfb after the section "Running headless tests without Xvfb" was removed.

The instructions do not work and the section used to say the following:

---
### Running headless tests without Xvfb

> Using the `ELECTRON_RUN_AS_NODE=1` env var is experimental and not fully tested, so may not work in all environments.
>
> Chromium based browsers and Firefox can spawn without Xvfb when run via the `--headless` flag. If you're testing against either of those browsers using the `--browser` flag, you can opt out of Cypress spawning an X11 server by setting the environment variable [`ELECTRON_RUN_AS_NODE=1`](https://www.electronjs.org/docs/api/environment-variables#electron_run_as_node).
>
> Electron cannot be run without an X11 server. Cypress's default browser is Electron and won't be able to launch if you set this environment variable. Likewise, Cypress's interactive mode (running via `cypress open`) is run via Electron and cannot be opened without an X11 server.

---

## Related issues

- https://github.com/cypress-io/cypress/issues/23636
- https://github.com/cypress-io/cypress/issues/19868