### PR TITLE
v13.14.0 Docs

### DIFF
--- a/docs/api/actions/type.mdx
+++ b/docs/api/actions/type.mdx
@@ -172,6 +172,10 @@ locale. `yyyy-MM-dd` is the format required by
 [the W3 spec](https://www.w3.org/TR/html/infrastructure.html#dates-and-times)
 and is what the input's `value` will be set to regardless of browser or locale.
 
+`{upArrow}` and `{downArrow}` can increase and decrease the day value,
+depending on "step" parameter provided. Using `.type()` with `{upArrow}` and `{downArrow}`
+mimics behavior of `stepUp` and `stepDown` input methods.
+
 Special characters (`{leftArrow}`, `{selectAll}`, etc.) are not permitted.
 
 ### Month Inputs
@@ -186,6 +190,10 @@ since month input support varies between browsers and the format varies based on
 locale. `yyyy-MM` is the format required by
 [the W3 spec](https://www.w3.org/TR/html/infrastructure.html#months) and is what
 the input's `value` will be set to regardless of browser or locale.
+
+`{upArrow}` and `{downArrow}` can increase and decrease the month value,
+depending on "step" parameter provided. Using `.type()` with `{upArrow}` and `{downArrow}`
+mimics behavior of `stepUp` and `stepDown` input methods.
 
 Special characters (`{leftArrow}`, `{selectAll}`, etc.) are not permitted.
 
@@ -207,6 +215,10 @@ and is what the input's `value` will be set to regardless of browser or locale.
 
 Special characters (`{leftArrow}`, `{selectAll}`, etc.) are not permitted.
 
+`{upArrow}` and `{downArrow}` can increase and decrease the week value,
+depending on "step" parameter provided. Using `.type()` with `{upArrow}` and `{downArrow}`
+mimics behavior of `stepUp` and `stepDown` input methods.
+
 ### Time Inputs
 
 Using `.type()` on a time input (`<input type="time">`) requires specifying a
@@ -217,6 +229,10 @@ valid time in the format:
 - `HH:mm:ss.SSS` (e.g. `12:00:00.384`)
 
 Where `HH` is 00-23, `mm` is 00-59, `ss` is 00-59, and `SSS` is 000-999.
+
+`{upArrow}` and `{downArrow}` can increase and decrease the seconds value,
+depending on "step" parameter provided. Using `.type()` with `{upArrow}` and `{downArrow}`
+mimics behavior of `stepUp` and `stepDown` input methods.
 
 Special characters (`{leftArrow}`, `{selectAll}`, etc.) are not permitted.
 
@@ -618,22 +634,23 @@ following:
 
 ## History
 
-| Version                                       | Changes                                                                                                                   |
-| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| [6.1.0](/guides/references/changelog#6-1-0)   | Added option `scrollBehavior`                                                                                             |
-| [5.6.0](/guides/references/changelog#5-6-0)   | Support single key combination syntax                                                                                     |
-| [5.5.0](/guides/references/changelog#5-5-0)   | Support `beforeinput` event                                                                                               |
-| [3.4.1](/guides/references/changelog#3-4-1)   | Added `parseSpecialCharSequences` option                                                                                  |
-| [3.3.0](/guides/references/changelog#3-3-0)   | Added `{insert}`, `{pageup}` and `{pagedown}` character sequences                                                         |
-| [3.2.0](/guides/references/changelog#3-2-0)   | Added `{home}` and `{end}` character sequences                                                                            |
-| [0.20.0](/guides/references/changelog#0-20-0) | Supports for typing in inputs of type `date`, `time`, `month`, and `week`                                                 |
-| [0.17.1](/guides/references/changelog#0-17-1) | Added `ctrl`, `cmd`, `shift`, and `alt` keyboard modifiers                                                                |
-| [0.16.3](/guides/references/changelog#0-16-3) | Supports for typing in elements with `tabindex` attribute                                                                 |
-| [0.16.2](/guides/references/changelog#0-16-2) | Added `{downarrow}` and `{uparrow}` character sequences                                                                   |
-| [0.8.0](/guides/references/changelog#0-8-0)   | Outputs Key Events Table to console on click                                                                              |
-| [0.8.0](/guides/references/changelog#0-8-0)   | Added `{selectall}`, `{del}`, `{backspace}`, `{esc}`, `{{}`, `{enter}`, `{leftarrow}`, `{rightarrow}` character sequences |
-| [0.8.0](/guides/references/changelog#0-8-0)   | Added small delay (10ms) between each keystroke during `cy.type()`                                                        |
-| [0.6.12](/guides/references/changelog#0-6-12) | Added option `force`                                                                                                      |
+| Version                                         | Changes                                                                                                                                |
+| ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | --- |
+| [13.14.0](/guides/references/changelog#13-14-0) | Added support for `.type({upArrow})` and `.type({downArrow})` to work on date, month, week, time, datetime-local and range input types |     |
+| [6.1.0](/guides/references/changelog#6-1-0)     | Added option `scrollBehavior`                                                                                                          |
+| [5.6.0](/guides/references/changelog#5-6-0)     | Support single key combination syntax                                                                                                  |
+| [5.5.0](/guides/references/changelog#5-5-0)     | Support `beforeinput` event                                                                                                            |
+| [3.4.1](/guides/references/changelog#3-4-1)     | Added `parseSpecialCharSequences` option                                                                                               |
+| [3.3.0](/guides/references/changelog#3-3-0)     | Added `{insert}`, `{pageup}` and `{pagedown}` character sequences                                                                      |
+| [3.2.0](/guides/references/changelog#3-2-0)     | Added `{home}` and `{end}` character sequences                                                                                         |
+| [0.20.0](/guides/references/changelog#0-20-0)   | Supports for typing in inputs of type `date`, `time`, `month`, and `week`                                                              |
+| [0.17.1](/guides/references/changelog#0-17-1)   | Added `ctrl`, `cmd`, `shift`, and `alt` keyboard modifiers                                                                             |
+| [0.16.3](/guides/references/changelog#0-16-3)   | Supports for typing in elements with `tabindex` attribute                                                                              |
+| [0.16.2](/guides/references/changelog#0-16-2)   | Added `{downarrow}` and `{uparrow}` character sequences                                                                                |
+| [0.8.0](/guides/references/changelog#0-8-0)     | Outputs Key Events Table to console on click                                                                                           |
+| [0.8.0](/guides/references/changelog#0-8-0)     | Added `{selectall}`, `{del}`, `{backspace}`, `{esc}`, `{{}`, `{enter}`, `{leftarrow}`, `{rightarrow}` character sequences              |
+| [0.8.0](/guides/references/changelog#0-8-0)     | Added small delay (10ms) between each keystroke during `cy.type()`                                                                     |
+| [0.6.12](/guides/references/changelog#0-6-12)   | Added option `force`                                                                                                                   |
 
 ## See also
 

--- a/docs/api/actions/type.mdx
+++ b/docs/api/actions/type.mdx
@@ -635,8 +635,8 @@ following:
 ## History
 
 | Version                                         | Changes                                                                                                                                |
-| ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | --- |
-| [13.14.0](/guides/references/changelog#13-14-0) | Added support for `.type({upArrow})` and `.type({downArrow})` to work on date, month, week, time, datetime-local and range input types |     |
+| ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| [13.14.0](/guides/references/changelog#13-14-0) | Added support for `.type({upArrow})` and `.type({downArrow})` to work on date, month, week, time, datetime-local and range input types |
 | [6.1.0](/guides/references/changelog#6-1-0)     | Added option `scrollBehavior`                                                                                                          |
 | [5.6.0](/guides/references/changelog#5-6-0)     | Support single key combination syntax                                                                                                  |
 | [5.5.0](/guides/references/changelog#5-5-0)     | Support `beforeinput` event                                                                                                            |

--- a/docs/guides/guides/command-line.mdx
+++ b/docs/guides/guides/command-line.mdx
@@ -673,8 +673,10 @@ you open. These persist on all projects until you quit Cypress. These options
 will also override values in the Cypress configuration file.
 
 By passing `--browser` and `--e2e` or `--component` when launching a project,
-you can open Cypress and launch the browser at the same time. Otherwise, you
-will be guided through selecting a browser, project, and/or testing type.
+you can open Cypress and launch the browser at the same time. If passing the
+`--browser` flag alone, the browser will launch automatically after being
+guided through project and/or testing type selection. Otherwise, you will
+be guided through selecting a browser, project, and/or testing type.
 
 | Option                | Description                                                                                                                                                                         |
 | --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/guides/references/advanced-installation.mdx
+++ b/docs/guides/references/advanced-installation.mdx
@@ -13,6 +13,7 @@ title: Advanced Installation
 | `CYPRESS_CACHE_FOLDER`            | [Changes the Cypress binary cache location](#Binary-cache)                                     |
 | `CYPRESS_RUN_BINARY`              | [Location of Cypress binary at run-time](#Run-binary)                                          |
 | `CYPRESS_VERIFY_TIMEOUT`          | Overrides the timeout duration for the `verify` command. The default value is 30000.           |
+| `CYPRESS_SKIP_VERIFY`             | Skips the `verify` command (for stable CI environments)                                        |
 | ~~CYPRESS_SKIP_BINARY_INSTALL~~   | <Badge type="danger">removed</Badge> use `CYPRESS_INSTALL_BINARY=0` instead                    |
 | ~~CYPRESS_BINARY_VERSION~~        | <Badge type="danger">removed</Badge> use `CYPRESS_INSTALL_BINARY` instead                      |
 

--- a/docs/guides/references/changelog.mdx
+++ b/docs/guides/references/changelog.mdx
@@ -18,6 +18,7 @@ _Released 8/27/2024_
 - `.type({upArrow})` and `.type({downArrow})` now also works for date, month, week, time, datetime-local and range input types. Addresses [#29665](https://github.com/cypress-io/cypress/issues/29665).
 - Added a `CYPRESS_SKIP_VERIFY` flag to enable suppressing Cypress verification checks. Addresses [#22243](https://github.com/cypress-io/cypress/issues/22243).
 - Updated the protocol to allow making Cloud API requests. Addressed in [#30066](https://github.com/cypress-io/cypress/pull/30066).
+- Passing `--browser` flag alone will automatically launch browser after being guided through project and/or testing type selection. Addressed in [#28538](https://github.com/cypress-io/cypress/pull/28538).
 
 **Bugfixes:**
 

--- a/docs/guides/references/changelog.mdx
+++ b/docs/guides/references/changelog.mdx
@@ -6,6 +6,33 @@ title: Changelog
 
 _Released 8/27/2024_
 
+**Performance:**
+
+- Fixed a potential memory leak in the Cypress server when re-connecting to an unintentionally disconnected CDP connection. Fixes [#29744](https://github.com/cypress-io/cypress/issues/29744). Addressed in [#29988](https://github.com/cypress-io/cypress/pull/29988).
+
+**Features:**
+
+- Added new
+  [`experimentalJustInTimeCompile`](/guides/references/experiments#Configuration)
+  configuration option for component testing. This option will only compile resources directly related to your spec, compiling them 'just-in-time' before spec execution. This should result in improved memory management and performance for component tests in `cypress open` and `cypress run` modes, in particular for large component testing suites. [`experimentalJustInTimeCompile`](/guides/references/experiments#Configuration) is currently supported for [`webpack`](https://www.npmjs.com/package/webpack) and [`vite`](https://www.npmjs.com/package/vite). Addresses [#29244](https://github.com/cypress-io/cypress/issues/29244).
+- `.type({upArrow})` and `.type({downArrow})` now also works for date, month, week, time, datetime-local and range input types. Addresses [#29665](https://github.com/cypress-io/cypress/issues/29665).
+- Added a `CYPRESS_SKIP_VERIFY` flag to enable suppressing Cypress verification checks. Addresses [#22243](https://github.com/cypress-io/cypress/issues/22243).
+- Updated the protocol to allow making Cloud API requests. Addressed in [#30066](https://github.com/cypress-io/cypress/pull/30066).
+
+**Bugfixes:**
+
+- Fixed an issue where files outside the Cypress project directory were not calculating the bundle output path correctly for the `file:preprocessor`. Addresses [#8599](https://github.com/cypress-io/cypress/issues/8599).
+- Fixed an issue where Cypress would not run if Node.js version `22.7.0` was being used with TypeScript and ES Modules. Fixes [#30084](https://github.com/cypress-io/cypress/issues/30084).
+- Correctly determines current browser family when choosing between `unload` and `pagehide` options in App Runner. Fixes [#29880](https://github.com/cypress-io/cypress/issues/29880).
+
+**Misc:**
+
+- Allow HiDPI Screen running wayland to use cypress window/browser by adding `--ozone-platform-hint=auto` flag to the electron's runtime argument. Addresses [#20891](https://github.com/cypress-io/cypress/issues/20891).
+
+**Dependency Updates:**
+
+- Updated `detect-port` from `1.3.0` to `1.6.1`. Addressed in [#30038](https://github.com/cypress-io/cypress/pull/30038).
+
 ## 13.13.3
 
 _Released 8/14/2024_

--- a/docs/guides/references/changelog.mdx
+++ b/docs/guides/references/changelog.mdx
@@ -27,7 +27,7 @@ _Released 8/27/2024_
 
 **Misc:**
 
-- Allow HiDPI Screen running wayland to use cypress window/browser by adding `--ozone-platform-hint=auto` flag to the electron's runtime argument. Addresses [#20891](https://github.com/cypress-io/cypress/issues/20891).
+- Allow HiDPI screen running Wayland to use Cypress window/browser by adding `--ozone-platform-hint=auto` flag to Electron's runtime argument. Addresses [#20891](https://github.com/cypress-io/cypress/issues/20891).
 
 **Dependency Updates:**
 

--- a/docs/guides/references/changelog.mdx
+++ b/docs/guides/references/changelog.mdx
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## 13.14.0
+
+_Released 8/27/2024_
+
 ## 13.13.3
 
 _Released 8/14/2024_

--- a/docs/guides/references/experiments.mdx
+++ b/docs/guides/references/experiments.mdx
@@ -327,7 +327,7 @@ configuration object:
 
 #### Experimental Just-In-Time Compile
 
-By default, Cypress compiles all specs used by Component Testing before allowing any spec to run. This works fine for smaller projects most of the time.
+By default, Cypress compiles all specs used by component testing before allowing any spec to run. This works fine for smaller projects most of the time.
 
 However, as a component testing suite grows, the dev server (`vite` or `webpack-dev-server`, depending on your application) also grows with it. This can get to a point where the dev server grows so large that it consumes a large majority of CPU and memory resources, leading to:
 

--- a/docs/guides/references/experiments.mdx
+++ b/docs/guides/references/experiments.mdx
@@ -329,7 +329,7 @@ configuration object:
 
 By default, Cypress compiles all specs used by Component Testing before allowing any spec to run. This works fine for smaller projects most of the time.
 
-However, as a Component Testing suite grows, the dev server (`vite` or `webpack-dev-server`, depending on your application) also grows with it. This can get to a point where the dev server grows so large that it consumes a large majority of CPU and memory resources, leading to:
+However, as a component testing suite grows, the dev server (`vite` or `webpack-dev-server`, depending on your application) also grows with it. This can get to a point where the dev server grows so large that it consumes a large majority of CPU and memory resources, leading to:
 
 - Out Of Memory (OOM) errors.
 - `chunk load error`, specific to Webpack where parts of the bundle fail to load.

--- a/docs/guides/references/experiments.mdx
+++ b/docs/guides/references/experiments.mdx
@@ -353,7 +353,7 @@ If you are using this experiment and would like to leave feedback, please commen
 
 | Version                                         | Changes                                                                                                                                       |
 | ----------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| [13.14.0](/guides/references/changelog#13-14-0) | Added support for configuring the Experimental Just-In-Time (JIT) Compiling for Component Testing via `experimentalJustInTimeCompile`.        |
+| [13.14.0](/guides/references/changelog#13-14-0) | Added support for configuring the Experimental Just-In-Time (JIT) Compiling for component testing via `experimentalJustInTimeCompile`.        |
 | [13.4.0](/guides/references/changelog#13-4-0)   | Added support for configuring the Experimental Flake Detection strategy via `retries.experimentalStrategy` and `retries.experimentalOptions`. |
 | [12.6.0](/guides/references/changelog#12-6-0)   | Removed `require`/`import` and added `Cypress.require` for `experimentalOriginDependencies`.                                                  |
 | [12.4.0](/guides/references/changelog#12-4-0)   | Added `experimentalSkipDomainInjection` and `experimentalMemoryManagement`.                                                                   |

--- a/docs/guides/references/experiments.mdx
+++ b/docs/guides/references/experiments.mdx
@@ -320,36 +320,62 @@ you will need to add the correct matching glob pattern.
 These experiments are available to be specified inside the `component`
 configuration object:
 
-| Option                         | Default | Description                                                                                                                                                                       |
-| ------------------------------ | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `experimentalSingleTabRunMode` | `false` | Run all specs in a single tab, instead of creating a new tab per spec. This can improve run mode performance, but can impact spec isolation and reliability on large test suites. |
+| Option                          | Default | Description                                                                                                                                                                       |
+| ------------------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `experimentalSingleTabRunMode`  | `false` | Run all specs in a single tab, instead of creating a new tab per spec. This can improve run mode performance, but can impact spec isolation and reliability on large test suites. |
+| `experimentalJustInTimeCompile` | `false` | Enables Just-In-Time (JIT) compiling for component testing, which will only compile assets related to the spec before the spec is run. Currently supported for Vite and Webpack.  |
+
+#### Experimental Just-In-Time Compile
+
+By default, Cypress compiles all specs used by Component Testing before allowing any spec to run. This works fine for smaller projects most of the time.
+
+However, as a Component Testing suite grows, the dev server (`vite` or `webpack-dev-server`, depending on your application) also grows with it. This can get to a point where the dev server grows so large that it consumes a large majority of CPU and memory resources, leading to:
+
+- Out Of Memory (OOM) errors.
+- `chunk load error`, specific to Webpack where parts of the bundle fail to load.
+- long run times while running component tests in CI in `cypress run` mode.
+- Unable to efficiently develop tests in `cypress open` mode because the initial and recompiling times for specs and related components are extremely long.
+- Inability to leverage [Smart orchestration](/guides/cloud/smart-orchestration/overview) effectively to scale resources due to all assets being compiled into the dev server regardless of what specs are run.
+
+The `experimentalJustInTimeCompile` option is designed to remedy this problem. Enabling this option will enable Just-In-Time (JIT) compiling for component testing, which will only compile assets and resources related to the spec before the spec is run. This is applicable in both `open` and `run` modes.
+
+In `open` and `run` modes, the dev server will start up when the Cypress application starts with the component testing type, but will only compile the spec once it is selected or run. When a different spec is run, the different spec is then compiled, omitting the previously run spec from the dev server.
+
+This makes developing your current spec much faster in `open` mode when it comes to initial compiling and recompiling, with a minor tradeoff being to recompile when you switch specs.
+
+This also significantly reduces the memory requirements needed to run your tests in `run` mode, with a tradeoff being that your tests might run slightly slower since the dev server needs to recompile. If time is a factor, [Smart orchestration](/guides/cloud/smart-orchestration/overview) can now be effectively used to parallelize your component testing runs on smaller infrastructure since the dev server only compiles what is needed to run the spec.
+
+We are using `experimentalJustInTimeCompile` internally within Cypress for our larger Component Testing suites and have noticed significant reductions in memory when running `cypress run` mode and have gained significantly faster compile times when leveraging `cypress open` to develop our tests.
+
+If you are using this experiment and would like to leave feedback, please comment on our [github discussion](https://github.com/cypress-io/cypress/discussions/30024).
 
 ## History
 
-| Version                                       | Changes                                                                                                                                       |
-| --------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| [13.4.0](/guides/references/changelog#13-4-0) | Added support for configuring the Experimental Flake Detection strategy via `retries.experimentalStrategy` and `retries.experimentalOptions`. |
-| [12.6.0](/guides/references/changelog#12-6-0) | Removed `require`/`import` and added `Cypress.require` for `experimentalOriginDependencies`.                                                  |
-| [12.4.0](/guides/references/changelog#12-4-0) | Added `experimentalSkipDomainInjection` and `experimentalMemoryManagement`.                                                                   |
-| [12.0.0](/guides/references/changelog#12-0-0) | Removed `experimentalSessionAndOrigin` and made it the default behavior. Added `experimentalOriginDependencies`.                              |
-| [11.2.0](/guides/references/changelog#11-2-0) | Added `experimentalRunAllSpecs`.                                                                                                              |
-| [10.8.0](/guides/references/changelog#10-8-0) | Added `experimentalWebKitSupport`.                                                                                                            |
-| [10.6.0](/guides/references/changelog#10-6-0) | Added support for `experimentalSingleTabRunMode`.                                                                                             |
-| [10.4.0](/guides/references/changelog#10-4-0) | Added support for `experimentalModifyObstructiveThirdPartyCode`.                                                                              |
-| [9.6.0](/guides/references/changelog#9-6-0)   | Added support for `experimentalSessionAndOrigin` and removed `experimentalSessionSupport`.                                                    |
-| [8.2.0](/guides/references/changelog#8-2-0)   | Added support for `experimentalSessionSupport`.                                                                                               |
-| [7.1.0](/guides/references/changelog#7-1-0)   | Added support for `experimentalInteractiveRunEvents`.                                                                                         |
-| [7.0.0](/guides/references/changelog#7-0-0)   | Removed `experimentalComponentTesting` and made it the default behavior.                                                                      |
-| [6.7.0](/guides/references/changelog#6-7-0)   | Removed `experimentalRunEvents` and made it the default behavior.                                                                             |
-| [6.3.0](/guides/references/changelog#6-3-0)   | Added support for `experimentalStudio`.                                                                                                       |
-| [6.2.0](/guides/references/changelog#6-2-0)   | Added support for `experimentalRunEvents`.                                                                                                    |
-| [6.0.0](/guides/references/changelog#6-0-0)   | Removed `experimentalNetworkStubbing` and made it the default behavior when using [cy.intercept()](/api/commands/intercept).                  |
-| [6.0.0](/guides/references/changelog#6-0-0)   | Deprecated `experimentalFetchPolyfill`.                                                                                                       |
-| [5.2.0](/guides/references/changelog#5-2-0)   | Removed `experimentalShadowDomSupport` and made it the default behavior.                                                                      |
-| [5.1.0](/guides/references/changelog#5-1-0)   | Added support for `experimentalNetworkStubbing`.                                                                                              |
-| [5.0.0](/guides/references/changelog#5-0-0)   | Removed `experimentalGetCookiesSameSite` and made it the default behavior.                                                                    |
-| [4.9.0](/guides/references/changelog#4-9-0)   | Added support for `experimentalFetchPolyfill`.                                                                                                |
-| [4.8.0](/guides/references/changelog#4-8-0)   | Added support for `experimentalShadowDomSupport`.                                                                                             |
-| [4.6.0](/guides/references/changelog#4-6-0)   | Added support for `experimentalSourceRewriting`.                                                                                              |
-| [4.5.0](/guides/references/changelog#4-5-0)   | Added support for `experimentalComponentTesting`.                                                                                             |
-| [4.3.0](/guides/references/changelog#4-3-0)   | Added support for `experimentalGetCookiesSameSite`.                                                                                           |
+| Version                                         | Changes                                                                                                                                       |
+| ----------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| [13.14.0](/guides/references/changelog#13-14-0) | Added support for configuring the Experimental Just-In-Time (JIT) Compiling for Component Testing via `experimentalJustInTimeCompile`.        |
+| [13.4.0](/guides/references/changelog#13-4-0)   | Added support for configuring the Experimental Flake Detection strategy via `retries.experimentalStrategy` and `retries.experimentalOptions`. |
+| [12.6.0](/guides/references/changelog#12-6-0)   | Removed `require`/`import` and added `Cypress.require` for `experimentalOriginDependencies`.                                                  |
+| [12.4.0](/guides/references/changelog#12-4-0)   | Added `experimentalSkipDomainInjection` and `experimentalMemoryManagement`.                                                                   |
+| [12.0.0](/guides/references/changelog#12-0-0)   | Removed `experimentalSessionAndOrigin` and made it the default behavior. Added `experimentalOriginDependencies`.                              |
+| [11.2.0](/guides/references/changelog#11-2-0)   | Added `experimentalRunAllSpecs`.                                                                                                              |
+| [10.8.0](/guides/references/changelog#10-8-0)   | Added `experimentalWebKitSupport`.                                                                                                            |
+| [10.6.0](/guides/references/changelog#10-6-0)   | Added support for `experimentalSingleTabRunMode`.                                                                                             |
+| [10.4.0](/guides/references/changelog#10-4-0)   | Added support for `experimentalModifyObstructiveThirdPartyCode`.                                                                              |
+| [9.6.0](/guides/references/changelog#9-6-0)     | Added support for `experimentalSessionAndOrigin` and removed `experimentalSessionSupport`.                                                    |
+| [8.2.0](/guides/references/changelog#8-2-0)     | Added support for `experimentalSessionSupport`.                                                                                               |
+| [7.1.0](/guides/references/changelog#7-1-0)     | Added support for `experimentalInteractiveRunEvents`.                                                                                         |
+| [7.0.0](/guides/references/changelog#7-0-0)     | Removed `experimentalComponentTesting` and made it the default behavior.                                                                      |
+| [6.7.0](/guides/references/changelog#6-7-0)     | Removed `experimentalRunEvents` and made it the default behavior.                                                                             |
+| [6.3.0](/guides/references/changelog#6-3-0)     | Added support for `experimentalStudio`.                                                                                                       |
+| [6.2.0](/guides/references/changelog#6-2-0)     | Added support for `experimentalRunEvents`.                                                                                                    |
+| [6.0.0](/guides/references/changelog#6-0-0)     | Removed `experimentalNetworkStubbing` and made it the default behavior when using [cy.intercept()](/api/commands/intercept).                  |
+| [6.0.0](/guides/references/changelog#6-0-0)     | Deprecated `experimentalFetchPolyfill`.                                                                                                       |
+| [5.2.0](/guides/references/changelog#5-2-0)     | Removed `experimentalShadowDomSupport` and made it the default behavior.                                                                      |
+| [5.1.0](/guides/references/changelog#5-1-0)     | Added support for `experimentalNetworkStubbing`.                                                                                              |
+| [5.0.0](/guides/references/changelog#5-0-0)     | Removed `experimentalGetCookiesSameSite` and made it the default behavior.                                                                    |
+| [4.9.0](/guides/references/changelog#4-9-0)     | Added support for `experimentalFetchPolyfill`.                                                                                                |
+| [4.8.0](/guides/references/changelog#4-8-0)     | Added support for `experimentalShadowDomSupport`.                                                                                             |
+| [4.6.0](/guides/references/changelog#4-6-0)     | Added support for `experimentalSourceRewriting`.                                                                                              |
+| [4.5.0](/guides/references/changelog#4-5-0)     | Added support for `experimentalComponentTesting`.                                                                                             |
+| [4.3.0](/guides/references/changelog#4-3-0)     | Added support for `experimentalGetCookiesSameSite`.                                                                                           |

--- a/docs/guides/references/experiments.mdx
+++ b/docs/guides/references/experiments.mdx
@@ -345,7 +345,7 @@ This makes developing your current spec much faster in `open` mode when it comes
 
 This also significantly reduces the memory requirements needed to run your tests in `run` mode, with a tradeoff being that your tests might run slightly slower since the dev server needs to recompile. If time is a factor, [Smart orchestration](/guides/cloud/smart-orchestration/overview) can now be effectively used to parallelize your component testing runs on smaller infrastructure since the dev server only compiles what is needed to run the spec.
 
-We are using `experimentalJustInTimeCompile` internally within Cypress for our larger Component Testing suites and have noticed significant reductions in memory when running `cypress run` mode and have gained significantly faster compile times when leveraging `cypress open` to develop our tests.
+We are using `experimentalJustInTimeCompile` internally within Cypress for our larger component testing suites and have noticed significant reductions in memory when running `cypress run` mode and have gained significantly faster compile times when leveraging `cypress open` to develop our tests.
 
 If you are using this experiment and would like to leave feedback, please comment on our [github discussion](https://github.com/cypress-io/cypress/discussions/30024).
 


### PR DESCRIPTION
- [x] CYPRESS_SKIP_VERIFY docs https://github.com/cypress-io/cypress-documentation/pull/5889 
- [x] `experimentalJustInTimeCompile` docs https://github.com/cypress-io/cypress-documentation/pull/5897 
- [x] stepup/stepdown behavior https://github.com/cypress-io/cypress-documentation/pull/5850
- [x] Updating cli docs for --browser flag behavior
- [x] CHANGELOG.md