### PR TITLE
Remove API Cypress.testingType experimental text

### DIFF
--- a/docs/api/cypress-api/testing-type.mdx
+++ b/docs/api/cypress-api/testing-type.mdx
@@ -19,7 +19,7 @@ Cypress.testingType // returns 'e2e' or 'component'
 ### Testing Type
 
 ```javascript
-it('is running experimental component testing mode', () => {
+it('is running component testing mode', () => {
   expect(Cypress.testingType).to.equal('component')
 })
 ```
@@ -38,6 +38,6 @@ it('does something differently', () => {
 
 ## History
 
-| Version                               | Changes                     |
-| ------------------------------------- | --------------------------- |
-| [7.0.0](/guides/references/changelog) | Added `Cypress.testingType` |
+| Version                                     | Changes                     |
+| ------------------------------------------- | --------------------------- |
+| [7.0.0](/guides/references/changelog#7-0-0) | Added `Cypress.testingType` |


### PR DESCRIPTION
## Changes

1. In the test spec on [API > Cypress API > Cypress.testingType > Examples](https://docs.cypress.io/api/cypress-api/testing-type#Testing-Type) remove the word "experimental". The Changelog [7.0.0](https://docs.cypress.io/guides/references/changelog#7-0-0) notes under "Breaking Changes":

    "`experimentalComponentTesting `must be removed from your configuration file"

    so by implication Component Testing became no longer experimental with the release of [cypress@7.0.0](https://docs.cypress.io/guides/references/changelog#7-0-0).

1. Link the entry in [API > Cypress API > Cypress.testingType > History](https://docs.cypress.io/api/cypress-api/testing-type#History) for Cypress `7.0.0` directly to the [Changelog section 7.0.0](https://docs.cypress.io/guides/references/changelog#7-0-0)