### PR TITLE
Update requirements to Fedora 38 and above

### DIFF
--- a/docs/guides/getting-started/installing-cypress.mdx
+++ b/docs/guides/getting-started/installing-cypress.mdx
@@ -152,7 +152,7 @@ Cypress is a desktop application that is installed on your computer. The desktop
 application supports these operating systems:
 
 - **macOS** 10.9 and above _(Intel or Apple Silicon 64-bit (x64 or arm64))_
-- **Linux** Ubuntu 20.04 and above, Fedora 21 and Debian 10 and above _(x64 or arm64)_ (see [Linux Prerequisites](#Linux-Prerequisites) down
+- **Linux** Ubuntu 20.04 and above, Fedora 38 and above, and Debian 10 and above _(x64 or arm64)_ (see [Linux Prerequisites](#Linux-Prerequisites) down
   below)
 - **Windows** 10 and above _(64-bit only)_
 


### PR DESCRIPTION
- relates to issue #5444

This PR updates the Fedora version in the list of supported operating systems under the section [Getting Started > Installing Cypress > System requirements > Operating System](https://docs.cypress.io/guides/getting-started/installing-cypress#Operating-System)

from

- Fedora 21

to

- Fedora 38 and above

## Background

[Getting Started > Installing Cypress > System requirements > Node.js](https://docs.cypress.io/guides/getting-started/installing-cypress#Nodejs) lists Node.js `18`, `20` and above as being supported.

The [Node.js 18 announcement](https://nodejs.org/en/blog/announcements/v18-release-announce) in the section [Toolchain and Compiler Upgrades](https://nodejs.org/en/blog/announcements/v18-release-announce#toolchain-and-compiler-upgrades) states:

> Node.js does not support running on operating systems that are no longer supported by their vendor.

[Fedora Linux Releases > Current supported releases](https://docs.fedoraproject.org/en-US/releases/#_current_supported_releases) shows Fedora 38 as the earliest version still supported. Fedora 21 entered end-of-life on Dec 1, 2015 according to [Fedora Linux Releases > End of Life Releases](https://docs.fedoraproject.org/en-US/releases/eol/) and is therefore no longer supported.
