### PR TITLE
Add Cypress uninstall instructions

### DIFF
--- a/docs/app/get-started/install-cypress.mdx
+++ b/docs/app/get-started/install-cypress.mdx
@@ -91,6 +91,7 @@ the desired version (ex.
 If you have more complex requirements, want to level-up your Cypress workflow or
 just need help with troubleshooting, check out our
 [Advanced Installation](/app/references/advanced-installation) reference.
+You can also find instructions to [uninstall Cypress](/app/references/advanced-installation#Uninstall-Cypress) in this reference documentation.
 
 ### <Icon name="sync-alt" /> Continuous integration
 

--- a/docs/app/references/advanced-installation.mdx
+++ b/docs/app/references/advanced-installation.mdx
@@ -414,3 +414,48 @@ Refer to Microsoft Learn [Windows Subsystem for Linux Documentation](https://lea
 Cypress.io does not specifically support the use of Cypress under Windows Subsystem for Linux (WSL). If you want to report an issue, please ensure that you can reproduce it without using WSL on one of the Cypress [supported operating systems](/app/get-started/install-cypress#Operating-System).
 
 :::
+
+## Uninstall Cypress
+
+To uninstall Cypress from a project, use the same package manager you used to [install Cypress](/app/get-started/install-cypress):
+
+<Tabs groupId="package-manager"
+  defaultValue="npm"
+  values={[
+    {label: 'npm', value: 'npm'},
+    {label: 'Yarn', value: 'yarn'},
+    {label: 'pnpm', value: 'pnpm'},
+  ]}>
+  <TabItem value="npm">
+
+```shell
+npm uninstall cypress
+```
+
+  </TabItem>
+  <TabItem value="yarn">
+
+```shell
+yarn remove cypress
+```
+
+  </TabItem>
+  <TabItem value="pnpm">
+
+```shell
+pnpm remove cypress
+```
+
+  </TabItem>
+</Tabs>
+
+To uninstall all cached Cypress binary versions, use the [cypress cache clear](./command-line#cypress-cache-clear) command with the appropriate package manager prefix described in [How to run commands](./command-line#How-to-run-commands).
+Alternatively, delete the [Cypress binary cache](#Binary-cache) (see above) manually.
+
+To delete cached [Cypress App Data](./troubleshooting#Clear-App-Data), manually delete the following directories / folders:
+
+- macOS: `~/Library/Application Support/Cypress`
+- Linux: `~/.config/Cypress`
+- Windows: `$APPDATA/Cypress` (POSIX-syntax) or `%APPDATA%\Cypress` (Windows-syntax)
+
+Refer to your package manager documentation for details of package manager `cache clean` commands to remove other packages cached by npm, Yarn or pnpm.


### PR DESCRIPTION
- closes https://github.com/cypress-io/cypress-documentation/issues/5945

## Issue

The documentation website contains no instructions about how to uninstall Cypress.

## Change

1. Add a section "Uninstall Cypress" to the bottom of the reference page [Advanced Installation](https://docs.cypress.io/app/references/advanced-installation)
2. Mention the availability of this description in the [Advanced Installation](https://docs.cypress.io/app/get-started/install-cypress#Advanced-Installation) section of the [Install Cypress](https://docs.cypress.io/app/get-started/install-cypress) page.
