### PR TITLE
Update Docker version in examples

### DIFF
--- a/docs/guides/continuous-integration/aws-codebuild.mdx
+++ b/docs/guides/continuous-integration/aws-codebuild.mdx
@@ -179,14 +179,14 @@ version: 0.2
 ## AWS CodeBuild Batch configuration
 ## https://docs.aws.amazon.com/codebuild/latest/userguide/batch-build-buildspec.html
 ## Define build to run using the
-## "cypress/browsers:node-20.9.0-chrome-118.0.5993.88-1-ff-118.0.2-edge-118.0.2088.46-1" image
+## "cypress/browsers:node-20.14.0-chrome-126.0.6478.114-1-ff-127.0.1-edge-126.0.2592.61-1" image
 ## from the Cypress Amazon ECR Public Gallery
 batch:
   fast-fail: false
   build-list:
     - identifier: cypress-e2e-tests
       env:
-        image: public.ecr.aws/cypress-io/cypress/browsers:node-20.9.0-chrome-118.0.5993.88-1-ff-118.0.2-edge-118.0.2088.46-1
+        image: public.ecr.aws/cypress-io/cypress/browsers:node-20.14.0-chrome-126.0.6478.114-1-ff-127.0.1-edge-126.0.2592.61-1
 
 phases:
   install:

--- a/docs/guides/continuous-integration/bitbucket-pipelines.mdx
+++ b/docs/guides/continuous-integration/bitbucket-pipelines.mdx
@@ -61,7 +61,7 @@ example, this allows us to run the tests in Firefox by passing the
 `--browser firefox` attribute to `cypress run`.
 
 ```yaml
-image: cypress/browsers:node-20.9.0-chrome-118.0.5993.88-1-ff-118.0.2-edge-118.0.2088.46-1
+image: cypress/browsers:node-20.14.0-chrome-126.0.6478.114-1-ff-127.0.1-edge-126.0.2592.61-1
 
 pipelines:
   default:
@@ -89,7 +89,7 @@ Artifacts from a job can be defined by providing paths to the `artifacts`
 attribute.
 
 ```yaml
-image: cypress/browsers:node-20.9.0-chrome-118.0.5993.88-1-ff-118.0.2-edge-118.0.2088.46-1
+image: cypress/browsers:node-20.14.0-chrome-126.0.6478.114-1-ff-127.0.1-edge-126.0.2592.61-1
 
 pipelines:
   default:
@@ -153,7 +153,7 @@ recording test results to [Cypress Cloud](/guides/cloud/introduction).
 :::
 
 ```yaml
-image: cypress/base:20.9.0
+image: cypress/base:20.14.0
 
 ## job definition for running E2E tests in parallel
 e2e: &e2e
@@ -212,7 +212,7 @@ definitions:
 The complete `bitbucket-pipelines.yml` is below:
 
 ```yaml
-image: cypress/base:20.9.0
+image: cypress/base:20.14.0
 
 ## job definition for running E2E tests in parallel
 e2e: &e2e

--- a/docs/guides/continuous-integration/github-actions.mdx
+++ b/docs/guides/continuous-integration/github-actions.mdx
@@ -194,7 +194,7 @@ jobs:
   cypress-run:
     runs-on: ubuntu-22.04
     container:
-      image: cypress/browsers:node-20.9.0-chrome-118.0.5993.88-1-ff-118.0.2-edge-118.0.2088.46-1
+      image: cypress/browsers:node-20.14.0-chrome-126.0.6478.114-1-ff-127.0.1-edge-126.0.2592.61-1
       options: --user 1001
     steps:
       - name: Checkout

--- a/docs/guides/continuous-integration/gitlab-ci.mdx
+++ b/docs/guides/continuous-integration/gitlab-ci.mdx
@@ -67,7 +67,7 @@ stages:
   - test
 
 test:
-  image: cypress/browsers:node-20.9.0-chrome-118.0.5993.88-1-ff-118.0.2-edge-118.0.2088.46-1
+  image: cypress/browsers:node-20.14.0-chrome-126.0.6478.114-1-ff-127.0.1-edge-126.0.2592.61-1
   stage: test
   script:
     # install dependencies
@@ -98,7 +98,7 @@ cache:
     - .npm/
 
 test:
-  image: cypress/browsers:node-20.9.0-chrome-118.0.5993.88-1-ff-118.0.2-edge-118.0.2088.46-1
+  image: cypress/browsers:node-20.14.0-chrome-126.0.6478.114-1-ff-127.0.1-edge-126.0.2592.61-1
   stage: test
   script:
     # install dependencies
@@ -165,7 +165,7 @@ cache:
 
 ## Install npm dependencies and Cypress
 install:
-  image: cypress/browsers:node-20.9.0-chrome-118.0.5993.88-1-ff-118.0.2-edge-118.0.2088.46-1
+  image: cypress/browsers:node-20.14.0-chrome-126.0.6478.114-1-ff-127.0.1-edge-126.0.2592.61-1
   stage: build
   script:
     - npm ci
@@ -210,13 +210,13 @@ cache:
 
 ## Install npm dependencies and Cypress
 install:
-  image: cypress/browsers:node-20.9.0-chrome-118.0.5993.88-1-ff-118.0.2-edge-118.0.2088.46-1
+  image: cypress/browsers:node-20.14.0-chrome-126.0.6478.114-1-ff-127.0.1-edge-126.0.2592.61-1
   stage: build
   script:
     - npm ci
 
 ui-chrome-tests:
-  image: cypress/browsers:node-20.9.0-chrome-118.0.5993.88-1-ff-118.0.2-edge-118.0.2088.46-1
+  image: cypress/browsers:node-20.14.0-chrome-126.0.6478.114-1-ff-127.0.1-edge-126.0.2592.61-1
   stage: test
   parallel: 5
   script:

--- a/docs/guides/continuous-integration/introduction.mdx
+++ b/docs/guides/continuous-integration/introduction.mdx
@@ -225,7 +225,7 @@ Mounting a project directory with an existing `node_modules` into a
 `cypress/base` docker image **will not work**:
 
 ```shell
-docker run -it -v /app:/app cypress/base:20.9.0 bash -c 'cypress run'
+docker run -it -v /app:/app cypress/base:20.14.0 bash -c 'cypress run'
 Error: the cypress binary is not installed
 ```
 

--- a/docs/guides/getting-started/installing-cypress.mdx
+++ b/docs/guides/getting-started/installing-cypress.mdx
@@ -247,7 +247,7 @@ container with the Node.js process.
   ui:
     image: cypress/base:latest
     # if targeting a specific node version, use e.g.
-    # image: cypress/base:18.12.1
+    # image: cypress/base:20.14.0
 ```
 
 `cypress/base` is a drop-in replacement for


### PR DESCRIPTION
## Issue

Cypress Docker versions used in examples in:

- [Continuous Integration section](https://docs.cypress.io/guides/continuous-integration/introduction) (based on Node.js `20.9`) and
- [Getting Started > Installing Cypress > System requirements > Linux Prerequisites > Docker](https://docs.cypress.io/guides/getting-started/installing-cypress#Docker) (based on Node.js `18.12`)

are outdated.

The outdated versions of Cypress Docker images are based on:

- [Node.js 20.9.0](https://nodejs.org/en/blog/release/v20.9.0) was released on Oct 24, 2023
- [Node.js 18.12.1](https://nodejs.org/en/blog/release/v18.12.1) was released on Nov 4, 2022

Although these versions are still supported and continue to work, users will generally experience better results by specifying up-to-date versions of Cypress Docker images.

Additionally, Cypress Docker images generated from [cypress/factory:4.0.0](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/CHANGELOG.md#400) and later, starting from May 30, 2024 are based on Debian `12.5` (`bullseye`) instead of Debian `11.9` (`bookworm`). This means that Cypress Docker images using Node.js `18.20.3` and later, and Node.js `20.14.0` and later, are based on Debian `12.x`.

## Change

Update examples using Cypress Docker images to:

- [cypress/base:20.14.0](https://hub.docker.com/layers/cypress/base/20.14.0/images/sha256-2314cbaca5d133d2c69f91cec9f6b6f1787b32ea2dc7c23c73bd817e0f8f4316)

- [cypress/browsers:node-20.14.0-chrome-126.0.6478.114-1-ff-127.0.1-edge-126.0.2592.61-1](https://hub.docker.com/layers/cypress/browsers/node-20.14.0-chrome-126.0.6478.114-1-ff-127.0.1-edge-126.0.2592.61-1/images/sha256-2d861960dadb4fe650d99bad6fca692cd61982ac584983a1af4de7c42ef595c1)
