### PR TITLE
Use Chromium download link https://on.cypress.io/chromium-downloads

### DIFF
--- a/docs/guides/guides/launching-browsers.mdx
+++ b/docs/guides/guides/launching-browsers.mdx
@@ -56,8 +56,8 @@ Cypress supports the browser versions below:
 ### Download specific Chrome version
 
 The Chrome browser is evergreen - meaning it will automatically update itself,
-sometimes causing a breaking change in your automated tests. You can use
-[https://vikyd.github.io/download-chromium-history-version](https://vikyd.github.io/download-chromium-history-version) to download a
+sometimes causing a breaking change in your automated tests.
+You can use the information in [Download Chromium](https://on.cypress.io/chromium-downloads) to download a
 specific released version of Chromium for every platform.
 
 ### Electron Browser

--- a/docs/guides/references/troubleshooting.mdx
+++ b/docs/guides/references/troubleshooting.mdx
@@ -76,8 +76,8 @@ problem:
 ## Download specific Chrome version
 
 The Chrome browser is evergreen - meaning it will automatically update itself,
-sometimes causing a breaking change in your automated tests. You can use
-[https://vikyd.github.io/download-chromium-history-version](https://vikyd.github.io/download-chromium-history-version) to download a
+sometimes causing a breaking change in your automated tests.
+You can use the information in [Download Chromium](https://on.cypress.io/chromium-downloads) to download a
 specific released version of Chromium for every platform.
 
 ## Clear Cypress cache


### PR DESCRIPTION
## Issue

The link https://vikyd.github.io/download-chromium-history-version/ to download Chromium is obsolete. It stops at version 121.0.6141.1 from November 2023.

This link is used in:

- https://docs.cypress.io/guides/guides/launching-browsers#Download-specific-Chrome-version
- https://docs.cypress.io/guides/references/troubleshooting#Download-specific-Chrome-version

## Change

- Align with the resolution to https://github.com/cypress-io/cypress/issues/29460 and use the vanity link https://on.cypress.io/chromium-downloads instead.
