### PR TITLE
docs: remove unused code example

### DIFF
--- a/docs/guides/end-to-end-testing/testing-strategies/working-with-graphql.mdx
+++ b/docs/guides/end-to-end-testing/testing-strategies/working-with-graphql.mdx
@@ -137,7 +137,6 @@ context('Tests', () => {
 
   it('should not display the load more button on the launches page', () => {
     cy.intercept('POST', 'http://localhost:3000/graphql', (req) => {
-      const { body } = req
       if (hasOperationName(req, 'GetLaunchList')) {
         // Declare the alias from the initial intercept in the beforeEach
         req.alias = 'gqlGetLaunchListQuery'


### PR DESCRIPTION
## Description

Remove unused code example. https://docs.cypress.io/guides/end-to-end-testing/working-with-graphql

## Changes

Removed the `const { body } = req` 

## Screenshots

AS IS
<img width="1920" alt="Screenshot 2024-04-29 at 2 12 40 PM" src="https://github.com/cypress-io/cypress-documentation/assets/22230889/c18f672a-51f7-47c1-842f-38c07d6276b0">

TO BE
<img width="1920" alt="Screenshot 2024-04-29 at 2 13 38 PM" src="https://github.com/cypress-io/cypress-documentation/assets/22230889/e2c729e7-bd41-4687-863b-d4174f693eb7">
