### PR TITLE
Remove AWS CodeBuild link for deleted RWA CI example

### DIFF
--- a/docs/guides/continuous-integration/aws-codebuild.mdx
+++ b/docs/guides/continuous-integration/aws-codebuild.mdx
@@ -429,12 +429,3 @@ are leveraging three useful features of
 [Cypress Cloud](/guides/cloud/introduction):
 
 <CiProviderCloudSteps />
-
-## Cypress Real World Example with AWS CodeBuild
-
-A complete CI workflow against multiple browsers, viewports and operating
-systems is available in the Cypress Real World App (RWA).
-
-Clone the <Icon name="github" inline="true" contentType="rwa" /> and refer to
-the [buildspec.yml](https://github.com/cypress-io/cypress-realworld-app/blob/develop/buildspec.yml)
-file.


### PR DESCRIPTION
## Issue

The section [Continuous Integration > AWS CodeBuild > Cypress Real World Example with AWS CodeBuild](https://docs.cypress.io/guides/continuous-integration/aws-codebuild#Cypress-Real-World-Example-with-AWS-CodeBuild) links to a non-existent workflow https://github.com/cypress-io/cypress-realworld-app/blob/develop/buildspec.yml in the [RWA](https://github.com/cypress-io/cypress-realworld-app) Real World App.

- The workflow was removed by PR https://github.com/cypress-io/cypress-realworld-app/pull/1539 in RWA.
- PR https://github.com/cypress-io/cypress-documentation/pull/5644 then removed one reference to the removed workflow in the documentation and omitted to remove the reference in [Continuous Integration > AWS CodeBuild > Cypress Real World Example with AWS CodeBuild](https://docs.cypress.io/guides/continuous-integration/aws-codebuild#Cypress-Real-World-Example-with-AWS-CodeBuild) (my oversight).

## Change

Delete the complete section [Continuous Integration > AWS CodeBuild > Cypress Real World Example with AWS CodeBuild](https://docs.cypress.io/guides/continuous-integration/aws-codebuild#Cypress-Real-World-Example-with-AWS-CodeBuild) which no longer applies, since the workflow has been disabled and removed.