### PR TITLE
Update examples Docker version to Node.js 22.x (LTS)

### DIFF
--- a/docs/app/continuous-integration/aws-codebuild.mdx
+++ b/docs/app/continuous-integration/aws-codebuild.mdx
@@ -132,14 +132,14 @@ version: 0.2
 ## https://docs.aws.amazon.com/codebuild/latest/userguide/batch-build-buildspec.html
 
 ## Define build to run using the
-## "cypress/browsers:node-20.14.0-chrome-126.0.6478.114-1-ff-127.0.1-edge-126.0.2592.61-1" image
+## "cypress/browsers:node-22.11.0-chrome-130.0.6723.69-1-ff-132.0-edge-130.0.2849.56-1" image
 ## from the Cypress Amazon ECR Public Gallery
 batch:
   fast-fail: false
   build-list:
     - identifier: cypress-e2e-tests
       env:
-        image: public.ecr.aws/cypress-io/cypress/browsers:node-20.14.0-chrome-126.0.6478.114-1-ff-127.0.1-edge-126.0.2592.61-1
+        image: public.ecr.aws/cypress-io/cypress/browsers:node-22.11.0-chrome-130.0.6723.69-1-ff-132.0-edge-130.0.2849.56-1
 
 phases:
   install:

--- a/docs/app/continuous-integration/bitbucket-pipelines.mdx
+++ b/docs/app/continuous-integration/bitbucket-pipelines.mdx
@@ -59,7 +59,7 @@ example, this allows us to run the tests in Firefox by passing the
 Read about [Cypress docker variants](/app/continuous-integration/overview#Cypress-Docker-variants) to decide which image is best for your project.
 
 ```yaml title="bitbucket-pipelines.yml"
-image: cypress/browsers:node-20.14.0-chrome-126.0.6478.114-1-ff-127.0.1-edge-126.0.2592.61-1
+image: cypress/browsers:node-22.11.0-chrome-130.0.6723.69-1-ff-132.0-edge-130.0.2849.56-1
 
 pipelines:
   default:
@@ -87,7 +87,7 @@ Artifacts from a job can be defined by providing paths to the `artifacts`
 attribute.
 
 ```yaml title="bitbucket-pipelines.yml"
-image: cypress/browsers:node-20.14.0-chrome-126.0.6478.114-1-ff-127.0.1-edge-126.0.2592.61-1
+image: cypress/browsers:node-22.11.0-chrome-130.0.6723.69-1-ff-132.0-edge-130.0.2849.56-1
 
 pipelines:
   default:
@@ -151,7 +151,7 @@ recording test results to [Cypress Cloud](/cloud/get-started/introduction).
 :::
 
 ```yaml title="bitbucket-pipelines.yml"
-image: cypress/base:20.14.0
+image: cypress/base:22.11.0
 
 ## job definition for running E2E tests in parallel
 e2e: &e2e
@@ -210,7 +210,7 @@ definitions:
 The complete `bitbucket-pipelines.yml` is below:
 
 ```yaml title="bitbucket-pipelines.yml"
-image: cypress/base:20.14.0
+image: cypress/base:22.11.0
 
 ## job definition for running E2E tests in parallel
 e2e: &e2e

--- a/docs/app/continuous-integration/github-actions.mdx
+++ b/docs/app/continuous-integration/github-actions.mdx
@@ -182,7 +182,7 @@ jobs:
   cypress-run:
     runs-on: ubuntu-22.04
     container:
-      image: cypress/browsers:node-20.14.0-chrome-126.0.6478.114-1-ff-127.0.1-edge-126.0.2592.61-1
+      image: cypress/browsers:node-22.11.0-chrome-130.0.6723.69-1-ff-132.0-edge-130.0.2849.56-1
       options: --user 1001
     steps:
       - name: Checkout

--- a/docs/app/continuous-integration/gitlab-ci.mdx
+++ b/docs/app/continuous-integration/gitlab-ci.mdx
@@ -68,7 +68,7 @@ stages:
   - test
 
 test:
-  image: cypress/browsers:node-20.14.0-chrome-126.0.6478.114-1-ff-127.0.1-edge-126.0.2592.61-1
+  image: cypress/browsers:node-22.11.0-chrome-130.0.6723.69-1-ff-132.0-edge-130.0.2849.56-1
   stage: test
   script:
     # install dependencies
@@ -99,7 +99,7 @@ cache:
     - .npm/
 
 test:
-  image: cypress/browsers:node-20.14.0-chrome-126.0.6478.114-1-ff-127.0.1-edge-126.0.2592.61-1
+  image: cypress/browsers:node-22.11.0-chrome-130.0.6723.69-1-ff-132.0-edge-130.0.2849.56-1
   stage: test
   script:
     # install dependencies
@@ -166,7 +166,7 @@ cache:
 
 ## Install npm dependencies and Cypress
 install:
-  image: cypress/browsers:node-20.14.0-chrome-126.0.6478.114-1-ff-127.0.1-edge-126.0.2592.61-1
+  image: cypress/browsers:node-22.11.0-chrome-130.0.6723.69-1-ff-132.0-edge-130.0.2849.56-1
   stage: build
   script:
     - npm ci
@@ -211,13 +211,13 @@ cache:
 
 ## Install npm dependencies and Cypress
 install:
-  image: cypress/browsers:node-20.14.0-chrome-126.0.6478.114-1-ff-127.0.1-edge-126.0.2592.61-1
+  image: cypress/browsers:node-22.11.0-chrome-130.0.6723.69-1-ff-132.0-edge-130.0.2849.56-1
   stage: build
   script:
     - npm ci
 
 ui-chrome-tests:
-  image: cypress/browsers:node-20.14.0-chrome-126.0.6478.114-1-ff-127.0.1-edge-126.0.2592.61-1
+  image: cypress/browsers:node-22.11.0-chrome-130.0.6723.69-1-ff-132.0-edge-130.0.2849.56-1
   stage: test
   parallel: 5
   script:


### PR DESCRIPTION
## Issue

Node.js has now released the version [Node v22.11.0 LTS](https://nodejs.org/en/blog/release/v22.11.0) with the introduction:

> This release marks the transition of Node.js 22.x into Long Term Support (LTS) with the codename 'Jod'. The 22.x release line now moves into "Active LTS" and will remain so until October 2025. After that time, it will move into "Maintenance" until end of life in April 2027.

Cypress Docker versions in examples should transition to use the new Node.js LTS version by default.

## Change

In examples:

- `cypress/base:20.14.0` is bumped to <br>`cypress/base:22.11.0`
- `cypress/browsers:node-20.14.0-chrome-126.0.6478.114-1-ff-127.0.1-edge-126.0.2592.61-1` is bumped to<br>`cypress/browsers:node-22.11.0-chrome-130.0.6723.69-1-ff-132.0-edge-130.0.2849.56-1`
