### PR TITLE
Fix typo (was sucess, is success)

### DIFF
--- a/docs/api/commands/intercept.mdx
+++ b/docs/api/commands/intercept.mdx
@@ -958,7 +958,7 @@ cy.intercept('POST', '/users', (req) => {
 // requests to create a user will be fulfilled
 // with a body of 'success'
 cy.intercept('POST', '/users', 'success')
-// { body: 'sucess' }
+// { body: 'success' }
 ```
 
 ## Intercepted requests


### PR DESCRIPTION
Hi,

I'm using the docs right now to test some upload action in [Apache Jena](https://github.com/apache/jena/pull/2123), they are really great thanks! This PR fixes a small typo.

Cheers