### PR TITLE
Fixed dark mode switch Button: Update DarkModeSwitch

### DIFF
--- a/src/theme/BackToTopButton/DarkModeSwitch.js
+++ b/src/theme/BackToTopButton/DarkModeSwitch.js
@@ -7,7 +7,8 @@ import {
 import { useColorMode } from '@docusaurus/theme-common'
 
 export default function DarkModeSwitch() {
-  const { colorMode, setColorMode } = useColorMode()
+   const storedTheme = localStorage.getItem('theme')
+  const { colorMode, setColorMode } = useColorMode(storedTheme)
   const isDark = colorMode === 'dark'
   return (
     <button

--- a/src/theme/BackToTopButton/DarkModeSwitch.js
+++ b/src/theme/BackToTopButton/DarkModeSwitch.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React , {useEffect} from 'react'
 import clsx from 'clsx'
 import {
   IconShapeSunLong,
@@ -7,8 +7,11 @@ import {
 import { useColorMode } from '@docusaurus/theme-common'
 
 export default function DarkModeSwitch() {
-   const storedTheme = localStorage.getItem('theme')
-  const { colorMode, setColorMode } = useColorMode(storedTheme)
+   
+  const { colorMode, setColorMode } = useColorMode(null)
+   useEffect(() => {
+    setColorMode(localStorage.getItem('theme'))
+  }, [])
   const isDark = colorMode === 'dark'
   return (
     <button


### PR DESCRIPTION
Issue : 
1. User sets dark theme and closes tab,
2. Again user visits cypress doc
3. Now the theme remains dark but button is stucked in light theme 

Fix:
The default value is now set from localstorage.

Resolution:
 Darkmode switch button now remembers the user set value.