### PR TITLE
Add cypress:* to table of DEBUG log sources

### DIFF
--- a/docs/guides/references/troubleshooting.mdx
+++ b/docs/guides/references/troubleshooting.mdx
@@ -344,6 +344,7 @@ want to enable them
 
 | Set `DEBUG` to value             | To enable debugging                                           |
 | -------------------------------- | ------------------------------------------------------------- |
+| `cypress:*`                      | ALL modules                                                   |
 | `cypress:cli*`                   | Top-level command line parsing and binary installation        |
 | `cypress:server:args`            | Incorrect parsed command line arguments                       |
 | `cypress:data-context:sources:*` | Not finding the expected project data                         |


### PR DESCRIPTION
## Issue

The table of `DEBUG` values in [References > Troubleshooting > Log sources](https://docs.cypress.io/guides/references/troubleshooting#Log-sources) is missing the value `cypress:*` to enable all debugging output.

## Change

Add `DEBUG` value `cypress:*` to the top of the table in [References > Troubleshooting > Log sources](https://docs.cypress.io/guides/references/troubleshooting#Log-sources).