### PR TITLE
Remove outdated Lighthouse references in FAQ

### DIFF
--- a/docs/app/faq.mdx
+++ b/docs/app/faq.mdx
@@ -1253,10 +1253,7 @@ steps, Cypress adds its own overhead. Thus, the performance numbers you get from
 Cypress tests are slower than "normal" use. Still, you can access the native
 `window.performance` object and grab the page time measurements, see the
 [Evaluate performance metrics](https://github.com/cypress-io/cypress-example-recipes#testing-the-dom)
-recipe. You can also
-[run Lighthouse audit straight from Cypress](https://www.testingwithmarie.com/post/web-performance-testing-with-google-lighthouse)
-via [cypress-audit](https://www.npmjs.com/package/cypress-audit) community
-plugin.
+recipe.
 
 ## Integrations with Other Tools/Frameworks/Libraries
 


### PR DESCRIPTION
- partially addresses https://github.com/cypress-io/cypress-documentation/issues/6026

## Issue

In the FAQ [Can Cypress be used for performance testing?](https://docs.cypress.io/app/faq#Can-Cypress-be-used-for-performance-testing) in the sentence:

> You can also [run Lighthouse audit straight from Cypress](https://www.testingwithmarie.com/post/web-performance-testing-with-google-lighthouse) via [cypress-audit](https://www.npmjs.com/package/cypress-audit) community plugin.

1. The link https://www.testingwithmarie.com/post/web-performance-testing-with-google-lighthouse produces a 404 error.
2. The plugin [cypress-audit](https://www.npmjs.com/package/cypress-audit) has been replaced, according to the documentation on https://mfrachet.github.io/cypress-audit/, which now recommends using:

   - [@cypress-audit/lighthouse](https://www.npmjs.com/package/@cypress-audit/lighthouse) - performance tool
   - [@cypress-audit/pa11y](https://www.npmjs.com/package/@cypress-audit/pa11y) - accessibility audit tool

## Change

The sentence in [Can Cypress be used for performance testing?](https://docs.cypress.io/app/faq#Can-Cypress-be-used-for-performance-testing) concerning Lighthouse audits is removed, as suggested by @jennifer-shehane in https://github.com/cypress-io/cypress-documentation/issues/6026#issuecomment-2532593618.
