### PR TITLE
Component support file with .jsx extension

### DIFF
--- a/docs/guides/component-testing/react/examples.mdx
+++ b/docs/guides/component-testing/react/examples.mdx
@@ -71,7 +71,7 @@ a React Router provider. Below is a sample mount command that uses
 `MemoryRouter` to wrap the component.
 
 <Tabs>
-<TabItem value="cypress/support/component.js">
+<TabItem value="cypress/support/component.jsx">
 
 ```jsx
 import { mount } from 'cypress/react'
@@ -146,7 +146,7 @@ To use a component that consumes state or actions from a
 wrap your component in a Redux Provider:
 
 <Tabs>
-<TabItem value="cypress/support/component.js">
+<TabItem value="cypress/support/component.jsx">
 
 ```jsx
 import { mount } from 'cypress/react'


### PR DESCRIPTION
As we introduce JSX syntax here, the component support file needs/should have the .jsx file extension.

Fixing this will especially be helpful to newcomers.