### PR TITLE
Correct Cypress.require history changelog links

### DIFF
--- a/docs/api/cypress-api/require.mdx
+++ b/docs/api/cypress-api/require.mdx
@@ -148,11 +148,11 @@ webpack preprocessor. Using `Cypress.require` is preprocessor-agnostic.
 
 ## History
 
-| Version                                        | Changes                                                                                             |
-| ---------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| [12.6.0](/guides/references/changelog#10-7-0)  | `Cypress.require` added and support for using CommonJS `require()` and ES module `import()` removed |
-| [10.11.0](/guides/references/changelog#10-7-0) | `Cypress.require` removed in favor of CommonJS `require()` and ES module `import()`                 |
-| [10.7.0](/guides/references/changelog#10-7-0)  | `Cypress.require` added                                                                             |
+| Version                                         | Changes                                                                                             |
+| ----------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| [12.6.0](/guides/references/changelog#12-6-0)   | `Cypress.require` added and support for using CommonJS `require()` and ES module `import()` removed |
+| [10.11.0](/guides/references/changelog#10-11-0) | `Cypress.require` removed in favor of CommonJS `require()` and ES module `import()`                 |
+| [10.7.0](/guides/references/changelog#10-7-0)   | `Cypress.require` added                                                                             |
 
 ## See also
 


### PR DESCRIPTION
## Issue

In the [API > Cypress.require > History](https://docs.cypress.io/api/cypress-api/require#History) table

| Version                                                               | Changes                                                                                             |
| --------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
| [12.6.0](https://docs.cypress.io/guides/references/changelog#10-7-0)  | `Cypress.require` added and support for using CommonJS `require()` and ES module `import()` removed |
| [10.11.0](https://docs.cypress.io/guides/references/changelog#10-7-0) | `Cypress.require` removed in favor of CommonJS `require()` and ES module `import()`                 |
| [10.7.0](https://docs.cypress.io/guides/references/changelog#10-7-0)  | `Cypress.require` added                                                                             |

the Changelog links for Cypress `12.6.0` and `10.11.0` are incorrectly linking to Cypress `10.7.0`.

- This was incorrectly added by PR https://github.com/cypress-io/cypress-documentation/pull/5020.

## Changes

Correct the links to correspond to the Cypress version displayed.