### PR TITLE
Fix Changelog typos

### DIFF
--- a/docs/guides/references/changelog.mdx
+++ b/docs/guides/references/changelog.mdx
@@ -170,7 +170,7 @@ _Released 11/8/2023_
 - Fixed a regression in [`13.3.3`](#13-3-3) where Cypress would hang on loading shared workers when using `cy.reload` to reload the page. Fixes [#28248](https://github.com/cypress-io/cypress/issues/28248).
 - Fixed an issue where network requests made from tabs, or windows other than the main Cypress tab, would be delayed. Fixes [#28113](https://github.com/cypress-io/cypress/issues/28113).
 - Fixed an issue with 'other' targets (e.g. pdf documents embedded in an object tag) not fully loading. Fixes [#28228](https://github.com/cypress-io/cypress/issues/28228) and [#28162](https://github.com/cypress-io/cypress/issues/28162).
-- Fixed an issue where clicking a link to download a file could cause a page load timeout when the download attribute was missing. Note: download behaviors in experimental Webkit are still an issue. Fixes [#14857](https://github.com/cypress-io/cypress/issues/14857).
+- Fixed an issue where clicking a link to download a file could cause a page load timeout when the download attribute was missing. Note: download behaviors in experimental WebKit are still an issue. Fixes [#14857](https://github.com/cypress-io/cypress/issues/14857).
 - Fixed an issue to account for canceled and failed downloads to correctly reflect these status in Command log as a download failure where previously it would be pending. Fixed in [#28222](https://github.com/cypress-io/cypress/pull/28222).
 - Fixed an issue determining visibility when an element is hidden by an ancestor with a shared edge. Fixes [#27514](https://github.com/cypress-io/cypress/issues/27514).
 - We now pass a flag to Chromium browsers to disable Chrome translation, both the manual option and the popup prompt, when a page with a differing language is detected. Fixes [#28225](https://github.com/cypress-io/cypress/issues/28225).
@@ -637,7 +637,7 @@ _Released 04/17/2023_
   [#22777](https://github.com/cypress-io/cypress/issues/22777) and
   [#26388](https://github.com/cypress-io/cypress/issues/26388).
 - Updated to use the `SEMAPHORE_GIT_WORKING_BRANCH`
-  [Semphore](https://docs.semaphoreci.com) CI environment variable to correctly
+  [Semaphore](https://docs.semaphoreci.com) CI environment variable to correctly
   associate a Cloud run to the current branch. Previously this was incorrectly
   associating a run to the target branch. Fixes
   [#26309](https://github.com/cypress-io/cypress/issues/26309).
@@ -5116,7 +5116,7 @@ _Released 12/07/2020_
   `before()` hook. Fixes
   [#9162](https://github.com/cypress-io/cypress/issues/9162).
 - We no longer strip `/` from URLs when they are explicitly passed with query
-  paramaters. Fixes [#9360](https://github.com/cypress-io/cypress/issues/9360).
+  parameters. Fixes [#9360](https://github.com/cypress-io/cypress/issues/9360).
 - Fixed the regression in `Cypress.dom.isVisible` behavior for elements with
   `position: fixed`, addresses
   [#8998](https://github.com/cypress-io/cypress/issues/8998) and
@@ -6039,7 +6039,7 @@ _Released 7/21/2020_
   now. Fixes [#7786](https://github.com/cypress-io/cypress/issues/7786).
 - The [Module API](/guides/guides/module-api) has a new
   `cypress.cli.parseRunArguments` function to assist in parsing user-supplied
-  command line arguments using the same logic as `cypress run` uses. Addesses
+  command line arguments using the same logic as `cypress run` uses. Addresses
   [#7760](https://github.com/cypress-io/cypress/issues/7760).
 
 **Bugfixes:**
@@ -7226,7 +7226,7 @@ _Released 01/10/2020_
   characters were typed in `type="number"` inputs. Fixes
   [#6055](https://github.com/cypress-io/cypress/issues/6055).
 - Child elements of an element that uses both `transform` and `height` or
-  `width` are now properly seen as visible during visiblity checks. Addresses
+  `width` are now properly seen as visible during visibility checks. Addresses
   [#5974](https://github.com/cypress-io/cypress/issues/5974).
 - We now properly check backface visibility when the parents of a target element
   have the CSS style `transform-style: preserve-3d`. Fixes
@@ -7638,7 +7638,7 @@ _Released 10/31/2019_
 - We updated `.type()` to properly respect focus selection changes during
   typing. Fixes [#5456](https://github.com/cypress-io/cypress/issues/5456).
 - We fixed a regression in [3.5.0](#3-5-0) that caused selected text to be
-  overwritten while typing a modifer key during `.type()`. Fixes
+  overwritten while typing a modifier key during `.type()`. Fixes
   [#5439](https://github.com/cypress-io/cypress/issues/5439).
 - We now send all the proper events during `.type()` to input elements with type
   `date`, `time`, and `datetime-local` so that it now behaves as it did prior to
@@ -7700,7 +7700,7 @@ _Released 10/23/2019_
   of the element. Addresses
   [#4440](https://github.com/cypress-io/cypress/issues/4440).
 - [cy.visit()](/api/commands/visit) now accepts a `qs` option representing an
-  object of query paramaters to be used in the URL. Addresses
+  object of query parameters to be used in the URL. Addresses
   [#5034](https://github.com/cypress-io/cypress/issues/5034).
 - [cy.viewport()](/api/commands/viewport) now allows for viewport sizes up to
   4,000 pixels. Addresses
@@ -7958,7 +7958,7 @@ _Released 10/23/2019_
   [#4720](https://github.com/cypress-io/cypress/pull/4720).
 - Upgraded `node` from `8.9.3` to `12.0.0`. Addressed in
   [#4720](https://github.com/cypress-io/cypress/pull/4720).
-- Upgaded `jquery` from `2.2.4` to `3.1.1`. Addressed in
+- Upgraded `jquery` from `2.2.4` to `3.1.1`. Addressed in
   [#1229](https://github.com/cypress-io/cypress/pull/1229).
 - Upgraded `sanitize-filename` from `1.6.1` to `1.6.3`. Addressed in
   [#5216](https://github.com/cypress-io/cypress/pull/5216).
@@ -8065,7 +8065,7 @@ _Released 7/29/2019_
   [#4781](https://github.com/cypress-io/cypress/pull/4781) and
   [#4817](https://github.com/cypress-io/cypress/pull/4817).
 - We increased the cypress binary verification phase from 10 seconds to 30
-  seconds to accomodate underpowered or overwhelmed machines typically found in
+  seconds to accommodate underpowered or overwhelmed machines typically found in
   CI environments. Addresses
   [#4624](https://github.com/cypress-io/cypress/issues/4624).
 
@@ -8342,7 +8342,7 @@ _Released 6/27/2019_
   Cypress Dashboard. Addresses
   [#3582](https://github.com/cypress-io/cypress/issues/3582).
 - The tests titles and headers in the Command Log no longer truncate with
-  elipsis when the text is longer than that width of the Command Log. Instead
+  ellipsis when the text is longer than that width of the Command Log. Instead
   the text wraps so that all text is shown. Addresses
   [#3947](https://github.com/cypress-io/cypress/issues/3947).
 - Special env vars are now truncated in `Cypress.env()` and the debug logs.
@@ -9109,7 +9109,7 @@ Merry Christmas everyone!
 **Misc:**
 
 - Removed the word 'already' from the Cypress install message in order to be
-  less confusing. Adresses
+  less confusing. Addresses
   [#2754](https://github.com/cypress-io/cypress/issues/2754).
 - Fixed incomplete type definitions for [cy.request](/api/commands/request).
   Fixes [#2305](https://github.com/cypress-io/cypress/issues/2305).
@@ -10624,7 +10624,7 @@ _Released 11/19/2017_
   [#533](https://github.com/cypress-io/cypress/issues/533).
 - We have created a
   [`@cypress/webpack-preprocessor`](https://github.com/cypress-io/cypress/tree/master/npm/webpack-preprocessor)
-  preprocessor npm package for you webpack users (because we are nice ￰ ﾟﾘﾉ).
+  preprocessor npm package for you webpack users (because we are nice!).
   Fixes [#676](https://github.com/cypress-io/cypress/issues/676).
 
 **Bugfixes:**
@@ -13884,7 +13884,7 @@ _Released 10/04/2015_
 **Features:**
 
 - [`.blur()`](/api/commands/blur) now accepts `{force: true}` which removes
-  error checking such as validating the element is urrently in focus.
+  error checking such as validating the element is currently in focus.
 
 **Bugfixes:**
 
@@ -13970,7 +13970,7 @@ _Released 09/25/2015_
   So you'll now always see the full assertion message.
 - Fixed some scenarios where assertions would not be logged as a child command.
 - Assertions based around the `window` or `document` object no longer cause Chai
-  to bomb on formatting their object structures (due to cylic references) and
+  to bomb on formatting their object structures (due to cyclic references) and
   instead now will show up as `<window>` and `<document>`.
 
 **Misc:**
@@ -14184,7 +14184,7 @@ _Released 09/13/2015_
 
 - The internal retry loop of Cypress now runs at `60fps`, instead of `20fps`.
 - Cypress overrides chai's default inspection function for DOM elements meaning
-  instead of seeing `{ Object (0, length, ...) }` you will now ee the nicely
+  instead of seeing `{ Object (0, length, ...) }` you will now see the nicely
   formatted Cypress DOM element like: `<button#primary.btn-large>`.
 - Cypress now overrides chai's `match` chainer and provides a specific error
   message when a non `regex` value is provided. Fixes
@@ -14208,7 +14208,7 @@ _Released 09/13/2015_
 **Other News:**
 
 - Cypress is currently seeking to raise a Series A. This will enable us to grow
-  the team and speed up development but seeking it has come at a ost for current
+  the team and speed up development but seeking it has come at a cost for current
   development speed. If you have any VC connections
   [please send them our way](mailto:support@cypress.io).
 
@@ -14371,7 +14371,7 @@ _Released 08/06/2015_
 - Cypress can now be run through the terminal.
 - You can now run all of your tests inside of the GUI App.
 - You can use the CLI tool to run Cypress in CI. The documentation for this
-  needs to be written, but it will be very simple to do. You will robably only
+  needs to be written, but it will be very simple to do. You will probably only
   have to write 2 lines in your CI scripts to run Cypress.
 - You can configure CI to use any reporter built into Mocha, and additionally we
   are adding JUnit XML output (for Jenkins) as a built in default.
@@ -14383,11 +14383,11 @@ _Released 08/06/2015_
 - Several security problems with projects have been closed in preparation for
   running in CI.
 - Extensive memory profiling has been done and Cypress has implemented several
-  strategies for aggressively causing garbage collection. The ebugging tools
+  strategies for aggressively causing garbage collection. The debugging tools
   (which allow you to walk back in time through DOM snapshots, or access objects
-  from previous tests) could exhaust all available emory in previous versions.
+  from previous tests) could exhaust all available memory in previous versions.
   This likely never affected most users, but if a user ran 1000's of tests
-  (which have been written in Cypress) it ould bomb. Now Cypress only stores
+  (which have been written in Cypress) it would bomb. Now Cypress only stores
   data for up to 50 tests, and will begin purging data past that. When run in
   the terminal, Cypress doesn't apply any of its debugging tools, so CI will be
   unaffected.
@@ -14397,7 +14397,7 @@ _Released 08/06/2015_
 
 - Everything except for the `cypress driver` is now minified.
 - Some users have reported problems upgrading previous versions. This is because
-  we changed the name from "cypress" to "Cypress" including some inaries. If
+  we changed the name from "cypress" to "Cypress" including some binaries. If
   your upgrade does not finish you can redownload the latest version of Cypress
   or use the CLI tool to reinstall it.
 - Our build and testing processes have been upgraded to accommodate Linux
@@ -14451,7 +14451,7 @@ _Released 07/06/2015_
 **Bugfixes:**
 
 - Fixed edge case with [`cy.contains()`](/api/commands/contains) and command
-  options `visible` and `exist` where it would always fail ven though the
+  options `visible` and `exist` where it would always fail even though the
   matched element was in the correct state.
 
 **Misc:**


### PR DESCRIPTION
This PR corrects multiple typos in the [Changelog](https://docs.cypress.io/guides/references/changelog).