### PR TITLE
Update repo link for cypress-multi-reporters

### DIFF
--- a/docs/app/tooling/reporters.mdx
+++ b/docs/app/tooling/reporters.mdx
@@ -188,7 +188,7 @@ additional feedback while the tests are running!
 The solution here is to use multiple reporters. You will have the benefit of
 both worlds.
 
-We suggest using the npm module, <Icon name="github" inline="true" url="https://github.com/you54f/cypress-multi-reporters" />
+We suggest using the npm module [cypress-multi-reporters](https://www.npmjs.com/package/cypress-multi-reporters).
 
 ### Examples
 
@@ -199,7 +199,7 @@ each spec file.
 
 We need to install additional dependencies:
 
-- [`cypress-multi-reporters`](https://github.com/you54f/cypress-multi-reporters):
+- [`cypress-multi-reporters`](https://github.com/YOU54F/cypress-plugins/tree/master/cypress-multi-reporters):
   enables multiple reporters
 - [`mocha-junit-reporter`](https://github.com/michaelleeallen/mocha-junit-reporter)
   the actual junit reporter, as we cannot use the `junit` reporter that comes


### PR DESCRIPTION
## Issue

The [Tooling > Reporters](https://docs.cypress.io/app/tooling/reporters) page, in the section [Multiple reporters](https://docs.cypress.io/app/tooling/reporters#Multiple-reporters), links to the archived repo https://github.com/you54f/cypress-multi-reporters.

The content for the npm module [cypress-multi-reporters](https://www.npmjs.com/package/cypress-multi-reporters) has been moved to https://github.com/YOU54F/cypress-plugins/tree/master/cypress-multi-reporters.

## Change

Link to

- npm module [cypress-multi-reporters](https://www.npmjs.com/package/cypress-multi-reporters)
- repo https://github.com/YOU54F/cypress-plugins/tree/master/cypress-multi-reporters