### PR TITLE
docs: Update what is not supported in Test Replay with issue links

### DIFF
--- a/docs/faq/questions/cloud-faq.mdx
+++ b/docs/faq/questions/cloud-faq.mdx
@@ -345,7 +345,7 @@ Yes! The test is captured in Cypress Cloud as it executed in your CI run. That m
 
 Expect an even performance exchange with Test Replay vs. video. There is more activity to capture and replay tests but without the overhead of recording, compressing, and storing video assets. `video` capture is set to `false` by default starting in Cypress `v13`. See the full [v13 changelog](/guides/references/changelog#13-0-0).
 
-### <Icon name="angle-right" /> Is every aspect of my stack included in Test Replay?
+### <Icon name="angle-right" /> Is everything captured and replayed in Test Replay?
 
 Our aim is to create an impactful debugging experience that covers the most ground for users. We will continue to expand support. Currently Test Replay does not support the following:
 

--- a/docs/faq/questions/cloud-faq.mdx
+++ b/docs/faq/questions/cloud-faq.mdx
@@ -364,7 +364,7 @@ Our aim is to create an impactful debugging experience that covers the most grou
 
 #### Other
 
-- Server side events ([see issue](https://github.com/cypress-io/cypress/issues/29908))
+- Server sent events ([see issue](https://github.com/cypress-io/cypress/issues/29908))
 - Web sockets ([see issue](https://github.com/cypress-io/cypress/issues/29907))
 - localStorage & sessionStorage ([see issue](https://github.com/cypress-io/cypress/issues/29909))
 - Cookies ([see issue](https://github.com/cypress-io/cypress/issues/29910))

--- a/docs/faq/questions/cloud-faq.mdx
+++ b/docs/faq/questions/cloud-faq.mdx
@@ -368,7 +368,7 @@ Our aim is to create an impactful debugging experience that covers the most grou
 - Web sockets ([see issue](https://github.com/cypress-io/cypress/issues/29907))
 - localStorage & sessionStorage ([see issue](https://github.com/cypress-io/cypress/issues/29909))
 - Cookies ([see issue](https://github.com/cypress-io/cypress/issues/29910))
-- Console props of Cypress commands outside of `cy.request()`. ([see issue](https://github.com/cypress-io/cypress/issues/29911))
+- Console props of Cypress commands outside of `cy.request()` ([see issue](https://github.com/cypress-io/cypress/issues/29911))
 
 ### <Icon name="angle-right" /> Can I use Test Replay for tests recorded in different browsers?
 

--- a/docs/faq/questions/cloud-faq.mdx
+++ b/docs/faq/questions/cloud-faq.mdx
@@ -370,7 +370,6 @@ Our aim is to create an impactful debugging experience that covers the most grou
 - Cookies ([see issue](https://github.com/cypress-io/cypress/issues/29910))
 - Console props of Cypress commands outside of `cy.request()`. ([see issue](https://github.com/cypress-io/cypress/issues/29911))
 
-
 ### <Icon name="angle-right" /> Can I use Test Replay for tests recorded in different browsers?
 
 Test Replay leverages [Chrome DevTools Protocol(CDP)](https://chromedevtools.github.io/devtools-protocol/), so currently supports Chromium-based browsers (Chrome, Edge, and Electron) only.

--- a/docs/faq/questions/cloud-faq.mdx
+++ b/docs/faq/questions/cloud-faq.mdx
@@ -354,7 +354,7 @@ Our aim is to create an impactful debugging experience that covers the most grou
 - Canvas ([see issue](https://github.com/cypress-io/cypress/issues/28289))
 - Video ([see issue](https://github.com/cypress-io/cypress/issues/29903))
 - Audio ([see issue](https://github.com/cypress-io/cypress/issues/29905))
-- Object that do not have `type="image/svg+xml"` ([see issue](https://github.com/cypress-io/cypress/issues/29904))
+- Objects that do not have `type="image/svg+xml"` ([see issue](https://github.com/cypress-io/cypress/issues/29904))
 - Shadow DOM with `slotAssignment="manual"` ([see issue](https://github.com/cypress-io/cypress/issues/29107))
 
 #### Browsers

--- a/docs/faq/questions/cloud-faq.mdx
+++ b/docs/faq/questions/cloud-faq.mdx
@@ -347,12 +347,29 @@ Expect an even performance exchange with Test Replay vs. video. There is more ac
 
 ### <Icon name="angle-right" /> Is every aspect of my stack included in Test Replay?
 
-Our aim is to create an impactful debugging experience that covers the most ground for users. We will continue to expand and can see a need to support (to name a few):
+Our aim is to create an impactful debugging experience that covers the most ground for users. We will continue to expand support. Currently Test Replay does not support the following:
 
-- Web sockets
-- Canvas elements
-- Shadow DOM
-- Server side events
+#### DOM elements
+
+- Canvas ([see issue](https://github.com/cypress-io/cypress/issues/28289))
+- Video ([see issue](https://github.com/cypress-io/cypress/issues/29903))
+- Audio ([see issue](https://github.com/cypress-io/cypress/issues/29905))
+- Object that do not have `type="image/svg+xml"` ([see issue](https://github.com/cypress-io/cypress/issues/29904))
+- Shadow DOM with `slotAssignment="manual"` ([see issue](https://github.com/cypress-io/cypress/issues/29107))
+
+#### Browsers
+
+- WebKit browser (Safari) ([see issue](https://github.com/cypress-io/cypress/issues/28895))
+- Firefox browser ([see issue](https://github.com/cypress-io/cypress/issues/28894))
+
+#### Other
+
+- Server side events ([see issue](https://github.com/cypress-io/cypress/issues/29908))
+- Web sockets ([see issue](https://github.com/cypress-io/cypress/issues/29907))
+- localStorage & sessionStorage ([see issue](https://github.com/cypress-io/cypress/issues/29909))
+- Cookies ([see issue](https://github.com/cypress-io/cypress/issues/29910))
+- Console props of Cypress commands outside of `cy.request()`. ([see issue](https://github.com/cypress-io/cypress/issues/29911))
+
 
 ### <Icon name="angle-right" /> Can I use Test Replay for tests recorded in different browsers?
 

--- a/docs/faq/questions/using-cypress-faq.mdx
+++ b/docs/faq/questions/using-cypress-faq.mdx
@@ -822,7 +822,7 @@ To test elements with those characters in ids, they need to be escaped with
 [`Cypress.$.escapeSelector`](https://api.jquery.com/jQuery.escapeSelector/).
 
 ```html
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <body>
     <div id="Configuration/Setup/TextField.id">Hello World</div>
@@ -995,7 +995,7 @@ Yes, you sure can. While executing tests, you can view the entire
 `<head>` element. Check out this example.
 
 ```html
-<!DOCTYPE html>
+<!doctype html>
 <html>
   <head>
     <meta charset="utf-8" />
@@ -1105,10 +1105,10 @@ a look at [cypress-movie](https://github.com/bahmutov/cypress-movie) project.
 Yes, for example see [this webinar](https://www.youtube.com/watch?v=U30BKedA2CY)
 hosted by Curiosity Software. In addition, since our
 
-<Icon name="github" inline="true" contentType="rwa" /> is implemented using XState
-model state library, we are looking for ways to make model-based testing simpler
-and more powerful. Read [Access XState from Cypress Test](https://glebbahmutov.com/blog/cypress-and-xstate/)
-for our start.
+<Icon name="github" inline="true" contentType="rwa" /> is implemented using
+XState model state library, we are looking for ways to make model-based testing
+simpler and more powerful. Read [Access XState from Cypress
+Test](https://glebbahmutov.com/blog/cypress-and-xstate/) for our start.
 
 ### <Icon name="angle-right" /> Can Cypress test WASM code?
 

--- a/docs/faq/questions/using-cypress-faq.mdx
+++ b/docs/faq/questions/using-cypress-faq.mdx
@@ -1105,10 +1105,10 @@ a look at [cypress-movie](https://github.com/bahmutov/cypress-movie) project.
 Yes, for example see [this webinar](https://www.youtube.com/watch?v=U30BKedA2CY)
 hosted by Curiosity Software. In addition, since our
 
-<Icon name="github" inline="true" contentType="rwa" /> is implemented using
-XState model state library, we are looking for ways to make model-based testing
-simpler and more powerful. Read [Access XState from Cypress
-Test](https://glebbahmutov.com/blog/cypress-and-xstate/) for our start.
+<Icon name="github" inline="true" contentType="rwa" /> is implemented using XState
+model state library, we are looking for ways to make model-based testing simpler
+and more powerful. Read [Access XState from Cypress Test](https://glebbahmutov.com/blog/cypress-and-xstate/)
+for our start.
 
 ### <Icon name="angle-right" /> Can Cypress test WASM code?
 

--- a/docs/faq/questions/using-cypress-faq.mdx
+++ b/docs/faq/questions/using-cypress-faq.mdx
@@ -822,7 +822,7 @@ To test elements with those characters in ids, they need to be escaped with
 [`Cypress.$.escapeSelector`](https://api.jquery.com/jQuery.escapeSelector/).
 
 ```html
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <body>
     <div id="Configuration/Setup/TextField.id">Hello World</div>
@@ -995,7 +995,7 @@ Yes, you sure can. While executing tests, you can view the entire
 `<head>` element. Check out this example.
 
 ```html
-<!doctype html>
+<!DOCTYPE html>
 <html>
   <head>
     <meta charset="utf-8" />

--- a/docs/guides/end-to-end-testing/testing-strategies/amazon-cognito-authentication.mdx
+++ b/docs/guides/end-to-end-testing/testing-strategies/amazon-cognito-authentication.mdx
@@ -245,7 +245,7 @@ const loginToCognito = (username: string, password: string) => {
       },
     },
     ({ username, password }) => {
-      cy.contains("Sign in with your email and password");
+      cy.contains('Sign in with your email and password')
       // Cognito log in page has some elements of the same id but are off screen.
       // We only want the visible elements to log in
       cy.get('input[name="username"]:visible').type(username)


### PR DESCRIPTION
The FAQ does not comprehensively reflect what is supported in Test Replay. Additionally it's incorrectly saying we don't support Shadow DOm. https://docs.cypress.io/faq/questions/cloud-faq#Is-every-aspect-of-my-stack-included-in-Test-Replay

This updates the FAQ to be comprehensive and also point to issues where people can actively express and track support. 