### PR TITLE
Add official Allure reporter to the plugins.json

### DIFF
--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -1234,10 +1234,10 @@
           "badge": "community"
         },
         {
-          "name": "cypress-allure-plugin",
-          "description": "Integrates Allure reporter with Cypress. Command logging and screenshot attachment out of the box.",
-          "link": "https://github.com/Shelex/cypress-allure-plugin",
-          "keywords": ["reporter", "allure"],
+          "name": "allure-cypress",
+          "description": "Allure reporter for Cypress. Creates rich HTML test reports with screenshots, steps and more.",
+          "link": "https://github.com/allure-framework/allure-js/tree/main/packages/allure-cypress",
+          "keywords": ["reporter", "allure", "step", "screenshot"],
           "badge": "community"
         },
         {


### PR DESCRIPTION
The PR adds a link to the official Allure integration with Cypress.

* Source code https://github.com/allure-framework/allure-js/tree/main/packages/allure-cypress
* E2E tests https://github.com/allure-framework/allure-js/tree/main/packages/allure-cypress/cypress/e2e
* CI https://github.com/allure-framework/allure-js/actions/workflows/build.yml
* NPM https://www.npmjs.com/package/allure-cypress
* Docs https://allurereport.org/docs/cypress/

However, since [cypress-allure-plugin](https://github.com/Shelex/cypress-allure-plugin) [isn't maintained anymore] (https://github.com/Shelex/cypress-allure-plugin/issues/220#issuecomment-1716130705) and will not support the latest Cypress version, I decided to replace it with the official one instead of adding an additional plugin.

