### PR TITLE
Update Plugin List - Explicitly deprecate out-of-date plugins

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,10 +143,10 @@ Each plugin submitted to the plugins list should have the following:
 
 Plugins are listed in in the following order to for users:
 
-- official
-- verified
-- community
-- experimental
+- official (Cypress owned)
+- verified (community owned and verified by Cypress)
+- community (community owned and unverified)
+- deprecated (npm registry missing, source repo archived or incompatible with v10+)
 
 ### Adding Pages
 

--- a/src/components/plugins-list/style.module.css
+++ b/src/components/plugins-list/style.module.css
@@ -81,20 +81,20 @@ ul.pluginsList li p {
   color: white;
 }
 
-.badgePill.badgeCommunity {
-  background-color: #737373;
-}
-
-.badgePill.badgeExperimental {
-  background-color: #965cc1;
-}
-
 .badgePill.badgeOfficial {
-  background-color: #257e8e;
+  background-color: #11d3d7;
 }
 
 .badgePill.badgeVerified {
-  background-color: #00805b;
+  background-color: #25bd4d;
+}
+
+.badgePill.badgeCommunity {
+  background-color: #9d44eb;
+}
+
+.badgePill.badgeDeprecated {
+  background-color: #7f112c;
 }
 
 .keyword {

--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -26,34 +26,6 @@
           "badge": "community"
         },
         {
-          "name": "Cytorus",
-          "description": "Run cucumber/gherkin-syntaxed specs with cypress.io.",
-          "link": "https://github.com/NaturalIntelligence/cytorus",
-          "keywords": ["gherkin", "cucumber"],
-          "badge": "community"
-        },
-        {
-          "name": "cypress-app-watcher-preprocessor",
-          "description": "Reruns Cypress tests when the back end server restarts.",
-          "link": "https://github.com/TheBrainFamily/cypress-app-watcher-preprocessor",
-          "keywords": ["file-watcher"],
-          "badge": "community"
-        },
-        {
-          "name": "cypress-eslint-preprocessor",
-          "description": "Runs linting via ESLint on your spec files as they are loaded and display errors in the console.",
-          "link": "https://github.com/chinchiheather/cypress-eslint-preprocessor",
-          "keywords": ["eslint"],
-          "badge": "community"
-        },
-        {
-          "name": "Rollup",
-          "description": "Watches and bundles your spec files via Rollup.",
-          "link": "https://github.com/bahmutov/cy-rollup",
-          "keywords": ["rollup"],
-          "badge": "community"
-        },
-        {
           "name": "cypress-markdown-preprocessor",
           "description": "Cypress preprocessor for extracting tests from Markdown files.",
           "link": "https://github.com/bahmutov/cypress-markdown-preprocessor",
@@ -75,18 +47,46 @@
           "badge": "community"
         },
         {
-          "name": "cypress-esbuild-preprocessor",
-          "description": "Uses evanw/esbuild to bundle your specs.",
-          "link": "https://github.com/sod/cypress-esbuild-preprocessor",
-          "keywords": ["esbuild"],
-          "badge": "community"
-        },
-        {
           "name": "cypress-vite",
           "description": "Cypress preproccessor for running specs using vite.",
           "link": "https://github.com/mammadataei/cypress-vite",
           "keywords": ["vite"],
           "badge": "community"
+        },
+        {
+          "name": "Cytorus",
+          "description": "Run cucumber/gherkin-syntaxed specs with cypress.io.",
+          "link": "https://github.com/NaturalIntelligence/cytorus",
+          "keywords": ["gherkin", "cucumber"],
+          "badge": "deprecated"
+        },
+        {
+          "name": "cypress-app-watcher-preprocessor",
+          "description": "Reruns Cypress tests when the back end server restarts.",
+          "link": "https://github.com/TheBrainFamily/cypress-app-watcher-preprocessor",
+          "keywords": ["file-watcher"],
+          "badge": "deprecated"
+        },
+        {
+          "name": "cypress-eslint-preprocessor",
+          "description": "Runs linting via ESLint on your spec files as they are loaded and display errors in the console.",
+          "link": "https://github.com/chinchiheather/cypress-eslint-preprocessor",
+          "keywords": ["eslint"],
+          "badge": "deprecated"
+        },
+        {
+          "name": "Rollup",
+          "description": "Watches and bundles your spec files via Rollup.",
+          "link": "https://github.com/bahmutov/cy-rollup",
+          "keywords": ["rollup"],
+          "badge": "deprecated"
+        },
+        {
+          "name": "cypress-esbuild-preprocessor",
+          "description": "Uses evanw/esbuild to bundle your specs.",
+          "link": "https://github.com/sod/cypress-esbuild-preprocessor",
+          "keywords": ["esbuild"],
+          "badge": "deprecated"
         }
       ]
     },
@@ -129,13 +129,6 @@
           "badge": "official"
         },
         {
-          "name": "@cypress/instrument-cra",
-          "description": "NPM module for create-react-app applications to instrument source code without ejecting react-scripts.",
-          "link": "https://github.com/cypress-io/instrument-cra",
-          "keywords": ["coverage"],
-          "badge": "official"
-        },
-        {
           "name": "Cypress Chrome Recorder",
           "description": "Tool to export Cypress Tests from Google Chrome DevTools' Recordings programmatically.",
           "link": "https://github.com/cypress-io/cypress-chrome-recorder",
@@ -164,31 +157,10 @@
           "badge": "official"
         },
         {
-          "name": "cypress-dark",
-          "description": "Several color themes for Cypress test runner.",
-          "link": "https://github.com/bahmutov/cypress-dark",
-          "keywords": ["theme"],
-          "badge": "verified"
-        },
-        {
           "name": "cypress-voice-plugin",
           "description": "Cypress plugin to announce spec result and time in Cypress Test Runner.",
           "link": "https://github.com/dennisbergevin/cypress-voice-plugin",
           "keywords": ["auditory", "ui", "results", "duration"],
-          "badge": "community"
-        },
-        {
-          "name": "cypress-protobuf",
-          "description": "Encode a fixture with Protocol Buffers.",
-          "link": "https://github.com/NoriSte/cypress-protobuf",
-          "keywords": ["encoding", "protobuf"],
-          "badge": "community"
-        },
-        {
-          "name": "Knapsack Pro Cypress",
-          "description": "Dynamic tests split across parallel CI nodes with Knapsack Pro Queue Mode to get faster CI builds. Note - this is 3rd party implementation, different from Cypress Cloud parallelization.",
-          "link": "https://github.com/KnapsackPro/knapsack-pro-cypress",
-          "keywords": ["CI parallelisation", "continuous-integration"],
           "badge": "community"
         },
         {
@@ -203,48 +175,6 @@
           "description": "Reloads Cypress when one of the watched files changes.",
           "link": "https://github.com/bahmutov/cypress-watch-and-reload",
           "keywords": ["file-watcher"],
-          "badge": "community"
-        },
-        {
-          "name": "cypress-autostub",
-          "description": "Alleviates the need to mantain brittle manual mocks by automating the recording and stubbing of requests.",
-          "link": "https://github.com/dan-cooke/cypress-autostub",
-          "keywords": ["mocking", "stubbing", "recording", "fetch", "xhr"],
-          "badge": "community"
-        },
-        {
-          "name": "cypress-plugin-livereload",
-          "description": "Reloads Cypress using livereload.",
-          "link": "https://github.com/unlocomqx/cypress-plugin-livereload",
-          "keywords": ["livereload"],
-          "badge": "community"
-        },
-        {
-          "name": "cypress-select-tests",
-          "description": "User space solution for grepping Cypress tests to run.",
-          "link": "https://github.com/bahmutov/cypress-select-tests",
-          "keywords": ["browserify"],
-          "badge": "community"
-        },
-        {
-          "name": "cypress-autorecord",
-          "description": "Simplify API mocking by auto-recording/stubbing HTTP interactions and automating the process of updating/deleting mocks.",
-          "link": "https://github.com/Nanciee/cypress-autorecord",
-          "keywords": ["mock", "recording", "http", "integration test"],
-          "badge": "community"
-        },
-        {
-          "name": "@cypress/fiddle",
-          "description": "Quickly generates Cypress E2E tests from HTML and JS code.",
-          "link": "https://github.com/cypress-io/cypress-fiddle",
-          "keywords": ["prototype"],
-          "badge": "community"
-        },
-        {
-          "name": "npm-cy",
-          "description": "This GitHub Action for npm enables arbitrary actions with the npm command-line client, including testing with cypress.io and publishing to a registry.",
-          "link": "https://github.com/bartlett705/npm-cy",
-          "keywords": ["github", "actions", "npm"],
           "badge": "community"
         },
         {
@@ -287,13 +217,6 @@
           "description": "Restarts tests when receiving webpack-dev-server HMR updates.",
           "link": "https://github.com/Svish/cypress-hmr-restarter",
           "keywords": ["webpack", "webpack-dev-server", "hmr"],
-          "badge": "community"
-        },
-        {
-          "name": "@bahmutov/cypress-extends",
-          "description": "Cypress plugin that adds \"extends\" support to the configuration file.",
-          "link": "https://github.com/bahmutov/cypress-extends",
-          "keywords": ["config"],
           "badge": "community"
         },
         {
@@ -340,7 +263,7 @@
         {
           "name": "cypress-tags",
           "description": "Use custom tags to slice up Cypress test runs.",
-          "link": "https://github.com/annaet/cypress-tags",
+          "link": "https://github.com/infosum/cypress-tags",
           "keywords": ["test", "tag", "browserify"],
           "badge": "community"
         },
@@ -355,7 +278,15 @@
           "name": "cypress-duration-metrics",
           "description": "Measure duration of commands and different stages of cypress lifecycle. Log to terminal.",
           "link": "https://github.com/archfz/cypress-duration-metrics",
-          "keywords": ["duration", "timings", "commands", "performance", "measurement", "metrics", "total"],
+          "keywords": [
+            "duration",
+            "timings",
+            "commands",
+            "performance",
+            "measurement",
+            "metrics",
+            "total"
+          ],
           "badge": "community"
         },
         {
@@ -406,6 +337,76 @@
           "link": "https://github.com/NoelDeMartin/cypress-solid",
           "keywords": ["solid", "solid-protocol"],
           "badge": "community"
+        },
+        {
+          "name": "@cypress/instrument-cra",
+          "description": "NPM module for create-react-app applications to instrument source code without ejecting react-scripts.",
+          "link": "https://github.com/cypress-io/instrument-cra",
+          "keywords": ["coverage"],
+          "badge": "deprecated"
+        },
+        {
+          "name": "cypress-dark",
+          "description": "Several color themes for Cypress test runner.",
+          "link": "https://github.com/bahmutov/cypress-dark",
+          "keywords": ["theme"],
+          "badge": "deprecated"
+        },
+        {
+          "name": "cypress-protobuf",
+          "description": "Encode a fixture with Protocol Buffers.",
+          "link": "https://github.com/NoriSte/cypress-protobuf",
+          "keywords": ["encoding", "protobuf"],
+          "badge": "deprecated"
+        },
+        {
+          "name": "Knapsack Pro Cypress",
+          "description": "Dynamic tests split across parallel CI nodes with Knapsack Pro Queue Mode to get faster CI builds. Note - this is 3rd party implementation, different from Cypress Cloud parallelization.",
+          "link": "https://github.com/KnapsackPro/knapsack-pro-cypress",
+          "keywords": ["CI parallelisation", "continuous-integration"],
+          "badge": "deprecated"
+        },
+        {
+          "name": "cypress-autostub",
+          "description": "Alleviates the need to mantain brittle manual mocks by automating the recording and stubbing of requests.",
+          "link": "https://github.com/dan-cooke/cypress-autostub",
+          "keywords": ["mocking", "stubbing", "recording", "fetch", "xhr"],
+          "badge": "deprecated"
+        },
+        {
+          "name": "cypress-select-tests",
+          "description": "User space solution for grepping Cypress tests to run.",
+          "link": "https://github.com/bahmutov/cypress-select-tests",
+          "keywords": ["browserify"],
+          "badge": "deprecated"
+        },
+        {
+          "name": "cypress-autorecord",
+          "description": "Simplify API mocking by auto-recording/stubbing HTTP interactions and automating the process of updating/deleting mocks.",
+          "link": "https://github.com/Nanciee/cypress-autorecord",
+          "keywords": ["mock", "recording", "http", "integration test"],
+          "badge": "deprecated"
+        },
+        {
+          "name": "@cypress/fiddle",
+          "description": "Quickly generates Cypress E2E tests from HTML and JS code.",
+          "link": "https://github.com/cypress-io/cypress-fiddle",
+          "keywords": ["prototype"],
+          "badge": "deprecated"
+        },
+        {
+          "name": "@bahmutov/cypress-extends",
+          "description": "Cypress plugin that adds \"extends\" support to the configuration file.",
+          "link": "https://github.com/bahmutov/cypress-extends",
+          "keywords": ["config"],
+          "badge": "deprecated"
+        },
+        {
+          "name": "Browserify",
+          "description": "Watches and bundles your spec files via browserify.",
+          "link": "https://github.com/cypress-io/cypress-browserify-preprocessor",
+          "keywords": ["browserify"],
+          "badge": "deprecated"
         }
       ]
     },
@@ -417,10 +418,7 @@
           "name": "Puppeteer",
           "description": "Utilize Puppeteer's browser API with one command within Cypress.",
           "link": "https://github.com/cypress-io/cypress/tree/develop/npm/puppeteer",
-          "keywords": [
-            "puppeteer",
-            "multi-tab"
-          ],
+          "keywords": ["puppeteer", "multi-tab"],
           "badge": "official"
         },
         {
@@ -432,13 +430,6 @@
             "dom-testing-library",
             "react-testing-library"
           ],
-          "badge": "verified"
-        },
-        {
-          "name": "cypress-unfetch",
-          "description": "Track, test, and block code execution based on network state.",
-          "link": "https://github.com/RcKeller/cypress-unfetch",
-          "keywords": ["commands", "routing", "networking"],
           "badge": "verified"
         },
         {
@@ -485,13 +476,6 @@
           "badge": "community"
         },
         {
-          "name": "cypress-redux",
-          "description": "Run assertions against Redux stores.",
-          "link": "https://github.com/RcKeller/cypress-redux",
-          "keywords": ["commands", "redux"],
-          "badge": "community"
-        },
-        {
           "name": "cypress-axe",
           "description": "Helps test your applications for accessibility issues using axe-core.",
           "link": "https://github.com/avanslaars/cypress-axe",
@@ -534,13 +518,6 @@
           "badge": "community"
         },
         {
-          "name": "cypress-graphql-mock",
-          "description": "Adds commands for executing a mocked GraphQL server using only the client.",
-          "link": "https://github.com/tgriesser/cypress-graphql-mock",
-          "keywords": ["graphql"],
-          "badge": "community"
-        },
-        {
           "name": "cy-mobile-commands",
           "description": "Mobile testing helper for Cypress.",
           "link": "https://gitlab.com/nTopus/cy-mobile-commands#readme",
@@ -548,31 +525,10 @@
           "badge": "community"
         },
         {
-          "name": "cypress-pipe",
-          "description": "Create custom commands using plain-old functions. Similar to `cy.then` but with retriability.",
-          "link": "https://github.com/NicholasBoll/cypress-pipe",
-          "keywords": ["commands"],
-          "badge": "community"
-        },
-        {
           "name": "cypress-downloadfile",
           "description": "A custom command to download different kinds of files and store them on your local machine",
           "link": "https://github.com/Xvier/cypress-downloadfile",
           "keywords": ["commands", "downloading"],
-          "badge": "community"
-        },
-        {
-          "name": "cypress-plugin-stripe-elements",
-          "description": "Simple commands that make it easy to target and fill in Stripe Elements input fields",
-          "link": "https://github.com/dbalatero/cypress-plugin-stripe-elements",
-          "keywords": ["stripe", "commands", "elements", "inputs"],
-          "badge": "community"
-        },
-        {
-          "name": "cypressautomocker",
-          "description": "Allow recording API results and replaying the APIs as a mock server.",
-          "link": "https://github.com/scottschafer/cypressautomocker",
-          "keywords": ["routing", "mock"],
           "badge": "community"
         },
         {
@@ -604,24 +560,10 @@
           "badge": "community"
         },
         {
-          "name": "@cypress/skip-test",
-          "description": "Simple commands to skip a test based on platform, browser or a url.",
-          "link": "https://github.com/cypress-io/cypress-skip-test",
-          "keywords": ["commands"],
-          "badge": "community"
-        },
-        {
           "name": "Cypress-SignalR-Mock",
           "description": "Easy way to publish messages from and to your SignalR hubs in Cypress E2E tests.",
           "link": "https://github.com/JasonLandbridge/Cypress-SignalR-Mock",
           "keywords": ["commands", "signalr", "mock", "websocket"],
-          "badge": "community"
-        },
-        {
-          "name": "cypress-websocket-testing",
-          "description": "Test WebSocket connections with Cypress",
-          "link": "https://github.com/lensesio/cypress-websocket-testing",
-          "keywords": ["commands", "websocket"],
           "badge": "community"
         },
         {
@@ -643,13 +585,6 @@
           "description": "Custom commands for indexedDb. Allows populating, modifying and asserting data stored in indexedDb.",
           "link": "https://github.com/thisdot/open-source/tree/main/libs/cypress-indexeddb",
           "keywords": ["commands", "indexedDb"],
-          "badge": "community"
-        },
-        {
-          "name": "cypress-iframe",
-          "description": "Custom commands for interacting with iframes.",
-          "link": "https://gitlab.com/kgroat/cypress-iframe",
-          "keywords": ["commands", "iframe"],
           "badge": "community"
         },
         {
@@ -688,26 +623,6 @@
           "badge": "community"
         },
         {
-          "name": "cypress-rest-graphql",
-          "description": "Add visual output and helper functions for performing REST and graphQL queries.",
-          "link": "https://github.com/BrandedEntertainmentNetwork/cypress-rest-graphql",
-          "keywords": ["api", "rest", "graphQL"],
-          "badge": "community"
-        },
-        {
-          "name": "cypress-forced-colors",
-          "description": "Cypress commands to enable and disable browser forced colors mode.",
-          "link": "https://github.com/ling1726/cypress-forced-colors",
-          "keywords": [
-            "forced colors",
-            "high contrast",
-            "high contrast mode",
-            "contrast",
-            "testing"
-          ],
-          "badge": "community"
-        },
-        {
           "name": "cy-verify-downloads",
           "description": "Cypress custom command to wait and verify that file was downloaded.",
           "link": "https://github.com/elaichenkov/cy-verify-downloads",
@@ -725,7 +640,14 @@
           "name": "cypress-mongodb",
           "description": "Plugin that allows interaction with MongoDB server using Cypress commands.",
           "link": "https://github.com/Zaista/cypress-mongodb",
-          "keywords": ["testing", "commands", "mongodb", "mongo", "database", "db"],
+          "keywords": [
+            "testing",
+            "commands",
+            "mongodb",
+            "mongo",
+            "database",
+            "db"
+          ],
           "badge": "community"
         },
         {
@@ -733,14 +655,14 @@
           "description": "Adds assertions from Spok library for easy schema and value validations.",
           "link": "https://github.com/bahmutov/cy-spok",
           "keywords": ["assertions"],
-          "badge": "experimental"
+          "badge": "community"
         },
         {
           "name": "cypress-plugin-tab",
           "description": "A Cypress plugin to add a tab command.",
           "link": "https://github.com/Bkucera/cypress-plugin-tab",
           "keywords": ["commands"],
-          "badge": "experimental"
+          "badge": "community"
         },
         {
           "name": "cypress-plugin-multiple-click",
@@ -767,35 +689,90 @@
           "name": "cypress-intercept-formdata",
           "description": "Work with Cypress' Intercept multipart/form-data requests",
           "link": "https://github.com/yoavniran/cypress-intercept-formdata",
-          "keywords": ["testing", "commands", "intercept", "form-data", "request"],
+          "keywords": [
+            "testing",
+            "commands",
+            "intercept",
+            "form-data",
+            "request"
+          ],
           "badge": "community"
+        },
+        {
+          "name": "cypress-unfetch",
+          "description": "Track, test, and block code execution based on network state.",
+          "link": "https://github.com/RcKeller/cypress-unfetch",
+          "keywords": ["commands", "routing", "networking"],
+          "badge": "deprecated"
+        },
+        {
+          "name": "cypress-redux",
+          "description": "Run assertions against Redux stores.",
+          "link": "https://github.com/RcKeller/cypress-redux",
+          "keywords": ["commands", "redux"],
+          "badge": "deprecated"
+        },
+        {
+          "name": "cypress-pipe",
+          "description": "Create custom commands using plain-old functions. Similar to `cy.then` but with retriability.",
+          "link": "https://github.com/NicholasBoll/cypress-pipe",
+          "keywords": ["commands"],
+          "badge": "deprecated"
+        },
+        {
+          "name": "cypress-plugin-stripe-elements",
+          "description": "Simple commands that make it easy to target and fill in Stripe Elements input fields",
+          "link": "https://github.com/dbalatero/cypress-plugin-stripe-elements",
+          "keywords": ["stripe", "commands", "elements", "inputs"],
+          "badge": "deprecated"
+        },
+        {
+          "name": "@cypress/skip-test",
+          "description": "Simple commands to skip a test based on platform, browser or a url.",
+          "link": "https://github.com/cypress-io/cypress-skip-test",
+          "keywords": ["commands"],
+          "badge": "deprecated"
+        },
+        {
+          "name": "cypress-websocket-testing",
+          "description": "Test WebSocket connections with Cypress",
+          "link": "https://github.com/lensesio/cypress-websocket-testing",
+          "keywords": ["commands", "websocket"],
+          "badge": "deprecated"
+        },
+        {
+          "name": "cypress-iframe",
+          "description": "Custom commands for interacting with iframes.",
+          "link": "https://gitlab.com/kgroat/cypress-iframe",
+          "keywords": ["commands", "iframe"],
+          "badge": "deprecated"
+        },
+        {
+          "name": "cypress-rest-graphql",
+          "description": "Add visual output and helper functions for performing REST and graphQL queries.",
+          "link": "https://github.com/BrandedEntertainmentNetwork/cypress-rest-graphql",
+          "keywords": ["api", "rest", "graphQL"],
+          "badge": "deprecated"
+        },
+        {
+          "name": "cypress-dotenv",
+          "description": "Cypress plugin that enables compatibility with dotenv.",
+          "link": "https://github.com/morficus/cypress-dotenv",
+          "keywords": ["dotenv", "env", "environment", "env var"],
+          "badge": "deprecated"
+        },
+        {
+          "name": "cypress-xpath",
+          "description": "Adds XPath command. This repo is also a good example of using custom commands to do retries, provide TypeScript definitions, etc.",
+          "link": "https://github.com/cypress-io/cypress/tree/develop/npm/xpath",
+          "keywords": ["xpath", "commands"],
+          "badge": "deprecated"
         }
       ]
     },
     {
       "name": "Extending other testing frameworks",
       "plugins": [
-        {
-          "name": "cyphell",
-          "description": "Converts WDIO automation tests to Cypress.",
-          "link": "https://github.com/intuit/cyphfell",
-          "keywords": ["wdio"],
-          "badge": "community"
-        },
-        {
-          "name": "cypress-capybara",
-          "description": "Several Capybara finders re-implemented in Cypress to locate UI elements by their text and labels.",
-          "link": "https://github.com/testdouble/cypress-capybara",
-          "keywords": ["testing-library", "capybara"],
-          "badge": "community"
-        },
-        {
-          "name": "cypress-jest-adapter",
-          "description": "Add jest assertion style to Cypress expect command.",
-          "link": "https://github.com/phongnd39/cypress-jest-adapter",
-          "keywords": ["jest"],
-          "badge": "community"
-        },
         {
           "name": "PickleJS",
           "description": "An addition to the Cucumber plugin, featuring a collection of phrases you can use for common actions (ex: \"I click on an &lt;Element&gt;\", \"I should see an &lt;Element&gt;\").",
@@ -809,6 +786,20 @@
           "link": "https://github.com/pactflow/pact-cypress-adapter",
           "keywords": ["pact", "pactflow", "contract testing", "commands"],
           "badge": "community"
+        },
+        {
+          "name": "cypress-capybara",
+          "description": "Several Capybara finders re-implemented in Cypress to locate UI elements by their text and labels.",
+          "link": "https://github.com/testdouble/cypress-capybara",
+          "keywords": ["testing-library", "capybara"],
+          "badge": "deprecated"
+        },
+        {
+          "name": "cypress-jest-adapter",
+          "description": "Add jest assertion style to Cypress expect command.",
+          "link": "https://github.com/phongnd39/cypress-jest-adapter",
+          "keywords": ["jest"],
+          "badge": "deprecated"
         }
       ]
     },
@@ -817,31 +808,11 @@
       "description": "Take a look at our auth guides for <a href=\"/guides/end-to-end-testing/amazon-cognito-authentication\">Amazon Cognito</a>, <a href=\"/guides/end-to-end-testing/amazon-cognito-authentication\">Amazon Cognito</a>, <a href=\"/guides/end-to-end-testing/auth0-authentication\">Auth0</a>, <a href=\"/guides/end-to-end-testing/amazon-cognito-authentication\">Amazon Cognito</a>, <a href=\"/guides/end-to-end-testing/google-authentication\">Google</a>, <a href=\"/guides/end-to-end-testing/okta-authentication\">Okta Cognito</a>, and <a href=\"/guides/end-to-end-testing/social-authentication\">Social Logins</a>. Also checkout our <a target=\"_blank\" href=\"https://github.com/cypress-io/cypress-example-recipes#logging-in-recipes\">Logging in</a> recipes.",
       "plugins": [
         {
-          "name": "cypress-keycloak-commands",
-          "description": "Cypress commands for authenticate users with Keycloak Identity Provider.",
-          "link": "https://github.com/Fredx87/cypress-keycloak-commands",
-          "keywords": [
-            "authentication",
-            "login",
-            "keycloak",
-            "oauth",
-            "openid"
-          ],
-          "badge": "verified"
-        },
-        {
           "name": "cypress-ntlm-auth",
           "description": "NTLM authentication support for Cypress.",
           "link": "https://github.com/bjowes/cypress-ntlm-auth",
           "keywords": ["authentication", "ntlm"],
           "badge": "verified"
-        },
-        {
-          "name": "cypress-otp",
-          "description": "Valid OTP token generation for Cypress.",
-          "link": "https://github.com/NoriSte/cypress-otp",
-          "keywords": ["authentication", "otp", "2fa", "mfa"],
-          "badge": "community"
         },
         {
           "name": "cypress-social-logins",
@@ -855,6 +826,26 @@
             "google"
           ],
           "badge": "community"
+        },
+        {
+          "name": "cypress-keycloak-commands",
+          "description": "Cypress commands for authenticate users with Keycloak Identity Provider.",
+          "link": "https://github.com/Fredx87/cypress-keycloak-commands",
+          "keywords": [
+            "authentication",
+            "login",
+            "keycloak",
+            "oauth",
+            "openid"
+          ],
+          "badge": "deprecated"
+        },
+        {
+          "name": "cypress-otp",
+          "description": "Valid OTP token generation for Cypress.",
+          "link": "https://github.com/NoriSte/cypress-otp",
+          "keywords": ["authentication", "otp", "2fa", "mfa"],
+          "badge": "deprecated"
         }
       ]
     },
@@ -869,13 +860,6 @@
           "badge": "official"
         },
         {
-          "name": "Vue CLI",
-          "description": "Vue CLI allows you to scaffold an application with Cypress E2E fully configured.",
-          "link": "https://github.com/vuejs/vue-cli/tree/dev/packages/%40vue/cli-plugin-e2e-cypress",
-          "keywords": ["vue.js", "vue", "cli"],
-          "badge": "verified"
-        },
-        {
           "name": "cypress-on-rails",
           "description": "Rubygem for using cypress.io with Ruby on Rails applications.",
           "link": "https://github.com/shakacode/cypress-on-rails",
@@ -887,13 +871,6 @@
           "description": "Smart, Fast and Extensible Build System.",
           "link": "https://nx.dev/cypress/overview",
           "keywords": ["angular", "react", "cli", "monorepo"],
-          "badge": "community"
-        },
-        {
-          "name": "Cypress Nuxt",
-          "description": "Utilities for using Cypress with Nuxt.",
-          "link": "https://github.com/NickBolles/cypress-nuxt",
-          "keywords": ["vue.js", "vue", "nuxt", "nuxt.js"],
           "badge": "community"
         },
         {
@@ -918,13 +895,6 @@
           "badge": "community"
         },
         {
-          "name": "Elm Batteries Included",
-          "description": "A project template to learn how Elm, Parcel, Cypress and Netlify work together.",
-          "link": "https://github.com/cedricss/elm-batteries",
-          "keywords": ["elm", "parcel", "netlify"],
-          "badge": "community"
-        },
-        {
           "name": "cypress-rails",
           "description": "Ruby gem to run Cypress against Rails apps, replacing Capybara in system tests.",
           "link": "https://github.com/testdouble/cypress-rails",
@@ -932,25 +902,32 @@
           "badge": "community"
         },
         {
+          "name": "Vue CLI",
+          "description": "Vue CLI allows you to scaffold an application with Cypress E2E fully configured.",
+          "link": "https://github.com/vuejs/vue-cli/tree/dev/packages/%40vue/cli-plugin-e2e-cypress",
+          "keywords": ["vue.js", "vue", "cli"],
+          "badge": "deprecated"
+        },
+        {
+          "name": "Elm Batteries Included",
+          "description": "A project template to learn how Elm, Parcel, Cypress and Netlify work together.",
+          "link": "https://github.com/cedricss/elm-batteries",
+          "keywords": ["elm", "parcel", "netlify"],
+          "badge": "deprecated"
+        },
+        {
           "name": "cypress-laravel",
           "description": "Add commands and hooks to test Laravel applications.",
           "link": "https://github.com/noeldemartin/cypress-laravel",
           "keywords": ["php", "laravel"],
-          "badge": "community"
+          "badge": "deprecated"
         },
         {
           "name": "cypress-splitio",
           "description": "Stores your split.io toggles as environment variables. Helps to decide which e2e tests you need to run.",
           "link": "https://gitlab.com/davidggevorgyan/cypress-splitio",
           "keywords": ["split.io", "feature flags"],
-          "badge": "community"
-        },
-        {
-          "name": "Bison",
-          "description": "A Full Stack Jamstack Template that uses Cypress and GitHub Actions for E2E testing.",
-          "link": "https://github.com/echobind/bisonapp",
-          "keywords": ["next.js", "react", "graphql", "prisma", "vercel"],
-          "badge": "community"
+          "badge": "deprecated"
         }
       ]
     },
@@ -998,35 +975,7 @@
           "description": "Test Angular component using Cypress Test Runner.",
           "link": "https://github.com/bahmutov/cypress-angular-unit-test",
           "keywords": ["component", "angular"],
-          "badge": "experimental"
-        },
-        {
-          "name": "cypress-angularjs-unit-test",
-          "description": "Unit test Angularjs code using Cypress Test Runner.",
-          "link": "https://github.com/bahmutov/cypress-angularjs-unit-test",
-          "keywords": ["component", "angular.js"],
-          "badge": "experimental"
-        },
-        {
-          "name": "cypress-cycle-unit-test",
-          "description": "Test Cycle.js components using Cypress Test Runner.",
-          "link": "https://github.com/bahmutov/cypress-cycle-unit-test",
-          "keywords": ["component", "cycle.js"],
-          "badge": "experimental"
-        },
-        {
-          "name": "cypress-hyperapp-unit-test",
-          "description": "Test Hyperapp components and applications using Cypress Test Runner.",
-          "link": "https://github.com/bahmutov/cypress-hyperapp-unit-test",
-          "keywords": ["component", "hyperapp"],
-          "badge": "experimental"
-        },
-        {
-          "name": "cypress-svelte-unit-test",
-          "description": "Test Svelte components using Cypress Test Runner.",
-          "link": "https://github.com/bahmutov/cypress-svelte-unit-test",
-          "keywords": ["component", "svelte"],
-          "badge": "experimental"
+          "badge": "community"
         },
         {
           "name": "cypress-ct-custom-devserver",
@@ -1048,6 +997,41 @@
           "link": "https://github.com/th3fallen/cypress-rspack-dev-server",
           "keywords": ["component", "Rspack", "dev-server"],
           "badge": "community"
+        },
+        {
+          "name": "Cypress Nuxt",
+          "description": "Utilities for using Cypress with Nuxt.",
+          "link": "https://github.com/NickBolles/cypress-nuxt",
+          "keywords": ["vue.js", "vue", "nuxt", "nuxt.js"],
+          "badge": "deprecated"
+        },
+        {
+          "name": "cypress-angularjs-unit-test",
+          "description": "Unit test Angularjs code using Cypress Test Runner.",
+          "link": "https://github.com/bahmutov/cypress-angularjs-unit-test",
+          "keywords": ["component", "angular.js"],
+          "badge": "deprecated"
+        },
+        {
+          "name": "cypress-cycle-unit-test",
+          "description": "Test Cycle.js components using Cypress Test Runner.",
+          "link": "https://github.com/bahmutov/cypress-cycle-unit-test",
+          "keywords": ["component", "cycle.js"],
+          "badge": "deprecated"
+        },
+        {
+          "name": "cypress-hyperapp-unit-test",
+          "description": "Test Hyperapp components and applications using Cypress Test Runner.",
+          "link": "https://github.com/bahmutov/cypress-hyperapp-unit-test",
+          "keywords": ["component", "hyperapp"],
+          "badge": "deprecated"
+        },
+        {
+          "name": "cypress-svelte-unit-test",
+          "description": "Test Svelte components using Cypress Test Runner.",
+          "link": "https://github.com/bahmutov/cypress-svelte-unit-test",
+          "keywords": ["component", "svelte"],
+          "badge": "deprecated"
         }
       ]
     },
@@ -1058,8 +1042,14 @@
         {
           "name": "SmartBear VisualTest",
           "description": "Visual regression testing for Cypress tests with SmartBear VisualTest.",
-          "link": "https://support.smartbear.com/visualtest/docs/sdks/cypress.html",
-          "keywords": ["visual-ai", "fullpage", "screenshots", "visual regression", "screenshots comparison"],
+          "link": "https://support.smartbear.com/visualtest/docs/en/software-development-kits--sdks-/cypress-sdk.html",
+          "keywords": [
+            "visual-ai",
+            "fullpage",
+            "screenshots",
+            "visual regression",
+            "screenshots comparison"
+          ],
           "badge": "verified"
         },
         {
@@ -1087,7 +1077,12 @@
           "name": "Pixeleye",
           "description": "Open-source, multi-browser visual review and testing platform.",
           "link": "https://pixeleye.io/docs/integrations/cypress",
-          "keywords": ["open-source", "screenshots", "visual regression", "multi-browser"],
+          "keywords": [
+            "open-source",
+            "screenshots",
+            "visual regression",
+            "multi-browser"
+          ],
           "badge": "community"
         },
         {
@@ -1095,13 +1090,6 @@
           "description": "Cross-platform, cross-browser screenshot testing for modern user interfaces.",
           "link": "https://github.com/happo/happo-cypress",
           "keywords": ["screenshots", "visual regression"],
-          "badge": "community"
-        },
-        {
-          "name": "cypress-plugin-snapshots",
-          "description": "Plugin for snapshot tests in Cypress. Same API as Jest, but with graphical interface for reviewing and approving changes.",
-          "link": "https://github.com/meinaart/cypress-plugin-snapshots",
-          "keywords": ["snapshot"],
           "badge": "community"
         },
         {
@@ -1126,13 +1114,6 @@
           "badge": "community"
         },
         {
-          "name": "cypress-blink-test",
-          "description": "Module for adding visual regression testing to Cypress.",
-          "link": "https://github.com/PatrickWalker/cypress-visual-regression",
-          "keywords": ["image-diff", "snapshot"],
-          "badge": "community"
-        },
-        {
           "name": "Visual Regression Tracker",
           "description": "Integration with open source service for visual testing and managing its results.",
           "link": "https://github.com/Visual-Regression-Tracker/agent-cypress",
@@ -1144,18 +1125,6 @@
           "description": "Visual regression testing plugin maintained by DIT - UK Gov.",
           "link": "https://github.com/uktrade/cypress-image-diff",
           "keywords": ["screenshots", "visual regression", "image-diff"],
-          "badge": "community"
-        },
-        {
-          "name": "Micoo",
-          "description": "Cypress plugin for doing visual regression testing with Micoo services",
-          "link": "https://github.com/Mikuu/Micoo/tree/master/clients/micoocypress",
-          "keywords": [
-            "visual regression testing",
-            "visual testing",
-            "screenshots comparison",
-            "testing service"
-          ],
           "badge": "community"
         },
         {
@@ -1171,6 +1140,25 @@
             "image snapshot"
           ],
           "badge": "community"
+        },
+        {
+          "name": "Micoo",
+          "description": "Cypress plugin for doing visual regression testing with Micoo services",
+          "link": "https://github.com/Mikuu/Micoo/tree/master/clients/micoocypress",
+          "keywords": [
+            "visual regression testing",
+            "visual testing",
+            "screenshots comparison",
+            "testing service"
+          ],
+          "badge": "community"
+        },
+        {
+          "name": "cypress-plugin-snapshots",
+          "description": "Plugin for snapshot tests in Cypress. Same API as Jest, but with graphical interface for reviewing and approving changes.",
+          "link": "https://github.com/meinaart/cypress-plugin-snapshots",
+          "keywords": ["snapshot"],
+          "badge": "deprecated"
         }
       ]
     },
@@ -1185,10 +1173,10 @@
           "badge": "community"
         },
         {
-          "name": "cypress-log-to-output",
-          "description": "Plugin that prints all browser console logs to the terminal while running Cypress tests. Currently, only Chrome is supported.",
-          "link": "https://github.com/flotwig/cypress-log-to-output",
-          "keywords": ["logging"],
+          "name": "cypress-terminal-report",
+          "description": "Logs to terminal and files mimicking cypress UI. Logs all cypress commands, request/response data and browser console logs.",
+          "link": "https://github.com/archfz/cypress-terminal-report",
+          "keywords": ["reporter", "logs", "terminal", "CI", "CLI"],
           "badge": "community"
         },
         {
@@ -1213,20 +1201,6 @@
           "badge": "community"
         },
         {
-          "name": "mochawesome-merge",
-          "description": "Merges multiple mochawesome JSON reports.",
-          "link": "https://github.com/antontelesh/mochawesome-merge",
-          "keywords": ["reporter", "mochawesome"],
-          "badge": "community"
-        },
-        {
-          "name": "cypress-slack-healthcheck",
-          "description": "A simple tool which integrates Cypress with Slack to report failing tests.",
-          "link": "https://github.com/bdimitrovski/cypress-healthcheck",
-          "keywords": ["reporter", "slack", "healthcheck"],
-          "badge": "community"
-        },
-        {
           "name": "cypress-slack-reporter",
           "description": "Slack reporting tool. Uses mochawesome json reports, provides links to VCS Provider (github/bitbucket) and CircleCI logs.",
           "link": "https://github.com/you54f/cypress-slack-reporter",
@@ -1234,17 +1208,10 @@
           "badge": "community"
         },
         {
-          "name": "cypress-terminal-report",
-          "description": "Logs cypress commands, route request data and browser console errors and warnings to terminal when tests fail on CI.",
-          "link": "https://github.com/archfz/cypress-terminal-report",
-          "keywords": ["reporter", "logs", "terminal", "CI", "CLI"],
-          "badge": "community"
-        },
-        {
-          "name": "allure-cypress",
-          "description": "Allure reporter for Cypress. Creates rich HTML test reports with screenshots, steps and more.",
-          "link": "https://github.com/allure-framework/allure-js/tree/main/packages/allure-cypress",
-          "keywords": ["reporter", "allure", "step", "screenshot"],
+          "name": "mochawesome-merge",
+          "description": "Merges multiple mochawesome JSON reports.",
+          "link": "https://github.com/antontelesh/mochawesome-merge",
+          "keywords": ["reporter", "mochawesome"],
           "badge": "community"
         },
         {
@@ -1255,11 +1222,25 @@
           "badge": "community"
         },
         {
+          "name": "allure-cypress",
+          "description": "Allure reporter for Cypress. Creates rich HTML test reports with screenshots, steps and more.",
+          "link": "https://github.com/allure-framework/allure-js/tree/main/packages/allure-cypress",
+          "keywords": ["reporter", "allure", "step", "screenshot"],
+          "badge": "community"
+        },
+        {
           "name": "cypress-msteams-reporter",
           "description": "A reporting tool which sends a message to Microsoft Teams with information about the latest cypress test execution results.",
           "link": "https://github.com/maritome/cypress-msteams-reporter",
           "keywords": ["reporter", "ms-teams", "allure-report"],
-          "badge": "community"
+          "badge": "deprecated"
+        },
+        {
+          "name": "cypress-log-to-output",
+          "description": "Plugin that prints all browser console logs to the terminal while running Cypress tests. Currently, only Chrome is supported.",
+          "link": "https://github.com/flotwig/cypress-log-to-output",
+          "keywords": ["logging"],
+          "badge": "deprecated"
         }
       ]
     },
@@ -1299,32 +1280,6 @@
           "description": "Create and use a randomly-generated email address from Guerrilla Mail.",
           "link": "https://github.com/e23thr/cypress-guerrillamail",
           "keywords": ["email", "guerrillamail", "test", "commands"],
-          "badge": "community"
-        }
-      ]
-    },
-    {
-      "name": "Legacy",
-      "plugins": [
-        {
-          "name": "Browserify",
-          "description": "Watches and bundles your spec files via browserify.",
-          "link": "https://github.com/cypress-io/cypress-browserify-preprocessor",
-          "keywords": ["browserify"],
-          "badge": "official"
-        },
-        {
-          "name": "cypress-xpath",
-          "description": "Adds XPath command. This repo is also a good example of using custom commands to do retries, provide TypeScript definitions, etc.",
-          "link": "https://github.com/cypress-io/cypress/tree/develop/npm/xpath",
-          "keywords": ["xpath", "commands"],
-          "badge": "official"
-        },
-        {
-          "name": "cypress-dotenv",
-          "description": "Cypress plugin that enables compatibility with dotenv.",
-          "link": "https://github.com/morficus/cypress-dotenv",
-          "keywords": ["dotenv", "env", "environment", "env var"],
           "badge": "community"
         }
       ]


### PR DESCRIPTION
The Plugins List currently contains a ton of unsupported or archived submissions. 
This change cleans up the list and explicitly labels these plugins as _deprecated_.

This was done by 
- Removing the `experimental` badge and renaming those select few plugins with `community`. In my opinion community plugins are "experimental" by nature if they aren't specifically `verified` by the Cypress team so this felt duplicated. Especially because only a handful had this distinction.
- Adding a few descriptors to what each badge represents to the best of my knowledge
- Adding the `deprecated` badge for plugins that meet **at least one of these three** following conditions
1. Npm registry deprecated
2. Source Repo Publicly Archived
3. Incompatible with v10+ (determined by inactivity over 3+ years ago and/or explicit community issues in the repo referencing incompatibility)
- Removing the Legacy section at the bottom and moving those three plugins into their respective categories as deprecated

After, the giant list of plugins was reviewed, one by one, and those considered "deprecated" were moved to the end of the list for that category. In a few cases I removed the plugin entirely, especially if the plugin was deprecated and clearly unused by the community. I've broken down why each plugin was deprecated below. 

If this change is too large I can break this list of changes up into multiple PRs for each section. There were a total of 47 plugins updated, which reflects the need for updating this list 😄 

**LIST OF DEPRECATED PLUGINS**

**Preprocessors:**
- [cytorus](https://github.com/NaturalIntelligence/cytorus) (v10+ incompatible)
- [cypress-app-watcher-preprocessor](https://github.com/TheBrainFamily/cypress-app-watcher-preprocessor) (v10+ incompatible, 5 years ago)
- [cypress-eslint-preprocessor](https://github.com/chinchiheather/cypress-eslint-preprocessor) (v10+ incompatible, 6 years ago)
- [cypress-rollup](https://github.com/bahmutov/cy-rollup) (v10+ incompatible)
- [cypress-esbuild-preprocessor](https://github.com/sod/cypress-esbuild-preprocessor)  (unsure what version is support, 4+ years ago, @bahmutov/cypress-esbuild-preprocessor plugin does the same thing and is maintained)

**Development Tools:**
- [@cypress/instrument-cra](https://github.com/cypress-io/instrument-cra) (publicly archived)
- [cypress-dark](https://github.com/bahmutov/cypress-dark) (super popular but v10+ incompatible, would like to replace in a follow-up PR with my plugin cypress-runner-themes which is v10+ supported)
- [cypress-protobuf](https://github.com/NoriSte/cypress-protobuf) (v10+ incompatible, 4 years ago) 
- [knapsack-pro-cypress](https://github.com/KnapsackPro/knapsack-pro-cypress) (publicly archived)
- [cypress-autostub](https://github.com/dan-cooke/cypress-autostub) (v10+ incompatible, 4 year ago)
- [cypress-plugin-liverload](https://github.com/unlocomqx/cypress-plugin-livereload) (removed entirely - no downloads on npm, v10+ incompatible, 4 years ago)
- [cypress-select-tests ](https://github.com/bahmutov/cypress-select-tests) (publicly archived)
- [cypress-autorecord](https://github.com/Nanciee/cypress-autorecord) (v10+ incompatible, 3 years ago)
- [cypress-fiddle](https://github.com/cypress-io/cypress-fiddle) (publicly archived)
- [npm-cy](https://github.com/bartlett705/npm-cy) (removed entirely - no npm repo, 5+ years ago)
- [cypress-extends](https://github.com/bahmutov/cypress-extends) (v10+ incompatible)
- [Browserify](https://github.com/cypress-io/cypress-browserify-preprocessor) (moved from Legacy)

**Custom Commands:**
- [cypress-unfetch](https://github.com/RcKeller/cypress-unfetch) (v10+ incompatible, 5 years ago)
- [cypress-redux](https://github.com/RcKeller/cypress-redux) (v10+ incompatible, 5 years ago)
- [cypress-graphql-mock](https://github.com/tgriesser/cypress-graphql-mock) (removed entirely - no npm repo, v10+ incompatible, 5 years ago, other updated solutions in list)
- [cypress-pipe](https://github.com/NicholasBoll/cypress-pipe) (v10+ incompatible, 4 years ago)
- [cypress-plugin-stripe-elements](https://github.com/dbalatero/cypress-plugin-stripe-elements) (v10+ incompatible, 3 years ago)
- [cypressautomocker](https://github.com/scottschafer/cypressautomocker) (removed entirely - no npm downloads, v10+ incompatible, 5 years ago)
- [cypress-skip-test](https://github.com/cypress-io/cypress-skip-test) (publicly archived)
- [cypress-websocket-testing](https://github.com/lensesio/cypress-websocket-testing)  (v10+ incompatible, 5 years ago)
- [cypress-iframe](https://gitlab.com/kgroat/cypress-iframe)  (v10+ incompatible, 4 years ago)
- [cypress-rest-graphql](https://github.com/BrandedEntertainmentNetwork/cypress-rest-graphql) (v10+ incompatible, 3 years ago)
- [cypress-forced-colors](https://github.com/ling1726/cypress-forced-color) (removed entirely - no npm downloads, v10+ incompatible, 3 years ago)
- [cypress-dotenv](https://github.com/morficus/cypress-dotenv) (moved from Legacy)
- [cypress-xpath](https://github.com/cypress-io/cypress/tree/develop/npm/xpath) (moved from Legacy)

**Extending other testing frameworks:**
- [cyphell](https://github.com/intuit/cyphfell) (removed entirely - no npm registry, 6 years ago)
- [cypress-capybara](https://github.com/testdouble/cypress-capybara) (publicly archived)
- [cypress-jest-adapter](https://github.com/phongnd39/cypress-jest-adapter) (v10+ incompatible, 5 years ago)

**Authentication:** 
- [cypress-keycloak-commands](https://github.com/Fredx87/cypress-keycloak-commands) (verified but clear issues against v10+, no support for 4 years despite popularity)
- [cypress-otp](https://github.com/NoriSte/cypress-otp) (super popular but clear issues against v10+, no support for 5 years)

**Framework Tooling:**
- [Vue Client](https://github.com/vuejs/vue-cli/tree/dev/packages/%40vue/cli-plugin-e2e-cypress) (super popular but clear issues against v10+) 
- [cypress-nuxt](https://github.com/NickBolles/cypress-nuxt) (v10+ incompatible, 4 years ago, moved to component category since it's for component testing)
- [elm-batteries](https://github.com/cedricss/elm-batteries) (v10+ incompatible, 5 years ago)
- [cypress-laravel](https://github.com/noeldemartin/cypress-laravel) (v10+ incompatible, 5 years ago)
- [cypress-splitio](https://gitlab.com/davidggevorgyan/cypress-splitio) (v10+ incompatible, 3 years ago)
- [Bison](https://github.com/echobind/bisonapp) (removed entirely - removed cypress from their examples in lieu of playwright)

**Component Testing:**
- [cypress-angularjs-unit-test](https://github.com/bahmutov/cypress-angularjs-unit-test) (assuming v10+ incompatible, 7 years ago) 
- [cypress-cycle-unit-test](https://github.com/bahmutov/cypress-cycle-unit-test) (assuming v10+ incompatible, 6 years ago) 
- [cypress-hyperapp-unit-test](https://github.com/bahmutov/cypress-hyperapp-unit-test) (assuming v10+ incompatible, 6 years ago) 
- [cypress-svelte-unit-test](https://github.com/bahmutov/cypress-svelte-unit-test) (v10+ incompatible) 

**Visual Testing:**
- SmartBear VisualTest - fixed link
- [cypress-plugin-snapshots](https://github.com/meinaart/cypress-plugin-snapshots) (v10+ incompatible)
- [cypress-blink-test](https://github.com/PatrickWalker/cypress-visual-regression) (removed entirely - no npm downloads, 5 years ago)f

**Reporting:**
- [cypress-log-to-output](https://github.com/flotwig/cypress-log-to-output) (v10+ incompatible)
- [cypress-slack-healthcheck](https://github.com/bdimitrovski/cypress-healthcheck) (removed entirely - no npm registry)
- [cypress-msteams-reporter](https://github.com/maritome/cypress-msteams-reporter) (outdated, last update 3 years ago, Cypress has Teams support now)
- Moved a few similar plugins adjacent in the list

Example: 
![image](https://github.com/cypress-io/cypress-documentation/assets/22203690/956a4288-9865-429c-a898-47d4a7548ef0)

Additionally, this addresses the following PRs:
- https://github.com/cypress-io/cypress-documentation/pull/4685
- https://github.com/cypress-io/cypress-documentation/pull/4744

Issues:
closes #5293
closes #5086 
closes #5073
closes #3728 
