### PR TITLE
a11y: Update tags on plugins to be lighter color in dark mode

### DIFF
--- a/src/components/plugins-list/style.module.css
+++ b/src/components/plugins-list/style.module.css
@@ -100,4 +100,8 @@ ul.pluginsList li p {
 .keyword {
   font-weight: 300;
   color: var(--ifm-color-gray-800);
+
+  html[data-theme='dark'] & {
+    color: var(--ifm-color-gray-100);
+  }
 }


### PR DESCRIPTION
Removes 405 elements from the color-contrast a11y violation. https://cloud.cypress.io/projects/imown1/branches/a11y-fixes-2/review?changeRequest=6080&insight=accessibility-failed-elements

#### Before

![Screenshot 2025-01-16 at 12 48 04 PM](https://github.com/user-attachments/assets/c8c2cefb-1826-4cb5-95d5-10856e346380)



#### AFter

![Screenshot 2025-01-16 at 12 48 24 PM](https://github.com/user-attachments/assets/91607821-6c75-4602-aa49-fd05574883cc)
