### PR TITLE
Remove obsolete --ipc=host Docker workaround

### DIFF
--- a/docs/guides/continuous-integration/introduction.mdx
+++ b/docs/guides/continuous-integration/introduction.mdx
@@ -541,12 +541,6 @@ See
 for an example that runs the `npx cypress install` command to ensure the Cypress
 binary is always present before the tests begin.
 
-### In Docker
-
-If you are running long runs on Docker, you need to set the `ipc` to `host`
-mode. [This issue](https://github.com/cypress-io/cypress/issues/350) describes
-exactly what to do.
-
 ### Xvfb
 
 When running on Linux, Cypress needs an X11 server; otherwise it spawns its own


### PR DESCRIPTION
## Issue

[Continuous Integration > Introduction > Common problems and solutions > In Docker](https://docs.cypress.io/guides/continuous-integration/introduction#In-Docker) states:

> If you are running long runs on Docker, you need to set the `ipc` to `host` mode. [This issue](https://github.com/cypress-io/cypress/issues/350) describes exactly what to do.

- The issue https://github.com/cypress-io/cypress/issues/350 referred to was closed in April 2021 with a reference to [Cypress 7.0.1](https://docs.cypress.io/guides/references/changelog#7-0-1) stating:

  > Cypress no longer crashes in certain circumstances when running in Docker without `--ipc=host`. Fixes _ [#15814](https://github.com/cypress-io/cypress/issues/15814) and [#350](https://github.com/cypress-io/cypress/issues/350).

## Change

The issue was resolved in [Cypress 7.0.1](https://docs.cypress.io/guides/references/changelog#7-0-1).

Remove the obsolete workaround section [Continuous Integration > Introduction > Common problems and solutions > In Docker](https://docs.cypress.io/guides/continuous-integration/introduction#In-Docker)
