### PR TITLE
docs: update link to debug-js/debug repo

### DIFF
--- a/docs/api/cypress-api/catalog-of-events.mdx
+++ b/docs/api/cypress-api/catalog-of-events.mdx
@@ -486,7 +486,7 @@ it('can assert on the alert text content', () => {
 
 ### Logging All Events
 
-Cypress uses the [`debug`](https://github.com/visionmedia/debug) node module for
+Cypress uses the [`debug`](https://github.com/debug-js/debug) node module for
 both the back end server process, and for everything running in the browser
 (called the driver).
 

--- a/docs/guides/guides/command-line.mdx
+++ b/docs/guides/guides/command-line.mdx
@@ -981,7 +981,7 @@ cypress cache prune
 
 ### Enable Debug Logs
 
-Cypress is built using the [debug](https://github.com/visionmedia/debug) module.
+Cypress is built using the [debug](https://github.com/debug-js/debug) module.
 That means you can receive helpful debugging output by running Cypress with this
 turned on prior to running `cypress open` or `cypress run`.
 

--- a/docs/guides/references/troubleshooting.mdx
+++ b/docs/guides/references/troubleshooting.mdx
@@ -247,7 +247,7 @@ an issue you have by clearing this app data.
 
 ## Print DEBUG logs
 
-Cypress is built using the [debug](https://github.com/visionmedia/debug) module.
+Cypress is built using the [debug](https://github.com/debug-js/debug) module.
 That means you can receive helpful debugging output by running Cypress with this
 turned on. **Note:** you will see a LOT of messages when running with
 `DEBUG=...` setting.


### PR DESCRIPTION
## Issue

The npm [debug](https://www.npmjs.com/package/debug) module's source repo moved

- from https://github.com/visionmedia/debug
- to https://github.com/debug-js/debug

See release notes [debug@4.3.3](https://github.com/debug-js/debug/releases/tag/4.3.3).

## Change

Replace the link above according to the repository migration.