### PR TITLE
Harmonize yarn cypress open instructions

### DIFF
--- a/docs/guides/getting-started/opening-the-app.mdx
+++ b/docs/guides/getting-started/opening-the-app.mdx
@@ -26,7 +26,7 @@ npx cypress open
 **Or by using `yarn`**
 
 ```shell
-yarn run cypress open
+yarn cypress open
 ```
 
 After a moment, the Cypress Launchpad will open.


### PR DESCRIPTION
## Issue

[Getting Started > Opening the App](https://docs.cypress.io/guides/getting-started/opening-the-app) instructs to use

```shell
yarn run cypress open
```

whereas [Guides > Command Line > How to run commands](https://docs.cypress.io/guides/guides/command-line#How-to-run-commands) instructs to use

```shell
yarn cypress run
```

Using these two equivalent forms (one with `run` and one without `run`) may be confusing.

## Change

Standardize on the shorter form without `run` and change this in [Getting Started > Opening the App](https://docs.cypress.io/guides/getting-started/opening-the-app) to:

```shell
yarn cypress open
```

(Reserve the use of `yarn run` for running scripts like `yarn run cy:open`.)

## References

### Yarn Classic (Version 1)

https://classic.yarnpkg.com/en/docs/cli/run

for background on how the two following commands are equivalent:

```shell
yarn run cypress
yarn cypress
```

### Yarn Modern (Version 4)

https://yarnpkg.com/cli/run

Similarly for Yarn 4

## Verification

Execute the following in a Node.js `20.11.1` LTS environment, Ubuntu 22.04.4 LTS & Windows 11 to confirm that the command `yarn cypress run` runs the Cypress test headlessly for both Yarn Classic and Yarn Modern examples:

```shell
npm install yarn@latest -g
git clone https://github.com/cypress-io/github-action
cd github-action/examples/yarn-classic
yarn install --frozen-lockfile
yarn cypress run
cd ../yarn-modern
yarn install --immutable
yarn cypress run
```
