### PR TITLE
Adding pixeleye to plugins.json

### DIFF
--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -1077,6 +1077,13 @@
           "badge": "verified"
         },
         {
+          "name": "Pixeleye",
+          "description": "Open-source, multi-browser visual review and testing platform.",
+          "link": "https://pixeleye.io/docs/integrations/cypress",
+          "keywords": ["open-source", "screenshots", "visual regression", "multi-browser"],
+          "badge": "community"
+        },
+        {
           "name": "Happo",
           "description": "Cross-platform, cross-browser screenshot testing for modern user interfaces.",
           "link": "https://github.com/happo/happo-cypress",


### PR DESCRIPTION
I've added [Pixeleye](https://pixeleye.io/home) to the plugin definitions. 

You can see an example of a cypress & pixeleye project [here](https://github.com/pixeleye-io/pixeleye/tree/main/examples/cypress).

I've added it with a community badge, but I would love to get it verified. What would be the steps to make that happen?