### PR TITLE
Consolidate Linux prerequisites

### DIFF
--- a/docs/guides/continuous-integration/introduction.mdx
+++ b/docs/guides/continuous-integration/introduction.mdx
@@ -309,22 +309,11 @@ shorter ones, following
 
 ### Dependencies
 
-If you are not using one of the above CI providers then make sure your system
-has these dependencies installed.
+Cypress runs on many CI providers' virtual machine environments out-of-the-box without needing additional dependencies installed.
 
 #### Linux
 
-#### Ubuntu/Debian
-
-```shell
-apt-get install libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libnss3 libxss1 libasound2 libxtst6 xauth xvfb
-```
-
-#### CentOS
-
-```shell
-yum install -y xorg-x11-server-Xvfb gtk2-devel gtk3-devel libnotify-devel GConf2 nss libXScrnSaver alsa-lib
-```
+If you see a message about a missing dependency when you run Cypress in a Linux CI environment, then refer to the [Linux Prerequisites](/guides/getting-started/installing-cypress#Linux-Prerequisites) lists for guidance.
 
 ### Caching
 

--- a/docs/guides/getting-started/installing-cypress.mdx
+++ b/docs/guides/getting-started/installing-cypress.mdx
@@ -139,8 +139,8 @@ just need help with troubleshooting, check out our
 
 Please read our
 [Continuous Integration](/guides/continuous-integration/introduction) docs for
-help installing Cypress in CI. When running in Linux you'll need to install some
-[system dependencies](/guides/continuous-integration/introduction#Dependencies)
+help installing Cypress in CI. When running in Linux you may need to install some
+[system dependencies](#Linux-Prerequisites)
 or you can use our [Docker images](/examples/docker) which have everything you
 need prebuilt.
 
@@ -203,7 +203,9 @@ requirements:
 ### Linux Prerequisites
 
 If you're using Linux, you'll want to have the required dependencies installed
-on your system.
+on your system. Depending on your system defaults, these dependencies may already be installed.
+If not, run the command line for your operating system listed below.
+[Cypress Docker images](#Docker), which are Debian-based, already include the necessary dependencies.
 
 #### Ubuntu/Debian
 


### PR DESCRIPTION
- Closes #5749

## Issue

The lists of required Linux dependencies are kept in two different locations, with differing contents:

1. [Continuous Integration > Advanced setup > Dependencies](https://docs.cypress.io/guides/continuous-integration/introduction#Dependencies)

   - [Ubuntu/Debian](https://docs.cypress.io/guides/continuous-integration/introduction#UbuntuDebian)
   - [CentOS](https://docs.cypress.io/guides/continuous-integration/introduction#CentOS)

2. [Getting Started > Installing Cypress > System requirements > Linux Prerequisites](https://docs.cypress.io/guides/getting-started/installing-cypress#Linux-Prerequisites)

   - [Ubuntu/Debian](https://docs.cypress.io/guides/getting-started/installing-cypress#UbuntuDebian)
   - [Arch](https://docs.cypress.io/guides/getting-started/installing-cypress#Arch)
   - [CentOS](https://docs.cypress.io/guides/getting-started/installing-cypress#CentOS)
   - [Amazon Linux 2023](https://docs.cypress.io/guides/getting-started/installing-cypress#Amazon-Linux-2023)
   - [Docker](https://docs.cypress.io/guides/getting-started/installing-cypress#Docker)

## Change

[Continuous Integration > Advanced setup > Dependencies](https://docs.cypress.io/guides/continuous-integration/introduction#Dependencies) is changed to point to the list on
[Getting Started > Installing Cypress > System requirements > Linux Prerequisites](https://docs.cypress.io/guides/getting-started/installing-cypress#Linux-Prerequisites).

Various texts and links are also updated. Default Ubuntu installations and GitHub Ubuntu runners already include the necessary Linux packages, so the text is changed to assume that it is more likely than not that the dependencies don't need to be additionally installed, without assuming that they are **always** already installed.

## Note

- https://on.cypress.io/required-dependencies also now redirects to
[Getting Started > Installing Cypress > System requirements > Linux Prerequisites](https://docs.cypress.io/guides/getting-started/installing-cypress#Linux-Prerequisites) (see https://github.com/cypress-io/cypress-documentation/issues/5749#issuecomment-1991788457). The URL https://on.cypress.io/required-dependencies is displayed by Cypress at runtime if a missing dependency is detected.