### PR TITLE
Update example CYPRESS_INSTALL_BINARY

### DIFF
--- a/docs/guides/references/advanced-installation.mdx
+++ b/docs/guides/references/advanced-installation.mdx
@@ -26,7 +26,7 @@ Cypress is installed. To override what is installed, you set
 
 - Install a version different than the default npm package.
   ```shell
-  CYPRESS_INSTALL_BINARY=2.0.1 npm install cypress@2.0.3
+  CYPRESS_INSTALL_BINARY=13.7.0 npm install cypress@13.7.1
   ```
 - Specify an external URL (to bypass a corporate firewall).
   ```shell


### PR DESCRIPTION
- closes #5762

## Issue

The example in [References > Advanced Installation > Install binary](https://docs.cypress.io/guides/references/advanced-installation#Install-binary) uses [cypress@2.0.1](https://docs.cypress.io/guides/references/changelog#2-0-1) and [cypress@2.0.2](https://docs.cypress.io/guides/references/changelog#2-0-2) shows the usage of the `CYPRESS_INSTALL_BINARY` environment variable.

> Install a version different than the default npm package.
```shell
CYPRESS_INSTALL_BINARY=2.0.1 npm install cypress@2.0.3
```

Cypress `2.x` are legacy versions which are not compatible with [currently supported versions of Ubuntu](https://docs.cypress.io/guides/getting-started/installing-cypress#Operating-System) where a minimum of Ubuntu `20.04` is described.

## Change

The example is updated to

```shell
CYPRESS_INSTALL_BINARY=13.7.0 npm install cypress@13.7.1
```

## Comments

Caution: using this optional method will result in a warning. In the above case this will be:

```text
⚠ Warning: Binary version 13.7.0 does not match the expected package version 13.7.1

  These versions may not work properly together.
```

Executing the above installation command causes the Cypress binary named under `CYPRESS_INSTALL_BINARY` to be cached under the version directory using the version from `npm install`. This can affect other projects intending to use the same `npm install` version. They will then also use the alternate version from `CYPRESS_INSTALL_BINARY`.

To reset the cache so that the binary version matches the cache directory name, execute

```shell
npx cypress install
```
