### PR TITLE
remove legacy CI Provider example webapp.io

### DIFF
--- a/docs/guides/continuous-integration/ci-provider-examples.mdx
+++ b/docs/guides/continuous-integration/ci-provider-examples.mdx
@@ -152,8 +152,3 @@ and
 ### AWS Amplify Console
 
 - [Basic Example (amplify.yml)](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/amplify.yml)
-
-### webapp.io
-
-- [cypress-example-layerci](https://github.com/bahmutov/cypress-example-layerci)
-- [Using cypress with webapp.io](https://webapp.io/docs/integrations/cypress)


### PR DESCRIPTION
- closes https://github.com/cypress-io/cypress-documentation/issues/5951
- closes https://github.com/cypress-io/cypress-documentation/pull/5632

## Issue

The example [Continuous Integration > CI Provider Examples > webapp.io](https://docs.cypress.io/guides/continuous-integration/ci-provider-examples#webappio) is based on legacy Cypress v9. This no longer aligns with the remainder of the Cypress documentation content which deals only with Cypress v10 and later.

The webapp.io documentation source on https://github.com/webappio/docs was last updated in Sept 2023.

- The link [webapp.io > Integrations > Cypress](https://docs.webapp.io/integrations/cypress) shows
  - an example of Cypress `9.4.1` (legacy) running with Node.js v14.7.6 (unsupported since April 2023)
  - a link to https://github.com/webappio/react-e2e-example last updated in Feb 2022 and based on the now (de facto) unsupported Create React App
  - a Layerfile using Ubuntu `18.04` (unsupported since June 2023)
  - a reference to Cypress Dashboard (rebranded to Cypress Cloud in Nov 2022)
- The link [bahmutov/cypress-example-layerci](https://github.com/bahmutov/cypress-example-layerci) uses the pre-rebranding name of LayerCI which preceded the [rebranding](https://webapp.io/blog/layerci-has-rebranded-to-webapp-io/) in Aug 2021.

## Change

Remove the webapp.io section from [Continuous Integration > CI Provider Examples](https://docs.cypress.io/guides/continuous-integration/ci-provider-examples#webappio).