### PR TITLE
Fix broken link to Applitools docs

### DIFF
--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -856,7 +856,7 @@
         {
           "name": "Applitools",
           "description": "Fast, easy and reliable visual UI testing with Cypress.",
-          "link": "https://applitools.com/tutorials/cypress.html",
+          "link": "https://applitools.com/tutorials/sdks/cypress/quickstart/getting-started",
           "keyword": ["screenshots", "visual regression", "visual-ai"],
           "badge": "verified"
         },


### PR DESCRIPTION
This PR fixes the broken link to the cypress quick start guide on Applitools