### PR TITLE
Update Ubuntu in GitHub Actions examples to ubuntu-24.04

### DIFF
--- a/docs/accessibility/results-api.mdx
+++ b/docs/accessibility/results-api.mdx
@@ -242,10 +242,10 @@ env:
 
 jobs:
   run-cypress:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: install
         run: npm install
       - name: Run

--- a/docs/app/continuous-integration/github-actions.mdx
+++ b/docs/app/continuous-integration/github-actions.mdx
@@ -98,7 +98,7 @@ on: push
 
 jobs:
   cypress-run:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -180,7 +180,7 @@ on: push
 
 jobs:
   cypress-run:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     container:
       image: cypress/browsers:node-22.11.0-chrome-130.0.6723.69-1-ff-132.0-edge-130.0.2849.56-1
       options: --user 1001
@@ -229,7 +229,7 @@ on: push
 
 jobs:
   install:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -249,7 +249,7 @@ jobs:
           path: build
 
   cypress-run:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: install
     steps:
       - name: Checkout
@@ -325,7 +325,7 @@ on: push
 
 jobs:
   install:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -363,7 +363,7 @@ jobs:
   # ... omitted install job from above
 
   cypress-run:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: install
     strategy:
       # don't fail the entire matrix on failure
@@ -494,7 +494,7 @@ on: push
 jobs:
   cypress-run:
     name: Cypress run
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -521,7 +521,7 @@ on: push
 jobs:
   cypress-run:
     name: Cypress run
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/docs/ui-coverage/results-api.mdx
+++ b/docs/ui-coverage/results-api.mdx
@@ -206,10 +206,10 @@ env:
 
 jobs:
   run-cypress:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: install
         run: npm install
       - name: Run


### PR DESCRIPTION
## Issue

GitHub Action examples using:

- `ubuntu-22.04` are outdated
- `ubuntu-latest` run the risk of unplanned breaking changes

## Background

[Notice of upcoming releases and breaking changes for GitHub Actions](https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/), dated Dec 5, 2024, announces the move of `ubuntu-latest` from `ubuntu-22.04` to `ubuntu-24.04`

[cypress-io/github-action](https://github.com/cypress-io/github-action) has already migrated to `ubuntu-24.04`.

## Change

Update [GitHub Actions Ubuntu runner images](https://github.com/actions/runner-images) in GitHub Actions examples to use [ubuntu-24.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md) consistently.

Update `actions/checkout@v3`(unsupported `node16` version) to [actions/checkout@v4](https://github.com/actions/checkout/tree/v4) (`node20` version).