### PR TITLE
Add product headings to UI Cov guides

### DIFF
--- a/docs/ui-coverage/guides/address-coverage-gaps.mdx
+++ b/docs/ui-coverage/guides/address-coverage-gaps.mdx
@@ -5,6 +5,8 @@ description: 'Learn how to address test coverage gaps with Cypress UI Coverage t
 sidebar_position: 20
 ---
 
+<ProductHeading product="ui-coverage" />
+
 # Address coverage gaps
 
 After [identifying test coverage gaps](/ui-coverage/guides/identify-coverage-gaps) using Cypress UI Coverage, the next step is to address these gaps to ensure your application is comprehensively tested. This guide outlines best practices and strategies for improving coverage and closing the identified gaps effectively.

--- a/docs/ui-coverage/guides/identify-coverage-gaps.mdx
+++ b/docs/ui-coverage/guides/identify-coverage-gaps.mdx
@@ -5,6 +5,8 @@ description: 'Learn how to identify coverage gaps with Cypress UI Coverage to en
 sidebar_position: 10
 ---
 
+<ProductHeading product="ui-coverage" />
+
 # Identify coverage gaps
 
 Understanding your application's test coverage is crucial for ensuring quality and reliability. Cypress's UI Coverage tool provides insights into which parts of your application are tested and highlights untested areas. This guide will help you get started with UI Coverage to identify and address coverage gaps effectively.

--- a/docs/ui-coverage/guides/ignore-elements.mdx
+++ b/docs/ui-coverage/guides/ignore-elements.mdx
@@ -5,6 +5,8 @@ description: 'Learn how to exclude irrelevant elements from your UI Coverage rep
 sidebar_position: 50
 ---
 
+<ProductHeading product="ui-coverage" />
+
 # Ignore elements
 
 Not all elements in your application are relevant to your test coverage. Cypress UI Coverage allows you to exclude specific elements from coverage reports, helping you focus on meaningful insights and avoid unnecessary noise. This guide explains why and how to ignore elements in your UI Coverage reports.

--- a/docs/ui-coverage/guides/ignore-views-and-links.mdx
+++ b/docs/ui-coverage/guides/ignore-views-and-links.mdx
@@ -5,6 +5,8 @@ description: 'Learn how to exclude irrelevant views and links from your UI Cover
 sidebar_position: 40
 ---
 
+<ProductHeading product="ui-coverage" />
+
 # Ignore views and links
 
 Cypress UI Coverage provides detailed insights into test coverage, but not all views or links in your application are relevant to your test suite. By ignoring certain URLs, you can focus on meaningful coverage and streamline your reports. This guide explains why and how to ignore views and links in your UI Coverage reports.

--- a/docs/ui-coverage/guides/monitor-changes.mdx
+++ b/docs/ui-coverage/guides/monitor-changes.mdx
@@ -5,6 +5,8 @@ description: 'Learn how to monitor changes to your UI Coverage scores over time 
 sidebar_position: 70
 ---
 
+<ProductHeading product="ui-coverage" />
+
 # Monitor changes
 
 Monitoring changes to your UI Coverage scores over time ensures that regressions are identified and addressed before they are merged. Cypress UI Coverage provides tools to track these changes, enabling proactive quality assurance in your development workflow.

--- a/docs/ui-coverage/guides/reduce-noise.mdx
+++ b/docs/ui-coverage/guides/reduce-noise.mdx
@@ -5,6 +5,8 @@ description: 'Learn how to exclude irrelevant elements from your UI Coverage rep
 sidebar_position: 60
 ---
 
+<ProductHeading product="ui-coverage" />
+
 # Reduce noise
 
 A clean and focused UI Coverage report enables you to make informed decisions about your testing strategy. Cypress UI Coverage provides tools to reduce noise in your reports by properly grouping elements, special attribute handling, and grouping views that share common URL patterns. This guide explains how and why to create a streamlined report.

--- a/docs/ui-coverage/guides/reduce-test-duplication.mdx
+++ b/docs/ui-coverage/guides/reduce-test-duplication.mdx
@@ -5,6 +5,8 @@ description: 'Optimize your test suite by identifying and consolidating duplicat
 sidebar_position: 30
 ---
 
+<ProductHeading product="ui-coverage" />
+
 # Reduce test duplication
 
 Efficient test suites not only maximize coverage but also avoid redundant tests that slow down development and CI pipelines. Cypress UI Coverage provides insights into areas where elements have been tested multiple times, helping you optimize your test strategy and reduce duplication. This guide explains how to identify and address test duplication for streamlined and effective testing.


### PR DESCRIPTION
Add the new product heading since these guides went in after that was merged.

![Screenshot 2025-01-15 at 1 53 56 PM](https://github.com/user-attachments/assets/b21f431e-3bc0-4799-8f42-e18860ba97a6)
