### PR TITLE
Add cypress-xray-plugin to list of plugins

### DIFF
--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -1021,6 +1021,13 @@
           "link": "https://github.com/allure-framework/allure-js/tree/main/packages/allure-cypress",
           "keywords": ["reporter", "allure", "step", "screenshot"],
           "badge": "community"
+        },
+        {
+          "name": "cypress-xray-plugin",
+          "description": "A plugin for uploading Cypress test results to Xray, including evidence such as screenshots, videos or custom data. Fully compatible with Cucumber.",
+          "link": "https://github.com/Qytera-Gmbh/cypress-xray-plugin",
+          "keywords": ["reporter", "xray", "jira", "cucumber", "screenshot", "video"],
+          "badge": "community"
         }
       ]
     },


### PR DESCRIPTION
I would like to submit the plugin I've been steadily maintaining for the past two years to the list of plugins in the documentation: https://www.npmjs.com/package/cypress-xray-plugin

> 1. Purpose of plugin articulated up front
- the purpose is summarized in the `README.md` and thus visible in npm as well as in GitHub
- the [landing page](https://qytera-gmbh.github.io/projects/cypress-xray-plugin/) of the documentation contains the same summary as well as a demo video

> 2. Installation guide
- the `README.md` contains a quick start
- there is an [extended installation guide](https://qytera-gmbh.github.io/projects/cypress-xray-plugin/section/setup/installation/) in the documentation

> 3. Options and API are documented
- the [documentation](https://qytera-gmbh.github.io/projects/cypress-xray-plugin/section/configuration/introduction/) explains all available options in detail

> 4. Easy to follow documentation. Users should not have to read the source code to get things working.
- (see mentioned documentation)

---

> Each plugin submitted to the plugins list should have the following:
> 1. Integration tests with Cypress
- there are integration tests in [the code](https://github.com/Qytera-Gmbh/cypress-xray-plugin/tree/main/test/integration) that are part of the release process

> 2. CI pipeline
- all releases are published using a [GitHub action](https://github.com/Qytera-Gmbh/cypress-xray-plugin/blob/main/.github/workflows/publish.yml) with provenance information

> 3. Compatibility with at least the latest major version of Cypress
- the plugin is [compatible](https://github.com/Qytera-Gmbh/cypress-xray-plugin/blob/00a2c3aefae2521e0f695cd11fd0ce4a6ead04c6/package.json#L56) with Cypress versions `>= 10` and `< 14`