### PR TITLE
Remove Node.js 21 support

### DIFF
--- a/docs/guides/getting-started/installing-cypress.mdx
+++ b/docs/guides/getting-started/installing-cypress.mdx
@@ -160,8 +160,7 @@ application supports these operating systems:
 
 Cypress requires Node.js in order to install. We support the versions listed below:
 
-- **Node.js** 18.x
-- **Node.js** 20.x and above
+- **Node.js** 18.x, 20.x, 22.x and above
 
 Cypress generally aligns with
 [Node's release schedule](https://github.com/nodejs/Release).


### PR DESCRIPTION
## Issue

- Node.js `21.x` reached [end-of-life](https://github.com/nodejs/Release/blob/main/README.md) on Jun 1, 2024
- [System requirements > Node.js](https://docs.cypress.io/guides/getting-started/installing-cypress#Nodejs) currently lists Node.js `18.x`, `20.x` and above, which does not exclude Node.js `21`.

## Change

Change [System requirements > Node.js](https://docs.cypress.io/guides/getting-started/installing-cypress#Nodejs) to

> Node.js `18.x`, `20.x`, `22.x` and above