### PR TITLE
Rework CYPRESS_RUN_BINARY instructions

### DIFF
--- a/docs/app/references/advanced-installation.mdx
+++ b/docs/app/references/advanced-installation.mdx
@@ -186,32 +186,56 @@ ensure this, consider exporting this environment variable. For example, in a
 Setting the environment variable `CYPRESS_RUN_BINARY` overrides where the npm
 module finds the Cypress binary.
 
-`CYPRESS_RUN_BINARY` should be a path to an already unzipped binary executable.
-The Cypress commands `open`, `run`, and `verify` will then launch the provided
-binary.
+`CYPRESS_RUN_BINARY` should be a path to an already unzipped Cypress binary executable.
+The Cypress commands [open](./command-line#cypress-open), [run](./command-line#cypress-run) and [verify](command-line#cypress-verify)
+will then launch the provided binary.
+
+The following example [cypress run](./command-line#cypress-run) commands assume that you have first
+downloaded the Cypress binary to the default `Downloads` directory of your operating system.
+
+Depending on how you then unzip the downloaded Cypress binary `cypress.zip` file,
+using a CLI command or alternatively a GUI interface,
+the directory structure may include one additional top-level directory named `cypress`,
+which you may need to add to the path defined by `CYPRESS_RUN_BINARY`.
+
+If available, use the following to avoid the additional top-level directory level:
+
+```shell
+unzip -q cypress
+```
+
+:::note
+
+The examples below are for npm.
+If you are using Yarn or pnpm as package manager, replace `npx` with `yarn` or `pnpm` as appropriate.
+See [How to run commands](./command-line.mdx#How-to-run-commands).
+
+:::
 
 ### Mac
 
 ```shell
-CYPRESS_RUN_BINARY=~/Downloads/Cypress.app/Contents/MacOS/Cypress cypress run
+CYPRESS_RUN_BINARY=~/Downloads/Cypress.app/Contents/MacOS/Cypress npx cypress run
 ```
 
 ### Linux
 
 ```shell
-CYPRESS_RUN_BINARY=~/Downloads/Cypress/Cypress cypress run
+CYPRESS_RUN_BINARY=~/Downloads/Cypress/Cypress npx cypress run
 ```
 
 ### Windows
 
 ```shell
-CYPRESS_RUN_BINARY=~/Downloads/Cypress/Cypress.exe cypress run
+CYPRESS_RUN_BINARY=~/Downloads/Cypress/Cypress.exe npx cypress run
 ```
 
-:::caution
+:::tip
 
-We recommend **not exporting** the `CYPRESS_RUN_BINARY` environment variable,
-since it will affect every cypress module installed on your file system.
+Cypress assumes that `CYPRESS_RUN_BINARY` points to a writeable directory structure so that it can save and re-use
+the results of verifying the Cypress binary.
+If you encounter a `permission denied` failure message from [cypress verify](./command-line.mdx#cypress-verify),
+you may be able to work around the failure by setting the environment variable `CYPRESS_SKIP_VERIFY` to `true`.
 
 :::
 


### PR DESCRIPTION
## Issue

[Advanced Installation > Run binary](https://docs.cypress.io/app/references/advanced-installation#Run-binary) includes instructions for using the environment variable `CYPRESS_RUN_BINARY` to override where the npm module finds the Cypress binary.

1. The instructions to run Cypress do not work as written. The package manager prefix `npx`, `yarn` or `pnpm` is missing and there is no hint that this would be needed.
2. There are no instructions about how to unzip the Cypress binary `cypress.zip`. Depending on how the extract or unzip operation is performed, there may be an extra directory level created. On Linux, for instance, this could mean that it is necessary to set the environment variable to `CYPRESS_RUN_BINARY=~/Downloads/cypress/Cypress/Cypress` instead of `CYPRESS_RUN_BINARY=~/Downloads/Cypress/Cypress`. This is quite confusing considering the multiple use of the names `cypress` and `Cypress` as directories and `Cypress` as an executable.
3. If the unzipped binary is located in a read-only location, then Cypress may fail to verify and therefore fail to run (see issue https://github.com/cypress-io/cypress/issues/30684). There is no mention of this issue or a possible workaround.
4. As written, the cautionary message, advising against exporting the `CYPRESS_RUN_BINARY` environment variable, does not make a lot of sense.

## Change

The instructions in [Advanced Installation > Run binary](https://docs.cypress.io/app/references/advanced-installation#Run-binary) for using the environment variable `CYPRESS_RUN_BINARY` are reworked.
