### PR TITLE
Cover Ubuntu 24.10 for Linux installation prerequisites

### DIFF
--- a/docs/app/get-started/install-cypress.mdx
+++ b/docs/app/get-started/install-cypress.mdx
@@ -189,7 +189,7 @@ It is worth noting that Cypress on Linux requires a minimum [`glibc`](https://ww
 apt-get install libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libnss3 libxss1 libasound2 libxtst6 xauth xvfb
 ```
 
-For Ubuntu 24.04 use the following command:
+For Ubuntu 24.04, and above, use the following command:
 
 ```shell
 apt-get install libgtk2.0-0t64 libgtk-3-0t64 libgbm-dev libnotify-dev libnss3 libxss1 libasound2t64 libxtst6 xauth xvfb


### PR DESCRIPTION
## Issue

Interim release [Ubuntu 24.10 (Oracular Oriole)](https://fridge.ubuntu.com/2024/10/10/ubuntu-24-10-oracular-oriole-released/), released on Oct 10, 2024, is not mentioned under [Linux Prerequisites](https://docs.cypress.io/app/get-started/install-cypress#Linux-Prerequisites). The generic instructions [Ubuntu/Debian](https://docs.cypress.io/app/get-started/install-cypress#UbuntuDebian) do not work for Ubuntu `24.10`. The ones for Ubuntu `24.04` have to be applied.

## Change

Under [Linux Prerequisites](https://docs.cypress.io/app/get-started/install-cypress#Linux-Prerequisites) change

> For Ubuntu 24.04

to
> For Ubuntu 24.04 and above

to cover the [Ubuntu 24.10 (Oracular Oriole)](https://fridge.ubuntu.com/2024/10/10/ubuntu-24-10-oracular-oriole-released/) interim release.

## Note

In practice, Ubuntu `24.04` and `24.10` Desktop do not require any additional prerequisites to run with Cypress, apart from Node.js, however other leaner configurations may require the prerequisites being additionally installed.