### PR TITLE
Remove CLI autoCancelAfterFailures npx prefix command examples

### DIFF
--- a/docs/guides/guides/command-line.mdx
+++ b/docs/guides/guides/command-line.mdx
@@ -137,14 +137,14 @@ The "autoCancelAfterFailures" argument is the number of times tests can fail
 before the run is canceled
 
 ```bash
-npx cypress run --record --key <<your_record_key>> --auto-cancel-after-failures 1
+cypress run --record --key <<your_record_key>> --auto-cancel-after-failures 1
 ```
 
 You can also specify `false` for the value to disable Auto Cancellation for the
 run:
 
 ```bash
-npx cypress run --record --key <<your_record_key>> --auto-cancel-after-failures false
+cypress run --record --key <<your_record_key>> --auto-cancel-after-failures false
 ```
 
 #### `cypress run --browser <browser-name-or-path>` {#cypress-run-browser-lt-browser-name-or-path-gt}


### PR DESCRIPTION
## Issue

Two CLI command examples on the [Guides > Command Line](https://docs.cypress.io/guides/guides/command-line#auto-cancel-after-runs) page related to `autoCancelAfterFailures` are given with `npx` prefixes. Other commands omit the prefix since the introductory section [How to run commands](https://docs.cypress.io/guides/guides/command-line#How-to-run-commands) explains about how the prefix depends on the package manager and that it has been omitted for brevity.

`npx` is the correct prefix for use with npm, however it is not recommended for pnpm or Yarn. If `npx` is executed on a Yarn Modern Plug'n'Play project it does not work at all (due to the absence of a `node_modules` directory).

## Changes

Remove the `npx` prefix from the examples [`cypress run --auto-cancel-after-failures <autoCancelAfterFailures>`](https://docs.cypress.io/guides/guides/command-line#auto-cancel-after-runs)
