### PR TITLE
docs: update plugins.json to add cypress-mailpit plugin

### DIFF
--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -1328,6 +1328,13 @@
           "link":"https://github.com/FC122/cymap",
           "keywords":["imap", "email", "test", "commands"],
           "badge":"community"
+        },
+        {
+          "name":"cypress-mailpit",
+          "description":"A collection of useful Cypress commands for testing Emails utilizing the Mailpit RestAPI. Comes with TypeScript support",
+          "link":"https://github.com/pushpak1300/cypress-mailpit",
+          "keywords":["mailpit", "email", "test", "commands", "email"],
+          "badge":"community"
         }
       ]
     },


### PR DESCRIPTION
### Changes
- add an entry on the plugin page for cypress-mailpit plugin