### PR TITLE
Change name from Run Cancellation to Auto Cancellation

### DIFF
--- a/docs/guides/cloud/account-management/projects.mdx
+++ b/docs/guides/cloud/account-management/projects.mdx
@@ -167,7 +167,7 @@ canceling.
 
 These settings can significantly improve developer resolution time, reduce your monthly CI bill and free up CI resources. See our
 [Spec Prioritization](/guides/cloud/smart-orchestration/spec-prioritization)
-and [Run Cancellation](/guides/cloud/smart-orchestration/run-cancellation) guides to learn more.
+and [Auto Cancellation](/guides/cloud/smart-orchestration/run-cancellation) guides to learn more.
 
 <DocsImage
   src="/img/guides/cloud/smart-orchestration/spec-prioritization-active.png"

--- a/docs/guides/cloud/recorded-runs.mdx
+++ b/docs/guides/cloud/recorded-runs.mdx
@@ -321,7 +321,7 @@ canceled by members of the project.
 
 :::tip
 
-<Icon name="check-circle" color="green" /> See our [Run Cancellation](/guides/cloud/smart-orchestration/run-cancellation)
+<Icon name="check-circle" color="green" /> See our [Auto Cancellation](/guides/cloud/smart-orchestration/run-cancellation)
 guide to learn how to improve developer resolution time, reduce your monthly CI bill
 and free up CI resources with `Auto Cancellation`.
 

--- a/docs/guides/cloud/smart-orchestration/overview.mdx
+++ b/docs/guides/cloud/smart-orchestration/overview.mdx
@@ -15,7 +15,7 @@ to speed up test runs, accelerate debugging workflows, and reduce costs:
 - [Spec Prioritization](/guides/cloud/smart-orchestration/spec-prioritization):
   Quickly verify that your latest changes fixed a build by prioritizing the
   specs that failed in the previous Cypress run.
-- [Run Cancellation](/guides/cloud/smart-orchestration/run-cancellation):
+- [Auto Cancellation](/guides/cloud/smart-orchestration/run-cancellation):
   Automatically cancel a Cypress run when tests fail. Canceling tests
   early reduces the number of “tests recorded” and thus your
   monthly bill as you won't be billed for tests that aren't valuable once your run

--- a/docs/guides/cloud/smart-orchestration/run-cancellation.mdx
+++ b/docs/guides/cloud/smart-orchestration/run-cancellation.mdx
@@ -1,5 +1,5 @@
 ---
-title: Run Cancellation
+title: Auto Cancellation
 sidebar_position: 50
 ---
 


### PR DESCRIPTION
this was some old verbiage still in-use and we call it auto cancellation in all other places