### PR TITLE
Fix typo for example in origin.mdx

### DIFF
--- a/docs/api/commands/origin.mdx
+++ b/docs/api/commands/origin.mdx
@@ -202,10 +202,10 @@ cy.origin('example.cypress.io', () => {
 })
 ```
 
-Here the `baseUrl` inside the `cy.origin()` callback is set to `www.cypress.io`
+Here the `baseUrl` inside the `cy.origin()` callback is set to `example.cypress.io`
 and the protocol defaults to `https`. When `cy.visit()` is called with the path
 `/history/founder`, the three are concatenated to make
-`https://www.cypress.io/history/founder`.
+`https://example.cypress.io/history/founder`.
 
 #### Alternative navigation
 


### PR DESCRIPTION
Update example in section `Navigating to secondary origin with cy.visit` to correctly refer to `example.cypress.io` instead of `www.cypress.io` as `example` is the subdomain being used in the `cy.origin` command

https://github.com/cypress-io/cypress-documentation/blob/9e3cd1f9bb30fb8951512a615b7654906234a79a/docs/api/commands/origin.mdx?plain=1#L198