### PR TITLE
chore: fix incorrect description of `cy.clear` command

### DIFF
--- a/docs/api/actions/clear.mdx
+++ b/docs/api/actions/clear.mdx
@@ -10,7 +10,7 @@ chain further commands that rely on the subject after `.clear()`.
 
 :::info
 
-An alias for [`.type('{selectall}{backspace}')`](/api/commands/type)
+An alias for [`.type('{selectall}{del}')`](/api/commands/type)
 
 :::
 
@@ -82,7 +82,7 @@ cy.get('textarea').clear().type('Hello, World')
 ### Documentation
 
 `.clear()` is an alias for
-[`.type({selectall}{backspace})`](/api/commands/type).
+[`.type({selectall}{del})`](/api/commands/type).
 
 Please read the [`.type()`](/api/commands/type) documentation for more details.
 


### PR DESCRIPTION
Relates to:
* https://github.com/cypress-io/cypress/pull/29339

https://docs.cypress.io/api/commands/clear