### PR TITLE
Harmonize package manager install / add instructions

### DIFF
--- a/docs/guides/component-testing/angular/overview.mdx
+++ b/docs/guides/component-testing/angular/overview.mdx
@@ -20,7 +20,7 @@ To get up and running with Cypress Component Testing in Angular, install Cypress
 into your project:
 
 ```bash
-npm install cypress -D
+npm install cypress --save-dev
 ```
 
 Open Cypress:

--- a/docs/guides/component-testing/getting-started.mdx
+++ b/docs/guides/component-testing/getting-started.mdx
@@ -18,7 +18,7 @@ Getting started with Component Testing is super simple. Follow the guide below f
 To begin we need to install Cypress in your project if you have not already done so.
 
 ```bash
-npm install cypress -D
+npm install cypress --save-dev
 ```
 
 ### Open Cypress

--- a/docs/guides/component-testing/react/overview.mdx
+++ b/docs/guides/component-testing/react/overview.mdx
@@ -26,7 +26,7 @@ To get up and running with Cypress Component Testing in React, install Cypress
 into your project:
 
 ```bash
-npm install cypress -D
+npm install cypress --save-dev
 ```
 
 Open Cypress:

--- a/docs/guides/component-testing/svelte/overview.mdx
+++ b/docs/guides/component-testing/svelte/overview.mdx
@@ -30,7 +30,7 @@ To get up and running with Cypress Component Testing in Svelte, install Cypress
 into your project:
 
 ```bash
-npm install cypress -D
+npm install cypress --save-dev
 ```
 
 Open Cypress:

--- a/docs/guides/component-testing/vue/overview.mdx
+++ b/docs/guides/component-testing/vue/overview.mdx
@@ -25,7 +25,7 @@ To get up and running with Cypress Component Testing in Vue, install Cypress
 into your project:
 
 ```bash
-npm install cypress -D
+npm install cypress --save-dev
 ```
 
 Open Cypress:

--- a/docs/guides/continuous-integration/introduction.mdx
+++ b/docs/guides/continuous-integration/introduction.mdx
@@ -107,7 +107,7 @@ If the server takes a very long time to start, we recommend trying the
 module.
 
 ```shell
-npm install --save-dev start-server-and-test
+npm install start-server-and-test --save-dev
 ```
 
 In your `package.json` scripts, pass the command to boot your server, the url

--- a/docs/guides/end-to-end-testing/migration/protractor-to-cypress.mdx
+++ b/docs/guides/end-to-end-testing/migration/protractor-to-cypress.mdx
@@ -252,14 +252,14 @@ Cypress manually.
   <TabItem value="npm" active>
 
 ```bash
-npm install --save-dev cypress
+npm install cypress --save-dev
 ```
 
   </TabItem>
   <TabItem value="yarn">
 
 ```bash
-yarn add --dev cypress
+yarn add cypress --dev
 ```
 
   </TabItem>
@@ -274,14 +274,14 @@ Angular app for Cypress to run tests against your application.
   <TabItem value="npm" active>
 
 ```bash
-npm install --save-dev concurrently
+npm install concurrently --save-dev
 ```
 
   </TabItem>
   <TabItem value="yarn">
 
 ```bash
-yarn add --dev concurrently
+yarn add concurrently --dev
 ```
 
   </TabItem>

--- a/docs/guides/end-to-end-testing/testing-strategies/amazon-cognito-authentication.mdx
+++ b/docs/guides/end-to-end-testing/testing-strategies/amazon-cognito-authentication.mdx
@@ -135,7 +135,7 @@ and install the [AWS Amazon Amplify CLI](https://docs.amplify.aws/cli) as
 follows:
 
 ```jsx
-npm install -g @aws-amplify/cli
+npm install @aws-amplify/cli --global
 ```
 
 The

--- a/docs/guides/getting-started/installing-cypress.mdx
+++ b/docs/guides/getting-started/installing-cypress.mdx
@@ -89,13 +89,13 @@ cd /your/project/path
 ```
 
 ```shell
-pnpm add cypress -D
+pnpm add --save-dev cypress
 ```
 
 :::info
 
 You need to make sure that you have the `pnpm` environment installed locally.
-If not you need to install it: `npm install pnpm@latest -g`.
+If not you need to install it: `npm install pnpm@latest --global`.
 
 :::
 

--- a/docs/guides/guides/launching-browsers.mdx
+++ b/docs/guides/guides/launching-browsers.mdx
@@ -178,7 +178,7 @@ these steps:
 1. Add `experimentalWebKitSupport: true` to your
    [configuration](/guides/references/configuration) to enable the experiment.
 2. Install the `playwright-webkit` npm package in your repo to acquire WebKit
-   itself: `npm install --save-dev playwright-webkit@1.34`.
+   itself: `npm install playwright-webkit@1.34 --save-dev`.
    - We built this experiment on top of the Playwright WebKit browser as a
      stepping stone towards creating a better UX with Cypress-provided browsers
      in the future. Thank you, Playwright contributors.

--- a/docs/guides/guides/test-retries.mdx
+++ b/docs/guides/guides/test-retries.mdx
@@ -262,7 +262,7 @@ retry attempts or failures when using Cypress test retries.
 
 ```ts
 // need to install these dependencies
-// npm i lodash del --save-dev
+// npm install lodash del --save-dev
 import _ from 'lodash'
 import del from 'del'
 ```

--- a/docs/guides/references/migration-guide.mdx
+++ b/docs/guides/references/migration-guide.mdx
@@ -2023,7 +2023,7 @@ The Component Test Runner requires the following dependencies:
    [installation steps](/guides/tooling/code-coverage)).
 
 ```shell
-npm i cypress @cypress/react @cypress/webpack-dev-server -D
+npm install cypress @cypress/react @cypress/webpack-dev-server --save-dev
 ```
 
 **Install Vue 3 dependencies**
@@ -2034,7 +2034,7 @@ npm i cypress @cypress/react @cypress/webpack-dev-server -D
    [`@cypress/webpack-dev-server`](https://www.npmjs.com/package/@cypress/webpack-dev-server).
 
 ```shell
-npm i cypress @cypress/vue@next @cypress/webpack-dev-server -D
+npm install cypress @cypress/vue@next @cypress/webpack-dev-server --save-dev
 ```
 
 **Install Vue 2 dependencies**
@@ -2045,7 +2045,7 @@ npm i cypress @cypress/vue@next @cypress/webpack-dev-server -D
    [`@cypress/webpack-dev-server`](https://www.npmjs.com/package/@cypress/webpack-dev-server).
 
 ```shell
-npm i cypress @cypress/vue @cypress/webpack-dev-server -D
+npm install cypress @cypress/vue @cypress/webpack-dev-server --save-dev
 ```
 
 #### 3. Update plugins file to use `dev-server:start`
@@ -2299,7 +2299,7 @@ for the latest steps.
 
 If you use `cy.react()` in your tests, you must manually install
 [`cypress-react-selector`](https://www.npmjs.com/package/cypress-react-selector)
-with `npm i cypress-react-selector -D`. You do not need to update your support
+with `npm install cypress-react-selector --save-dev`. You do not need to update your support
 file.
 
 #### HTML Side effects

--- a/docs/guides/tooling/code-coverage.mdx
+++ b/docs/guides/tooling/code-coverage.mdx
@@ -298,7 +298,7 @@ documentation for up-to-date installation instructions.
 :::
 
 ```shell
-npm install -D @cypress/code-coverage
+npm install @cypress/code-coverage --save-dev
 ```
 
 Then add the code below to the

--- a/docs/guides/tooling/reporters.mdx
+++ b/docs/guides/tooling/reporters.mdx
@@ -194,7 +194,7 @@ We need to install additional dependencies:
   with Cypress
 
 ```shell
-npm install --save-dev cypress-multi-reporters mocha-junit-reporter
+npm install cypress-multi-reporters mocha-junit-reporter --save-dev
 ```
 
 Specify your reporter and reporterOptions in your Cypress configuration or via
@@ -280,7 +280,7 @@ JSON file per test file, and then combine all JSON reports into a single report.
 We need to install some additional dependencies.
 
 ```shell
-npm install --save-dev mochawesome mochawesome-merge mochawesome-report-generator
+npm install mochawesome mochawesome-merge mochawesome-report-generator --save-dev
 ```
 
 We need to configure the reporter in your

--- a/docs/guides/tooling/typescript-support.mdx
+++ b/docs/guides/tooling/typescript-support.mdx
@@ -17,14 +17,14 @@ install it:
 <TabItem value='npm'>
 
 ```shell
-npm install --save-dev typescript
+npm install typescript --save-dev
 ```
 
 </TabItem>
 <TabItem value='yarn'>
 
 ```shell
-yarn add --dev typescript
+yarn add typescript --dev
 ```
 
 </TabItem>

--- a/docs/guides/tooling/visual-testing.mdx
+++ b/docs/guides/tooling/visual-testing.mdx
@@ -91,7 +91,7 @@ it('completes todo', () => {
 
   cy.contains('.todo-list li', 'write tests').should('have.class', 'completed')
 
-  // run 'npm i cypress-plugin-snapshots -S'
+  // run 'npm install cypress-plugin-snapshots --save'
   // capture the element screenshot and
   // compare to the baseline image
   cy.get('.todoapp').toMatchImageSnapshot({


### PR DESCRIPTION
- closes https://github.com/cypress-io/cypress-documentation/issues/5764

## Issue

Instructions for installing [cypress](https://www.npmjs.com/package/cypress) and other npm modules are shown inconsistently throughout the website for npm, pnpm and Yarn package managers.

1. The examples vary; sometimes using a short-form optional flag and sometimes an equivalent long-form:
    ```shell
    npm install cypress -D
    npm install cypress --save-dev
    ```

2. Similarly varied is the positioning of an optional flag:
    ```shell
    npm install --save-dev cypress
    npm install cypress --save-dev
    ```

Although the different variations are correct, it can be confusing to have examples which are arbitrarily different.

## Changes

1. The long-form is used for optional flags, e.g. `--save-dev`. This makes for better comprehension for readers unfamiliar with the meaning of the alternative short-form optional flag, e.g.
    ```shell
    npm install cypress --save-dev
    ```

2. The positioning of optional flags is aligned to the package manager documentation, e.g.
    ```shell
    npm install cypress --save-dev
    yarn add cypress --dev
    pnpm add --save-dev cypress
    ```

Historical entries in the [Changelog](https://docs.cypress.io/guides/references/changelog) are left unchanged.

## References

- [`npm-install`](https://docs.npmjs.com/cli/v10/commands/npm-install#description) showing `-D, --save-dev` and [`save-dev`](https://docs.npmjs.com/cli/v10/using-npm/config#save-dev)
- [`yarn add`](https://classic.yarnpkg.com/en/docs/cli/add) showing [`yarn add <package...> [--dev/-D]`](https://classic.yarnpkg.com/en/docs/cli/add#toc-yarn-add-dev-d)
- [`pnpm add`](https://pnpm.io/cli/add) showing [`--save-dev, -D`](https://pnpm.io/cli/add#--save-dev--d)
