### PR TITLE
chore: update react documentation for Cypress 14

### DIFF
--- a/docs/api/commands/mount.mdx
+++ b/docs/api/commands/mount.mdx
@@ -35,10 +35,6 @@ to start with for your commands:
 <TabItem value='React'>
 
 ```js
-// React 18
-import { mount } from 'cypress/react18'
-
-// React 16, 17
 import { mount } from 'cypress/react'
 
 Cypress.Commands.add('mount', (component, options) => {

--- a/docs/app/component-testing/get-started.mdx
+++ b/docs/app/component-testing/get-started.mdx
@@ -40,8 +40,8 @@ following development servers and frameworks:
 
 | Framework                                                                                                          | UI Library    | Bundler     |
 | ------------------------------------------------------------------------------------------------------------------ | ------------- | ----------- |
-| [React with Vite](/app/component-testing/react/overview#React-with-Vite)                                           | React 16-18   | Vite 4-5    |
-| [React with Webpack](/app/component-testing/react/overview#React-with-Webpack)                                     | React 16-18   | Webpack 4-5 |
+| [React with Vite](/app/component-testing/react/overview#React-with-Vite)                                           | React 18      | Vite 4-5    |
+| [React with Webpack](/app/component-testing/react/overview#React-with-Webpack)                                     | React 18      | Webpack 4-5 |
 | [Next.js 14](/app/component-testing/react/overview#Nextjs)                                                         | React 18      | Webpack 5   |
 | [Vue with Vite](/app/component-testing/vue/overview#Vue-with-Vite)                                                 | Vue 3         | Vite 4-5    |
 | [Vue with Webpack](/app/component-testing/vue/overview#Vue-with-Webpack)                                           | Vue 3         | Webpack 4-5 |

--- a/docs/app/component-testing/react/api.mdx
+++ b/docs/app/component-testing/react/api.mdx
@@ -9,10 +9,6 @@ sidebar_label: API
 ### mount
 
 ```js
-// React 18
-import { mount } from 'cypress/react18'
-
-// React 16, 17
 import { mount } from 'cypress/react'
 ```
 

--- a/docs/app/component-testing/react/overview.mdx
+++ b/docs/app/component-testing/react/overview.mdx
@@ -15,7 +15,7 @@ sidebar_label: Overview
 
 ## Framework Support
 
-Cypress Component Testing currently supports React 16+ with the following
+Cypress Component Testing currently supports React 18 with the following
 frameworks:
 
 - [React with Vite](#React-with-Vite)
@@ -65,7 +65,7 @@ are for reference purposes.
 
 ### React with Vite
 
-Cypress Component Testing works with React apps that use Vite 2+ as the bundler.
+Cypress Component Testing works with React apps that use Vite 4+ as the bundler.
 
 #### Vite Configuration
 

--- a/docs/app/component-testing/vue/overview.mdx
+++ b/docs/app/component-testing/vue/overview.mdx
@@ -63,7 +63,7 @@ and configure them properly. The examples below are for reference purposes.
 
 ### Vue with Vite
 
-Cypress Component Testing works with Vue apps that use Vite 2+ as the bundler.
+Cypress Component Testing works with Vue apps that use Vite 4+ as the bundler.
 
 #### Vite Configuration
 

--- a/docs/app/references/changelog.mdx
+++ b/docs/app/references/changelog.mdx
@@ -8,9 +8,9 @@ _Released 12/3/2024_
 
 **Summary:**
 
-Cypress v14.0.0 expands our support for new component testing framework versions, a few bug fixes, and an update to Electron. We've removed support for older versions of Node.js, 
-Linux distributions, browsers and component testing frameworks and dev servers. We've also removed some deprecated Cypress APIs. 14.0.0 also includes breaking changes to `cy.origin` 
-that are necessary to handle Chrome's deprecation of document.domain injection - this should fix issues for some users in recent Chrome versions. 
+Cypress v14.0.0 expands our support for new component testing framework versions, a few bug fixes, and an update to Electron. We've removed support for older versions of Node.js,
+Linux distributions, browsers and component testing frameworks and dev servers. We've also removed some deprecated Cypress APIs. 14.0.0 also includes breaking changes to `cy.origin`
+that are necessary to handle Chrome's deprecation of document.domain injection - this should fix issues for some users in recent Chrome versions.
 
 Overall, we don't anticipate this release to be too disruptive for most users. We recommend bumping your version to see if your tests still run as expected.
 

--- a/docs/app/references/migration-guide.mdx
+++ b/docs/app/references/migration-guide.mdx
@@ -148,6 +148,44 @@ to
 import { mount } from `cypress/angular`
 ```
 
+### React versions under `18.x.x` are no longer supported in Component Testing.
+
+With [LTS ending](https://github.com/reactjs/react.dev/issues/1745#issuecomment-466767389) for React 16 and 17 several years ago, the minimum required React version for component testing is now `18.0.0`.
+
+If for any reason an older version of React must be used, please download [`@cypress/react`](https://www.npmjs.com/package/@cypress/angular) `8.x.x` from `npm`.
+
+```sh
+npm install --save-dev @cypress/react@8
+```
+
+Then, import the `mount` from this package in place of `cypress/react`.
+
+```ts
+import { mount } from `cypress/react`
+```
+
+to
+
+```ts
+import { mount } from `@cypress/react`
+```
+
+### `cypress/react` now supports React 18. The `cypress/react18` test harness has been removed from the binary.
+
+Now that the minimum version of React supported for Component Testing is `18.0.0`, Cypress is able to merge the `cypress/react18` test harness into the main `cypress/react` test harness. Because of this, the `@cypress/react18` harness is deprecated and no longer shipped with the binary. Support has been moved to `cypress/react`.
+
+To migrate, just change the test harness from `cypress/react18` to `cypress/react`:
+
+```ts
+import { mount } from `cypress/react18`
+```
+
+to
+
+```ts
+import { mount } from `cypress/react`
+```
+
 ### Create React App for Component Testing is no longer supported
 
 [create-react-app](https://create-react-app.dev/) is no longer actively maintained or supported (see [CRA issue #13393](https://github.com/facebook/create-react-app/issues/13393)).

--- a/docs/partials/_import-mount-functions.mdx
+++ b/docs/partials/_import-mount-functions.mdx
@@ -15,10 +15,6 @@ module supports standard JSX syntax for mounting components.
 :::
 
 ```js
-// React 18
-import { mount } from 'cypress/react18'
-
-// React 16, 17
 import { mount } from 'cypress/react'
 ```
 


### PR DESCRIPTION
updates the `cypress/react` documentation to support react 18 and adds the migration guide to move from `cypress/react18` to `cypress/react`

see https://github.com/cypress-io/cypress-component-testing-apps/pull/36 for updating webpack in react app (react app vite updated in https://github.com/cypress-io/cypress-component-testing-apps/pull/29)