### PR TITLE
chore: make sure prettier doesnt run on these lines 

### DIFF
--- a/docs/app/references/migration-guide.mdx
+++ b/docs/app/references/migration-guide.mdx
@@ -48,15 +48,25 @@ Because of this, tests that visit more than one origin (defined as a composite o
 Without `cy.origin()`, interacting with a second origin in the same test will cause the test to fail, even if the two origins
 are in the same superdomain. This means you must now use `cy.origin()` in more situations than before.
 
-<Icon name="exclamation-triangle" color="red" /> **Failing Test** ```js cy.visit('https://www.cypress.io')
-cy.visit('https://docs.cypress.io') cy.get('[role="banner"]').should('be.visible')
-// Cypress will not be able to interact with the page, causing the test to fail ```
+{/* prettier-ignore-start */}
+<Icon name="exclamation-triangle" color="red" /> **Failing Test**
+```js 
+cy.visit('https://www.cypress.io')
+cy.visit('https://docs.cypress.io')
+// Cypress will not be able to interact with the page, causing the test to fail 
+cy.get('[role="banner"]').should('be.visible')
+```
 
-<Icon name="check-circle" color="green" /> **Fixed Test** ```js cy.visit('https://www.cypress.io')
-cy.visit('https://docs.cypress.io') cy.origin('https://docs.cypress.io', () => {cy
-  .get('[role="banner"]')
-  .should('be.visible')}
-) ```
+<Icon name="check-circle" color="green" /> **Fixed Test** 
+
+```js 
+cy.visit('https://www.cypress.io')
+cy.visit('https://docs.cypress.io')
+cy.origin('https://docs.cypress.io', () => {
+  cy.get('[role="banner"]').should('be.visible')
+}) 
+```
+{/* prettier-ignore-end */}
 
 :::info
 


### PR DESCRIPTION
prettier has a bit of a strange format on the migration guide. this PR is to fix this

### before
![Screenshot 2025-01-16 at 3 15 56 PM](https://github.com/user-attachments/assets/4f250ddc-8ac2-4925-9238-3fa45cc514f6)


### after
![Screenshot 2025-01-16 at 3 15 32 PM](https://github.com/user-attachments/assets/34854808-9b0d-4077-9dcc-fb7f53e1d6db)
