### PR TITLE
add plugin: `cypress-temp-mail` : Temporary email provider for cypress testing

### DIFF
--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -1302,6 +1302,13 @@
           "link": "https://github.com/e23thr/cypress-guerrillamail",
           "keywords": ["email", "guerrillamail", "test", "commands"],
           "badge": "community"
+        },
+        {
+          "name": "cypress-temp-mail",
+          "description": "Lightweight npm package with quick setup that offers temporary test email accounts to facilitate end-to-end testing",
+          "link": "https://github.com/madhusaran/cypress-temp-mail",
+          "keywords": ["cypress-temp-mail", "email", "temp-mail", "test-email", "test", "commands"],
+          "badge": "community"
         }
       ]
     }

--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -1305,7 +1305,7 @@
         },
         {
           "name": "cypress-temp-mail",
-          "description": "Lightweight npm package with quick setup that offers temporary test email accounts to facilitate end-to-end testing",
+          "description": "Temporary email provider for cypress testing",
           "link": "https://github.com/madhusaran/cypress-temp-mail",
           "keywords": ["cypress-temp-mail", "email", "temp-mail", "test-email", "test", "commands"],
           "badge": "community"


### PR DESCRIPTION
Lightweight NPM package with quick setup that offers temporary test email accounts to facilitate end-to-end testing