### PR TITLE
Convert https://docs.cypress.io/ links to local

### DIFF
--- a/docs/api/cypress-api/require.mdx
+++ b/docs/api/cypress-api/require.mdx
@@ -15,7 +15,7 @@ in browser-targeted code.
 
 :::caution
 
-Using `Cypress.require()` within the [`cy.origin()`](https://docs.cypress.io/api/commands/origin)
+Using `Cypress.require()` within the [`cy.origin()`](/api/commands/origin)
 callback requires enabling the
 [`experimentalOriginDependencies`](/app/references/experiments#End-to-End-Testing) option in the Cypress configuration.
 

--- a/docs/app/continuous-integration/overview.mdx
+++ b/docs/app/continuous-integration/overview.mdx
@@ -235,7 +235,7 @@ Cypress Docker images are available from:
 
 - [cypress/base](https://github.com/cypress-io/cypress-docker-images/tree/master/base) is the entry-level Cypress Docker image, allowing you to test in the Electron browser, built in to Cypress.
   It contains a complete Linux (Debian) operating system, together with the
-  [prerequisite operating system packages](https://docs.cypress.io/app/get-started/install-cypress#UbuntuDebian) for Cypress,
+  [prerequisite operating system packages](/app/get-started/install-cypress#UbuntuDebian) for Cypress,
   Node.js, npm and Yarn v1 Classic.
   An image `<tag>` gives you the choice of Node.js version.
 

--- a/docs/app/faq.mdx
+++ b/docs/app/faq.mdx
@@ -1485,5 +1485,5 @@ You will need to add a `tsconfig.json` to the folder and specify the types the
 files inside that folder should use.
 
 Don't forget to update your
-[`specPattern`](https://docs.cypress.io/app/references/configuration#component)
+[`specPattern`](/app/references/configuration#component)
 to include the new file location.

--- a/docs/app/guides/migration/protractor-to-cypress.mdx
+++ b/docs/app/guides/migration/protractor-to-cypress.mdx
@@ -88,7 +88,7 @@ With [Cypress](/app/core-concepts/open-mode), your tests run in an
 interactive browser environment in real time. Cypress's
 [Command Log](/app/core-concepts/open-mode#Command-Log) displays the tests
 from your test suite and their assertions. When you
-[click on a command or assertion](https://docs.cypress.io/app/core-concepts/open-mode#Clicking-on-Commands)
+[click on a command or assertion](/app/core-concepts/open-mode#Command-Log)
 in the command log, a DOM snapshot displays so you can see what the application
 under test looked like at the time of the test's execution. This allows you to
 see the **real rendered UI** and the behavior of the app under **real user
@@ -98,7 +98,7 @@ scenario.
 
 Cypress also helps you to write your tests by making it as easy as possible to
 find the right CSS selectors for the DOM elements in your application with its
-[Selector Playground](https://docs.cypress.io/app/core-concepts/open-mode#Selector-Playground) and [Cypress Studio](/app/guides/cypress-studio).
+[Selector Playground](/app/core-concepts/open-mode#Selector-Playground) and [Cypress Studio](/app/guides/cypress-studio).
 These tools help you cut down on time spent finding the right
 selectors so you can focus on what's important: writing tests that verify your
 app's logic.
@@ -216,7 +216,7 @@ Check out the
 documentation for more details like how to
 [configure your tests to run in a specific browser](#Running-the-builder-with-a-specific-browser)
 or [record test results](#Recording-test-results-to-Cypress-Cloud) to
-[Cypress Cloud](https://docs.cypress.io/cloud/get-started/introduction).
+[Cypress Cloud](/cloud/get-started/introduction).
 
 :::
 
@@ -707,7 +707,7 @@ cy.get('#example-input')
 
 Cypress has one additional feature that can make a critical difference in the
 reliability of your tests' assertions:
-[retry-ability](https://docs.cypress.io/app/core-concepts/retry-ability).
+[retry-ability](/app/core-concepts/retry-ability).
 When your test fails an assertion or command, Cypress will mimic a real user
 with build-in wait times and multiple attempts at asserting your tests in order
 to minimize the amount of false negatives / positives.
@@ -1077,7 +1077,7 @@ environment.
 parallel across multiple CI machines.
 
 With Cypress, your tests can be
-[parallelized on a per spec file basis](https://docs.cypress.io/cloud/features/smart-orchestration/parallelization).
+[parallelized on a per spec file basis](/cloud/features/smart-orchestration/parallelization).
 This is an important distinction between Protractor and Cypress parallelization.
 One of the reasons why Cypress parallelizes tests per file is because some users
 may write tests that build up state that subsequent tests, although we
@@ -1136,7 +1136,7 @@ to learn more.
 ### Recording test results to Cypress Cloud
 
 We recommend setting your
-[Cypress Cloud](https://docs.cypress.io/cloud/get-started/introduction) recording key
+[Cypress Cloud](/cloud/get-started/introduction) recording key
 as an environment variable and _NOT_ as a builder option when running it in CI.
 
 ```json

--- a/docs/app/references/changelog.mdx
+++ b/docs/app/references/changelog.mdx
@@ -759,7 +759,7 @@ Refer to the [v13 Migration Guide](/app/references/migration-guide#Migrating-to-
 
 **Features:**
 
-- Added [`--runner-ui`](/app/references/command-line#cypress-run-runner-ui) and [`--no-runner-ui`](https://docs.cypress.io/app/references/command-line#cypress-run-no-runner-ui) CLI flags to control whether the Cypress Runner UI is visible during a run. Addressed in [#27582](https://github.com/cypress-io/cypress/pull/27582).
+- Added [`--runner-ui`](/app/references/command-line#cypress-run-runner-ui) and [`--no-runner-ui`](/app/references/command-line#cypress-run-no-runner-ui) CLI flags to control whether the Cypress Runner UI is visible during a run. Addressed in [#27582](https://github.com/cypress-io/cypress/pull/27582).
 - Consolidates and improves terminal output when uploading test artifacts to Cypress Cloud. Addressed in [#27402](https://github.com/cypress-io/cypress/pull/27402)
 
 **Bugfixes:**


### PR DESCRIPTION
## Issue

Source links stored in `*.mdx` files with the published domain name `https://docs.cypress.io/...` are not portable and may produce unexpected results when testing locally under `localhost`.

Secondly, Docusaurus does not report errors for links with external domains, meaning errors may go undetected. It only checks local links.

### Missing target bookmarks

The following links resolve to a page, however the corresponding bookmark is missing from the page and so, when the link is used, the cursor is placed at the top of the page, leaving the reader to figure out what was intended:

- https://docs.cypress.io/faq/questions/cloud-faq#Is-everything-captured-and-replayed-in-Test-Replay resolves to https://docs.cypress.io/cloud/faq#Is-everything-captured-and-replayed-in-Test-Replay. The bookmark `Is-everything-captured-and-replayed-in-Test-Replay` is missing. This is logged as a separate issue https://github.com/cypress-io/cypress-documentation/issues/6054.
- https://docs.cypress.io/app/core-concepts/open-mode#Clicking-on-Commands. The bookmark `Clicking-on-Commands` is missing.

## Change

- Remove the external part of URLs in `*.mdx` file links containing `https://docs.cypress.io/...`

- Change https://docs.cypress.io/app/core-concepts/open-mode#Clicking-on-Commands to the internal link `/app/core-concepts/open-mode#Command-Log`
