### PR TITLE
chore: update angular docs to include Angular 19

### DIFF
--- a/docs/app/component-testing/angular/examples.mdx
+++ b/docs/app/component-testing/angular/examples.mdx
@@ -70,7 +70,7 @@ for your component to mount successfully, you can set them in the options
 (similar to setting them up in `ngModule` in a app):
 
 :::info
-Note: `imports`, `declarations`, or `providers` options do not work with `standalone` components as they are set within the test `ngModule`. This is the default behavior in Angular 19.
+Note: `imports`, `declarations`, and `providers` options do not work with `standalone` components as they are set within the test `ngModule`. This is the default behavior in Angular 19.
 :::
 
 ```ts

--- a/docs/app/component-testing/angular/examples.mdx
+++ b/docs/app/component-testing/angular/examples.mdx
@@ -69,6 +69,10 @@ If you need to set up any additional `imports`, `declarations`, or `providers`
 for your component to mount successfully, you can set them in the options
 (similar to setting them up in `ngModule` in a app):
 
+:::info
+Note: `imports`, `declarations`, or `providers` options do not work with `standalone` components as they are set within the test `ngModule`. This is the default behavior in Angular 19.
+:::
+
 ```ts
 cy.mount(ComponentThatFetchesData, {
   imports: [HttpClientModule],

--- a/docs/app/component-testing/angular/overview.mdx
+++ b/docs/app/component-testing/angular/overview.mdx
@@ -119,5 +119,5 @@ export default {
 
 #### Sample Angular Apps
 
-- [Angular 17](https://github.com/cypress-io/cypress-component-testing-apps/tree/main/angular)
-- [Angular 18 Standalone](https://github.com/cypress-io/cypress-component-testing-apps/tree/main/angular-standalone)
+- [Angular 18](https://github.com/cypress-io/cypress-component-testing-apps/tree/main/angular)
+- [Angular 19 Standalone](https://github.com/cypress-io/cypress-component-testing-apps/tree/main/angular-standalone)

--- a/docs/app/component-testing/get-started.mdx
+++ b/docs/app/component-testing/get-started.mdx
@@ -45,7 +45,7 @@ following development servers and frameworks:
 | [Next.js 14-15](/app/component-testing/react/overview#Nextjs)                                                      | React 18-19   | Webpack 5   |
 | [Vue with Vite](/app/component-testing/vue/overview#Vue-with-Vite)                                                 | Vue 3         | Vite 4-5    |
 | [Vue with Webpack](/app/component-testing/vue/overview#Vue-with-Webpack)                                           | Vue 3         | Webpack 4-5 |
-| [Angular](/app/component-testing/angular/overview#Framework-Configuration)                                         | Angular 17-18 | Webpack 5   |
+| [Angular](/app/component-testing/angular/overview#Framework-Configuration)                                         | Angular 17-19 | Webpack 5   |
 | [Svelte with Vite](/app/component-testing/svelte/overview#Svelte-with-Vite) <Badge type="info">Alpha</Badge>       | Svelte 4      | Vite 4-5    |
 | [Svelte with Webpack](/app/component-testing/svelte/overview#Svelte-with-Webpack) <Badge type="info">Alpha</Badge> | Svelte 4      | Webpack 4-5 |
 


### PR DESCRIPTION
Updates the angular docs to represent Angular 19

see https://github.com/cypress-io/cypress-component-testing-apps/pull/38 for Angular 19 standalone updates. Angular 18 update for non standalone was updated in https://github.com/cypress-io/cypress-component-testing-apps/pull/31