### PR TITLE
docs: adding Cypress Test Explorer extension

### DIFF
--- a/docs/app/tooling/IDE-integration.mdx
+++ b/docs/app/tooling/IDE-integration.mdx
@@ -73,6 +73,8 @@ with Cypress.
 - [Test Utils](https://marketplace.visualstudio.com/items?itemName=chrisbreiding.test-utils):
   Easily add or remove `.only` and `.skip` modifiers with keyboard shortcuts or
   the command palette.
+- [Cypress Test Explorer](https://marketplace.visualstudio.com/items?itemName=dpanshug.cypress-test-explorer):
+  Helps you discover, navigate and run Cypress tests directly from the editor.
 
 ### IntelliJ Platform
 


### PR DESCRIPTION
This PR adds a reference to a new VS Code extension https://marketplace.visualstudio.com/items?itemName=dpanshug.cypress-test-explorer

Features are mentioned in the README of the [repository](https://github.com/dpanshug/cypress-test-explorer)

I would appreciate suggestions on whether this is the appropriate way to introduce the extension in the documentation and any recommendations for improvement.