### PR TITLE
Use Docker image short-form Node.js tag in examples

### DIFF
--- a/docs/accessibility/results-api.mdx
+++ b/docs/accessibility/results-api.mdx
@@ -288,7 +288,7 @@ run-cypress:
 pipeline {
   agent {
     docker {
-      image 'cypress/base:latest'
+      image 'cypress/base:22.12.0'
     }
   }
 
@@ -359,7 +359,7 @@ version: 2.1
 jobs:
   linux-test:
     docker:
-      - image: cypress/base:latest
+      - image: cypress/base:22.12.0
 
     working_directory: ~/repo
     steps:

--- a/docs/app/continuous-integration/aws-codebuild.mdx
+++ b/docs/app/continuous-integration/aws-codebuild.mdx
@@ -132,14 +132,14 @@ version: 0.2
 ## https://docs.aws.amazon.com/codebuild/latest/userguide/batch-build-buildspec.html
 
 ## Define build to run using the
-## "cypress/browsers:node-22.11.0-chrome-130.0.6723.69-1-ff-132.0-edge-130.0.2849.56-1" image
+## "cypress/browsers:22.12.0" image
 ## from the Cypress Amazon ECR Public Gallery
 batch:
   fast-fail: false
   build-list:
     - identifier: cypress-e2e-tests
       env:
-        image: public.ecr.aws/cypress-io/cypress/browsers:node-22.11.0-chrome-130.0.6723.69-1-ff-132.0-edge-130.0.2849.56-1
+        image: public.ecr.aws/cypress-io/cypress/browsers:22.12.0
 
 phases:
   install:

--- a/docs/app/continuous-integration/bitbucket-pipelines.mdx
+++ b/docs/app/continuous-integration/bitbucket-pipelines.mdx
@@ -151,7 +151,7 @@ recording test results to [Cypress Cloud](/cloud/get-started/introduction).
 :::
 
 ```yaml title="bitbucket-pipelines.yml"
-image: cypress/base:22.11.0
+image: cypress/base:22.12.0
 
 ## job definition for running E2E tests in parallel
 e2e: &e2e
@@ -210,7 +210,7 @@ definitions:
 The complete `bitbucket-pipelines.yml` is below:
 
 ```yaml title="bitbucket-pipelines.yml"
-image: cypress/base:22.11.0
+image: cypress/base:22.12.0
 
 ## job definition for running E2E tests in parallel
 e2e: &e2e

--- a/docs/app/continuous-integration/bitbucket-pipelines.mdx
+++ b/docs/app/continuous-integration/bitbucket-pipelines.mdx
@@ -59,7 +59,7 @@ example, this allows us to run the tests in Firefox by passing the
 Read about [Cypress docker variants](/app/continuous-integration/overview#Cypress-Docker-variants) to decide which image is best for your project.
 
 ```yaml title="bitbucket-pipelines.yml"
-image: cypress/browsers:node-22.11.0-chrome-130.0.6723.69-1-ff-132.0-edge-130.0.2849.56-1
+image: cypress/browsers:22.12.0
 
 pipelines:
   default:
@@ -87,7 +87,7 @@ Artifacts from a job can be defined by providing paths to the `artifacts`
 attribute.
 
 ```yaml title="bitbucket-pipelines.yml"
-image: cypress/browsers:node-22.11.0-chrome-130.0.6723.69-1-ff-132.0-edge-130.0.2849.56-1
+image: cypress/browsers:22.12.0
 
 pipelines:
   default:

--- a/docs/app/continuous-integration/github-actions.mdx
+++ b/docs/app/continuous-integration/github-actions.mdx
@@ -182,7 +182,7 @@ jobs:
   cypress-run:
     runs-on: ubuntu-22.04
     container:
-      image: cypress/browsers:node-22.11.0-chrome-130.0.6723.69-1-ff-132.0-edge-130.0.2849.56-1
+      image: cypress/browsers:22.12.0
       options: --user 1001
     steps:
       - name: Checkout

--- a/docs/app/continuous-integration/gitlab-ci.mdx
+++ b/docs/app/continuous-integration/gitlab-ci.mdx
@@ -68,7 +68,7 @@ stages:
   - test
 
 test:
-  image: cypress/browsers:node-22.11.0-chrome-130.0.6723.69-1-ff-132.0-edge-130.0.2849.56-1
+  image: cypress/browsers:22.12.0
   stage: test
   script:
     # install dependencies
@@ -99,7 +99,7 @@ cache:
     - .npm/
 
 test:
-  image: cypress/browsers:node-22.11.0-chrome-130.0.6723.69-1-ff-132.0-edge-130.0.2849.56-1
+  image: cypress/browsers:22.12.0
   stage: test
   script:
     # install dependencies
@@ -166,7 +166,7 @@ cache:
 
 ## Install npm dependencies and Cypress
 install:
-  image: cypress/browsers:node-22.11.0-chrome-130.0.6723.69-1-ff-132.0-edge-130.0.2849.56-1
+  image: cypress/browsers:22.12.0
   stage: build
   script:
     - npm ci
@@ -211,13 +211,13 @@ cache:
 
 ## Install npm dependencies and Cypress
 install:
-  image: cypress/browsers:node-22.11.0-chrome-130.0.6723.69-1-ff-132.0-edge-130.0.2849.56-1
+  image: cypress/browsers:22.12.0
   stage: build
   script:
     - npm ci
 
 ui-chrome-tests:
-  image: cypress/browsers:node-22.11.0-chrome-130.0.6723.69-1-ff-132.0-edge-130.0.2849.56-1
+  image: cypress/browsers:22.12.0
   stage: test
   parallel: 5
   script:

--- a/docs/ui-coverage/results-api.mdx
+++ b/docs/ui-coverage/results-api.mdx
@@ -252,7 +252,7 @@ run-cypress:
 pipeline {
   agent {
     docker {
-      image 'cypress/base:latest'
+      image 'cypress/base:22.12.0'
     }
   }
 
@@ -323,7 +323,7 @@ version: 2.1
 jobs:
   linux-test:
     docker:
-      - image: cypress/base:latest
+      - image: cypress/base:22.12.0
 
     working_directory: ~/repo
     steps:


### PR DESCRIPTION
## Issue

Using the long-form tag for `cypress/browsers` Docker images, such as in 

`cypress/browsers:node-22.11.0-chrome-130.0.6723.69-1-ff-132.0-edge-130.0.2849.56-1`

causes code examples to be so wide that scrolling can be necessary to view. See for example https://docs.cypress.io/app/continuous-integration/aws-codebuild#Cypress-Amazon-Public-ECR.

Starting from the release of the Cypress Docker image `cypress/browsers:22.11.0`, a short-form tag e.g. 

`22.11.0` 

is available, which takes far less space to display than the long-form tag e.g. 

`node-22.11.0-chrome-130.0.6723.69-1-ff-132.0-edge-130.0.2849.56-1`

See [`cypress/browsers` Tags](https://github.com/cypress-io/cypress-docker-images/tree/master/browsers#tags).

## Change

Replace all long-form tags for `cypress/browser` in examples with their equivalent short-form tag `22.12.0`, which is the [Node.js Active LTS version](https://nodejs.org/en/about/releases). The full Docker image reference is then  `cypress/browsers:22.12.0`.

For consistency, update also `cypress/base` tags in examples to the same short-form tag `22.12.0`.