### PR TITLE
add plugin anchor workaround

### DIFF
--- a/docs/api/cypress-api/custom-commands.mdx
+++ b/docs/api/cypress-api/custom-commands.mdx
@@ -942,6 +942,6 @@ registerCommands()
   [Writing a Custom Cypress Command](https://glebbahmutov.com/blog/writing-custom-cypress-command/)
   and
   [How to Publish Custom Cypress Command on NPM](https://glebbahmutov.com/blog/publishing-cypress-command/).
-- [Plugins using custom commands](/plugins#custom-commands)
+- <a href="/plugins#custom-commands">Plugins using custom commands</a>
 - [Cypress.log()](/api/cypress-api/cypress-log)
 - [Recipe: Logging In](/examples/recipes#Logging-In)

--- a/docs/api/cypress-api/custom-queries.mdx
+++ b/docs/api/cypress-api/custom-queries.mdx
@@ -435,5 +435,5 @@ Try not to overcomplicate things and create too many abstractions.
 
 - See how to add
   [TypeScript support for custom commands](/guides/tooling/typescript-support#Types-for-Custom-Commands)
-- [Plugins using custom commands](/plugins#custom-commands)
+- <a href="/plugins#custom-commands">Plugins using custom commands</a>
 - [Cypress.log()](/api/cypress-api/cypress-log)

--- a/docs/api/table-of-contents.mdx
+++ b/docs/api/table-of-contents.mdx
@@ -170,6 +170,7 @@ Cypress exposes interfaces to write
 details.
 
 The Cypress community has created a large number of
+
 <a href="/plugins#custom-commands">Command Plugins</a> which you can install or download.
 
 ### APIs

--- a/docs/api/table-of-contents.mdx
+++ b/docs/api/table-of-contents.mdx
@@ -170,7 +170,7 @@ Cypress exposes interfaces to write
 details.
 
 The Cypress community has created a large number of
-[Command Plugins](/plugins#custom-commands) which you can install or download.
+<a href="/plugins#custom-commands">Command Plugins</a> which you can install or download.
 
 ### APIs
 

--- a/docs/examples/recipes.mdx
+++ b/docs/examples/recipes.mdx
@@ -65,7 +65,7 @@ Recipes show you how to test common scenarios in Cypress.
 | [Json Web Tokens](https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/logging-in__jwt)                   | Log in using JWT                            |
 | [Using application code](https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/logging-in__using-app-code) | Log in by calling the application code      |
 
-Also see [Authentication plugins](/plugins#authentication) and watch
+Also see <a href="/plugins#authentication">Authentication plugins</a> and watch
 [Organizing Tests, Logging In, Controlling State](https://www.youtube.com/watch?v=5XQOK0v_YRE)
 
 ## Preprocessors

--- a/docs/faq/questions/using-cypress-faq.mdx
+++ b/docs/faq/questions/using-cypress-faq.mdx
@@ -492,7 +492,7 @@ email's functionality and visual style:
 
 3. You can use a 3rd party email service that provides temporary email addresses
    for testing. Some of these services even offer a
-   [Cypress plugin](/plugins#email) to access emails.
+   <a href="/plugins#email">Cypress plugin</a> to access emails.
 
 ### <Icon name="angle-right" /> How do I wait for multiple requests to the same url?
 
@@ -691,7 +691,7 @@ You can modify the screenshot and video size when running headlessly with
 ### <Icon name="angle-right" /> Does Cypress support ES7?
 
 Yes. You can customize how specs are processed by using one of our
-[preprocessor plugins](/plugins#preprocessors) or by
+<a href="/plugins#preprocessors">preprocessor plugins</a> or by
 [writing your own custom preprocessor](/api/plugins/preprocessors-api).
 
 Typically you'd reuse your existing Babel and webpack configurations.

--- a/docs/faq/questions/using-cypress-faq.mdx
+++ b/docs/faq/questions/using-cypress-faq.mdx
@@ -690,9 +690,9 @@ You can modify the screenshot and video size when running headlessly with
 
 ### <Icon name="angle-right" /> Does Cypress support ES7?
 
-Yes. You can customize how specs are processed by using one of our
-<a href="/plugins#preprocessors">preprocessor plugins</a> or by
-[writing your own custom preprocessor](/api/plugins/preprocessors-api).
+{/* prettier-ignore */}
+Yes. You can customize how specs are processed by using one of our <a href="/plugins#preprocessors">preprocessor plugins</a>
+or by [writing your own custom preprocessor](/api/plugins/preprocessors-api).
 
 Typically you'd reuse your existing Babel and webpack configurations.
 

--- a/docs/guides/core-concepts/writing-and-organizing-tests.mdx
+++ b/docs/guides/core-concepts/writing-and-organizing-tests.mdx
@@ -1028,7 +1028,7 @@ preprocessor explicitly: it exposes options that allow you to configure behavior
 such as _what_ is watched and the delay before emitting an "update" event after
 a change.
 
-Cypress also ships other [file-watching preprocessors](/plugins#preprocessors);
+Cypress also ships other <a href="/plugins#preprocessors">file-watching preprocessors</a>;
 you'll have to configure these explicitly if you want to use them.
 
 - [Cypress Watch Preprocessor](https://github.com/cypress-io/cypress-watch-preprocessor)

--- a/docs/guides/overview/why-cypress.mdx
+++ b/docs/guides/overview/why-cypress.mdx
@@ -226,6 +226,7 @@ it('adds a todo', () => {
 
 Finally, through a large number of [official and 3rd party plugins](/plugins)
 you can write Cypress [a11y](https://github.com/component-driven/cypress-axe),
+
 <a href="/plugins#visual-testing">visual</a>,
 [email](/faq/questions/using-cypress-faq#How-do-I-check-that-an-email-was-sent-out)
 and other types of tests.

--- a/docs/guides/overview/why-cypress.mdx
+++ b/docs/guides/overview/why-cypress.mdx
@@ -226,7 +226,7 @@ it('adds a todo', () => {
 
 Finally, through a large number of [official and 3rd party plugins](/plugins)
 you can write Cypress [a11y](https://github.com/component-driven/cypress-axe),
-[visual](/plugins#visual-testing),
+<a href="/plugins#visual-testing">visual</a>,
 [email](/faq/questions/using-cypress-faq#How-do-I-check-that-an-email-was-sent-out)
 and other types of tests.
 

--- a/docs/guides/references/best-practices.mdx
+++ b/docs/guides/references/best-practices.mdx
@@ -437,7 +437,7 @@ email's functionality and visual style:
    exposes an API to read off emails. You will then need the proper
    authentication credentials, which your server could provide, or you could use
    environment variables. Some email services already provide
-   [Cypress plugins](/plugins#email) to access emails.
+   <a href="/plugins#email">Cypress plugins</a> to access emails.
 
 ## <Icon name="angle-right" /> Having Tests Rely On The State Of Previous Tests
 

--- a/docs/guides/tooling/visual-testing.mdx
+++ b/docs/guides/tooling/visual-testing.mdx
@@ -123,13 +123,13 @@ mouse hover:
 ## Tooling
 
 There are several published, open source plugins, listed in the
-[Visual Testing plugins](/plugins#visual-testing) section, and several
+<a href="/plugins#visual-testing">Visual Testing Plugins</a> section, and several
 commercial companies have developed visual testing solutions on top of Cypress
 listed below.
 
 ### Open source
 
-Listed in the [Visual Testing plugins](/plugins#visual-testing) section.
+Listed in the <a href="/plugins#visual-testing">Visual Testing Plugins</a> section.
 
 ### Applitools
 
@@ -335,7 +335,7 @@ the
 - [cy.screenshot()](/api/commands/screenshot)
 - [Cypress.Screenshot](/api/cypress-api/screenshot-api)
 - [Plugins](/guides/tooling/plugins-guide)
-- [Visual Testing Plugins](/plugins#visual-testing)
+- <a href="/plugins#visual-testing">Visual Testing Plugins</a>
 - [Writing a Plugin](/api/plugins/writing-a-plugin)
 - <Icon name="github" contentType="rwa" /> is a full stack example application that
   demonstrates **best practices and scalable strategies with Cypress in practical

--- a/docs/guides/tooling/visual-testing.mdx
+++ b/docs/guides/tooling/visual-testing.mdx
@@ -122,10 +122,12 @@ mouse hover:
 
 ## Tooling
 
+{/* prettier-ignore */}
 There are several published, open source plugins, listed in the
+
 <a href="/plugins#visual-testing">Visual Testing Plugins</a> section, and several
-commercial companies have developed visual testing solutions on top of Cypress
-listed below.
+commercial companies have developed visual testing solutions on top of Cypress listed
+below.
 
 ### Open source
 


### PR DESCRIPTION
Docusaurus is flagging these anchors as broken because of a timing issue as the plugin page is dynamically generated. We've set the build process to fail if legit broken anchors are caught. This workaround swaps markdown links with anchor tags which avoid flagging them as broken. Neither a glorious or long term solution but one that bandwidth allows and will improve upon broken anchors not making it into a build. 