### PR TITLE
Replace CT Supported Frameworks "+" notation with fixed version ranges

### DIFF
--- a/docs/guides/component-testing/overview.mdx
+++ b/docs/guides/component-testing/overview.mdx
@@ -101,19 +101,19 @@ Cypress currently has official mounting libraries for
 [Svelte](/guides/component-testing/svelte/overview) and support for the
 following development servers and frameworks:
 
-| Framework                                                                                                             | UI Library  | Bundler    |
-| --------------------------------------------------------------------------------------------------------------------- | ----------- | ---------- |
-| [Create React App 4+](/guides/component-testing/react/overview#Create-React-App-CRA)                                  | React 16+   | Webpack 4+ |
-| [Next.js 11+](/guides/component-testing/react/overview#Nextjs)                                                        | React 16+   | Webpack 5  |
-| [React with Vite](/guides/component-testing/react/overview#React-with-Vite)                                           | React 16+   | Vite 2+    |
-| [React with Webpack](/guides/component-testing/react/overview#React-with-Webpack)                                     | React 16+   | Webpack 4+ |
-| [Vue CLI](/guides/component-testing/vue/overview#Vue-CLI)                                                             | Vue 2+      | Webpack 4+ |
-| [Nuxt 2](/guides/component-testing/vue/overview#Nuxt) <Badge type="info">Alpha</Badge>                                | Vue 2+      | Webpack 4+ |
-| [Vue with Vite](/guides/component-testing/vue/overview#Vue-with-Vite)                                                 | Vue 2+      | Vite 2+    |
-| [Vue with Webpack](/guides/component-testing/vue/overview#Vue-with-Webpack)                                           | Vue 2+      | Webpack 4+ |
-| [Angular](/guides/component-testing/angular/overview#Framework-Configuration)                                         | Angular 13+ | Webpack 5  |
-| [Svelte with Vite](/guides/component-testing/svelte/overview#Svelte-with-Vite) <Badge type="info">Alpha</Badge>       | Svelte 3+   | Vite 2+    |
-| [Svelte with Webpack](/guides/component-testing/svelte/overview#Svelte-with-Webpack) <Badge type="info">Alpha</Badge> | Svelte 3+   | Webpack 4+ |
+| Framework                                                                                                             | UI Library    | Bundler     |
+| --------------------------------------------------------------------------------------------------------------------- | ------------- | ----------- |
+| [Create React App 4-5](/guides/component-testing/react/overview#Create-React-App-CRA)                                 | React 16-18   | Webpack 4-5 |
+| [Next.js 10-14](/guides/component-testing/react/overview#Nextjs)                                                      | React 16-18   | Webpack 5   |
+| [React with Vite](/guides/component-testing/react/overview#React-with-Vite)                                           | React 16-18   | Vite 2-5    |
+| [React with Webpack](/guides/component-testing/react/overview#React-with-Webpack)                                     | React 16-18   | Webpack 4-5 |
+| [Vue CLI 4-5](/guides/component-testing/vue/overview#Vue-CLI)                                                         | Vue 2-3       | Webpack 4-5 |
+| [Nuxt 2](/guides/component-testing/vue/overview#Nuxt) <Badge type="info">Alpha</Badge>                                | Vue 2-3       | Webpack 4-5 |
+| [Vue with Vite](/guides/component-testing/vue/overview#Vue-with-Vite)                                                 | Vue 2-3       | Vite 2-5    |
+| [Vue with Webpack](/guides/component-testing/vue/overview#Vue-with-Webpack)                                           | Vue 2-3       | Webpack 4-5 |
+| [Angular](/guides/component-testing/angular/overview#Framework-Configuration)                                         | Angular 13-18 | Webpack 5   |
+| [Svelte with Vite](/guides/component-testing/svelte/overview#Svelte-with-Vite) <Badge type="info">Alpha</Badge>       | Svelte 3-4    | Vite 2-5    |
+| [Svelte with Webpack](/guides/component-testing/svelte/overview#Svelte-with-Webpack) <Badge type="info">Alpha</Badge> | Svelte 3-4    | Webpack 4-5 |
 
 ## Community Supported Frameworks
 


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress-documentation/issues/5412

## Issue

[Supported Frameworks](https://docs.cypress.io/guides/component-testing/overview#Supported-Frameworks) lists framework versions with a base version and a "+" to indicate later versions.

This is not consistent with the way that Cypress detects frameworks, which works on discrete versions, rather than minimum versions. Versions which are not verified by Cypress may not work. Leaving the highest supported version open is misleading.

## Change

The table [Supported Frameworks](https://docs.cypress.io/guides/component-testing/overview#Supported-Frameworks) is reworked to conform to the supported versions specified in https://github.com/cypress-io/cypress/blob/develop/packages/scaffold-config/src/dependencies.ts.
