### PR TITLE
chore: remove react 19 rc warning

### DIFF
--- a/docs/app/component-testing/react/overview.mdx
+++ b/docs/app/component-testing/react/overview.mdx
@@ -22,12 +22,6 @@ frameworks:
 - [React with Webpack](#React-with-Webpack)
 - [Next.js](#Nextjs)
 
-:::caution
-
-Cypress currently supports the release candidate (rc) of React 19. Though unlikely, release candidates are subject to change and could cause unprecedented issues with the React 19 release candidate and Cypress Component Testing.
-
-:::
-
 ## Tutorial
 
 Visit the


### PR DESCRIPTION
React 19 released yesterday, which means we no longer need to support the Release Candidate. This PR removes the warning about the RC being supported temporarily.