### PR TITLE
docs: Update clearLocalStorage docs to properly document what it yields

### DIFF
--- a/docs/api/commands/clearlocalstorage.mdx
+++ b/docs/api/commands/clearlocalstorage.mdx
@@ -48,7 +48,7 @@ Pass in an options object to change the default behavior of
 
 ### Yields [<Icon name="question-circle"/>](/guides/core-concepts/introduction-to-cypress#Subject-Management) {#Yields}
 
-- `cy.clearLocalStorage()` yields `null`.
+- `cy.clearLocalStorage()` yields the localStorage for the current domain.
 
 ## Examples
 


### PR DESCRIPTION
Close: https://github.com/cypress-io/cypress-documentation/issues/4732

cy.clearLocalStorage does yield the localStorage

![Screenshot 2024-04-26 at 2 45 16 PM](https://github.com/cypress-io/cypress-documentation/assets/1271364/66a65cf9-90d7-4554-8917-b884a3761b5e)
