### PR TITLE
Add Environment variable CYPRESS_SKIP_VERIFY setting

### DIFF
--- a/docs/app/references/advanced-installation.mdx
+++ b/docs/app/references/advanced-installation.mdx
@@ -25,7 +25,7 @@ title: Advanced Installation
 | `CYPRESS_CACHE_FOLDER`            | [Changes the Cypress binary cache location](#Binary-cache)                                     |
 | `CYPRESS_RUN_BINARY`              | [Location of Cypress binary at run-time](#Run-binary)                                          |
 | `CYPRESS_VERIFY_TIMEOUT`          | Overrides the timeout duration for the `verify` command. The default value is 30000.           |
-| `CYPRESS_SKIP_VERIFY`             | Skips the `verify` command (for stable CI environments)                                        |
+| `CYPRESS_SKIP_VERIFY`             | Skips the [`verify` command](command-line#cypress-verify) when `true`                          |
 | ~~CYPRESS_SKIP_BINARY_INSTALL~~   | <Badge type="danger">removed</Badge> use `CYPRESS_INSTALL_BINARY=0` instead                    |
 | ~~CYPRESS_BINARY_VERSION~~        | <Badge type="danger">removed</Badge> use `CYPRESS_INSTALL_BINARY` instead                      |
 

--- a/docs/app/references/command-line.mdx
+++ b/docs/app/references/command-line.mdx
@@ -834,6 +834,8 @@ and `cypress run` commands. The `CYPRESS_VERIFY_TIMEOUT` environment variable
 should be provided for those commands if you wish to modify the timeout
 duration.
 
+You can disable verification by setting the `CYPRESS_SKIP_VERIFY` environment variable to `true`.
+
 ### `cypress version`
 
 Prints the installed Cypress binary version, the Cypress package version, the


### PR DESCRIPTION
## Issue

1. [Advanced Installation > Environment variables](https://docs.cypress.io/app/references/advanced-installation#Environment-variables) lists `CYPRESS_SKIP_VERIFY` as follows:

    | Name                  | Description                                             |
    | --------------------- | ------------------------------------------------------- |
    | `CYPRESS_SKIP_VERIFY` | Skips the `verify` command (for stable CI environments) |

    It does not however say what the variable should be set to.

    https://github.com/cypress-io/cypress/blob/12df40ed8c1101c5c4053a1fe63c06fcd2809bc7/cli/lib/tasks/verify.js#L261

    ```js
    skipVerify: util.getEnv('CYPRESS_SKIP_VERIFY') === 'true',
    ```
    
    shows that Cypress is specifically looking for the contents of `CYPRESS_SKIP_VERIFY` to be strictly equal to `true`.

2. [References > Command Line > cypress verify](https://docs.cypress.io/app/references/command-line#cypress-verify) does not mention `CYPRESS_SKIP_VERIFY`.

## Change

1. In [Advanced Installation > Environment variables](https://docs.cypress.io/app/references/advanced-installation#Environment-variables) modify the description for `CYPRESS_SKIP_VERIFY` as follows:

   - State that skip requires `true`
   - Link to the CLI `verify` command description https://docs.cypress.io/app/references/command-line#cypress-verify
   - Remove the text "for stable CI environments" since this is not a restriction of the variable, only a possible use-case.

2. In [References > Command Line > cypress verify](https://docs.cypress.io/app/references/command-line#cypress-verify) add information about the use of `CYPRESS_SKIP_VERIFY`.
