### PR TITLE
Plugin: Add last-failed plugin to Cypress plugins page

### DIFF
--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -171,6 +171,13 @@
           "badge": "community"
         },
         {
+          "name": "cypress-plugin-last-failed",
+          "description": "A companion Cypress plugin for `cy-grep` that re-runs the last failed test(s).",
+          "link": "https://github.com/dennisbergevin/cypress-plugin-last-failed",
+          "keywords": ["grep", "ui", "failure", "results"],
+          "badge": "community"
+        },
+        {
           "name": "cly",
           "description": "A prototype of generating quicker project scaffolding for Cypress.",
           "link": "https://github.com/bahmutov/cly",


### PR DESCRIPTION
[cypress-plugin-last-failed](https://github.com/dennisbergevin/cypress-plugin-last-failed) is a companion Cypress plugin for `cy-grep` that re-runs the last failed test(s).

Tests and CI are included in the linked repository.

Please let me know what else is needed to be included in the official Cypress plugins list, thank you!