### PR TITLE
Bump lowest supported to Fedora Linux 40

### DIFF
--- a/docs/app/get-started/install-cypress.mdx
+++ b/docs/app/get-started/install-cypress.mdx
@@ -110,7 +110,7 @@ Cypress is a desktop application that is installed on your computer. The desktop
 application supports these operating systems:
 
 - **macOS** 10.15 and above _(Intel or Apple Silicon 64-bit (x64 or arm64))_.
-- **Linux** Ubuntu 20.04 and above, Fedora 39 and above, and Debian 11 and above _(x64 or arm64)_ (see [Linux Prerequisites](#Linux-Prerequisites) down
+- **Linux** Ubuntu 20.04 and above, Fedora 40 and above, and Debian 11 and above _(x64 or arm64)_ (see [Linux Prerequisites](#Linux-Prerequisites) down
   below).
   - Cypress deprecated the use of Node.js `16.x` in Cypress [`13.0.0`](/app/references/changelog#13-0-0). We recommend that users update to at least Node.js `18.x`.
     For related reasons, Cypress deprecates the use of Linux operating systems with library [`glibc`](https://www.gnu.org/software/libc/) versions `2.17` - `2.27`. The Linux CLI command `ldd --version` displays your glibc version.


### PR DESCRIPTION
## Issue

The [Fedora Linux Release Life Cycle](https://docs.fedoraproject.org/en-US/releases/lifecycle/) says:

> The Fedora Project releases a new version of Fedora Linux approximately every six months and provides updated packages (maintenance) to these releases for approximately 13 months.

| Fedora Linux release                                      | Status           |
| --------------------------------------------------------- | ---------------- |
| [F41](https://docs.fedoraproject.org/en-US/releases/f41/) | Supported        |
| [F40](https://docs.fedoraproject.org/en-US/releases/f40/) | Supported        |
| [F39](https://docs.fedoraproject.org/en-US/releases/f39/) | EOL Nov 26, 2024 |

Reference [End of Life Releases](https://docs.fedoraproject.org/en-US/releases/eol/)

## Change

In the section [Install Cypress > Operating System](https://docs.cypress.io/app/get-started/install-cypress#Operating-System)

- Change the lowest supported version of Fedora Linux from `39` to `40`.