### PR TITLE
updated `sample.cy.js` to correct `spec.cy.js`

### DIFF
--- a/docs/guides/end-to-end-testing/introduction/testing-your-app.mdx
+++ b/docs/guides/end-to-end-testing/introduction/testing-your-app.mdx
@@ -89,11 +89,11 @@ only against a deployed production app.
 
 Once your server is running, it's time to visit it.
 
-Let's delete the `sample.cy.js` file created in the previous tutorial now that
+Let's delete the `spec.cy.js` file created in the previous tutorial now that
 it's no longer needed.
 
 ```shell
-rm cypress/e2e/sample.cy.js
+rm cypress/e2e/spec.cy.js
 ```
 
 Now let's create our own spec file called `home_page.cy.js`.


### PR DESCRIPTION
https://docs.cypress.io/guides/end-to-end-testing/testing-your-app#Step-2-Visit-your-server `sample.cy.js` is referenced as the file created from the previous page but the file created in https://docs.cypress.io/guides/end-to-end-testing/writing-your-first-end-to-end-test#Add-a-test-file is `spec.cy.js`

<table>
<tr>
 <td>Before</td>
 <td>After</td>
<tr>
 <td>
<img width="1093" alt="Screenshot 2024-05-09 at 11 36 21" src="https://github.com/cypress-io/cypress-documentation/assets/88001922/61257d11-ebee-4041-90ea-347ffd79a24b">
</td>
 <td>
<img width="1217" alt="Screenshot 2024-05-09 at 11 36 32" src="https://github.com/cypress-io/cypress-documentation/assets/88001922/79c5fc67-e180-43c5-83a7-71f6075b7e56">
</td>
</table>