### PR TITLE
Updating cli docs for `--browser` flag behavior

### DIFF
--- a/docs/guides/guides/command-line.mdx
+++ b/docs/guides/guides/command-line.mdx
@@ -673,8 +673,10 @@ you open. These persist on all projects until you quit Cypress. These options
 will also override values in the Cypress configuration file.
 
 By passing `--browser` and `--e2e` or `--component` when launching a project,
-you can open Cypress and launch the browser at the same time. Otherwise, you
-will be guided through selecting a browser, project, and/or testing type.
+you can open Cypress and launch the browser at the same time. If passing the
+`--browser` flag alone, the browser will launch automatically after being
+guided through project and/or testing type selection. Otherwise, you will 
+be guided through selecting a browser, project, and/or testing type.
 
 | Option                | Description                                                                                                                                                                         |
 | --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/guides/guides/command-line.mdx
+++ b/docs/guides/guides/command-line.mdx
@@ -675,7 +675,7 @@ will also override values in the Cypress configuration file.
 By passing `--browser` and `--e2e` or `--component` when launching a project,
 you can open Cypress and launch the browser at the same time. If passing the
 `--browser` flag alone, the browser will launch automatically after being
-guided through project and/or testing type selection. Otherwise, you will 
+guided through project and/or testing type selection. Otherwise, you will
 be guided through selecting a browser, project, and/or testing type.
 
 | Option                | Description                                                                                                                                                                         |

--- a/docs/guides/references/changelog.mdx
+++ b/docs/guides/references/changelog.mdx
@@ -6,6 +6,10 @@ title: Changelog
 
 _Released 8/27/2024_
 
+**Features:**
+
+- Passing `--browser` flag alone will automatically launch browser after being guided through project and/or testing type selection Addressed in [#28538](https://github.com/cypress-io/cypress/pull/28538)
+
 ## 13.13.3
 
 _Released 8/14/2024_


### PR DESCRIPTION
closes [#22003](https://github.com/cypress-io/cypress/issues/22003)

Updates the behavior of the `--browser` flag when passed alone to the cli.