### PR TITLE
docs: rename cypress-accessibility plugin to cypress-a11y-report

### DIFF
--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -530,9 +530,9 @@
           "badge": "community"
         },
         {
-          "name": "cypress-accessibility",
+          "name": "cypress-a11y-report",
           "description": "Test your web applications and components for accessibility issues with axe-core®.",
-          "link": "https://github.com/rowellx68/cypress-accessibility",
+          "link": "https://github.com/rowellx68/cypress-a11y-report",
           "keywords": ["accessibility", "a11y", "axe-core"],
           "badge": "community"
         },


### PR DESCRIPTION
Renamed the plugin to avoid any confusion between it and the official offering from Cypress. See PR https://github.com/cypress-io/cypress-documentation/pull/5942 for reference.