### PR TITLE
Add experimental caution to Cypress.require()

### DIFF
--- a/docs/api/cypress-api/require.mdx
+++ b/docs/api/cypress-api/require.mdx
@@ -13,6 +13,14 @@ in browser-targeted code.
 
 ## Syntax
 
+:::caution
+
+Using `Cypress.require()` within the [`cy.origin()`](https://docs.cypress.io/api/commands/origin)
+callback requires enabling the
+[`experimentalOriginDependencies`](/guides/references/experiments#End-to-End-Testing) option in the Cypress configuration.
+
+:::
+
 ```js
 Cypress.require(moduleNameOrPath)
 ```


### PR DESCRIPTION
## Issue

[Cypress.require()](https://docs.cypress.io/api/cypress-api/require) needs the experimental option `experimentalOriginDependencies`. This is mentioned lower down on the [cy.origin()](https://docs.cypress.io/api/commands/origin) page in the Notes section [Dependencies / Sharing Code](https://docs.cypress.io/api/commands/origin#Dependencies--Sharing-Code) and is missing from the [Cypress.require()](https://docs.cypress.io/api/cypress-api/require) page itself.

The need for the experimental option `experimentalOriginDependencies` should be shown clearly on the page for [Cypress.require()](https://docs.cypress.io/api/cypress-api/require).

## Change

Add a caution note

> Using `Cypress.require()` within the [`cy.origin()`](https://docs.cypress.io/api/commands/origin) callback requires enabling the [`experimentalOriginDependencies`](https://docs.cypress.io/guides/references/experiments#End-to-End-Testing) option in the Cypress configuration.

to the [Syntax](https://docs.cypress.io/api/cypress-api/require#Syntax) section of [Cypress.require()](https://docs.cypress.io/api/cypress-api/require).
