### PR TITLE
docs(assertions): update link to custom chai assertions guide

### DIFF
--- a/docs/app/references/assertions.mdx
+++ b/docs/app/references/assertions.mdx
@@ -164,7 +164,7 @@ Because we are using `chai`, that means you can extend it however you'd like.
 Cypress will "just work" with new assertions added to `chai`. You can:
 
 - Write your own `chai` assertions as
-  [documented here](http://chaijs.com/api/node-events/).
+  [documented here](https://chaijs.com/guide/helpers/).
 - npm install any existing `chai` library and import into your test file or
   [support file](/app/core-concepts/writing-and-organizing-tests#Support-file).
 


### PR DESCRIPTION
Link to chai guide https://www.chaijs.com/api/node-events/ on the documentation for [writing new custom assertions](https://docs.cypress.io/app/references/assertions#Adding-New-Assertions) is no longer reachable (404).

![image](https://github.com/user-attachments/assets/f56201a1-f8c9-4457-a31c-37436ec382e1)
