### PR TITLE
Add cymap to plugins.json

### DIFF
--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -1309,7 +1309,14 @@
           "link": "https://github.com/madhusaran/cypress-temp-mail",
           "keywords": ["cypress-temp-mail", "email","temp-mail", "test", "commands"],
           "badge": "community"
-        }        
+        },
+        {
+          "name":"cymap",
+          "description":"Access email from any email server by leveraging IMAP capabilities inside Cypress.",
+          "link":"https://github.com/FC122/cymap",
+          "keywords":["imap", "email", "test", "commands"],
+          "badge":"community"
+        }
       ]
     },
     {


### PR DESCRIPTION
Cypress plugin for accessing mail from email servers.

The purpose of this plugin is to use existing email servers instead of deploying your own. Cymap leverages the capabilities of the IMAP protocol.

By using cymap:

- you are not dependant on an email server nor its REST API
- you have no need to deploy your own email server, you can use gmail or any other similar service
- if you have your own email server it will work with it to since IMAP is standardized
- you can access mail from multiple clients