### PR TITLE
Remove Gatsby FAQ

### DIFF
--- a/docs/app/faq.mdx
+++ b/docs/app/faq.mdx
@@ -1260,17 +1260,6 @@ plugin.
 
 ## Integrations with Other Tools/Frameworks/Libraries
 
-### <Icon name="angle-right" /> Can I test Gatsby.js sites using Cypress?
-
-For end-to-end tests, yes, as you can read in the official
-[Gatsby docs](https://www.gatsbyjs.com/docs/end-to-end-testing/). You can also
-watch the "Cypress + Gatsby webinar"
-[recording](https://www.youtube.com/watch?v=Tx6Lg9mwcCE).
-
-For component testing, Gatsby is not currently supported out of the box, but it
-might be possible by
-[configuring a custom devServer](/app/references/configuration#devServer).
-
 ### <Icon name="angle-right" /> Can I test React applications using Cypress?
 
 For end-to-end testing, yes, absolutely. A good example of a fully tested React


### PR DESCRIPTION
- closes https://github.com/cypress-io/cypress-documentation/issues/6025

## Issue

The FAQ entry [Can I test Gatsby.js sites using Cypress?](https://docs.cypress.io/app/faq#Can-I-test-Gatsbyjs-sites-using-Cypress) contains bad links

- https://www.gatsbyjs.com/docs/end-to-end-testing/ no longer works

https://www.gatsbyjs.com/ states

> Gatsby Cloud and Netlify Cloud are uniting!

with an announcement from August 2023.

## Change

Remove the outdated FAQ entry [Can I test Gatsby.js sites using Cypress?](https://docs.cypress.io/app/faq#Can-I-test-Gatsbyjs-sites-using-Cypress) as suggested by @jennifer-shehane in https://github.com/cypress-io/cypress-documentation/issues/6025#issuecomment-2532589333.