### PR TITLE
Note `nodeVersion` removal in Legacy Configuration for Cypress 13

### DIFF
--- a/docs/guides/references/configuration_legacy.mdx
+++ b/docs/guides/references/configuration_legacy.mdx
@@ -148,9 +148,9 @@ For more information, see the docs on
 
 :::caution
 
-The `nodeVersion` configuration option is deprecated and will be removed in a
-future version of Cypress. Please remove this option from your configuration
-file.
+The `nodeVersion` configuration option is deprecated and has been removed as an option from
+[current configurations](/guides/references/configuration#History) of
+[Cypress `13.0.0`](/guides/references/changelog#13-0-0) and above. Please remove this option from your configuration file.
 
 :::
 


### PR DESCRIPTION
## Issue

The [Legacy configuration > nodeVersion](https://docs.cypress.io/guides/references/legacy-configuration#Node-version) section says:

> The nodeVersion configuration option is deprecated and will be removed in a future version of Cypress. Please remove this option from your configuration file.

and does not mention that the future version of Cypress ([`13.0.0`](https://docs.cypress.io/guides/references/changelog#13-0-0)), where `nodeVersion` was removed, has already been released.

This causes an interested reader to have to search elsewhere to find out if and when this event has already occurred. This is quite hard to find because the Changelog for [Cypress `13.0.0`](https://docs.cypress.io/guides/references/changelog#13-0-0) doesn't mention it, nor does the linked [Migrating to Cypress 13.0](https://docs.cypress.io/guides/references/migration-guide#Migrating-to-Cypress-130) include it. It is however listed in the [History section](https://docs.cypress.io/guides/references/configuration#History) of the [current Configuration page](https://docs.cypress.io/guides/references/configuration).

## Change

Add the specific removal information to the above paragraph, so that it now reads:

> The `nodeVersion` configuration option is deprecated and has been removed from [current configurations](https://docs.cypress.io/guides/references/configuration#History) for [Cypress `13.0.0`](https://docs.cypress.io/guides/references/changelog#13-0-0) and above. Please remove this option from your configuration file.