### PR TITLE
add plugin `cypress-temp-mail` : Temporary email provider for cypress testing

### DIFF
--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -1302,6 +1302,13 @@
           "link": "https://github.com/e23thr/cypress-guerrillamail",
           "keywords": ["email", "guerrillamail", "test", "commands"],
           "badge": "community"
+        },
+        {
+          "name": "cypress-temp-mail",
+          "description": "Lightweight npm library designed to generate temporary email addresses for end-to-end testing with Cypress",
+          "link": "https://github.com/madhusaran/cypress-temp-mail",
+          "keywords": ["cypress-temp-mail", "email","temp-mail", "test", "commands"],
+          "badge": "community"
         }
       ]
     }


### PR DESCRIPTION
Lightweight NPM package with quick setup that offers temporary test email accounts to facilitate end-to-end testing