### PR TITLE
fix: remove extra word spacing in codeblock

### DIFF
--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -117,7 +117,6 @@
   --ifm-color-purple-900: theme(colors.purple.900);
   --ifm-color-purple-1000: theme(colors.purple.1000);
 
-
   --ifm-font-family-base: ui-sans-serif, system-ui, -apple-system, Segoe UI,
     Roboto, Helvetica Neue, Arial;
   --ifm-heading-font-family: Poppins;
@@ -427,6 +426,7 @@ div[class^='codeBlockTitle'] {
 
 [class^='docItemContainer'] [class^='codeBlockLines'] {
   max-width: 0;
+  word-spacing: 0;
 }
 
 /* hides the osano widget */


### PR DESCRIPTION
#### Description
Fixed an issue where tables within code blocks had incorrect word spacing, causing layout issues. Added `word-spacing: 0` to the code block lines.

#### Related Issues
closes #5788

#### Testing
- Verified table formatting in code blocks displays correctly
- Checked that the fix doesn't affect other code block content