### PR TITLE
Remove obsolete centOS Linux prerequisites

### DIFF
--- a/docs/guides/getting-started/installing-cypress.mdx
+++ b/docs/guides/getting-started/installing-cypress.mdx
@@ -223,12 +223,6 @@ apt-get install libgtk2.0-0t64 libgtk-3-0t64 libgbm-dev libnotify-dev libnss3 li
 pacman -S gtk2 gtk3 alsa-lib xorg-server-xvfb libxss nss libnotify
 ```
 
-#### CentOS
-
-```shell
-yum install -y xorg-x11-server-Xvfb gtk2-devel gtk3-devel libnotify-devel GConf2 nss libXScrnSaver alsa-lib
-```
-
 #### Amazon Linux 2023
 
 ```shell


### PR DESCRIPTION
- contributes to resolution of issue #5859

## Issue

CentOS Linux 7 reached end of life (EOL) on June 30, 2024 (see [What to know about CentOS Linux EOL](https://www.redhat.com/en/topics/linux/centos-linux-eol)).

CentOS is listed on [Getting Started > Installing Cypress > System requirements > Linux Prerequisites > CentOS](https://docs.cypress.io/guides/getting-started/installing-cypress#CentOS). Cypress cannot support operating systems which are themselves no longer supported. Additionally [Node.js states](https://nodejs.org/en/blog/announcements/v18-release-announce#toolchain-and-compiler-upgrades)
> Node.js does not support running on operating systems that are no longer supported by their vendor.

## Change

Remove the obsolete CentOS section [Getting Started > Installing Cypress > System requirements > Linux Prerequisites > CentOS](https://docs.cypress.io/guides/getting-started/installing-cypress#CentOS).

Although RedHat does not consider CentOS Stream to be the replacement for CentOS (the goals are different), I did test CentOS Stream 9. On [CentOS Stream release 9](https://centos.org/centos-stream/) Cypress `13.13.0` works out of the box. It is only necessary to install Node.js LTS then the full set of scaffolded Cypress specs runs without error. Therefore there is no longer any need to specify prerequisites for the current CentOS (Stream) release.

