### PR TITLE
chore: add release 13.13.2 changelog

### DIFF
--- a/docs/guides/references/changelog.mdx
+++ b/docs/guides/references/changelog.mdx
@@ -2,6 +2,26 @@
 title: Changelog
 ---
 
+## 13.13.2
+
+_Released 7/31/2024_
+
+**Performance:**
+
+- Fixed a memory leak with command logs with Test Replay enabled. Addressed in [#29939](https://github.com/cypress-io/cypress/pull/29939).
+- Improved performance of `reduce` in a method within our proxy. Addressed in [#29887](https://github.com/cypress-io/cypress/pull/29887).
+
+**Bugfixes:**
+
+- Fixed an issue where yarn PnP was not working correctly with Cypress and `@cypress/webpack-batteries-included-preprocessor`. Fixes [#27947](https://github.com/cypress-io/cypress/issues/27947).
+
+**Dependency Updates:**
+
+- Updated `@cypress/request` from `3.0.0` to `3.0.1`. Addresses [#29863](https://github.com/cypress-io/cypress/issues/29863).
+- Updated `chrome-remote-interface` from `0.33.0` to `0.33.2`. Addressed in [#29932](https://github.com/cypress-io/cypress/pull/29932).
+- Updated `mime` from `2.4.4` to `2.6.0`. Addressed in [#29870](https://github.com/cypress-io/cypress/pull/29870).
+- Updated `strip-ansi` from `6.0.0` to `6.0.1`. Addressed in [#29931](https://github.com/cypress-io/cypress/pull/29931).
+
 ## 13.13.1
 
 _Released 7/16/2024_

--- a/docs/guides/references/changelog.mdx
+++ b/docs/guides/references/changelog.mdx
@@ -13,7 +13,7 @@ _Released 7/31/2024_
 
 **Bugfixes:**
 
-- Fixed an issue where yarn PnP was not working correctly with Cypress and `@cypress/webpack-batteries-included-preprocessor`. Fixes [#27947](https://github.com/cypress-io/cypress/issues/27947).
+- Fixed an issue where Yarn PnP was not working correctly with Cypress and `@cypress/webpack-batteries-included-preprocessor`. Fixes [#27947](https://github.com/cypress-io/cypress/issues/27947).
 
 **Dependency Updates:**
 


### PR DESCRIPTION
adds the Cypress `13.13.2` changelog