### PR TITLE
chore: update nextjs documentation to reflect Cypress 14

### DIFF
--- a/docs/app/component-testing/get-started.mdx
+++ b/docs/app/component-testing/get-started.mdx
@@ -41,7 +41,7 @@ following development servers and frameworks:
 | Framework                                                                                                          | UI Library    | Bundler     |
 | ------------------------------------------------------------------------------------------------------------------ | ------------- | ----------- |
 | [Create React App 4-5](/app/component-testing/react/overview#Create-React-App-CRA)                                 | React 16-18   | Webpack 4-5 |
-| [Next.js 10-14](/app/component-testing/react/overview#Nextjs)                                                      | React 16-18   | Webpack 5   |
+| [Next.js 14](/app/component-testing/react/overview#Nextjs)                                                         | React 18      | Webpack 5   |
 | [React with Vite](/app/component-testing/react/overview#React-with-Vite)                                           | React 16-18   | Vite 4-5    |
 | [React with Webpack](/app/component-testing/react/overview#React-with-Webpack)                                     | React 16-18   | Webpack 4-5 |
 | [Vue CLI 4-5](/app/component-testing/vue/overview#Vue-CLI)                                                         | Vue 3         | Webpack 4-5 |

--- a/docs/app/component-testing/react/overview.mdx
+++ b/docs/app/component-testing/react/overview.mdx
@@ -94,7 +94,7 @@ Cypress Component Testing works with CRA 4+.
 
 ### Next.js
 
-Cypress Component Testing works with Next.js 11+.
+Cypress Component Testing works with Next.js 14+.
 
 #### Next.js Configuration
 
@@ -132,7 +132,7 @@ Next.js pages and Component Testing for individual components in a Next.js app.
 
 #### Sample Next.js Apps
 
-- [Next.js 13 with TypeScript](https://github.com/cypress-io/cypress-component-testing-apps/tree/main/react-next13-ts)
+- [Next.js 14 with TypeScript](https://github.com/cypress-io/cypress-component-testing-apps/tree/main/react-next14-ts)
 
 ### React with Vite
 


### PR DESCRIPTION
Updates Next.js supported versions to be 14 as 10, 11, 12, and 13 are no longer supported.

requires https://github.com/cypress-io/cypress-component-testing-apps/pull/25 to be merged into the `cypress-component-testing-apps` `release/14.0.0` branch