### PR TITLE
Update requirements to macOS 10.15 and above

### DIFF
--- a/docs/guides/getting-started/installing-cypress.mdx
+++ b/docs/guides/getting-started/installing-cypress.mdx
@@ -151,7 +151,7 @@ need prebuilt.
 Cypress is a desktop application that is installed on your computer. The desktop
 application supports these operating systems:
 
-- **macOS** 10.9 and above _(Intel or Apple Silicon 64-bit (x64 or arm64))_
+- **macOS** 10.15 and above _(Intel or Apple Silicon 64-bit (x64 or arm64))_
 - **Linux** Ubuntu 20.04 and above, Fedora 38 and above, and Debian 10 and above _(x64 or arm64)_ (see [Linux Prerequisites](#Linux-Prerequisites) down
   below)
 - **Windows** 10 and above _(64-bit only)_


### PR DESCRIPTION
- relates to issue #5444

This PR updates the macOS version in the list of supported operating systems under the section [Getting Started > Installing Cypress > System requirements > Operating System](https://docs.cypress.io/guides/getting-started/installing-cypress#Operating-System) to "macOS 10.15 and above".

This change aligns the Cypress support statement with Node.js `18` details.

## Background

[Getting Started > Installing Cypress > System requirements > Node.js](https://docs.cypress.io/guides/getting-started/installing-cypress#Nodejs) lists Node.js `18`, `20` and above as being supported.

The [Node.js 18 announcement](https://nodejs.org/en/blog/announcements/v18-release-announce) in the section [Toolchain and Compiler Upgrades](https://nodejs.org/en/blog/announcements/v18-release-announce#toolchain-and-compiler-upgrades) states:

> Prebuilt binaries for macOS now require macOS 10.15 or later.
