### PR TITLE
Remove outdated omerose TS customer command example

### DIFF
--- a/docs/guides/tooling/typescript-support.mdx
+++ b/docs/guides/tooling/typescript-support.mdx
@@ -250,8 +250,6 @@ As you can see there are generic parameters `<'type', 'element'>` are used:
 - See
   [Adding Custom Commands](https://github.com/cypress-io/cypress-example-recipes#fundamentals)
   example recipe.
-- You can find an example with custom commands written in TypeScript in
-  [omerose/cypress-support](https://github.com/omerose/cypress-support) repo.
 - Example project
   [cypress-example-todomvc custom commands](https://github.com/cypress-io/cypress-example-todomvc#custom-commands)
   uses custom commands to avoid boilerplate code.


### PR DESCRIPTION
- This PR address an item in https://github.com/cypress-io/cypress-documentation/issues/5262#issuecomment-1561698982.

## Issues

[Tooling > TypeScript > Examples](https://docs.cypress.io/guides/tooling/typescript-support#Examples) includes the line

- You can find an example with custom commands written in TypeScript in [omerose/cypress-support](https://github.com/omerose/cypress-support) repo.

The repo https://github.com/omerose/cypress-support was last updated 5 years ago and it is based on [cypress@3.6.0](https://docs.cypress.io/guides/references/changelog#3-6-0) (released in October 2019) and on the npm module [@bahmutov/add-typescript-to-cypress](https://www.npmjs.com/package/@bahmutov/add-typescript-to-cypress) (last updated in July 2019).

- [cypress@4.4.0](https://docs.cypress.io/guides/references/changelog#4-4-0) and higher versions include the feature "TypeScript test files are now supported without using special preprocessors plugins.". This means that the plugin [@bahmutov/add-typescript-to-cypress](https://www.npmjs.com/package/@bahmutov/add-typescript-to-cypress) is obsolete (see https://github.com/bahmutov/add-typescript-to-cypress/issues/126). The repo [omerose/cypress-support](https://github.com/omerose/cypress-support) is out of date (see https://github.com/omerose/cypress-support/issues/7) because it demonstrates TypeScript with the use of the obsolete plugin.

The repo [omerose/cypress-support](https://github.com/omerose/cypress-support) is configured for [typescript@3.6.4](https://github.com/microsoft/TypeScript/releases/tag/v3.6.4) whereas [cypress@13.0.0](https://docs.cypress.io/guides/references/changelog#13-0-0) specifies "The minimum supported Typescript version is `4.x`."

## Change

In [Tooling > TypeScript > Examples](https://docs.cypress.io/guides/tooling/typescript-support#Examples) remove the line

- You can find an example with custom commands written in TypeScript in [omerose/cypress-support](https://github.com/omerose/cypress-support) repo.

In its current state, the repo [omerose/cypress-support](https://github.com/omerose/cypress-support) is not useful or up-to-date as an example of Cypress with TypeScript in current versions.
