### PR TITLE
Update example versions for direct downloads to 12.17.4

### DIFF
--- a/docs/guides/getting-started/installing-cypress.mdx
+++ b/docs/guides/getting-started/installing-cypress.mdx
@@ -125,7 +125,7 @@ to install any dependencies.
 
 It is possible to download an old version from our CDN by suffixing the URL with
 the desired version (ex.
-[https://download.cypress.io/desktop/6.8.0](https://download.cypress.io/desktop/6.8.0)).
+[https://download.cypress.io/desktop/12.17.4](https://download.cypress.io/desktop/12.17.4)).
 
 :::
 

--- a/docs/guides/references/advanced-installation.mdx
+++ b/docs/guides/references/advanced-installation.mdx
@@ -156,10 +156,10 @@ for all available platforms.
 | `GET`  | `/desktop/:version`                   | Download Cypress with a specified version                                  |
 | `GET`  | `/desktop/:version?platform=p&arch=a` | Download Cypress with a specified version and platform and/or architecture |
 
-**Example of downloading Cypress `3.0.0` for Windows 64-bit:**
+**Example of downloading Cypress `12.17.4` for Windows 64-bit:**
 
 ```text
-https://download.cypress.io/desktop/3.0.0?platform=win32&arch=x64
+https://download.cypress.io/desktop/12.17.4?platform=win32&arch=x64
 ```
 
 ## Mirroring


### PR DESCRIPTION
## Issues

1. [Getting Started > Installing Cypress > Direct Download](https://docs.cypress.io/guides/getting-started/installing-cypress#Direct-download) uses

    > https://download.cypress.io/desktop/6.8.0

    as an example of how to download an old Cypress version.

    [cypress@6.8.0](https://docs.cypress.io/guides/references/changelog#6-8-0) is a legacy version released in March 2021.

2. [References > Advanced Installation > Download URLs](https://docs.cypress.io/guides/references/advanced-installation#Download-URLs) uses

    > https://download.cypress.io/desktop/3.0.0?platform=win32&arch=x64

    as an example of how to download a specific Cypress version for a given platform (Operating System).

    [cypress@3.0.0](https://docs.cypress.io/guides/references/changelog#3-0-0) is a legacy version released in May 2018.


## Change

The examples are changed to use instead [cypress@12.17.4](https://docs.cypress.io/guides/references/changelog#12-17-4), released in Aug 2023. This is the latest `12.x` version and it is one major version previous to the current latest version [cypress@13.7.0](https://docs.cypress.io/guides/references/changelog#13-7-0), released in March 2024.

This is an example of downloading an older **non-legacy** version (instead of a old legacy version).

## Verification

1. In Google Chrome on Windows 11, use the URL https://download.cypress.io/desktop/12.17.4 to download the binary `cypress.zip` without specifying a platform or architecture.

    After the download is shown as completed by Chrome, click the Chrome Download icon and select the "Show in folder" option next to `cypress.zip`. Right-click `cypress.zip` in Windows Explorer and select "Extract All...". Accept the defaults and click "Extract". After all files have been extracted (which can take several minutes) navigate to the extracted `cypress\Cypress` folder in Windows Explorer. Right-click on `Cypress.exe` and select Open. If Microsoft Defender SmartScreen opens, then click on "More info". Confirm that the publisher is "Cypress.io" and click on "Run anyway". Confirm that Cypress `12.17.4` opens in Projects view.

    Delete the `cypress.zip` downloaded file and the complete extracted folder `cypress`.

2. Using instead the URL https://download.cypress.io/desktop/12.17.4?platform=win32&arch=x64 repeat the above steps.
