### PR TITLE
Update RWA CircleCI hardware specs references

### DIFF
--- a/docs/guides/continuous-integration/introduction.mdx
+++ b/docs/guides/continuous-integration/introduction.mdx
@@ -266,9 +266,9 @@ command.
 ```css
 npx cypress info
 ...
-Cypress Version: 6.3.0
-System Platform: linux (Debian - 10.5)
-System Memory: 73.8 GB free 25 GB
+Cypress Version: 13.6.6 (stable)
+System Platform: linux (Debian - 11.6)
+System Memory: 73.6 GB free 48.6 GB
 ```
 
 You can see the CPU parameters on the CI machines by executing the command
@@ -288,15 +288,12 @@ node -p 'os.cpus()'
 
 **Example projects and the machine configurations used to run them on CI:**
 
-- [Cypress Documentation](https://github.com/cypress-io/cypress-documentation)
-  and [Real World App](https://github.com/cypress-io/cypress-realworld-app)
-  projects run tests on the default CircleCI machine using the
-  [Docker executor](https://circleci.com/docs/2.0/executor-types/) on the
-  [default medium size machine](https://circleci.com/docs/2.0/configuration-reference/#resource_class)
-  with 2 vCPUs and 4GB of RAM. `cypress info` reports
-  `System Memory: 73.8 GB free 25 GB` with CPUs reported as
-  `Intel(R) Xeon(R) Platinum 8124M CPU @ 3.00GHz`. Note that the free memory
-  varies on CircleCI, typically we see values anywhere from 6GB to 30GB.
+- The [Real World App](https://github.com/cypress-io/cypress-realworld-app)
+  project runs tests on a CircleCI machine using the
+  [Docker executor](https://circleci.com/docs/executor-intro/#docker) with
+  [`resource_class: large`](https://circleci.com/docs/configuration-reference/#docker-execution-environment)
+  providing 4 vCPUs and 8 GB of RAM. `cypress info` reports
+  `System Memory: 73.6 GB free 48.6 GB`.
 - [Real World App](https://github.com/cypress-io/cypress-realworld-app) also
   executes its tests using
   [GitHub Actions](https://github.com/cypress-io/github-action) with the


### PR DESCRIPTION
## Issue

The CircleCI runner hardware dimensioning reference in [Continuous Integration > Introduction > Machine requirements](https://docs.cypress.io/guides/continuous-integration/introduction#Machine-requirements) is out of date.

> [Cypress Documentation](https://github.com/cypress-io/cypress-documentation) and [Real World App](https://github.com/cypress-io/cypress-realworld-app) projects run tests on the default CircleCI machine using the [Docker executor](https://circleci.com/docs/2.0/executor-types/) on the [default medium size machine](https://circleci.com/docs/2.0/configuration-reference/#resource_class) with 2 vCPUs and 4GB of RAM. `cypress info` reports `System Memory: 73.8 GB free 25 GB` with CPUs reported as `Intel(R) Xeon(R) Platinum 8124M CPU @ 3.00GHz`. Note that the free memory varies on CircleCI, typically we see values anywhere from 6GB to 30GB.

Cypress Documentation uses `resource_class: medium+`
RWA uses `resource_class: large`

RWA shows:

Cypress Version: 13.6.6 (stable)
System Platform: linux (Debian - 11.6)
System Memory: 73.6 GB free 48.6 GB

## Changes

1. Drop the reference to [Cypress Documentation](https://github.com/cypress-io/cypress-documentation) since there are no Cypress tests run in this repo and no `cypress info` reports available.
2. Update links
3. Update example output from `cypress info`
4. Change Real World App to `resource_class: large` with 4 vCPUs and 8 GB RAM
5. Change `cypress info` to `System Memory: 73.6 GB free 48.6 GB`
6. Remove info on variable free memory. Since it is not reliably quantifiable this information is not really helpful.
7. Remove info about CPU, since the [RWA CircleCI pipelines](https://app.circleci.com/pipelines/github/cypress-io/cypress-realworld-app) logs do not report this information.

## References

- [Cypress Documentation CircleCI workflow](https://github.com/cypress-io/cypress-documentation/blob/main/.circleci/config.yml)
- [RWA CircleCI workflow](https://github.com/cypress-io/cypress-realworld-app/blob/develop/.circleci/config.yml)
- [RWA CircleCI pipelines](https://app.circleci.com/pipelines/github/cypress-io/cypress-realworld-app)

