### PR TITLE
docs: Update notes for views/viewFilters config

### DIFF
--- a/docs/partials/_viewfilters.mdx
+++ b/docs/partials/_viewfilters.mdx
@@ -3,8 +3,9 @@ By default, every URL visited within a test run is included in reports. However,
 ## Why use view filters?
 
 :::info
-Note: setting `viewFilters` impacts both Accessibility and UI Coverage reports.
-This cannot be nested.
+**Note:** setting `viewFilters` impacts both Accessibility and UI Coverage reports.
+Nesting this property under an `accessibility` or `uiCoverage` key is
+supported, if you need to split them up.
 :::
 
 - **Exclude Third-Party URLs**: If your application integrates with third-party services, you might want to exclude their URLs from analysis.

--- a/docs/partials/_views.mdx
+++ b/docs/partials/_views.mdx
@@ -5,9 +5,8 @@ The `groupBy` property of a view definition allows you to create multiple views 
 ## Why use views?
 
 :::info
-**Note:** setting `views` impacts both Accessibility and UI Coverage reports.
-Nesting this property under an `accessibility` or `uiCoverage` key is
-supported, if you need to split them up.
+**Note**: setting `views` impacts both Accessibility and UI Coverage reports.
+This cannot be nested.
 :::
 
 - **Group Dynamic URLs**: Group URLs with dynamic path parameters (e.g., `/users/alice` and `/users/bob`) that are not ids or uuids into a single view.


### PR DESCRIPTION
These were flip-flopped - `viewFilters`, not `views`, are not configurable per-product.