### PR TITLE
Correct anchor link in Error messages

### DIFF
--- a/docs/guides/references/error-messages.mdx
+++ b/docs/guides/references/error-messages.mdx
@@ -684,7 +684,7 @@ You passed the `--ci-build-id`,
 [--group](/guides/guides/command-line#cypress-run-group-lt-name-gt),
 [--tag](/guides/guides/command-line#cypress-run-tag-lt-tag-gt),
 [--parallel](/guides/guides/command-line#cypress-run-parallel), or
-[--auto-cancel-after-failures](/guides/guides/command-line/#auto-cancel-after-runs)
+[--auto-cancel-after-failures](/guides/guides/command-line#auto-cancel-after-runs)
 flag without also passing the `--record` flag.
 
 These flags can only be used when recording to


### PR DESCRIPTION
- This PR addresses an anchor link issue in [References > Error Messages](https://docs.cypress.io/guides/references/error-messages). Anchor link issues are listed in https://github.com/cypress-io/cypress-documentation/issues/5630.

## Issues

The target bookmark for the following anchor link was flagged as an anchor link error by Docusaurus, although in practice the link works:

- [/guides/guides/command-line/#auto-cancel-after-runs](https://docs.cypress.io/guides/guides/command-line/#auto-cancel-after-runs)

## Changes

In [References > Error Messages](https://docs.cypress.io/guides/references/error-messages) the following link is changed:

| Current                                                                                                                           | Corrected                                                                                                                       |
| --------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
| [/guides/guides/command-line/#auto-cancel-after-runs](https://docs.cypress.io/guides/guides/command-line/#auto-cancel-after-runs) | [/guides/guides/command-line#auto-cancel-after-runs](https://docs.cypress.io/guides/guides/command-line#auto-cancel-after-runs) |


The `/` before the HTML fragment is removed.

## Verification

```shell
npm run build
```

Ensure that Docusaurus no longer reports `#auto-cancel-after-runs` as an anchor link error.
