### PR TITLE
Replace @cypress/mocha-teamcity-reporter with mocha-teamcity-reporter

### DIFF
--- a/docs/app/tooling/reporters.mdx
+++ b/docs/app/tooling/reporters.mdx
@@ -41,7 +41,7 @@ By default, Cypress uses the `spec` reporter to output information to `STDOUT`.
 We've also added the two most common 3rd party reporters for Mocha. These are
 built into Cypress and you can use them without installing anything.
 
-- [`teamcity`](https://github.com/cypress-io/mocha-teamcity-reporter)
+- [`teamcity`](https://github.com/travisjeffery/mocha-teamcity-reporter)
 - [`junit`](https://github.com/michaelleeallen/mocha-junit-reporter)
 
 ## Custom reporters


### PR DESCRIPTION
- closes #6010

## Issue

The [Tooling > Reporters](https://docs.cypress.io/app/tooling/reporters) page, in the section [Built in reporterts](https://docs.cypress.io/app/tooling/reporters#Built-in-reporters) links to the repo

https://github.com/cypress-io/mocha-teamcity-reporter. This is an archived repo. It is an outdated fork based on the repo

https://github.com/travisjeffery/mocha-teamcity-reporter.

Cypress currently includes the npm module [mocha-teamcity-reporter](https://www.npmjs.com/package/mocha-teamcity-reporter) which is also linked to the repo https://github.com/travisjeffery/mocha-teamcity-reporter.

## Change

Replace the outdated repo link

- https://github.com/cypress-io/mocha-teamcity-reporter

using instead

- https://github.com/travisjeffery/mocha-teamcity-reporter
