### PR TITLE
Remove dangling link to getting started install video

### DIFF
--- a/docs/guides/overview/why-cypress.mdx
+++ b/docs/guides/overview/why-cypress.mdx
@@ -134,12 +134,9 @@ do that no other testing framework can:
 ### <Icon name="cog" /> Setting up tests
 
 There are no servers, drivers, or any other dependencies to install or
-configure. You can write your first passing test in 60 seconds.
-
-<DocsVideo
-  src="/img/snippets/installing-cli.mp4"
-  title="Installing and opening Cypress"
-/>
+configure. You can quickly see your first passing test using template example test specs for
+[End-to-end tests](/guides/end-to-end-testing/writing-your-first-end-to-end-test) or
+[Component tests](/guides/component-testing/getting-started).
 
 ### <Icon name="code" /> Writing tests
 


### PR DESCRIPTION
- closes https://github.com/cypress-io/cypress-documentation/issues/5782

## Issue

- PR https://github.com/cypress-io/cypress-documentation/pull/5738

deleted the following files due to their outdated content:

- `static/img/snippets/installing-cli.mp4`
- `static/img/snippets/installing-cli.png`

References to these files were overlooked in [Overview > Why Cypress? > Features > Setting up tests](https://docs.cypress.io/guides/overview/why-cypress#Setting-up-tests).

The original text claims "You can write your first passing test in 60 seconds." however the deleted video did not demonstrate that claim. Earlier versions of Cypress scaffolded E2E specs automatically. That has now changed. Nothing is automatically scaffolded and there are differences between E2E and Component Testing scaffolding.

## Change

Links to the files

- `static/img/snippets/installing-cli.mp4`
- `static/img/snippets/installing-cli.png`

are removed from [Overview > Why Cypress? > Features > Setting up tests](https://docs.cypress.io/guides/overview/why-cypress#Setting-up-tests).

The text is updated to refer to the scaffolded examples. Links are added, which demonstrate details of setting up E2E and component tests:

- [End-to-end tests](https://docs.cypress.io/guides/end-to-end-testing/writing-your-first-end-to-end-test) or
- [Component tests](https://docs.cypress.io/guides/component-testing/getting-started)

---
AFTER

![image](https://github.com/cypress-io/cypress-documentation/assets/66998419/beb162e8-7501-447c-b7a8-8eb3571dde3d)


