### PR TITLE
Harmonize CI Docker Hub references

### DIFF
--- a/docs/guides/continuous-integration/aws-codebuild.mdx
+++ b/docs/guides/continuous-integration/aws-codebuild.mdx
@@ -80,7 +80,7 @@ example project and place the above
   - Start the project web server (`npm start:ci`)
   - Run the Cypress tests within our GitHub repository within Electron.
 
-## Testing in Chrome and Firefox with Cypress Docker Images
+## Testing with Cypress Docker Images
 
 :::info
 
@@ -126,7 +126,7 @@ offers a way to specify an image hosted on DockerHub or the
 
 The Cypress team maintains the official
 [Docker Images](https://github.com/cypress-io/cypress-docker-images) for running
-Cypress locally and in CI, which are built with Google Chrome, Firefox and Microsoft Edge. For
+Cypress locally and in CI, which are built with Google Chrome, Mozilla Firefox and Microsoft Edge. For
 example, this allows us to run the tests in Firefox by passing the
 `--browser firefox` attribute to `cypress run`.
 
@@ -285,7 +285,7 @@ projects:
 
 The Cypress team maintains the official
 [Docker Images](https://github.com/cypress-io/cypress-docker-images) for running
-Cypress locally and in CI, which are built with Google Chrome and Firefox. This
+Cypress locally and in CI, which are built with Google Chrome, Mozilla Firefox and Microsoft Edge. This
 allows us to run the tests in Firefox by passing the `--browser firefox`
 attribute to `cypress run`.
 

--- a/docs/guides/continuous-integration/bitbucket-pipelines.mdx
+++ b/docs/guides/continuous-integration/bitbucket-pipelines.mdx
@@ -52,11 +52,11 @@ pipelines:
   - Start the project web server (`npm start`)
   - Run the Cypress tests within our GitHub/Bitbucket repository within Electron
 
-## Testing in Chrome and Firefox with Cypress Docker Images
+## Testing with Cypress Docker Images
 
 The Cypress team maintains the official
 [Docker Images](https://github.com/cypress-io/cypress-docker-images) for running
-Cypress locally and in CI, which are built with Google Chrome and Firefox. For
+Cypress locally and in CI, which are built with Google Chrome, Mozilla Firefox and Microsoft Edge. For
 example, this allows us to run the tests in Firefox by passing the
 `--browser firefox` attribute to `cypress run`.
 

--- a/docs/guides/continuous-integration/github-actions.mdx
+++ b/docs/guides/continuous-integration/github-actions.mdx
@@ -402,7 +402,7 @@ jobs:
 
 <strong>Ensure Correct Container</strong>
 
-If a docker container was used in the install job, the same docker container
+If a Docker container was used in the install job, the same Docker container
 must also be used in the worker jobs.
 
 :::

--- a/docs/guides/continuous-integration/gitlab-ci.mdx
+++ b/docs/guides/continuous-integration/gitlab-ci.mdx
@@ -54,11 +54,11 @@ test:
   - Start the project web server (`npm start`)
   - Run the Cypress tests within the GitLab repository using Electron.
 
-## Testing in Chrome and Firefox with Cypress Docker Images
+## Testing with Cypress Docker Images
 
 The Cypress team maintains the official
 [Docker Images](https://github.com/cypress-io/cypress-docker-images) for running
-Cypress tests locally and in CI, which are built with Google Chrome, Firefox and Microsoft Edge.
+Cypress tests locally and in CI, which are built with Google Chrome, Mozilla Firefox and Microsoft Edge.
 For example, this allows us to run the tests in Firefox by passing the
 `--browser firefox` attribute to `cypress run`.
 


### PR DESCRIPTION
## Issue

The [Continuous Integration section](https://docs.cypress.io/guides/continuous-integration/introduction) contains examples for use of Cypress Docker images in CI from [Cypress on Docker Hub](https://hub.docker.com/u/cypress).

Section headings mention Chrome and Firefox, and omit Edge.

- [AWS CodeBuild](https://docs.cypress.io/guides/continuous-integration/aws-codebuild#Testing-in-Chrome-and-Firefox-with-Cypress-Docker-Images)
- [Bitbucket Pipelines](https://docs.cypress.io/guides/continuous-integration/bitbucket-pipelines#Testing-in-Chrome-and-Firefox-with-Cypress-Docker-Images)
- [GitLab CI](https://docs.cypress.io/guides/continuous-integration/gitlab-ci#Testing-in-Chrome-and-Firefox-with-Cypress-Docker-Images)

## Change

- Remove Chrome and Firefox from section headings
- Harmonize browser naming to full names on first mention: Google Chrome, Mozilla Firefox & Microsoft Edge
- Refer to "Docker" capitalized