### PR TITLE
Remove obsolete centOS troubleshooting

### DIFF
--- a/docs/guides/cloud/test-replay.mdx
+++ b/docs/guides/cloud/test-replay.mdx
@@ -142,10 +142,6 @@ If you do not want to capture test data for replay and debugging purposes, simpl
 3. Check that Test Replay is enabled in Cypress Cloud project settings.
 4. Review the standard output of the test run to ensure there was not an error capturing Test Replay. If you encounter an error capturing Test Replay, please open an issue so that we can investigate.
 
-**CentOS users may experience errors when _using_ Test Replay**
-
-CentOS Linux 7 has an [end of life in 2024](https://blog.centos.org/2023/04/end-dates-are-coming-for-centos-stream-8-and-centos-linux-7/). We have had these users report issues when accessing Test Replay in Cypress Cloud. This could be due to GCC version compatibility with better-sqlite3. We recommend using CentOS 8 rather than 7, or try following the steps noted in this [_installing better-sqlite3 on Centos 7_ Github Issue](https://github.com/WiseLibs/better-sqlite3/issues/648#issuecomment-1000361827).
-
 **Safari 16.3 and under users may experience errors when _viewing_ Test Replay**
 
 Cypress Cloud relies on certain web APIs implemented by specific browsers. Safari versions older than 16.4 may be missing certain APIs required for rendering Test Replay. To view Test Replay in Safari, version 16.4 and above may be used. This does not affect running tests or recording to Cypress Cloud.


### PR DESCRIPTION
- contributes to resolution of issue #5859

## Issue

[Cypress Cloud > Test Replay > Troubleshooting](https://docs.cypress.io/guides/cloud/test-replay#Troubleshooting) includes an outdated section with the following contents:

---

**CentOS users may experience errors when _using_ Test Replay**

CentOS Linux 7 has an [end of life in 2024](https://blog.centos.org/2023/04/end-dates-are-coming-for-centos-stream-8-and-centos-linux-7/). We have had these users report issues when accessing Test Replay in Cypress Cloud. This could be due to GCC version compatibility with better-sqlite3. We recommend using CentOS 8 rather than 7, or try following the steps noted in this [_installing better-sqlite3 on Centos 7_ Github Issue](https://github.com/WiseLibs/better-sqlite3/issues/648#issuecomment-1000361827).

---

The linked article [end of life in 2024](https://blog.centos.org/2023/04/end-dates-are-coming-for-centos-stream-8-and-centos-linux-7/) notes:

> CentOS Stream 8 End of Builds: May 31, 2024
> After May 31, 2024, CentOS Stream 8 will be archived and no further updates will be provided
> CentOS Linux 7 End of Life: June 30, 2024

This means that neither of the referenced operating systems are supported anymore.


## Change

Remove the obsolete CentOS section [Getting Started > Installing Cypress > System requirements > Linux Prerequisites > CentOS](https://docs.cypress.io/guides/getting-started/installing-cypress#CentOS).
