### PR TITLE
Add Ubuntu 24.04 prerequisites

### DIFF
--- a/docs/guides/getting-started/installing-cypress.mdx
+++ b/docs/guides/getting-started/installing-cypress.mdx
@@ -212,6 +212,12 @@ If not, run the command line for your operating system listed below.
 apt-get install libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libnss3 libxss1 libasound2 libxtst6 xauth xvfb
 ```
 
+For Ubuntu 24.04 use the following command:
+
+```shell
+apt-get install libgtk2.0-0t64 libgtk-3-0t64 libgbm-dev libnotify-dev libnss3 libxss1 libasound2t64 libxtst6 xauth xvfb
+```
+
 #### Arch
 
 ```shell


### PR DESCRIPTION
- closes #5816

## Issue

Following the instructions [Getting Started > Installing Cypress > Linux Prerequisites > Ubuntu/Debian](https://docs.cypress.io/guides/getting-started/installing-cypress#Linux-Prerequisites) on Ubuntu `24.04` (Noble Numbat) LTS for package installation:

> apt-get install libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libnss3 libxss1 libasound2 libxtst6 xauth xvfb

results in warnings and an error message:

> Note, selecting 'libgtk2.0-0t64' instead of 'libgtk2.0-0'
> Note, selecting 'libgtk-3-0t64' instead of 'libgtk-3-0'
> E: Package 'libasound2' has no installation candidate

## Change

For Ubuntu `24.04` make the following changes

| Package    | Ubuntu <= `23.10` (current) | Ubuntu `24.04`  (new)  |
| ---------- | ----------------- | ---------------- |
| `alsa-lib` | `libasound2`      | `libasound2t64`  |
| `gtk+2.0`  | `libgtk2.0-0`     | `libgtk2.0-0t64` |
| `gtk+3.0`  | `libgtk-3-0`      | `libgtk-3-0t64`  |

The package installation for Ubuntu `24.04` is added with:

```shell
apt-get install libgtk2.0-0t64 libgtk-3-0t64 libgbm-dev libnotify-dev libnss3 libxss1 libasound2t64 libxtst6 xauth xvfb
```

### Background

According to the [Ubuntu 24.04 release notes](https://discourse.ubuntu.com/t/noble-numbat-release-notes/39890) in the section [Year 2038 support for the armhf architecture](https://discourse.ubuntu.com/t/noble-numbat-release-notes/39890#year-2038-support-for-the-armhf-architecture-5)

> More than a thousand packages have been updated to handle time using a 64-bit value rather than a 32-bit one, making it possible to handle times up to 292 billion years in the future.

## References

- [Ubuntu wiki > List of releases](https://wiki.ubuntu.com/Releases)
- [Ubuntu 24.04 release notes](https://discourse.ubuntu.com/t/noble-numbat-release-notes/39890)
- [Ubuntu alsa-lib package overview](https://launchpad.net/ubuntu/+source/alsa-lib)
- [Ubuntu gtk+2.0 package overview](https://launchpad.net/ubuntu/+source/gtk+2.0)
- [Ubuntu gtk+3.0 package overview](https://launchpad.net/ubuntu/+source/gtk+3.0)

## Verification

On [Ubuntu `24.04`](https://releases.ubuntu.com/noble/) LTS Desktop

### Verify package installation

```shell
sudo apt-get install libgtk2.0-0t64 libgtk-3-0t64 libgbm-dev libnotify-dev libnss3 libxss1 libasound2t64 libxtst6 xauth xvfb
```

Should produce no errors or warnings.

Note that the Desktop edition already has the following packages installed by default:

```text
libgtk2.0-0t64 is already the newest version (2.24.33-4ubuntu1).
libgtk-3-0t64 is already the newest version (3.24.41-4ubuntu1).
libnss3 is already the newest version (2:3.98-1build1).
libxss1 is already the newest version (1:1.2.3-1build3).
libasound2t64 is already the newest version (1.2.11-1build2).
libxtst6 is already the newest version (2:1.2.3-1.1build1).
xauth is already the newest version (1:1.1.2-1build1).
```

### Verify Cypress runs

```shell
sudo apt-get install git make curl
curl -L https://bit.ly/n-install | bash
. ~/.bashrc
mkdir cypress-io
cd cypress-io
git clone https://github.com/cypress-io/cypress-example-kitchensink
cd cypress-example-kitchensink
n auto
npm ci
npm run local:run
```
