### PR TITLE
Update minimum Linux to Fedora 39 and Debian 11

### DIFF
--- a/docs/guides/getting-started/installing-cypress.mdx
+++ b/docs/guides/getting-started/installing-cypress.mdx
@@ -164,7 +164,7 @@ Cypress is a desktop application that is installed on your computer. The desktop
 application supports these operating systems:
 
 - **macOS** 10.15 and above _(Intel or Apple Silicon 64-bit (x64 or arm64))_.
-- **Linux** Ubuntu 20.04 and above, Fedora 38 and above, and Debian 10 and above _(x64 or arm64)_ (see [Linux Prerequisites](#Linux-Prerequisites) down
+- **Linux** Ubuntu 20.04 and above, Fedora 39 and above, and Debian 11 and above _(x64 or arm64)_ (see [Linux Prerequisites](#Linux-Prerequisites) down
   below).
   - Cypress deprecated the use of Node.js `16.x` in Cypress [`13.0.0`](/guides/references/changelog#13-0-0). We recommend that users update to at least Node.js `18.x`.
     For related reasons, Cypress deprecates the use of Linux operating systems with library [`glibc`](https://www.gnu.org/software/libc/) versions `2.17` - `2.27`. The Linux CLI command `ldd --version` displays your glibc version.


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress-documentation/issues/5878
- Closes https://github.com/cypress-io/cypress-documentation/issues/5879

## Issue

[Getting Started > Installing Cypress > System requirements > Operating System](https://docs.cypress.io/guides/getting-started/installing-cypress#Operating-System) currently lists the supported Linux operating systems as:

> Linux Ubuntu 20.04 and above, Fedora 38 and above, and Debian 10 and above (x64 or arm64)

- According to https://wiki.debian.org/LTS Debian 10 "Buster" reached End of Life on June 30, 2024.
- According to https://docs.fedoraproject.org/en-US/releases/eol/ "Fedora Linux 38" reached End of Life on May 21, 2024.

Node.js also has a policy not to support operating systems which are no longer supported by their vendor.

## Change

Bump the minimum Linux operating system versions to:
- "Fedora Linux 39". See https://docs.fedoraproject.org/en-US/releases/.
- "Debian 11 (Bullseye)". See https://wiki.debian.org/LTS.