### PR TITLE
fix formatting for "Install binary"

### DIFF
--- a/docs/guides/references/advanced-installation.mdx
+++ b/docs/guides/references/advanced-installation.mdx
@@ -25,11 +25,17 @@ Cypress is installed. To override what is installed, you set
 **This is helpful if you want to:**
 
 - Install a version different than the default npm package.
-  `shell CYPRESS_INSTALL_BINARY=2.0.1 npm install cypress@2.0.3 `
+  ```shell
+  CYPRESS_INSTALL_BINARY=2.0.1 npm install cypress@2.0.3
+  ```
 - Specify an external URL (to bypass a corporate firewall).
-  `shell CYPRESS_INSTALL_BINARY=https://company.domain.com/cypress.zip npm install cypress `
+  ```shell
+  CYPRESS_INSTALL_BINARY=https://company.domain.com/cypress.zip npm install cypress
+  ```
 - Specify a file to install locally instead of using the internet.
-  `shell CYPRESS_INSTALL_BINARY=/local/path/to/cypress.zip npm install cypress `
+  ```shell
+  CYPRESS_INSTALL_BINARY=/local/path/to/cypress.zip npm install cypress
+  ```
 
 In all cases, the fact that the binary was installed from a custom location _is
 not saved in your `package.json` file_. Every repeated installation needs to use


### PR DESCRIPTION
## Issue

[References > Advanced Installation > Install binary](https://docs.cypress.io/guides/references/advanced-installation#Install-binary) is displaying `shell` as part of the command line, when it is supposed to be an `.MDX` formatting instruction, for instance:

> Install a version different than the default npm package. `shell CYPRESS_INSTALL_BINARY=2.0.1 npm install cypress@2.0.3`

This is an issue that was introduced unnoticed some years ago.

## Changes

Revert to the original use of `shell` as a triple backtick styler in the [References > Advanced Installation > Install binary](https://docs.cypress.io/guides/references/advanced-installation#Install-binary) section.
