### PR TITLE
docs: fix missing colon in circleci.mdx

### DIFF
--- a/docs/app/continuous-integration/circleci.mdx
+++ b/docs/app/continuous-integration/circleci.mdx
@@ -42,7 +42,7 @@ orbs:
 workflows:
   build:
     jobs:
-      - cypress/run # "run" job comes from "cypress" orb
+      - cypress/run: # "run" job comes from "cypress" orb
           start-command: 'npm run start'
 ```
 


### PR DESCRIPTION
Hello.

The CircleCI configuration example in the Cypress documentation ([https://docs.cypress.io/app/continuous-integration/circleci](https://docs.cypress.io/app/continuous-integration/circleci)) is missing a colon in the `orbs` section. 
Specifically, the line defining the `cypress` orb (`cypress cypress-io/cypress@3`) lacks a colon (`:`) between the key and value. 

This commit adds the missing colon to ensure the example is correct and ready for use without modification.

A screenshot highlighting the issue is attached to provide additional context.
![image](https://github.com/user-attachments/assets/1374d4e7-eb2f-483e-9508-a55be0ace9e2)