### PR TITLE
chore: update supported vite versions for cypress 14

### DIFF
--- a/docs/api/commands/intercept.mdx
+++ b/docs/api/commands/intercept.mdx
@@ -130,21 +130,21 @@ glob-matched against the request using
 [`Cypress.minimatch`](/api/utilities/minimatch) with the `{ matchBase: true }`
 minimatch option applied.
 
-| Option       | Description                                                                                                                                       |
-| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| auth         | HTTP Basic Authentication (`object` with keys `username` and `password`)                                                                          |
-| headers      | HTTP request headers (`object`)                                                                                                                   |
-| hostname     | HTTP request hostname                                                                                                                             |
-| https        | `true`: only secure (https://) requests, `false`: only insecure (http://) requests                                                                |
-| method       | HTTP request method (matches any method by default)                                                                                               |
-| middleware   | `true`: match route first and in defined order, `false`: match route in reverse order (default)                                                   |
-| path         | HTTP request path after the hostname, including query parameters                                                                                  |
-| pathname     | Like `path`, but without query parameters                                                                                                         |
-| port         | HTTP request port(s) (`number` or `Array`)                                                                                                        |
-| query        | Parsed query string (`object`)                                                                                                                    |
+| Option                                                | Description                                                                                                                                       |
+| ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| auth                                                  | HTTP Basic Authentication (`object` with keys `username` and `password`)                                                                          |
+| headers                                               | HTTP request headers (`object`)                                                                                                                   |
+| hostname                                              | HTTP request hostname                                                                                                                             |
+| https                                                 | `true`: only secure (https://) requests, `false`: only insecure (http://) requests                                                                |
+| method                                                | HTTP request method (matches any method by default)                                                                                               |
+| middleware                                            | `true`: match route first and in defined order, `false`: match route in reverse order (default)                                                   |
+| path                                                  | HTTP request path after the hostname, including query parameters                                                                                  |
+| pathname                                              | Like `path`, but without query parameters                                                                                                         |
+| port                                                  | HTTP request port(s) (`number` or `Array`)                                                                                                        |
+| query                                                 | Parsed query string (`object`)                                                                                                                    |
 | resourceType <Badge type="caution">deprecated</Badge> | The resource type of the request. See ["Request object properties"](#Request-object-properties) for a list of possible values for `resourceType`. |
-| times        | Maximum number of times to match (`number`)                                                                                                       |
-| url          | Full HTTP request URL                                                                                                                             |
+| times                                                 | Maximum number of times to match (`number`)                                                                                                       |
+| url                                                   | Full HTTP request URL                                                                                                                             |
 
 See [examples](#With-RouteMatcher) below.
 

--- a/docs/app/component-testing/get-started.mdx
+++ b/docs/app/component-testing/get-started.mdx
@@ -42,14 +42,14 @@ following development servers and frameworks:
 | ------------------------------------------------------------------------------------------------------------------ | ------------- | ----------- |
 | [Create React App 4-5](/app/component-testing/react/overview#Create-React-App-CRA)                                 | React 16-18   | Webpack 4-5 |
 | [Next.js 10-14](/app/component-testing/react/overview#Nextjs)                                                      | React 16-18   | Webpack 5   |
-| [React with Vite](/app/component-testing/react/overview#React-with-Vite)                                           | React 16-18   | Vite 2-5    |
+| [React with Vite](/app/component-testing/react/overview#React-with-Vite)                                           | React 16-18   | Vite 4-5    |
 | [React with Webpack](/app/component-testing/react/overview#React-with-Webpack)                                     | React 16-18   | Webpack 4-5 |
 | [Vue CLI 4-5](/app/component-testing/vue/overview#Vue-CLI)                                                         | Vue 2-3       | Webpack 4-5 |
 | [Nuxt 2](/app/component-testing/vue/overview#Nuxt) <Badge type="info">Alpha</Badge>                                | Vue 2-3       | Webpack 4-5 |
-| [Vue with Vite](/app/component-testing/vue/overview#Vue-with-Vite)                                                 | Vue 2-3       | Vite 2-5    |
+| [Vue with Vite](/app/component-testing/vue/overview#Vue-with-Vite)                                                 | Vue 2-3       | Vite 4-5    |
 | [Vue with Webpack](/app/component-testing/vue/overview#Vue-with-Webpack)                                           | Vue 2-3       | Webpack 4-5 |
 | [Angular](/app/component-testing/angular/overview#Framework-Configuration)                                         | Angular 13-18 | Webpack 5   |
-| [Svelte with Vite](/app/component-testing/svelte/overview#Svelte-with-Vite) <Badge type="info">Alpha</Badge>       | Svelte 3-4    | Vite 2-5    |
+| [Svelte with Vite](/app/component-testing/svelte/overview#Svelte-with-Vite) <Badge type="info">Alpha</Badge>       | Svelte 3-4    | Vite 4-5    |
 | [Svelte with Webpack](/app/component-testing/svelte/overview#Svelte-with-Webpack) <Badge type="info">Alpha</Badge> | Svelte 3-4    | Webpack 4-5 |
 
 The following integrations are built and maintained by Cypress community members.

--- a/docs/app/references/changelog.mdx
+++ b/docs/app/references/changelog.mdx
@@ -9,8 +9,8 @@ _Released 12/3/2024 (PENDING)_
 **Breaking Changes:**
 
 - Removed support for Node.js 16 and Node.js 21. Addresses [#29930](https://github.com/cypress-io/cypress/issues/29930).
-- Prebuilt binaries for Linux are no longer compatible with Linux distributions based on glibc `<2.28`, 
-for example: Ubuntu 14-18, RHEL 7, CentOS 7, Amazon Linux 2. Addresses [#29601](https://github.com/cypress-io/cypress/issues/29601).
+- Prebuilt binaries for Linux are no longer compatible with Linux distributions based on glibc `<2.28`,
+  for example: Ubuntu 14-18, RHEL 7, CentOS 7, Amazon Linux 2. Addresses [#29601](https://github.com/cypress-io/cypress/issues/29601).
 - The
   `experimentalJustInTimeCompile`
   configuration option for component testing has been replaced with a `justInTimeCompile` option that is `true` by default. This option will only compile resources directly related to your spec, compiling them 'just-in-time' before spec execution. This should result in improved memory management and performance for component tests in `cypress open` and `cypress run` modes, in particular for large component testing suites. `justInTimeCompile` is currently supported for [`webpack`](https://www.npmjs.com/package/webpack) and [`vite`](https://www.npmjs.com/package/vite). Addresses [#30234](https://github.com/cypress-io/cypress/issues/30234). Addressed in [#30402](https://github.com/cypress-io/cypress/pull/30402).
@@ -21,7 +21,6 @@ for example: Ubuntu 14-18, RHEL 7, CentOS 7, Amazon Linux 2. Addresses [#29601](
 **Bugfixes:**
 
 - The CSS pseudo-class `:dir()` is now supported when testing in Electron. Addresses [#29766](https://github.com/cypress-io/cypress/issues/29766).
-
 
 **Dependency Updates:**
 
@@ -101,8 +100,8 @@ _Released 8/27/2024_
 
 - Added new
   [`experimentalJustInTimeCompile`](/app/references/experiments#Configuration)
-  configuration option for component testing. This option will only compile resources directly related to your spec, compiling 
-  them 'just-in-time' before spec execution. This should result in improved memory management and performance for component 
+  configuration option for component testing. This option will only compile resources directly related to your spec, compiling
+  them 'just-in-time' before spec execution. This should result in improved memory management and performance for component
   tests in `cypress open` and `cypress run` modes, in particular for large component testing suites. [`experimentalJustInTimeCompile`](/app/references/experiments#Configuration) is currently supported for [`webpack`](https://www.npmjs.com/package/webpack) and [`vite`](https://www.npmjs.com/package/vite). Addresses [#29244](https://github.com/cypress-io/cypress/issues/29244).
 - `.type({upArrow})` and `.type({downArrow})` now also works for date, month, week, time, datetime-local and range input types. Addresses [#29665](https://github.com/cypress-io/cypress/issues/29665).
 - Added a `CYPRESS_SKIP_VERIFY` flag to enable suppressing Cypress verification checks. Addresses [#22243](https://github.com/cypress-io/cypress/issues/22243).

--- a/docs/app/references/migration-guide.mdx
+++ b/docs/app/references/migration-guide.mdx
@@ -19,12 +19,12 @@ on your system.
 version 16 and 21 will no longer be supported when installing Cypress. The minimum Node.js
 version supported to install Cypress is Node.js 18+.
 
-### Unsupported Linux Distributions 
+### Unsupported Linux Distributions
 
 Prebuilt binaries for Linux are no longer compatible with Linux distributions based on glibc `<2.28`.
 This support is inline with Node.js's support for Linux in 18+.
 
-If you're using a Linux distribution based on glibc `<2.28`, for example, Ubuntu 14-18, RHEL 7, CentOS 7, Amazon Linux 2, you'll need to 
+If you're using a Linux distribution based on glibc `<2.28`, for example, Ubuntu 14-18, RHEL 7, CentOS 7, Amazon Linux 2, you'll need to
 update your system to a newer version to install Cypress.
 
 ### Updated Browser Support
@@ -39,10 +39,10 @@ The `resourceType` option on `cy.intercept` has been deprecated in Cypress 14.0.
 We anticipate the types of the `resourceType` to change in the future or be completely removed
 from the API. The future implementation of `resourceType` is dependent on decisions made in the WebDriver BiDi specification for `resourceType`.
 
-If you're using `resourceType` in your tests, please leave feedback on which `resourceType` values are important to you 
+If you're using `resourceType` in your tests, please leave feedback on which `resourceType` values are important to you
 in this [GitHub issue](https://github.com/cypress-io/cypress/issues/30447).
 
-### Just in Time Compile Changes for Component Testing 
+### Just in Time Compile Changes for Component Testing
 
 In Cypress 13.14.0, we released an experimental flag, `experimentalJustInTimeCompile`,
 to enable Just in Time (JIT) compilation for Component Testing. The response from this change


### PR DESCRIPTION
vite 2 and 3 support is dropped in cypress 14. This updates the docs to the corresponding change