### PR TITLE
Remove link to archived cypress-example-docker-codeship repo

### DIFF
--- a/docs/guides/continuous-integration/ci-provider-examples.mdx
+++ b/docs/guides/continuous-integration/ci-provider-examples.mdx
@@ -136,7 +136,6 @@ and
 
 ### CodeShip Pro
 
-- [cypress-example-docker-codeship](https://github.com/cypress-io/cypress-example-docker-codeship)
 - [Basic](https://github.com/cypress-io/cypress-example-kitchensink/tree/master/basic/codeship-pro)
 - [Parallel codeship-steps.yml](https://github.com/cypress-io/cypress-example-kitchensink/tree/master/codeship-steps.yml)
 - [Parallel codeship-services.yml](https://github.com/cypress-io/cypress-example-kitchensink/tree/master/codeship-services.yml)


### PR DESCRIPTION
## Issue

[Continuous Integration > CI Provider Examples > CodeShip Pro](https://docs.cypress.io/guides/continuous-integration/ci-provider-examples#CodeShip-Pro) lists a link to the repo https://github.com/cypress-io/cypress-example-docker-codeship.

This repo demonstrates the legacy [cypress@9.4.1](https://docs.cypress.io/guides/references/changelog#9-4-1) (released on Jan 31, 2022) running in Cypress Docker image [cypress/base:10](https://hub.docker.com/layers/cypress/base/10/images/sha256-7fb73651d4a48762d5f370a497a155891eba90605ea395a4d86cafdefb153f8c?context=explore) published 4 years ago. Node.js `10` entered [end-of-life](https://github.com/nodejs/release#release-schedule) on Apr 30, 2021 and is no longer supported.

The repo https://github.com/cypress-io/cypress-example-docker-codeship was archived on Jun 9, 2022.

The CodeShip Pro project link [ ![Codeship Status for cypress-io/cypress-example-docker-codeship](https://app.codeship.com/projects/c989dc20-2399-0135-8805-66761da64e8c/status?branch=master)](https://app.codeship.com/projects/222054) in the [repos' README](https://github.com/cypress-io/cypress-example-docker-codeship/blob/master/README.md) says "project not found".

## Change

Remove the link to the archived and obsolete https://github.com/cypress-io/cypress-example-docker-codeship repo from the list on [Continuous Integration > CI Provider Examples > CodeShip Pro](https://docs.cypress.io/guides/continuous-integration/ci-provider-examples#CodeShip-Pro).

Note that the linked examples [cypress-example-kitchensink > CI Workflow Examples](https://github.com/cypress-io/cypress-example-kitchensink/tree/master#ci-workflow-examples) to CloudBees CodeShip Pro, using up-to-date Docker containers based on Node.js `20`, remain available for reference.
