### PR TITLE
Add pnpm instructions to run Cypress

### DIFF
--- a/docs/guides/getting-started/opening-the-app.mdx
+++ b/docs/guides/getting-started/opening-the-app.mdx
@@ -15,7 +15,8 @@ title: Opening the App
 
 ## `cypress open`
 
-You can open Cypress from your **project root** one of the following ways:
+You can open Cypress from your **project root** in one of the following ways,
+depending on the package manager (npm, Yarn or pnpm) you are using:
 
 **Using `npx`**
 
@@ -27,6 +28,12 @@ npx cypress open
 
 ```shell
 yarn run cypress open
+```
+
+**Or by using `pnpm`**
+
+```shell
+pnpm cypress open
 ```
 
 After a moment, the Cypress Launchpad will open.

--- a/docs/guides/guides/command-line.mdx
+++ b/docs/guides/guides/command-line.mdx
@@ -35,14 +35,20 @@ command's documentation.
 To run a command, you'll need to prefix each command in order to properly locate
 the cypress executable.
 
-```
+```shell
 npx cypress run
 ```
 
 ...or by using Yarn...
 
-```
+```shell
 yarn cypress run
+```
+
+...or by using pnpm...
+
+```shell
+pnpm cypress run
 ```
 
 You may find it easier to add the cypress command to the `scripts` object in


### PR DESCRIPTION
## Issue

[Getting Started > Installing Cypress >  `>_ pnpm add`](https://docs.cypress.io/guides/getting-started/installing-cypress#pnpm-add) includes instructions to install Cypress using the package manager [pnpm](https://pnpm.io/). Information about how to **run** Cypress using pnpm is however missing in the documentation.

Cypress run instructions for pnpm are missing from the pages:

- [Getting Started > Opening the App > `cypress open`](https://docs.cypress.io/guides/getting-started/opening-the-app#cypress-open)
- [Guides > Command Line > How to run commands](https://docs.cypress.io/guides/guides/command-line#How-to-run-commands)

## Changes

### open

Add the command

```shell
pnpm cypress open
```

to the page [Getting Started > Opening the App > `cypress open`](https://docs.cypress.io/guides/getting-started/opening-the-app#cypress-open).

### run

Add the command

```shell
pnpm cypress run
```

to the page [Guides > Command Line > How to run commands](https://docs.cypress.io/guides/guides/command-line#How-to-run-commands).

## Explanation

### open

```shell
pnpm cypress open
```

is equivalent to

```shell
pnpm exec cypress open
```

### run

```shell
pnpm cypress run
```

is equivalent to

```shell
pnpm exec cypress run
```

## References

[pnpm > CLI commands > Run scripts > `pnpm exec`](https://pnpm.io/cli/exec)

## Verification

Execute the following in a Node.js `20.11.1` LTS environment, Ubuntu `22.04.4` LTS & Windows 11 to confirm that the command `pnpm cypress run` runs the Cypress test headlessly and `pnpm cypress open` correctly starts the Cypress Launchpad in interactive mode:

```shell
npm install pnpm@latest -g
git clone https://github.com/cypress-io/github-action
cd github-action/examples/basic-pnpm
pnpm install --frozen-lockfile
pnpm cypress run
pnpm cypress open
```
