### PR TITLE
fix: code block with incorrect language

### DIFF
--- a/docs/guides/tooling/reporters.mdx
+++ b/docs/guides/tooling/reporters.mdx
@@ -226,9 +226,7 @@ Then add the separate `reporter-config.json` file (defined in your
 configuration) to enable `spec` and `junit` reporters and direct the `junit`
 reporter to save separate XML files.
 
-:::cypress-config-example
-
-```ts
+```json
 {
   reporterEnabled: 'spec, mocha-junit-reporter',
   mochaJunitReporterReporterOptions: {
@@ -236,8 +234,6 @@ reporter to save separate XML files.
   }
 }
 ```
-
-:::
 
 We recommend deleting all files from the `cypress/results` folder before running
 this command, since each run will output new XML files. For example, you can add

--- a/docs/guides/tooling/reporters.mdx
+++ b/docs/guides/tooling/reporters.mdx
@@ -228,9 +228,9 @@ reporter to save separate XML files.
 
 ```json
 {
-  reporterEnabled: 'spec, mocha-junit-reporter',
-  mochaJunitReporterReporterOptions: {
-    mochaFile: 'cypress/results/results-[hash].xml'
+  "reporterEnabled": "spec, mocha-junit-reporter",
+  "mochaJunitReporterReporterOptions": {
+    "mochaFile": "cypress/results/results-[hash].xml"
   }
 }
 ```


### PR DESCRIPTION
According to the context, the below code block should be for a JSON file. However, it is rendered as `cypress.config.js/ts`:

<img width="1139" alt="Screenshot 2024-08-16 at 14 44 28" src="https://github.com/user-attachments/assets/0b69dbe2-da66-4694-b2a3-79544d5adcb5">
