### PR TITLE
docs: consolidate cli debug commands

### DIFF
--- a/docs/guides/guides/command-line.mdx
+++ b/docs/guides/guides/command-line.mdx
@@ -981,48 +981,16 @@ cypress cache prune
 
 ### Enable Debug Logs
 
-Cypress is built using the [debug](https://github.com/visionmedia/debug) module.
-That means you can receive helpful debugging output by running Cypress with this
-turned on prior to running `cypress open` or `cypress run`.
-
-**On Mac or Linux:**
+If you are using macOS, Linux or Windows (Git Bash)
+and your package manager is npm, you can run Cypress with debug logs using the following CLI command:
 
 ```shell
-DEBUG=cypress:* cypress open
+DEBUG=cypress:* npx cypress run
 ```
 
-```shell
-DEBUG=cypress:* cypress run
-```
-
-**On Windows:**
-
-```shell
-set DEBUG=cypress:*
-```
-
-```shell
-cypress run
-```
-
-Cypress is a rather large and complex project involving a dozen or more
-submodules, and the default output can be overwhelming.
-
-**To filter debug output to a specific module**
-
-```shell
-DEBUG=cypress:cli cypress run
-```
-
-```shell
-DEBUG=cypress:launcher cypress run
-```
-
-...or even a 3rd level deep submodule
-
-```shell
-DEBUG=cypress:server:project cypress run
-```
+See [Troubleshooting](../references/troubleshooting#Print-DEBUG-logs) for more detailed instructions on options
+to generate debug logs, also with Yarn and pnpm package managers,
+and with Windows CMD and PowerShell terminal windows.
 
 ## History
 


### PR DESCRIPTION
## Issues

[Guides > Command Line > Debugging commands](https://docs.cypress.io/guides/guides/command-line#How-to-run-commands) partially duplicates the [Troubleshooting](https://docs.cypress.io/guides/references/troubleshooting#Print-DEBUG-logs) instructions and is not linked to the [Troubleshooting](https://docs.cypress.io/guides/references/troubleshooting#Print-DEBUG-logs) page.

## Change

- Simplify debug details in [Guides > Command Line > Debugging commands](https://docs.cypress.io/guides/guides/command-line#How-to-run-commands) and refer to [References > Troubleshooting > Print DEBUG logs](https://docs.cypress.io/guides/references/troubleshooting#Print-DEBUG-logs) to avoid duplication and to ease future maintenance.