### PR TITLE
Correct folder/files legacy Changelog anchor links

### DIFF
--- a/docs/guides/references/changelog.mdx
+++ b/docs/guides/references/changelog.mdx
@@ -7597,7 +7597,7 @@ _Released 10/31/2019_
 
 **Features:**
 
-- [testFiles](/guides/references/configuration#Folders-Files) now also accepts
+- [testFiles](/guides/references/legacy-configuration#Folders--Files) now also accepts
   an Array of glob patterns when specifying what test files to load in
   configuration. Addresses
   [#5401](https://github.com/cypress-io/cypress/issues/5401).
@@ -7684,12 +7684,12 @@ _Released 10/23/2019_
   pass `false` to the `--config-file` to not use any configuration file.
   Addresses [#1369](https://github.com/cypress-io/cypress/issues/1369).
 - You can now use your system's Node version by setting the
-  [nodeVersion](/guides/references/configuration#Node-version) to `system` in
+  [nodeVersion](/guides/references/legacy-configuration#Node-version) to `system` in
   your configuration. This Node version will be used to build files in your
-  [integrationFolder](/guides/references/configuration#Folders-Files) and
-  [supportFile](/guides/references/configuration#Folders-Files) and also be used
+  [integrationFolder](/guides/references/legacy-configuration#Folders--Files) and
+  [supportFile](/guides/references/legacy-configuration#Folders--Files) and also be used
   to execute code in your
-  [pluginsFile](/guides/references/configuration#Folders-Files). If not set,
+  [pluginsFile](/guides/references/legacy-configuration#Folders--Files). If not set,
   Cypress will continue to use the Node version bundled with Cypress. Addresses
   [#4432](https://github.com/cypress-io/cypress/issues/4432).
 - [.dblclick()](/api/commands/dblclick) now accepts `position`, `x`, and `y`
@@ -9259,8 +9259,8 @@ _Released 11/2/2018_
 - We updated how we handle
   [trashAssetsBeforeRuns](/guides/references/configuration#Screenshots)
   behavior. We now trash the contents of the
-  [screenshotsFolder](/guides/references/configuration#Folders-Files) and
-  [videosFolder](/guides/references/configuration#Folders-Files) directories
+  [screenshotsFolder](/guides/references/legacy-configuration#Folders--Files) and
+  [videosFolder](/guides/references/legacy-configuration#Folders--Files) directories
   instead of trashing the directories themselves. This helps maintain any file
   access permissions for the directories. Fixes
   [#1943](https://github.com/cypress-io/cypress/issues/1943) and
@@ -9661,7 +9661,7 @@ _Released 6/28/2018_
   elements with `position: sticky`. Fixes
   [#1475](https://github.com/cypress-io/cypress/issues/1475).
 - Fixed a bug where changing the
-  [integrationFolder](/guides/references/configuration#Folders-Files) in Windows
+  [integrationFolder](/guides/references/legacy-configuration#Folders--Files) in Windows
   would lead to errors with plugins. Fixes
   [#1704](https://github.com/cypress-io/cypress/issues/1704).
 - Cypress no longer crashes when a 3rd party server sends invalid `gzip`
@@ -12967,12 +12967,12 @@ _Released 03/28/2016_
 - Cypress no longer looks at your `tests` directory for test files. Now, by
   default, it looks in the `cypress/integration` directory.
 - We've removed the configuration option `testFolder` and renamed it to
-  [`integrationFolder`](/guides/references/configuration#Folders-Files) inside
+  [`integrationFolder`](/guides/references/legacy-configuration#Folders--Files) inside
   of the `cypress.json`.
 - We've renamed the `cypress` npm package to be `cypress-cli`. You'll see a
   giant deprecation warning until your scripts have been updated to reference
   `cypress-cli`.. You can also uninstall the `cypress` npm package.
-- Added new [`fileServerFolder`](/guides/references/configuration#Folders-Files)
+- Added new [`fileServerFolder`](/guides/references/legacy-configuration#Folders--Files)
   configuration option that can mount a directory other than your project root
   when using Cypress as a web server.
 


### PR DESCRIPTION
- This PR addresses anchor link issues in the [References > Changelog](https://docs.cypress.io/guides/references/changelog) for some legacy versions `3.6.0` and below. Anchor link issues are listed in https://github.com/cypress-io/cypress-documentation/issues/5630.

## Issues

In the following [References > Changelog](https://docs.cypress.io/guides/references/changelog) sections:

- [3.6.0](https://docs.cypress.io/guides/references/changelog#3-6-0)
- [3.5.0](https://docs.cypress.io/guides/references/changelog#3-5-0)
- [3.1.1](https://docs.cypress.io/guides/references/changelog#3-1-1)
- [3.0.2](https://docs.cypress.io/guides/references/changelog#3-0-2)
- [0.15.0](https://docs.cypress.io/guides/references/changelog#0-15-0)

the target bookmark for the following anchor link does not exist:

- `/guides/references/configuration#Folders-Files`

For

- [3.5.0](https://docs.cypress.io/guides/references/changelog#3-5-0)

additionally

- `/guides/references/configuration#Node-version` does not exist.

(Bundled in this PR, since `nodeVersion` refers in the same sentence to legacy files and folders.)

## Changes

In the above Changelog sections the following links are changed:

| Current                                       | Corrected                                                                                                               |
| --------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
| `/guides/references/configuration#Folders-Files` | [/guides/references/legacy-configuration#Folders--Files](https://docs.cypress.io/guides/references/legacy-configuration#Folders--Files) |
`/guides/references/configuration#Node-version` | [/guides/references/legacy-configuration#Node-version](https://docs.cypress.io/guides/references/legacy-configuration#Node-version)

For consistency, each of the failing links is mapped to the [Legacy configurations > Folders / Files](https://docs.cypress.io/guides/references/legacy-configuration#Folders--Files) section, whether or not the option has been carried over unchanged into current [configuration options](https://docs.cypress.io/guides/references/configuration#e2e) for Cypress `10` and above.

## Notes

### Cypress 10 Migration

See [Migration Guide Cypress 10 > Config Option Changes](https://docs.cypress.io/guides/references/migration-guide#Config-Option-Changes)

1. [testFiles -> specPattern](https://docs.cypress.io/guides/references/migration-guide#Config-Option-Changes)
2. [integrationFolder](https://docs.cypress.io/guides/references/migration-guide#integrationFolder)
3. [supportFile](https://docs.cypress.io/guides/references/migration-guide#supportFile)
4. [pluginsFile](https://docs.cypress.io/guides/references/migration-guide#pluginsFile)

### `nodeVersion` removal

[Legacy configuration > nodeVersion](https://docs.cypress.io/guides/references/legacy-configuration#Node-version) says:

> The nodeVersion configuration option is deprecated and will be removed in a future version of Cypress. Please remove this option from your configuration file.

`nodeVersion` was removed in [Cypress 13.0.0](https://docs.cypress.io/guides/references/changelog#13-0-0) and therefore only appears in the [History section](https://docs.cypress.io/guides/references/configuration#History) of the [current Configuration page](https://docs.cypress.io/guides/references/configuration).

