### PR TITLE
fix: wrong args order in introduction-to-cypress.mdx

### DIFF
--- a/docs/guides/core-concepts/introduction-to-cypress.mdx
+++ b/docs/guides/core-concepts/introduction-to-cypress.mdx
@@ -1298,7 +1298,7 @@ with regular Cypress DOM commands.
 cy.get('p').should(($p) => {
   // massage our subject from a DOM element
   // into an array of texts from all of the p's
-  let texts = $p.map((i, el) => {
+  let texts = $p.map((el) => {
     return Cypress.$(el).text()
   })
 


### PR DESCRIPTION
+ removed unused index arg.