### PR TITLE
Fix links to Test Replay and content limitations

### DIFF
--- a/docs/accessibility/core-concepts/how-it-works.mdx
+++ b/docs/accessibility/core-concepts/how-it-works.mdx
@@ -43,4 +43,4 @@ In rare cases - such as if an Axe Core® update contains a critical security pat
 
 ## Powered by Test Replay
 
-Because Cypress Accessibility uses data captured through Cypress Test Replay, it is subject [Test Replay limitations](https://docs.cypress.io/faq/questions/cloud-faq#Is-everything-captured-and-replayed-in-Test-Replay).
+Because Cypress Accessibility uses data captured through Cypress Test Replay, it is subject to Test Replay limitations. Read [How Test Replay Works](/cloud/features/test-replay#How-Test-Replay-Works) to discover which data is captured and which browsers are supported.

--- a/docs/ui-coverage/get-started/introduction.mdx
+++ b/docs/ui-coverage/get-started/introduction.mdx
@@ -54,4 +54,4 @@ UI Coverage captures "snapshots" of every page visited by your Cypress tests (an
 
 As a result, a UI Coverage score is generated. This score quantifies coverage across your application by measuring the ratio of the unique elements that have been tested to the total unique elements that are found across your application.
 
-Because Cypress Accessibility uses data captured through Cypress Test Replay, it is subject to any [limitations of Test Replay](https://docs.cypress.io/faq/questions/cloud-faq#Is-everything-captured-and-replayed-in-Test-Replay) data captured and browser support.
+Because Cypress UI Coverage uses data captured through Cypress Test Replay, it is subject to Test Replay limitations. Read [How Test Replay Works](/cloud/features/test-replay#How-Test-Replay-Works) to discover which data is captured and which browsers are supported.


### PR DESCRIPTION
- closes https://github.com/cypress-io/cypress-documentation/issues/6054

## Issue

The target https://docs.cypress.io/faq/questions/cloud-faq#Is-everything-captured-and-replayed-in-Test-Replay no longer exists and the contents were moved to https://docs.cypress.io/cloud/features/test-replay#What-is-not-captured.

It is used in:

- https://docs.cypress.io/accessibility/core-concepts/how-it-works#Powered-by-Test-Replay
  > Because Cypress Accessibility uses data captured through Cypress Test Replay, it is subject [Test Replay limitations](https://docs.cypress.io/faq/questions/cloud-faq#Is-everything-captured-and-replayed-in-Test-Replay).

- https://docs.cypress.io/ui-coverage/get-started/introduction#How-it-Works
  > Because Cypress Accessibility uses data captured through Cypress Test Replay, it is subject to any [limitations of Test Replay](https://docs.cypress.io/faq/questions/cloud-faq#Is-everything-captured-and-replayed-in-Test-Replay) data captured and browser support.

The above two references are inconsistent. The accessibility statement does not mention browser support. The UI Coverage statement confusingly refers to Accessibility instead of to UI Coverage.

  ## Change

Reword the restrictions notices in:

- `/docs/accessibility/core-concepts/how-it-works.mdx`
- `/docs/ui-coverage/get-started/introduction.mdx`

referring to the local location `/cloud/features/test-replay#How-Test-Replay-Works` and correcting the text appropriately.
