### PR TITLE
Stop recommending bluebird's own event

### DIFF
--- a/docs/api/utilities/promise.mdx
+++ b/docs/api/utilities/promise.mdx
@@ -82,17 +82,7 @@ If the test code has an unhandled rejected promise, it does not automatically
 fail the test. If you do want to fail the test if there is an unhandled rejected
 promise in the test code you have to do one of two things:
 
-If you use `Cypress.Promise` in your test code, register a callback using
-Bluebird's API
-
-```javascript
-Cypress.Promise.onPossiblyUnhandledRejection((error, promise) => {
-  throw error
-})
-```
-
-If you use native built-in promises in your test code, register an event
-listener on the test `window` object:
+Register an event listener on the test `window` object:
 
 ```javascript
 window.addEventListener('unhandledrejection', (event) => {


### PR DESCRIPTION
Bluebird has emitted the window unhandled rejection event in addition to having an onPossiblyUnhandledRejection hook for around 10 years at this point..