### PR TITLE
Update requirements to Debian 10 and above

### DIFF
--- a/docs/guides/getting-started/installing-cypress.mdx
+++ b/docs/guides/getting-started/installing-cypress.mdx
@@ -152,8 +152,7 @@ Cypress is a desktop application that is installed on your computer. The desktop
 application supports these operating systems:
 
 - **macOS** 10.9 and above _(Intel or Apple Silicon 64-bit (x64 or arm64))_
-- **Linux** Ubuntu 20.04 and above, Fedora 21 and Debian 8 _(x86_64 or Arm
-  64-bit (x64 or arm64))_ (see [Linux Prerequisites](#Linux-Prerequisites) down
+- **Linux** Ubuntu 20.04 and above, Fedora 21 and Debian 10 and above _(x64 or arm64)_ (see [Linux Prerequisites](#Linux-Prerequisites) down
   below)
 - **Windows** 10 and above _(64-bit only)_
 


### PR DESCRIPTION
- relates to issue #5444

This PR updates the Debian version in the list of supported operating systems under the section [Getting Started > Installing Cypress > System requirements > Operating System](https://docs.cypress.io/guides/getting-started/installing-cypress#Operating-System)

from

- Debian 8 (x86_64 or Arm 64-bit (x64 or arm64))

to

- Debian 10 (x64 or arm64) and above

## Background

[Getting Started > Installing Cypress > System requirements > Node.js](https://docs.cypress.io/guides/getting-started/installing-cypress#Nodejs) lists Node.js `18`, `20` and above as being supported.

The [Node.js 18 announcement](https://nodejs.org/en/blog/announcements/v18-release-announce) provides detailed information in the [Toolchain and Compiler Upgrades](https://nodejs.org/en/blog/announcements/v18-release-announce#toolchain-and-compiler-upgrades) section which lists:
> Prebuilt binaries for Linux are now built on Red Hat Enterprise Linux (RHEL) 8 and are compatible with Linux distributions based on glibc 2.28 or later, for example, Debian 10, RHEL 8, Ubuntu 20.04.

Executing `ldd --version` on Debian `8.11.1` (jessie) shows that GLIBC `2.19` is installed, which is below GLIBC `2.28` or later required by Node.js `18`. Attempting to run `node` or `npm` from Node.js `18.19.1` LTS on Debian `8.11.1` (jessie) fails with fatal error messages related to the GLIBC version requirements not being fulfilled.

[Debian “buster” (10)](https://www.debian.org/releases/buster/) is therefore the earliest version which is supported by Node.js `18` and is compatible with the prebuilt binaries of Node.js `18`. Debian `10` is under [Long Term Support](https://wiki.debian.org/LTS) until June 30, 2024.
