### PR TITLE
Rework Docker prerequisites

### DIFF
--- a/docs/guides/getting-started/installing-cypress.mdx
+++ b/docs/guides/getting-started/installing-cypress.mdx
@@ -248,7 +248,7 @@ allows you to generate your own customized Docker image easily.
 
 If you are not using a Cypress Docker image, make sure that your base operating system is a Linux system listed in the supported
 [Operating Systems](#Operating-System) above and that Node.js is installed in the image.
-It is recommended to have `unzip` installed. This avoids the Cypress binary installation falling back to a slower unzip method built in to Node.js.
+It is recommended to have `unzip` installed. This avoids the Cypress binary installation falling back to a slower unzip method using Node.js.
 
 ## Next Steps
 

--- a/docs/guides/getting-started/installing-cypress.mdx
+++ b/docs/guides/getting-started/installing-cypress.mdx
@@ -141,7 +141,7 @@ Please read our
 [Continuous Integration](/guides/continuous-integration/introduction) docs for
 help installing Cypress in CI. When running in Linux you may need to install some
 [system dependencies](#Linux-Prerequisites)
-or you can use our [Docker images](/examples/docker) which have everything you
+or you can use our [Docker images](#Docker-Prerequisites) which have everything you
 need prebuilt.
 
 ## System requirements
@@ -203,7 +203,7 @@ requirements:
 If you're using Linux, you'll want to have the required dependencies installed
 on your system. Depending on your system defaults, these dependencies may already be installed.
 If not, run the command line for your operating system listed below.
-[Cypress Docker images](#Docker), which are Debian-based, already include the necessary dependencies.
+See below under [Docker Prerequisites](#Docker-Prerequisites) for information on [Cypress Docker images](https://github.com/cypress-io/cypress-docker-images). These already include the necessary dependencies.
 
 #### Ubuntu/Debian
 
@@ -235,25 +235,20 @@ yum install -y xorg-x11-server-Xvfb gtk2-devel gtk3-devel libnotify-devel GConf2
 dnf install -y xorg-x11-server-Xvfb gtk3-devel nss alsa-lib
 ```
 
-#### Docker
+### Docker Prerequisites
 
-Docker images with all of the required dependencies installed are available
-under [cypress/base](https://github.com/cypress-io/cypress-docker-images)
+[Cypress Docker images](../continuous-integration/introduction#Cypress-Docker-variants) are available from
+[Docker Hub](https://hub.docker.com/u/cypress) and the
+[Amazon ECR (Elastic Container Registry) Public Gallery](https://gallery.ecr.aws/cypress-io).
+These images, which are Linux (Debian) based, include all of the required dependencies pre-installed.
 
-If you're running your projects in containers, then you'll want Cypress in the
-container with the Node.js process.
+If you need Node.js, browser or Cypress version combinations which are not covered by the published Cypress Docker images,
+then the [cypress/factory](https://github.com/cypress-io/cypress-docker-images/tree/master/factory) image
+allows you to generate your own customized Docker image easily.
 
-```
-  ui:
-    image: cypress/base:latest
-    # if targeting a specific node version, use e.g.
-    # image: cypress/base:20.14.0
-```
-
-`cypress/base` is a drop-in replacement for
-[base docker node images](https://hub.docker.com/_/node/).
-
-**Great, now [install Cypress](#Installing)!**
+If you are not using a Cypress Docker image, make sure that your base operating system is a Linux system listed in the supported
+[Operating Systems](#Operating-System) above and that Node.js is installed in the image.
+It is recommended to have `unzip` installed. This avoids the Cypress binary installation falling back to a slower unzip method built in to Node.js.
 
 ## Next Steps
 


### PR DESCRIPTION
## Issue

The section [Getting Started > Installing Cypress > System requirements > Linux prerequisites > Docker](https://docs.cypress.io/guides/getting-started/installing-cypress#Docker) is outdated and only mentions `cypress/base`.

The use of Bun or Alpine Linux images isn't covered.

## Change

On the page [Getting Started > Installing Cypress](https://docs.cypress.io/guides/getting-started/installing-cypress)

- Change the heading from "Docker" to "Docker Prerequisites"
- Rewrite the contents
- Refer to the operating systems section for supported OS Ubuntu, Fedora and Debian
- Address Alpine and Bun without explicitly mentioning them:
  - Stand-alone Alpine Linux is ruled out by referring to the supported OS list
  - Bun Docker images don't have Node.js installed (Bun is supposed to be a replacement for Node.js), so Node.js is explicitly listed to be added
  - Bun comes in a Debian variant and an Alpine variant. Alpine is ruled out (see above)
