### PR TITLE
Clarify minimum Chrome 64 (run) / Chrome 80 (open)

### DIFF
--- a/docs/guides/guides/launching-browsers.mdx
+++ b/docs/guides/guides/launching-browsers.mdx
@@ -49,7 +49,7 @@ browser by using the drop down near the top right corner:
 
 Cypress supports the browser versions below:
 
-- Chrome 80 and above.
+- Chrome 64 and above. Chrome 80 and above is required for `cypress open` usage.
 - Edge 80 and above.
 - Firefox 86 and above.
 
@@ -85,7 +85,8 @@ seeing failures in CI, to easily debug them you may want to run locally with the
 ### Chrome Browsers
 
 All Chrome\* flavored browsers will be detected and are supported above
-Chrome 64.
+Chrome 64, with the restriction that a minimum of Chrome 80 is required to use
+`cypress open`.
 
 You can launch Chrome like this:
 


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress-documentation/issues/5446

## Issue

[Guides > Launching Browsers > Chrome Browsers](https://docs.cypress.io/guides/guides/launching-browsers#Chrome-Browsers) names both Chrome 64 and Chrome 80 as minimum versions on the same page without further explanation.

- See https://github.com/cypress-io/cypress-documentation/pull/5104#issuecomment-1614637130 for dev explanation.

## Change

Clarify that Chrome 80 minimum applies to `cypress open` and make the references on the same page consistent with each other.
