### PR TITLE
Add cypress-runner-themes to Cypress plugins page

### DIFF
--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -157,6 +157,13 @@
           "badge": "official"
         },
         {
+          "name": "cypress-runner-themes",
+          "description": "Alternative themes for the Cypress Test Runner.",
+          "link": "https://github.com/dingraham/cypress-runner-themes",
+          "keywords": ["theme", "dark", "light", "colorblind"],
+          "badge": "community"
+        },
+        {
           "name": "cypress-voice-plugin",
           "description": "Cypress plugin to announce spec result and time in Cypress Test Runner.",
           "link": "https://github.com/dennisbergevin/cypress-voice-plugin",


### PR DESCRIPTION
[cypress-runner-themes](https://github.com/dingraham/cypress-runner-themes) is a Cypress plugin that provides alternative themes for the Cypress Test Runner

It replaces the now deprecated `cypress-dark` plugin since it supports Cypress v10+

Thanks!