### PR TITLE
Correct link to "Adding Custom Commands (TS)"

### DIFF
--- a/docs/guides/tooling/typescript-support.mdx
+++ b/docs/guides/tooling/typescript-support.mdx
@@ -248,7 +248,7 @@ As you can see there are generic parameters `<'type', 'element'>` are used:
 #### Examples:
 
 - See
-  [Adding Custom Commands](https://github.com/cypress-io/cypress-example-recipes#fundamentals)
+  [Adding Custom Commands (TS)](https://github.com/cypress-io/cypress-example-recipes#fundamentals)
   example recipe.
 - You can find an example with custom commands written in TypeScript in
   [omerose/cypress-support](https://github.com/omerose/cypress-support) repo.


### PR DESCRIPTION
- This PR addresses an item in https://github.com/cypress-io/cypress-documentation/issues/5262#issuecomment-1561698982.

## Issue

[Tooling > TypeScript > Examples](https://docs.cypress.io/guides/tooling/typescript-support#Examples) includes the line

- See [Adding Custom Commands](https://github.com/cypress-io/cypress-example-recipes#fundamentals) example recipe.

linking to https://github.com/cypress-io/cypress-example-recipes#fundamentals.

There are two related entries in the [cypress-example-recipes > Fundamentals](https://github.com/cypress-io/cypress-example-recipes#fundamentals) table:

| Recipe                                                                                                                            | Description                                                                                 |
| --------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
| [Adding Custom Commands](https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/fundamentals__add-custom-command)         | Write your own custom commands using JavaScript with correct types for IntelliSense to work |
| [Adding Custom Commands (TS)](https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/fundamentals__add-custom-command-ts) | Write your own custom commands using TypeScript                                             |

The relevant example is [Adding Custom Commands (TS)](https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/fundamentals__add-custom-command-ts) with "(TS)" in the title. The example without "(TS)" is for JavaScript, not TypeScript.

## Change

In [Tooling > TypeScript > Examples](https://docs.cypress.io/guides/tooling/typescript-support#Examples) change the link text to "Adding Custom Commands (TS)".

https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/fundamentals__add-custom-command

## Reference

- [add custom command in TypeScript](https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/fundamentals__add-custom-command-ts)
