### PR TITLE
Correct DEBUG cypress:launcher with wildcard

### DIFF
--- a/docs/guides/guides/command-line.mdx
+++ b/docs/guides/guides/command-line.mdx
@@ -846,7 +846,7 @@ System Memory: 17.2 GB free 670 MB
 
 **Tip:** set
 [DEBUG environment variable](/guides/references/troubleshooting#Print-DEBUG-logs)
-to `cypress:launcher` when running `cypress info` to troubleshoot browser
+to `cypress:launcher:*` when running `cypress info` to troubleshoot browser
 detection.
 
 ### `cypress verify`

--- a/docs/guides/references/troubleshooting.mdx
+++ b/docs/guides/references/troubleshooting.mdx
@@ -122,7 +122,7 @@ You can see the full list of found browsers and their properties within the
 in the **Settings** tab of Cypress.
 
 Another way to log what is found by Cypress is to run Cypress with the
-[DEBUG environment variable](#Print-DEBUG-logs) set to `cypress:launcher`. This
+[DEBUG environment variable](#Print-DEBUG-logs) set to `cypress:launcher:*`. This
 will print information about the found browsers and their properties to the
 terminal.
 


### PR DESCRIPTION
## Issue

- [Guides > Command Line `cypress info`](https://docs.cypress.io/guides/guides/command-line#cypress-info) provides

  > **Tip:** set [DEBUG environment variable](/guides/references/troubleshooting#Print-DEBUG-logs)
  > to `cypress:launcher` when running `cypress info` to troubleshoot browser detection.

  This setting however produces no debug output.

- [Troubleshooting > Launching browsers](https://docs.cypress.io/guides/references/troubleshooting#Launching-browsers) also suggests this non-working setting.

## Change

On the above-mentioned pages, add a wildcard to the DEBUG module selector so that it becomes `cypress:launcher:*`.