### PR TITLE
Use Cypress.require() in experimentalOriginDependencies description

### DIFF
--- a/docs/guides/references/experiments.mdx
+++ b/docs/guides/references/experiments.mdx
@@ -261,7 +261,7 @@ object:
 | --------------------------------- | ------- | ---------------------------------------------------------------------------------------------------------- |
 | `experimentalStudio`              | `false` | Generate and save commands directly to your test suite by interacting with your app as an end user would.  |
 | `experimentalRunAllSpecs`         | `false` | Enables the "Run All Specs" UI feature, allowing the execution of multiple specs sequentially.             |
-| `experimentalOriginDependencies`  | `false` | Enables support for `require`/`import` within `cy.origin`.                                                 |
+| `experimentalOriginDependencies`  | `false` | Enables support for `Cypress.require` within `cy.origin`.                                                  |
 | `experimentalSkipDomainInjection` | `null`  | Removes injecting `document.domain` into `text/html` pages for any sites that match the provided patterns. |
 
 #### Experimental Skip Domain Injection
@@ -328,7 +328,8 @@ configuration object:
 
 | Version                                       | Changes                                                                                                                                       |
 | --------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| [12.3.0](/guides/references/changelog#13-4-0) | Added support for configuring the Experimental Flake Detection strategy via `retries.experimentalStrategy` and `retries.experimentalOptions`. |
+| [13.4.0](/guides/references/changelog#13-4-0) | Added support for configuring the Experimental Flake Detection strategy via `retries.experimentalStrategy` and `retries.experimentalOptions`. |
+| [12.6.0](/guides/references/changelog#12-6-0) | Removed `require`/`import` and added `Cypress.require` for `experimentalOriginDependencies`.                                                  |
 | [12.4.0](/guides/references/changelog#12-4-0) | Added `experimentalSkipDomainInjection` and `experimentalMemoryManagement`.                                                                   |
 | [12.0.0](/guides/references/changelog#12-0-0) | Removed `experimentalSessionAndOrigin` and made it the default behavior. Added `experimentalOriginDependencies`.                              |
 | [11.2.0](/guides/references/changelog#11-2-0) | Added `experimentalRunAllSpecs`.                                                                                                              |


### PR DESCRIPTION
## Issue

In the table [References > Experiments > End-to-End Testing](https://docs.cypress.io/guides/references/experiments#End-to-End-Testing) the entry for `experimentalOriginDependencies` has an outdated description. Support for `require`/`import` was removed in [Cypress 12.6.0](https://docs.cypress.io/guides/references/changelog#12-6-0).

| Option                           | Default | Description                                                |
| -------------------------------- | ------- | ---------------------------------------------------------- |
| `experimentalOriginDependencies` | `false` | Enables support for `require`/`import` within `cy.origin`. |

According to the section [Cypress.require > History](https://docs.cypress.io/api/cypress-api/require#History)

| Version                                                              | Changes                                                                                             |
| -------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
| [12.6.0](https://docs.cypress.io/guides/references/changelog#12-6-0) | `Cypress.require` added and support for using CommonJS `require()` and ES module `import()` removed |

## Changes

1. The text is changed to

> Enables support for `Cypress.require` within `cy.origin`.

2. A corresponding entry is added to the [Cypress.require > History](https://docs.cypress.io/api/cypress-api/require#History) table for [Cypress 12.6.0](https://docs.cypress.io/guides/references/changelog#12-6-0).

3. A typo in an adjacent row added by https://github.com/cypress-io/cypress-documentation/pull/5551 into the history table is also corrected. The change for [13.4.0](https://docs.cypress.io/guides/references/changelog#13-4-0) incorrectly named Cypress `12.3.0` whilst linking to [Changelog 13.4.0](https://docs.cypress.io/guides/references/changelog#13-4-0).
