### PR TITLE
docs: fix results-api.mdx getResults script

### DIFF
--- a/docs/accessibility/results-api.mdx
+++ b/docs/accessibility/results-api.mdx
@@ -52,6 +52,24 @@ The Cypress App [repository](https://github.com/cypress-io/cypress) uses the Res
 ```javascript title="scripts/verifyAccessibilityResults.js"
 const { getAccessibilityResults } = require('@cypress/extract-cloud-results')
 
+/**
+ * The list of rules that currently have 1+ elements that have been flagged with
+ * violations within the Cypress Accessibility report that need to be addressed.
+ *
+ * Once the violation is fixed in the Accessibility report,
+ * the fixed rule should be removed from this list.
+ *
+ * View the Accessibility report for the Cypress run in the Cloud
+ * for more details on how to address these failures.
+ */
+const rulesWithExistingViolations = [
+  'aria-required-children',
+  'empty-heading',
+  'aria-dialog-name',
+  'link-in-text-block',
+  'list',
+]
+
 getAccessibilityResults({
   projectId: '...', // optional if set from env
   recordKey: '...', // optional if set from env
@@ -60,11 +78,10 @@ getAccessibilityResults({
   const { runNumber, accessibilityReportUrl, summary, rules } = results
   const { total } = summary.violationCounts
 
-  console
-    .log(
-      `Received ${summary.isPartialReport ? 'partial' : ''} results for run #${runNumber}.`
-    )
-    .console.log(`See full report at ${accessibilityReportUrl}.`)
+  console.log(
+    `Received ${summary.isPartialReport ? 'partial' : ''} results for run #${runNumber}.`
+  )
+  console.log(`See full report at ${accessibilityReportUrl}.`)
 
   // write your logic to conditionally fail based on the results
   if (total === 0) {
@@ -101,24 +118,6 @@ getAccessibilityResults({
   }
 
   console.log('No new Accessibility violations detected!')
-
-  /**
-   * The list of rules that currently have 1+ elements that have been flagged with
-   * violations within the Cypress Accessibility report that need to be addressed.
-   *
-   * Once the violation is fixed in the Accessibility report,
-   * the fixed rule should be removed from this list.
-   *
-   * View the Accessibility report for the Cypress run in the Cloud
-   * for more details on how to address these failures.
-   */
-  const rulesWithExistingViolations = [
-    'aria-required-children',
-    'empty-heading',
-    'aria-dialog-name',
-    'link-in-text-block',
-    'list',
-  ]
 })
 ```
 

--- a/docs/ui-coverage/results-api.mdx
+++ b/docs/ui-coverage/results-api.mdx
@@ -55,11 +55,10 @@ getUICoverageResults({
 }).then((results) => {
   const { runNumber, uiCoverageReportUrl, summary, views } = results
 
-  console
-    .log(
-      `Received ${summary.isPartialReport ? 'partial' : ''} results for run #${runNumber}.`
-    )
-    .console.log(`See full report at ${uiCoverageReportUrl}.`)
+  console.log(
+    `Received ${summary.isPartialReport ? 'partial' : ''} results for run #${runNumber}.`
+  )
+  console.log(`See full report at ${uiCoverageReportUrl}.`)
 
   // verify project coverage
   if (summary.coverage < 80) {


### PR DESCRIPTION
## Summary

This pull request addresses two typos in the getResults scripts for the Results API. These typos are causing errors in the pipeline during execution.

### Errors Resolved

#### 1. `console.log` misplacement:
The `console.log` statement was incorrectly written as .console.log, leading to the following error:

```
/builds/acme/acme-app/packages/ui/scripts/verifyAccessibilityResults.js:13
    .console.log(`See full report at ${accessibilityReportUrl}.`);
    ^
TypeError: Cannot read properties of undefined (reading 'console')
    at /builds/acme/acme-app/packages/ui/scripts/verifyAccessibilityResults.js:13:5
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```

#### 2. `rulesWithExistingViolations` Initialization Issue.
The variable rulesWithExistingViolations was being used before it was initialized, resulting in:

```
/builds/acme/acme-app/packages/ui/scripts/verifyAccessibilityResults.js:29
    return !rulesWithExistingViolations.includes(rule.name);
    ^
ReferenceError: Cannot access 'rulesWithExistingViolations' before initialization
    at /builds/acme/acme-app/packages/ui/scripts/verifyAccessibilityResults.js:29:5
    at Array.filter (<anonymous>)
    at /builds/acme/acme-app/packages/ui/scripts/verifyAccessibilityResults.js:28:35
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```