### PR TITLE
Plugin: Add voice plugin to Cypress plugins page

### DIFF
--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -171,6 +171,13 @@
           "badge": "verified"
         },
         {
+          "name": "cypress-voice-plugin",
+          "description": "Cypress plugin to announce spec result and time in Cypress Test Runner.",
+          "link": "https://github.com/dennisbergevin/cypress-voice-plugin",
+          "keywords": ["auditory", "ui", "results", "duration"],
+          "badge": "community"
+        },
+        {
           "name": "cypress-protobuf",
           "description": "Encode a fixture with Protocol Buffers.",
           "link": "https://github.com/NoriSte/cypress-protobuf",


### PR DESCRIPTION
[cypress-voice-plugin](https://github.com/dennisbergevin/cypress-voice-plugin) is a Cypress plugin to announce spec result and time in Cypress Test Runner.

Tests and CI are included in the linked repository.

Please let me know what else is needed to be included in the official Cypress plugins list, thank you!