### PR TITLE
Correct start-server-and-test code blocks

### DIFF
--- a/docs/app/continuous-integration/overview.mdx
+++ b/docs/app/continuous-integration/overview.mdx
@@ -105,13 +105,25 @@ module.
 
 <Tabs>
   <TabItem value="npm">
-    ```shell npm install start-server-and-test --save-dev ```
+
+    ```shell
+    npm install start-server-and-test --save-dev
+    ```
+
   </TabItem>
   <TabItem value="yarn">
-    ```shell yarn add start-server-and-test --dev ```
+
+    ```shell
+    yarn add start-server-and-test --dev
+    ```
+
   </TabItem>
   <TabItem value="pnpm">
-    ```shell pnpm add --save-dev start-server-and-test ```
+
+    ```shell
+    pnpm add --save-dev start-server-and-test
+    ```
+
   </TabItem>
 </Tabs>
 


### PR DESCRIPTION
## Issue

In [Continuous Integration > Overview > Solutions](https://docs.cypress.io/app/continuous-integration/overview#Solutions) there is a formatting error for `start-server-and-test` where the Markdown fenced block instruction `shell` appears as part of the command to be executed by the user.

## Change

Add newlines into the code blocks for `start-server-and-test` in [Continuous Integration > Overview > Solutions](https://docs.cypress.io/app/continuous-integration/overview#Solutions) to correct the formatting and to prevent Prettier from incorrectly reformatting the code blocks.