### PR TITLE
docs: fix missing changelog entry from 13.3.0

### DIFF
--- a/docs/guides/references/changelog.mdx
+++ b/docs/guides/references/changelog.mdx
@@ -355,6 +355,7 @@ _Released 09/27/2023_
 **Bugfixes:**
 
 - Fixed an issue where actionability checks trigger a flood of font requests. Removing the font requests has the potential to improve performance and removes clutter from Test Replay. Addressed in [#27860](https://github.com/cypress-io/cypress/pull/27860).
+- Fixed network stubbing not permitting status code 999. Fixes [#27567](https://github.com/cypress-io/cypress/issues/27567). Addressed in [#27853](https://github.com/cypress-io/cypress/pull/27853).
 
 ## 13.2.0
 


### PR DESCRIPTION
This bugfix is completely missing from the changelog in the docs. It's referenced in the cli/changelog https://github.com/cypress-io/cypress/blob/develop/cli/CHANGELOG.md#1330