### PR TITLE
Plugin: Add cypress-voice-plugin to plugins list

### DIFF
--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -174,7 +174,7 @@
           "name": "cypress-voice-plugin",
           "description": "Cypress plugin to announce spec result and time in Cypress Test Runner.",
           "link": "https://github.com/dennisbergevin/cypress-voice-plugin",
-          "keywords": ["auditory", "results", "duration", "ui"],
+          "keywords": ["auditory", "ui", "results", "duration"],
           "badge": "community"
         },
         {

--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -169,7 +169,8 @@
           "link": "https://github.com/bahmutov/cypress-dark",
           "keywords": ["theme"],
           "badge": "verified"
-        },       {
+        },       
+        {
           "name": "cypress-voice-plugin",
           "description": "Cypress plugin to announce spec result and time in Cypress Test Runner.",
           "link": "https://github.com/dennisbergevin/cypress-voice-plugin",

--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -169,6 +169,12 @@
           "link": "https://github.com/bahmutov/cypress-dark",
           "keywords": ["theme"],
           "badge": "verified"
+        },       {
+          "name": "cypress-voice-plugin",
+          "description": "Cypress plugin to announce spec result and time in Cypress Test Runner.",
+          "link": "https://github.com/dennisbergevin/cypress-voice-plugin",
+          "keywords": ["auditory", "results", "duration", "ui"],
+          "badge": "community"
         },
         {
           "name": "cypress-protobuf",


### PR DESCRIPTION
[cypress-voice-plugin](https://github.com/dennisbergevin/cypress-voice-plugin) is a Cypress plugin to announce spec result and time in Cypress Test Runner.

Tests and CI are included in the linked repository.

Please let me know what else is needed to be included in the official Cypress plugins list, thank you!