### PR TITLE
Correct CI overview Docker links

### DIFF
--- a/docs/app/continuous-integration/overview.mdx
+++ b/docs/app/continuous-integration/overview.mdx
@@ -212,9 +212,9 @@ cypress run --record --key=abc123 --parallel
 
 CI providers, such as [GitHub Actions](https://docs.github.com/en/actions/using-jobs/running-jobs-in-a-container) and
 [CircleCI](https://circleci.com/docs/executor-intro/#docker), allow workflows to run using
-[Docker container images](https://docs.docker.com/app/docker-concepts/the-basics/what-is-a-container/).
+[Docker container images](https://docs.docker.com/get-started/docker-concepts/the-basics/what-is-a-container/).
 
-Cypress supports the use of [Docker](https://docs.docker.com/app/docker-overview/)
+Cypress supports the use of [Docker](https://docs.docker.com/get-started/docker-overview/)
 through the provisioning of official [Cypress Docker images](https://github.com/cypress-io/cypress-docker-images).
 Images are Linux-based and support the following platforms:
 


### PR DESCRIPTION
## Issue

https://docs.cypress.io/app/continuous-integration/overview contains bad links to Docker materials resulting in 404 errors

- https://docs.docker.com/app/docker-overview/
- https://docs.docker.com/app/docker-concepts/the-basics/what-is-a-container/

These links were incorrectly changed from `guides` to `app` by

- PR #5947

## Change

Update the Docker links on [docs/app/continuous-integration/overview.mdx](https://github.com/cypress-io/cypress-documentation/blob/main/docs/app/continuous-integration/overview.mdx) to their current location on the https://docs.docker.com/ site:

https://docs.docker.com/get-started/docker-overview/
https://docs.docker.com/get-started/docker-concepts/the-basics/what-is-a-container/