### PR TITLE
fix incorrect built in reporters link

### DIFF
--- a/docs/app/tooling/reporters.mdx
+++ b/docs/app/tooling/reporters.mdx
@@ -21,7 +21,7 @@ Cypress provides several options to review results of a test run.
   screenshots, videos, and Test Replay in Cypress Cloud.
 - Cypress App's open source built in and custom reporters.
 
-This document covers how to use [built in](#Built in reporter) and [custom](#Custom-reporters) reporters in Cypress App.
+This document covers how to use [built in](#Built-in-reporters) and [custom](#Custom-reporters) reporters in Cypress App.
 
 :::tip
 


### PR DESCRIPTION
## Issue

The [Reporters > Introduction](https://docs.cypress.io/app/tooling/reporters#Introduction) section contains an invalid markdown link `[built in](#Built in reporter)` to the [Built in reporters](https://docs.cypress.io/app/tooling/reporters#Built-in-reporters) section on the same page.

## Change

In the [Reporters > Introduction](https://docs.cypress.io/app/tooling/reporters#Introduction) section fix the invalid link to the [Built in reporters](https://docs.cypress.io/app/tooling/reporters#Built-in-reporters) section.