### PR TITLE
Add Windows Server OS names to supported list

### DIFF
--- a/docs/app/get-started/install-cypress.mdx
+++ b/docs/app/get-started/install-cypress.mdx
@@ -106,8 +106,7 @@ need prebuilt.
 
 ### Operating System
 
-Cypress is a desktop application that is installed on your computer. The desktop
-application supports these operating systems:
+Cypress supports running under these operating systems:
 
 - **macOS** 10.15 and above _(Intel or Apple Silicon 64-bit (x64 or arm64))_.
 - **Linux** Ubuntu 20.04 and above, Fedora 40 and above, and Debian 11 and above _(x64 or arm64)_ (see [Linux Prerequisites](#Linux-Prerequisites) down
@@ -115,6 +114,7 @@ application supports these operating systems:
   - Cypress deprecated the use of Node.js `16.x` in Cypress [`13.0.0`](/app/references/changelog#13-0-0). We recommend that users update to at least Node.js `18.x`.
     For related reasons, Cypress deprecates the use of Linux operating systems with library [`glibc`](https://www.gnu.org/software/libc/) versions `2.17` - `2.27`. The Linux CLI command `ldd --version` displays your glibc version.
 - **Windows** 10 and above _(x64)_.
+- **Windows Server** 2019 and 2022 _(x64)_.
 
 ### Node.js
 


### PR DESCRIPTION
- closes https://github.com/cypress-io/cypress-documentation/issues/6022

## Issue

1. The documentation section [Get Started > Install Cypress > Operating System](https://docs.cypress.io/app/get-started/install-cypress#Operating-System) does not cover the common usage of Cypress in CI systems, where it runs on server operating systems.
2. The names of supported Microsoft Windows Server operating systems are missing.

## Change

1. Make the [Get Started > Install Cypress > Operating System](https://docs.cypress.io/app/get-started/install-cypress#Operating-System) more generic to cover usage on both Desktop and Server operating systems.
2. Add the Microsoft Windows Server operating systems which are currently offered under [GitHub Actions - Runner Images](https://github.com/actions/runner-images) and under [CircleCI machine images](https://circleci.com/developer/images?imageType=machine) with `amd64` (`x64`) architecture:

  - Windows Server 2019
  - Windows Server 2022