### PR TITLE
Correct video recording debug statement

### DIFF
--- a/docs/guides/guides/screenshots-and-videos.mdx
+++ b/docs/guides/guides/screenshots-and-videos.mdx
@@ -136,7 +136,10 @@ a bigger video file size and higher quality video.
 
 If you are an FFmpeg pro and want to see all the settings and debug messages
 during the encoding, run Cypress with the following environment variable:
-`DEBUG=cypress:server:video cypress run`
+
+```shell
+DEBUG=cypress:server:video
+```
 
 :::
 


### PR DESCRIPTION
## Issue

In [Guides > Screenshots and Videos > Video encoding](https://docs.cypress.io/guides/guides/screenshots-and-videos#Video-encoding) the instructions say:

> If you are an FFmpeg pro and want to see all the settings and debug messages
> during the encoding, run Cypress with the following environment variable:
> `DEBUG=cypress:server:video cypress run`

This instruction does not work as it stands, since it is missing the package manager prefix (`npx`, `yarn` or `pnpm`).

## Change

Remove `cypress run` from the text, leaving the environment variable statement `DEBUG=cypress:server:video` on its own.
