### PR TITLE
Add built in reporter info to CLI --quiet option

### DIFF
--- a/docs/app/references/command-line.mdx
+++ b/docs/app/references/command-line.mdx
@@ -204,7 +204,7 @@ cypress run [options]
 | `--parallel`                   | [Run recorded specs in parallel across multiple machines](#cypress-run-parallel)                                                                                                              |
 | `--port`,`-p`                  | [Override default port](#cypress-run-port-lt-port-gt)                                                                                                                                         |
 | `--project`, `-P`              | [Path to a specific project](#cypress-run-project-lt-project-path-gt)                                                                                                                         |
-| `--quiet`, `-q`                | If passed, Cypress output will not be printed to `stdout`. Only output from the configured [Mocha reporter](/app/tooling/reporters) will print.                                               |
+| `--quiet`, `-q`                | [Reduce output to `stdout`](#cypress-run-quiet)                                                                                                                                               |
 | `--record`                     | [Whether to record the test run](#cypress-run-record-key-lt-record-key-gt)                                                                                                                    |
 | `--reporter`, `-r`             | [Specify a Mocha reporter](#cypress-run-reporter-lt-reporter-gt)                                                                                                                              |
 | `--reporter-options`, `-o`     | [Specify Mocha reporter options](#cypress-run-reporter-lt-reporter-gt)                                                                                                                        |
@@ -433,6 +433,17 @@ To see this in action we've set up an
 ```shell
 cypress run --project ./some/nested/folder
 ```
+
+#### `cypress run --quiet` {#cypress-run-quiet}
+
+To reduce the output from Cypress printed to `stdout`, use
+`--quiet`.
+
+```shell
+cypress run --quiet
+```
+
+If passed, Cypress will only print output to `stdout` from the [built-in](/app/tooling/reporters#Built-in-reporters) default [Mocha spec reporter](https://mochajs.org/#spec), or from any other configured [Mocha reporter](/app/tooling/reporters).
 
 #### `cypress run --record --key <record-key>` {#cypress-run-record-key-lt-record-key-gt}
 


### PR DESCRIPTION
- Follows on from https://github.com/cypress-io/cypress/issues/30661

## Issue

The [cypress run Options](https://docs.cypress.io/app/references/command-line#Options) describes the effect of the  `--quiet` option as follows:

| Option          | Description                                                                                                                                     |
| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
| `--quiet`, `-q` | If passed, Cypress output will not be printed to `stdout`. Only output from the configured [Mocha reporter](https://docs.cypress.io/app/tooling/reporters) will print. |

This can be misleading because Cypress includes the [Mocha `spec` reporter](https://mochajs.org/#spec) as a [built-in reporter](https://docs.cypress.io/app/tooling/reporters#Built-in-reporters) which is enabled by default. This reporter output is **not** suppressed by the `--quiet` option.

## Change

Change the `--quiet` option description in the [cypress run Options](https://docs.cypress.io/app/references/command-line#Options) section to the following and add a new entry below for `cypress run --quiet`, since the description is too big in comparison to other table entries:

If passed, Cypress will only print output to `stdout` from the [built-in](https://docs.cypress.io/app/tooling/reporters#Built-in-reporters) default [Mocha spec reporter](https://mochajs.org/#spec), or from any other configured [Mocha reporter](https://docs.cypress.io/app/tooling/reporters).

---

![image](https://github.com/user-attachments/assets/05f8ddd2-35dc-4687-a0af-0a371c30df16)

---

![image](https://github.com/user-attachments/assets/4732b172-ce73-441a-87b9-2d73423e1c4f)
