### PR TITLE
Remove linked Cypress versions Markdown as code

### DIFF
--- a/docs/guides/references/changelog.mdx
+++ b/docs/guides/references/changelog.mdx
@@ -256,7 +256,7 @@ _Released 4/23/2024_
 
 **Bugfixes:**
 
-- Fixed a regression introduced in [`13.6.0`](#13-6-0) where Cypress would occasionally exit with status code 1, even when a test run was successful, due to an unhandled WebSocket exception (`Error: WebSocket connection closed`). Addresses [#28523](https://github.com/cypress-io/cypress/issues/28523).
+- Fixed a regression introduced in [13.6.0](#13-6-0) where Cypress would occasionally exit with status code 1, even when a test run was successful, due to an unhandled WebSocket exception (`Error: WebSocket connection closed`). Addresses [#28523](https://github.com/cypress-io/cypress/issues/28523).
 - Fixed an issue where Cypress would hang on some commands when an invalid `timeout` option was provided. Fixes [#29323](https://github.com/cypress-io/cypress/issues/29323).
 
 **Misc:**
@@ -277,7 +277,7 @@ _Released 4/18/2024_
 
 **Bugfixes:**
 
-- Fixed a regression introduced in [`13.7.3`](#13-7-3) where Cypress could hang handling long assertion messages. Fixes [#29350](https://github.com/cypress-io/cypress/issues/29350).
+- Fixed a regression introduced in [13.7.3](#13-7-3) where Cypress could hang handling long assertion messages. Fixes [#29350](https://github.com/cypress-io/cypress/issues/29350).
 
 **Misc:**
 
@@ -341,7 +341,7 @@ _Released 3/13/2024_
 
 **Performance:**
 
-- Fixed a performance regression from [`13.6.3`](#13-6-3) where unhandled service worker requests may not correlate correctly. Fixes [#28868](https://github.com/cypress-io/cypress/issues/28868).
+- Fixed a performance regression from [13.6.3](#13-6-3) where unhandled service worker requests may not correlate correctly. Fixes [#28868](https://github.com/cypress-io/cypress/issues/28868).
 - Reduces the number of attempts to retry failed Test Replay artifact uploads from 8 to 3, to reduce time spent on artifact upload attempts that will not succeed. Addressed in [#28986](https://github.com/cypress-io/cypress/pull/28986).
 
 **Bugfixes:**
@@ -368,7 +368,7 @@ _Released 2/22/2024_
 
 **Bugfixes:**
 
-- Fixed a regression introduced in [`13.6.5`](#13-6-5) where `cypress verify` would fail for [`nx`](https://nx.dev/) users. Fixes [#28982](https://github.com/cypress-io/cypress/issues/28982).
+- Fixed a regression introduced in [13.6.5](#13-6-5) where `cypress verify` would fail for [`nx`](https://nx.dev/) users. Fixes [#28982](https://github.com/cypress-io/cypress/issues/28982).
 
 ## 13.6.5
 
@@ -379,7 +379,7 @@ _Released 2/20/2024_
 - Fixed tests hanging when the Chrome browser extension is disabled. Fixes [#28392](https://github.com/cypress-io/cypress/issues/28392).
 - Fixed an issue which caused the browser to relaunch after closing the browser from the Launchpad. Fixes [#28852](https://github.com/cypress-io/cypress/issues/28852).
 - Fixed an issue with the unzip promise never being rejected when an empty error happens. Fixed in [#28850](https://github.com/cypress-io/cypress/pull/28850).
-- Fixed a regression introduced in [`13.6.3`](#13-6-3) where Cypress could crash when processing service worker requests through our proxy. Fixes [#28950](https://github.com/cypress-io/cypress/issues/28950).
+- Fixed a regression introduced in [13.6.3](#13-6-3) where Cypress could crash when processing service worker requests through our proxy. Fixes [#28950](https://github.com/cypress-io/cypress/issues/28950).
 - Fixed incorrect type definition of `dom.getContainsSelector`. Fixed in [#28339](https://github.com/cypress-io/cypress/pull/28339).
 
 **Misc:**
@@ -402,7 +402,7 @@ _Released 1/30/2024_
 
 **Performance:**
 
-- Fixed a performance regression from [`13.3.2`](#13-3-2) where aborted requests may not correlate correctly. Fixes [#28734](https://github.com/cypress-io/cypress/issues/28734).
+- Fixed a performance regression from [13.3.2](#13-3-2) where aborted requests may not correlate correctly. Fixes [#28734](https://github.com/cypress-io/cypress/issues/28734).
 
 **Bugfixes:**
 
@@ -423,7 +423,7 @@ _Released 1/16/2024_
 - Now `node_modules` will not be ignored if a project path or a provided path to spec files contains it. Fixes [#23616](https://github.com/cypress-io/cypress/issues/23616).
 - Updated display of assertions and commands with a URL argument to escape markdown formatting so that values are displayed as is and assertion values display as bold. Fixes [#24960](https://github.com/cypress-io/cypress/issues/24960) and [#28100](https://github.com/cypress-io/cypress/issues/28100).
 - When generating assertions via Cypress Studio, the preview of the generated assertions now correctly displays the past tense of 'expected' instead of 'expect'. Fixed in [#28593](https://github.com/cypress-io/cypress/pull/28593).
-- Fixed a regression in [`13.6.2`](#13-6-2) where the `body` element was not highlighted correctly in Test Replay. Fixed in [#28627](https://github.com/cypress-io/cypress/pull/28627).
+- Fixed a regression in [13.6.2](#13-6-2) where the `body` element was not highlighted correctly in Test Replay. Fixed in [#28627](https://github.com/cypress-io/cypress/pull/28627).
 - Correctly sync `Cypress.currentRetry` with secondary origin so test retries that leverage [`cy.origin()`](/api/commands/origin) render logs as expected. Fixes [#28574](https://github.com/cypress-io/cypress/issues/28574).
 - Fixed an issue where some cross-origin logs, like assertions or cy.clock(), were getting too many dom snapshots. Fixes [#28609](https://github.com/cypress-io/cypress/issues/28609).
 - Fixed asset capture for Test Replay for requests that are routed through service workers. This addresses an issue where styles were not being applied properly in Test Replay and [`cy.intercept()`](/api/commands/intercept) was not working properly for requests in this scenario. Fixes [#28516](https://github.com/cypress-io/cypress/issues/28516).
@@ -433,7 +433,7 @@ _Released 1/16/2024_
 
 **Performance:**
 
-- Fixed a performance regression from [`13.3.2`](#13-3-2) where requests may not correlate correctly when test isolation is off. Fixes [#28545](https://github.com/cypress-io/cypress/issues/28545).
+- Fixed a performance regression from [13.3.2](#13-3-2) where requests may not correlate correctly when test isolation is off. Fixes [#28545](https://github.com/cypress-io/cypress/issues/28545).
 
 **Dependency Updates:**
 
@@ -453,8 +453,8 @@ _Released 12/26/2023_
 
 **Bugfixes:**
 
-- Fixed a regression in [`13.6.1`](#13-6-1) where a malformed URI would crash Cypress. Fixes [#28521](https://github.com/cypress-io/cypress/issues/28521).
-- Fixed a regression in [`12.4.0`](#12-4-0) where erroneous `<br>` tags were displaying in error messages in the Command Log making them less readable. Fixes [#28452](https://github.com/cypress-io/cypress/issues/28452).
+- Fixed a regression in [13.6.1](#13-6-1) where a malformed URI would crash Cypress. Fixes [#28521](https://github.com/cypress-io/cypress/issues/28521).
+- Fixed a regression in [12.4.0](#12-4-0) where erroneous `<br>` tags were displaying in error messages in the Command Log making them less readable. Fixes [#28452](https://github.com/cypress-io/cypress/issues/28452).
 
 **Performance:**
 
@@ -512,7 +512,7 @@ _Released 11/14/2023_
 
 **Bugfixes:**
 
-- Fixed a regression in [`13.5.0`](#13-5-0) where requests cached within a given spec may take longer to load than they did previously. Addresses [#28295](https://github.com/cypress-io/cypress/issues/28295).
+- Fixed a regression in [13.5.0](#13-5-0) where requests cached within a given spec may take longer to load than they did previously. Addresses [#28295](https://github.com/cypress-io/cypress/issues/28295).
 - Fixed an issue where pages opened in a new tab were missing response headers, causing them not to load properly. Fixes [#28293](https://github.com/cypress-io/cypress/issues/28293) and [#28303](https://github.com/cypress-io/cypress/issues/28303).
 - We now pass a flag to Chromium browsers to disable default component extensions. This is a common flag passed during browser automation. Fixed in [#28294](https://github.com/cypress-io/cypress/pull/28294).
 
@@ -527,7 +527,7 @@ _Released 11/8/2023_
 **Bugfixes:**
 
 - Fixed an issue in chromium based browsers, where global style updates can trigger flooding of font face requests in DevTools and Test Replay. This can affect performance due to the flooding of messages in CDP. Fixes [#28150](https://github.com/cypress-io/cypress/issues/28150) and [#28215](https://github.com/cypress-io/cypress/issues/28215).
-- Fixed a regression in [`13.3.3`](#13-3-3) where Cypress would hang on loading shared workers when using `cy.reload` to reload the page. Fixes [#28248](https://github.com/cypress-io/cypress/issues/28248).
+- Fixed a regression in [13.3.3](#13-3-3) where Cypress would hang on loading shared workers when using `cy.reload` to reload the page. Fixes [#28248](https://github.com/cypress-io/cypress/issues/28248).
 - Fixed an issue where network requests made from tabs, or windows other than the main Cypress tab, would be delayed. Fixes [#28113](https://github.com/cypress-io/cypress/issues/28113).
 - Fixed an issue with 'other' targets (e.g. pdf documents embedded in an object tag) not fully loading. Fixes [#28228](https://github.com/cypress-io/cypress/issues/28228) and [#28162](https://github.com/cypress-io/cypress/issues/28162).
 - Fixed an issue where clicking a link to download a file could cause a page load timeout when the download attribute was missing. Note: download behaviors in experimental WebKit are still an issue. Fixes [#14857](https://github.com/cypress-io/cypress/issues/14857).
@@ -546,7 +546,7 @@ _Released 10/30/2023_
 
 **Bugfixes:**
 
-- Fixed a regression in [`13.3.2`](#13-3-2) where Cypress would crash with 'Inspected target navigated or closed' or 'Session with given id not found'. Fixes [#28141](https://github.com/cypress-io/cypress/issues/28141) and [#28148](https://github.com/cypress-io/cypress/issues/28148).
+- Fixed a regression in [13.3.2](#13-3-2) where Cypress would crash with 'Inspected target navigated or closed' or 'Session with given id not found'. Fixes [#28141](https://github.com/cypress-io/cypress/issues/28141) and [#28148](https://github.com/cypress-io/cypress/issues/28148).
 
 ## 13.3.3
 
@@ -1461,12 +1461,12 @@ _Released 1/03/2023_
 - Updated the Jenkins environment variable mappings so pull request data is
   correctly linked to the corresponding Cloud run. Fixed in
   [#25036](https://github.com/cypress-io/cypress/pull/25036).
-- Fixed a regression in [`10.11.0`](#10-11-0) where the mocha test results no
+- Fixed a regression in [10.11.0](#10-11-0) where the mocha test results no
   longer sent the pending boolean to reporters. This caused the
   [`mochaawesome`](https://www.npmjs.com/package/mochawesome) reporter to
   incorrectly report pending tests as pending and skipped. Fixes
   [#24477](https://github.com/cypress-io/cypress/issues/24477).
-- Fix for regression introduced in [`12.1.0`](#12-1-0), where
+- Fix for regression introduced in [12.1.0](#12-1-0), where
   [`.contains()`](/api/commands/contains) could return multiple elements instead
   of one element when it was matching directly on the subject, rather than on
   the subject's children. Fixes
@@ -12295,7 +12295,7 @@ _Released 11/16/2016_
   [#294](https://github.com/cypress-io/cypress/issues/294).
 - There is a new [configuration](/guides/references/configuration) property
   called: ~~`trashAssetsBeforeHeadlessRuns`~~ (This was changed to
-  `trashAssetsBeforeRuns` in [`3.0.0`](#3-0-0)) that is set to `true` by default
+  `trashAssetsBeforeRuns` in [3.0.0](#3-0-0)) that is set to `true` by default
   and will automatically clear out screenshots + videos folders before each run.
   These files are not deleted, they are just moved to your trash.
 - There are several new [configuration](/guides/references/configuration)


### PR DESCRIPTION
## Issue

The [Changelog](https://docs.cypress.io/guides/references/changelog) contains links from one Cypress release to another Cypress release, and in some cases the version is formatted as Markdown code. This produces a sub-optimal display of the version number, which is highlighted (as a hyperlink) and underlined (as code).

![image](https://github.com/user-attachments/assets/83ef93cd-f2b1-4175-9ccd-f8c9335f32bf)


The document [Cypress App - Managing the Release Changelog](https://github.com/cypress-io/cypress/blob/develop/guides/writing-the-cypress-changelog.md) specifies in [Writing Guidelines](https://github.com/cypress-io/cypress/blob/develop/guides/writing-the-cypress-changelog.md#writing-guidelines)

- If a changelog item is a regression, the description should start with `Fixed a regression in [9.1.0](#9-1-0)` with a link to the release that introduced it.

## Change

In the [Changelog](https://docs.cypress.io/guides/references/changelog) remove Markdown code backticks for linked versions of Cypress for clearer highlighted display of the version number without underlining and to conform to the [Writing Guidelines](https://github.com/cypress-io/cypress/blob/develop/guides/writing-the-cypress-changelog.md#writing-guidelines).