### PR TITLE
docs: Update minimum Firefox version to reflect reality

### DIFF
--- a/docs/guides/guides/launching-browsers.mdx
+++ b/docs/guides/guides/launching-browsers.mdx
@@ -51,7 +51,7 @@ Cypress supports the browser versions below:
 
 - Chrome 64 and above. Chrome 80 and above is required for `cypress open` usage.
 - Edge 80 and above.
-- Firefox 86 and above.
+- Firefox 91 and above.
 
 ### Download specific Chrome version
 


### PR DESCRIPTION
We're not sure when 86-90 versions stopped working, but verifying versions today shows that they don't work in Cypress so just reflecting reality.