### PR TITLE
Remove reference to cypress-example-todomvc-redux repo

### DIFF
--- a/docs/examples/applications.mdx
+++ b/docs/examples/applications.mdx
@@ -63,26 +63,6 @@ vanilla Selenium.
   alt="TodoMvc testing in Cypress"
 />
 
-## TodoMVC Redux
-
-<Icon
-  name="github"
-  url="https://github.com/cypress-io/cypress-example-todomvc-redux"
-/>
-
-A fork the
-[official Redux TodoMVC example](https://github.com/reduxjs/redux/tree/master/examples/todomvc).
-Through a combination of end-to-end and unit tests shows how you can achieve
-100% code coverage.
-
-- Instrument and collect code coverage following the Cypress
-  [Code Coverage](/guides/tooling/code-coverage) guide.
-
-<DocsImage
-  src="/img/examples/todomvc-redux-100percent.png"
-  alt="TodoMVC Redux application code coverage report"
-/>
-
 ## Realworld
 
 <Icon

--- a/docs/faq/questions/using-cypress-faq.mdx
+++ b/docs/faq/questions/using-cypress-faq.mdx
@@ -1157,7 +1157,7 @@ might be possible by
 
 For end-to-end testing, yes, absolutely. A good example of a fully tested React
 application is our
-[Cypress RealWorld App](https://github.com/cypress-io/cypress-example-realworld).
+[Cypress RealWorld App](https://github.com/cypress-io/cypress-realworld-app).
 You can even use React DevTools while testing your application, read
 [The easiest way to connect Cypress and React DevTools](https://dev.to/dmtrkovalenko/the-easiest-way-to-connect-cypress-and-react-devtools-5hgm).
 If you really need to select React components by their name, props, or state,

--- a/docs/faq/questions/using-cypress-faq.mdx
+++ b/docs/faq/questions/using-cypress-faq.mdx
@@ -1157,9 +1157,7 @@ might be possible by
 
 For end-to-end testing, yes, absolutely. A good example of a fully tested React
 application is our
-[Cypress RealWorld App](https://github.com/cypress-io/cypress-example-realworld)
-and
-[TodoMVC Redux App](https://github.com/cypress-io/cypress-example-todomvc-redux).
+[Cypress RealWorld App](https://github.com/cypress-io/cypress-example-realworld).
 You can even use React DevTools while testing your application, read
 [The easiest way to connect Cypress and React DevTools](https://dev.to/dmtrkovalenko/the-easiest-way-to-connect-cypress-and-react-devtools-5hgm).
 If you really need to select React components by their name, props, or state,

--- a/docs/guides/tooling/code-coverage.mdx
+++ b/docs/guides/tooling/code-coverage.mdx
@@ -149,14 +149,6 @@ crucial parts of your application. The collected information can be sent to
 external services, automatically run during pull request reviews, and integrated
 into CI.
 
-:::info
-
-The full source code for this guide can be found in the
-[cypress-io/cypress-example-todomvc-redux](https://github.com/cypress-io/cypress-example-todomvc-redux)
-repository.
-
-:::
-
 ## Instrumenting code
 
 Cypress does not instrument your code - you need to do it yourself. The golden
@@ -758,8 +750,6 @@ following repositories:
   The RWA achieves full code coverage with end-to-end tests
   [across multiple browsers](/guides/guides/cross-browser-testing) and
   [device sizes](/api/commands/viewport).
-- [cypress-io/cypress-example-todomvc-redux](https://github.com/cypress-io/cypress-example-todomvc-redux)
-  is the example code used in this guide.
 - [cypress-io/cypress-example-conduit-app](https://github.com/cypress-io/cypress-example-conduit-app)
   shows how to collect the coverage information from both back and front end
   code and merge it into a single report.


### PR DESCRIPTION
This repo is not being actively maintained and was archived. Remove references to it that are likely outdated.