### PR TITLE
Specify Windows x64 as supported OS

### DIFF
--- a/docs/guides/getting-started/installing-cypress.mdx
+++ b/docs/guides/getting-started/installing-cypress.mdx
@@ -168,7 +168,7 @@ application supports these operating systems:
   below).
   - Cypress deprecated the use of Node.js `16.x` in Cypress [`13.0.0`](/guides/references/changelog#13-0-0). We recommend that users update to at least Node.js `18.x`.
     For related reasons, Cypress deprecates the use of Linux operating systems with library [`glibc`](https://www.gnu.org/software/libc/) versions `2.17` - `2.27`. The Linux CLI command `ldd --version` displays your glibc version.
-- **Windows** 10 and above _(64-bit only)_.
+- **Windows** 10 and above _(x64)_.
 
 ### Node.js
 


### PR DESCRIPTION
## Issue

[System requirements > Operating System](https://docs.cypress.io/guides/getting-started/installing-cypress#Operating-System) lists

> - **Windows** 10 and above _(64-bit only)_.

This could be taken to mean both `x64` and `arm64`, although the intention was to rule out Windows 32-bit support only.

Microsoft provides [Windows on Arm](https://learn.microsoft.com/en-us/windows/arm/overview) and this is likely to receive more visibility due to Windows 11 24H2.

Cypress is built as `win32 x64` only. There is no `arm64` version of Cypress built.

## Change

Specify `x64` for Windows.