### PR TITLE
Hide CI "try it out" instructions

### DIFF
--- a/docs/guides/continuous-integration/github-actions.mdx
+++ b/docs/guides/continuous-integration/github-actions.mdx
@@ -106,6 +106,11 @@ jobs:
           start: npm start
 ```
 
+<!--
+TODO - Protect existing workflows from failing in fork
+See https://github.com/cypress-io/cypress-documentation/issues/5754
+Until this is issue is resolved, the "Try it out" instructions should not be displayed.
+
 :::tip
 
 <strong>Try it out</strong>
@@ -116,6 +121,7 @@ example project and place the above GitHub Action configuration in a newly
 created `main.yml` file within `.github/workflows/`.
 
 :::
+ -->
 
 **How this action works:**
 


### PR DESCRIPTION
- related to #5754

## Issue

Executing the **Try it out** instructions [Continuous Integration > GitHub Actions > Basic Setup](https://docs.cypress.io/guides/continuous-integration/github-actions#Basic-Setup) causes workflow errors in exisiting workflows.

> **Try it out**
>
>To try out the example above yourself, fork the [Cypress Kitchen Sink](https://github.com/cypress-io/cypress-example-kitchensink) example project and place the above GitHub Action configuration in a newly created `main.yml` file within `.github/workflows/`.

## Change

The instructions are commented out so they are not displayed. A TODO notice is added, which is kept in the source .mdx and not published.

---
BEFORE
![basic ci before](https://github.com/cypress-io/cypress-documentation/assets/66998419/35a0163d-eb52-4723-ad98-e80e0a8690c8)

---
AFTER
![basic ci after](https://github.com/cypress-io/cypress-documentation/assets/66998419/ec554ec6-e31a-4134-9f89-53ef7be0593a)
