### PR TITLE
Tab package manager option display in "How to run commands"

### DIFF
--- a/docs/guides/getting-started/opening-the-app.mdx
+++ b/docs/guides/getting-started/opening-the-app.mdx
@@ -19,26 +19,32 @@ description: 'Open the app effectively in Cypress. Get started with a guide on o
 
 ## `cypress open`
 
-You can open Cypress from your **project root** in one of the following ways,
+You can open Cypress from your **project root** using one of the following commands,
 depending on the package manager (npm, Yarn or pnpm) you are using:
 
-**Using `npx`**
-
-```shell
-npx cypress open
-```
-
-**Or by using `yarn`**
-
-```shell
-yarn cypress open
-```
-
-**Or by using `pnpm`**
-
-```shell
-pnpm cypress open
-```
+<Tabs
+  defaultValue="npm"
+  values={[
+    {label: 'npm', value: 'npm'},
+    {label: 'Yarn', value: 'yarn'},
+    {label: 'pnpm', value: 'pnpm'},
+  ]}>
+  <TabItem value="npm">
+  ```shell
+  npx cypress open
+  ```
+  </TabItem>
+  <TabItem value="yarn">
+  ```shell
+  yarn cypress open
+  ```
+  </TabItem>
+  <TabItem value="pnpm">
+  ```shell
+  pnpm cypress open
+  ```
+  </TabItem>
+</Tabs>
 
 After a moment, the Cypress Launchpad will open.
 

--- a/docs/guides/getting-started/opening-the-app.mdx
+++ b/docs/guides/getting-started/opening-the-app.mdx
@@ -30,19 +30,25 @@ depending on the package manager (npm, Yarn or pnpm) you are using:
     {label: 'pnpm', value: 'pnpm'},
   ]}>
   <TabItem value="npm">
-  ```shell
-  npx cypress open
-  ```
+
+```shell
+npx cypress open
+```
+
   </TabItem>
   <TabItem value="yarn">
-  ```shell
-  yarn cypress open
-  ```
+
+```shell
+yarn cypress open
+```
+
   </TabItem>
   <TabItem value="pnpm">
-  ```shell
-  pnpm cypress open
-  ```
+
+```shell
+pnpm cypress open
+```
+
   </TabItem>
 </Tabs>
 


### PR DESCRIPTION
## Situation

The [Getting Started > Opening the App > `cypress open`](https://docs.cypress.io/guides/getting-started/opening-the-app#cypress-open) section shows how to use `npx`, `yarn` and `pnpm` as alternative ways of executing `cypress open` in a list format.

## Change

Display the alternatives using [Docusaurus Tabs](https://docusaurus.io/docs/markdown-features/tabs) for a more compact and readable side-by-side display.

---
BEFORE
![cypress open before](https://github.com/cypress-io/cypress-documentation/assets/66998419/b66fb557-2f20-441b-a86b-ac8dd779146d)

---
AFTER

**Option npm**
![cypress open npm after](https://github.com/cypress-io/cypress-documentation/assets/66998419/1f27b952-afd2-4046-a920-23a2c3a351a2)

**Option Yarn**
![cypress open yarn after](https://github.com/cypress-io/cypress-documentation/assets/66998419/bc61aba2-bdfb-4216-ac16-b0516f8a012f)

**Open pnpm**
![cypress open pnpm after](https://github.com/cypress-io/cypress-documentation/assets/66998419/51ee8174-d120-4ae3-8f4e-fbf60d022870)