### PR TITLE
Refer to npm consistently

### DIFF
--- a/docs/guides/continuous-integration/github-actions.mdx
+++ b/docs/guides/continuous-integration/github-actions.mdx
@@ -97,7 +97,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      # Install NPM dependencies, cache them correctly
+      # Install npm dependencies, cache them correctly
       # and run all Cypress tests
       - name: Cypress run
         uses: cypress-io/github-action@v6

--- a/docs/guides/end-to-end-testing/testing-strategies/amazon-cognito-authentication.mdx
+++ b/docs/guides/end-to-end-testing/testing-strategies/amazon-cognito-authentication.mdx
@@ -517,7 +517,7 @@ such as AWS AppSync for GraphQL APIs or AWS API Gateway for REST APIs. These
 backend services can be configured to verify cognito JWTs without additional
 code. However, if you are hosting a webserver backend, like the [cypress
 real-world app](https://github.com/cypress-io/cypress-realworld-app) does with
-the Express NPM library, it must be adapted, as the real-world app is, to verify
+the Express npm library, it must be adapted, as the real-world app is, to verify
 the Cognito JWTs to authorize the frontend's requests.
 
 :::

--- a/docs/guides/guides/launching-browsers.mdx
+++ b/docs/guides/guides/launching-browsers.mdx
@@ -177,7 +177,7 @@ these steps:
 
 1. Add `experimentalWebKitSupport: true` to your
    [configuration](/guides/references/configuration) to enable the experiment.
-2. Install the `playwright-webkit` NPM package in your repo to acquire WebKit
+2. Install the `playwright-webkit` npm package in your repo to acquire WebKit
    itself: `npm install --save-dev playwright-webkit@1.34`.
    - We built this experiment on top of the Playwright WebKit browser as a
      stepping stone towards creating a better UX with Cypress-provided browsers

--- a/docs/guides/references/advanced-installation.mdx
+++ b/docs/guides/references/advanced-installation.mdx
@@ -217,7 +217,7 @@ CYPRESS_DOWNLOAD_PATH_TEMPLATE=\${endpoint}/\${platform}-\${arch}/cypress.zip
 
 ## Using a custom certificate authority (CA)
 
-Cypress can be configured to use the `ca` and `cafile` options from your NPM
+Cypress can be configured to use the `ca` and `cafile` options from your npm
 config file to download the Cypress binary.
 
 For example, to use the CA at `/home/person/certs/ca.crt` when downloading

--- a/docs/guides/references/changelog.mdx
+++ b/docs/guides/references/changelog.mdx
@@ -3275,7 +3275,7 @@ _Released 1/31/2022_
 **Bugfixes:**
 
 - Fixed a regression in [9.4.0](/guides/references/changelog#9-4-0) where the
-  line endings in the public NPM package prevented some users from running
+  line endings in the public npm package prevented some users from running
   Cypress. Fixes [#19986](https://github.com/cypress-io/cypress/issues/19986).
 
 ## 9.4.0
@@ -4244,7 +4244,7 @@ _Released 05/10/2021_
 - Setting the env var `DEBUG=cypress:server:record:ci-info` will print commit
   information and CI provider information that's sent to the Dashboard as debug
   logs. Addresses [#16236](https://github.com/cypress-io/cypress/issues/16236).
-- Cypress can now use the certificate authority specified in NPM config if
+- Cypress can now use the certificate authority specified in npm config if
   `CYPRESS_DOWNLOAD_USE_CA` is specified. See
   ["Using a custom CA"](/guides/references/advanced-installation#Using-a-custom-certificate-authority-CA)
   for more information. Addresses
@@ -14381,7 +14381,7 @@ _Released 08/06/2015_
   tool has been created which abstracts away these differences and orchestrates
   the Desktop App regardless of which OS you are running.
 - This
-  [CLI tool is now published on NPM](https://www.npmjs.com/package/cypress),
+  [CLI tool is now published on npm](https://www.npmjs.com/package/cypress),
   though the documentation still needs to be written.
 - There is now a download service to access the latest version of Cypress and
   previous versions.

--- a/docs/guides/tooling/plugins-guide.mdx
+++ b/docs/guides/tooling/plugins-guide.mdx
@@ -206,7 +206,7 @@ can `npm install` any of the plugins listed below:
 Plugins from our [official list](/plugins) are npm modules. This enables them to
 be versioned and updated separately without needing to update Cypress itself.
 
-You can install any published plugin using NPM:
+You can install any published plugin using npm:
 
 ```shell
 npm install <plugin name> --save-dev

--- a/docs/guides/tooling/typescript-support.mdx
+++ b/docs/guides/tooling/typescript-support.mdx
@@ -362,7 +362,7 @@ Both Jest and Expect (bundled inside Cypress) provide the clashing types for the
 1. Configure a separate `tsconfig.json` for E2E tests. See our example
    [cypress-io/cypress-and-jest-typescript-example](https://github.com/cypress-io/cypress-and-jest-typescript-example)
    repo.
-2. Remove Cypress global variables by using NPM package
+2. Remove Cypress global variables by using npm package
    [local-cypress](https://github.com/bahmutov/local-cypress). Read the blog
    post
    [How to Avoid Using Global Cypress Variables](https://glebbahmutov.com/blog/local-cypress/)


### PR DESCRIPTION
## Issue

The repo refers to [npm](https://github.com/npm/cli/blob/latest/README.md) using both upper case "NPM" and lower case "npm".

Usage of capitalized "NPM" is however not in line with [npm branding guidelines](https://github.com/npm/cli#faq-on-branding) which state:

> **`npm`** should never be capitalized unless it is being displayed in a location that is customarily all-capitals (ex. titles on `man` pages).

## Changes

Change all relevant usage of "NPM" to lower case "npm", aligning with [npm branding guidelines](https://github.com/npm/cli#faq-on-branding).

Only one of the instances of "NPM" was in a title. This was in an external blog article and this was left in place.
