### PR TITLE
Correct debug cypress:server:browsers selection

### DIFF
--- a/docs/guides/references/troubleshooting.mdx
+++ b/docs/guides/references/troubleshooting.mdx
@@ -348,7 +348,7 @@ want to enable them
 | `cypress:server:args`            | Incorrect parsed command line arguments                       |
 | `cypress:data-context:sources:*` | Not finding the expected project data                         |
 | `cypress:server:project`         | Opening the project                                           |
-| `cypress:server:browsers:*`      | Finding installed browsers                                    |
+| `cypress:server:browsers*`       | Finding installed browsers                                    |
 | `cypress:launcher:*`             | Launching the found browser                                   |
 | `cypress:server:video`           | Video recording                                               |
 | `cypress:network:*`              | Adding network interceptors                                   |


### PR DESCRIPTION
## Issue

The example `DEBUG` value `cypress:server:browsers:*` is incomplete.

Debug output for `cypress:server:browsers` is not logged in this case.

The [debug](https://www.npmjs.com/package/debug) module does not support any hierarchy based on colon characters `:`. This is a simple string match.

## Change

To also log debug output from [packages/server/lib/browsers/index.ts](https://github.com/cypress-io/cypress/blob/develop/packages/server/lib/browsers/index.ts) which defines a debug module name `cypress:server:browsers`, the environment value is changed to

`cypress:server:browsers*`

removing the colon character `:`.

## Note

- This was an error in the correction made by PR https://github.com/cypress-io/cypress-documentation/pull/5921, which added the sub-modules of `cypress:server:browsers` and accidentally left out the top-level in the correction process.
