### PR TITLE
Update GitHub CI default hardware specs

### DIFF
--- a/docs/guides/continuous-integration/introduction.mdx
+++ b/docs/guides/continuous-integration/introduction.mdx
@@ -294,13 +294,14 @@ node -p 'os.cpus()'
   [`resource_class: large`](https://circleci.com/docs/configuration-reference/#docker-execution-environment)
   providing 4 vCPUs and 8 GB of RAM. `cypress info` reports
   `System Memory: 73.6 GB free 48.6 GB`.
-- [Real World App](https://github.com/cypress-io/cypress-realworld-app) also
-  executes its tests using
-  [GitHub Actions](https://github.com/cypress-io/github-action) with the
-  [default hosted runner](https://docs.github.com/en/actions/reference/specifications-for-github-hosted-runners)
-  with 2 vCPUs and 7GB of RAM. `cypress info` reports
-  `System Memory: 7.29 GB free 632 MB` with CPUs reported as
-  `Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz`.
+- The [Real World App](https://github.com/cypress-io/cypress-realworld-app) project also
+  executes its tests on
+  [GitHub Actions](https://docs.github.com/en/actions) using the
+  [Cypress GitHub Action](https://github.com/cypress-io/github-action) with the
+  [standard Ubuntu GitHub-hosted runner for Public repositories](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners)
+  providing 4 vCPUs and 16 GB of RAM. `cypress info` reports
+  `System Memory: 16.8 GB free 15.5 GB` with CPUs reported as
+  `AMD EPYC 7763 64-Core Processor`.
 
 **Tip:** if there are problems with longer specs, try splitting them into
 shorter ones, following


### PR DESCRIPTION
## Issue

The GitHub runner hardware dimensioning reference in [Continuous Integration > Introduction > Machine requirements](https://docs.cypress.io/guides/continuous-integration/introduction#Machine-requirements) is out of date.

> [Real World App](https://github.com/cypress-io/cypress-realworld-app) also executes its tests using [GitHub Actions](https://github.com/cypress-io/github-action) with the [default hosted runner](https://docs.github.com/en/actions/reference/specifications-for-github-hosted-runners) with 2 vCPUs and 7GB of RAM. `cypress info` reports  `System Memory: 7.29 GB free 632 MB` with CPUs reported as `Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz`.

The [RWA > Cypress Test](https://github.com/cypress-io/cypress-realworld-app/actions/workflows/main.yml?query=branch%3Adevelop) workflow log running on the standard GitHub runner `ubuntu-latest` for Public repositories shows:

Cypress Version: 13.6.6 (stable)
System Platform: linux (Debian - 11.6)
System Memory: 16.8 GB free 15.5 GB

4 vCPUs 'AMD EPYC 7763 64-Core Processor'

## Changes

1. Update the link to https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners
2. Update to 4 vCPUs and 16 GB RAM
3. Update to "`cypress info` reports `System Memory: 16.8 GB free 15.5 GB` with CPUs reported as `AMD EPYC 7763 64-Core Processor`.

## References

- [About GitHub-hosted runners](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners)
- [Standard GitHub-hosted runners for Public repositories](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories)
- [Standard GitHub-hosted runners for Private repositories](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-private-repositories)
