### PR TITLE
docs(cy.stub): Update syntax to use callsFake() instead of deprecated third argument

### DIFF
--- a/docs/api/commands/stub.mdx
+++ b/docs/api/commands/stub.mdx
@@ -19,7 +19,6 @@ assertion. It is not retryable, chainable, or timeout-able.
 ```javascript
 cy.stub()
 cy.stub(object, method)
-cy.stub(object, method, replacerFn)
 ```
 
 ### Usage
@@ -40,10 +39,6 @@ The `object` that has the `method` to be replaced.
 <Icon name="angle-right" /> **method _(String)_**
 
 The name of the `method` on the `object` to be wrapped.
-
-<Icon name="angle-right" /> **replacerFn _(Function)_**
-
-The function used to replace the `method` on the `object`.
 
 ### Yields [<Icon name="question-circle"/>](/guides/core-concepts/introduction-to-cypress#Subject-Management) {#Yields}
 
@@ -82,7 +77,7 @@ expect(util.addListeners).to.be.called
 // assume App.start calls util.addListeners
 let listenersAdded = false
 
-cy.stub(util, 'addListeners', () => {
+cy.stub(util, 'addListeners').callsFake(() => {
   listenersAdded = true
 })
 


### PR DESCRIPTION
While using Cypress, I encountered a deprecated notice when following the official documentation for `cy.stub(object, method, replacerFn)`. Upon investigation, I found that [this syntax has been deprecated in Sinon.JS since version 3.0.0](https://sinonjs.org/releases/v19/stubs/). As Cypress is currently using Sinon.JS version 7.3.2(as per package.json), I determined that this was a deprecated specification.

So I made changes in document:
1. Removed the deprecated `cy.stub(object, method, replacerFn)` syntax from the documentation.
2. Updated related examples to use the new recommended syntax `cy.stub(object, method).callsFake(replacerFn)`.

These changes will help Cypress users write more up-to-date and future-proof test code, avoiding potential deprecation warnings or errors.

Please review and let me know if any further changes or clarifications are needed.