### PR TITLE
Add pnpm v10 install allowlist pnpm.onlyBuiltDependencies instructions

### DIFF
--- a/docs/app/get-started/install-cypress.mdx
+++ b/docs/app/get-started/install-cypress.mdx
@@ -23,7 +23,15 @@ First, make sure you have all the [system requirements](#System-requirements).
 
 ## Install
 
-Install Cypress via your preferred package manager. This will install Cypress locally as a dev dependency for your project. For pnpm, make sure that you have the `pnpm` environment installed: `npm install pnpm@latest --global`.
+Install Cypress via your preferred package manager. This will install Cypress locally as a dev dependency for your project.
+
+For `pnpm`, make sure that you have the `pnpm` environment installed.
+Use `npm install pnpm@latest --global` or refer to [pnpm installation](https://pnpm.io/installation) for alternate `pnpm` installation instructions.
+Starting with `pnpm` `v10` you must explicitly allow `pnpm` to execute the `postinstall` script of `cypress` to install the Cypress binary.
+See the [pnpm package.json](https://pnpm.io/package_json) documentation for
+[pnpm.onlyBuiltDependencies](https://pnpm.io/package_json#pnpmonlybuiltdependencies) or
+[pnpm.onlyBuiltDependenciesFile](https://pnpm.io/package_json#pnpmonlybuiltdependenciesfile)
+configuration options and use one of these to add `cypress` to the list of packages that are allowed to run install scripts.
 
 <CypressInstallCommands />
 


### PR DESCRIPTION
- closes https://github.com/cypress-io/cypress-documentation/issues/6069

## Issue

[pnpm@10.0.0](https://github.com/pnpm/pnpm/releases/tag/v10.0.0), released Jan 7, 2025 includes a breaking change:

> Lifecycle scripts of dependencies are not executed during installation by default!

`cypress` needs to be added to the allowlist for pnpm life cycle scripts in `package.json`, for instance using the following:

```json
  "pnpm": {
    "onlyBuiltDependencies": ["cypress"]
  }
```

## Change

The [installation instructions for Cypress with pnpm](https://docs.cypress.io/app/get-started/install-cypress#Install) are updated to include references to the pnpm documentation:

- [pnpm package.json](https://pnpm.io/package_json)
- [pnpm.onlyBuiltDependencies](https://pnpm.io/package_json#pnpmonlybuiltdependencies)
- [pnpm.onlyBuiltDependenciesFile](https://pnpm.io/package_json#pnpmonlybuiltdependenciesfile)

## Note

Currently, executing `npm install pnpm@latest --global` installs `pnpm@9`.

The [pnpm installation](https://pnpm.io/installation) document instructions for [using npm](https://pnpm.io/installation#using-npm) currently lists `npm install -g pnpm@latest-10` for `pnpm@10`.

According to the pnpm maintainer https://github.com/orgs/pnpm/discussions/8945#discussioncomment-11775139 this is for a temporary burn-in period. Sooner or later `pnpm@latest` will be equivalent to `pnpm@10.x`.