### PR TITLE
Chaining command typo

### DIFF
--- a/docs/api/table-of-contents.mdx
+++ b/docs/api/table-of-contents.mdx
@@ -6,7 +6,7 @@ sidebar_position: 10
 ## Commands
 
 Cypress commands don't do anything at the moment they are invoked, but rather
-enqueue themselves to be run later. Commands can be chained commands together
+enqueue themselves to be run later. Commands can be chained together
 because Cypress manages a Promise chain on your behalf, with each command
 yielding a 'subject' to the next command, until the chain ends or an error is
 encountered.


### PR DESCRIPTION
## Issue

The second sentence in https://docs.cypress.io/api/table-of-contents#Commands doesn't read well. I think there is a typo:

> Commands can be chained commands together because Cypress manages a Promise chain on your behalf, with each command yielding a 'subject' to the next command, until the chain ends or an error is encountered.

## Change

Remove the second "commands":

> Commands can be chained together because Cypress manages a Promise chain on your behalf, with each command yielding a 'subject' to the next command, until the chain ends or an error is encountered.

Please cross-check if this correction enhances the meaning or if I have misread.