### PR TITLE
Fix test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "clear": "docusaurus clear",
     "preserve": "npm run build:plugins",
     "serve": "docusaurus serve --dir dist",
-    "test": "npm run cypress run",
+    "test": "cypress run",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
     "typecheck": "tsc"


### PR DESCRIPTION
## Issue

The [package.json](https://github.com/cypress-io/cypress-documentation/blob/main/package.json) script [test](https://github.com/cypress-io/cypress-documentation/blob/65a52bed5517be8f113791206c18ffdc547f81bc/package.json#L22) fails.

https://github.com/cypress-io/cypress-documentation/blob/65a52bed5517be8f113791206c18ffdc547f81bc/package.json#L22

## Issue Log

```text
$ npm test

> cypress-docusaurus-ts@0.0.0 test
> npm run cypress run

npm ERR! Missing script: "cypress"
npm ERR!
npm ERR! To see a list of scripts, run:
npm ERR!   npm run
```


## Change

See Cypress documentation [Using scripts](https://docs.cypress.io/app/references/command-line#Using-scripts).

Use instead

```json
    "test": "cypress run",
```

## Verification

Ubuntu `24.04.1` LTS, Node `18.17.1` LTS

Execute:

```shell
npm ci
npm start
```

In a separate terminal window, execute:

```shell
npm test
```

Confirm that Cypress tests are run.
