### PR TITLE
Correct error message infos for "auto-cancel-after-failures"

### DIFF
--- a/docs/app/references/error-messages.mdx
+++ b/docs/app/references/error-messages.mdx
@@ -851,7 +851,7 @@ regedit or gpedit.
 The `--auto-cancel-after-failures` flag is only available in Cypress 12.6.0 and
 later, and must be used with the `cypress run` command.
 
-### <Icon name="exclamation-triangle" color="red" /> --auto-cancel-after-failures must be a integer or false
+### <Icon name="exclamation-triangle" color="red" /> --auto-cancel-after-failures must be an integer or false
 
 You passed in an invalid value for the `--auto-cancel-after-failures` flag. It
 must be an integer or false.
@@ -869,8 +869,7 @@ Cancellation.
 You passed the `--auto-cancel-after-failures` flag, but this run originally
 started with a different value on this `--auto-cancel-after-failures` flag.
 
-The first setting of `--auto-cancel-after-failures` for any given run takes
-precedent.
+The first setting of `--auto-cancel-after-failures` for any given run takes precedence.
 
 ## Page Load Errors
 


### PR DESCRIPTION
## Issue

1. The error message heading [--auto-cancel-after-failures must be a integer or false](https://docs.cypress.io/app/references/error-messages#--auto-cancel-after-failures-must-be-a-integer-or-false) contains a grammatical typo "a integer".
2. The text for the error message [You passed the --auto-cancel-after-failures flag for a run that is already in progress](https://docs.cypress.io/app/references/error-messages#You-passed-the---auto-cancel-after-failures-flag-for-a-run-that-is-already-in-progress) contains a typo "takes precedent".

## Change

In the above error message sections:

1. Change the error message heading to read "--auto-cancel-after-failures must be an integer or false"
2. Change "takes precedent" to "takes precedence" (see https://www.merriam-webster.com/dictionary/precedence)
