### PR TITLE
Update Node.js instructions for version managers

### DIFF
--- a/docs/app/get-started/install-cypress.mdx
+++ b/docs/app/get-started/install-cypress.mdx
@@ -40,18 +40,6 @@ for the download of the Cypress binary. You can also use the npm properties
 they will only be used if the system properties are being resolved to not use a
 proxy.
 
-:::info
-
-<strong>snap</strong>
-
-The [Node.js Snap for Linux](https://github.com/nodejs/snap) package manager has constrained operating system access. Install using:
-
-```shell
-npm install cypress --save-dev --foreground-scripts
-```
-
-:::
-
 ### <Icon name="download" /> Direct download
 
 The recommended approach is to install Cypress with `npm` because:
@@ -131,17 +119,22 @@ Cypress generally aligns with
 
 Follow the instructions on [Download Node.js](https://nodejs.org/en/download/) to download and install [Node.js](https://nodejs.org/).
 
-If you are using a [Cypress Docker image](../continuous-integration/overview#Cypress-Docker-variants), you will find a fixed version of Node.js is pre-installed in the image.
-You select the Node.js version using the Docker image tag.
-
 :::tip
 
 <strong>Best Practice</strong>
 
-Use a [Node.js package manager](https://nodejs.org/en/download/package-manager/all) to install Node.js.
-Package managers for Node.js allow you to switch between different versions easily.
+Use a Node.js version manager as suggested on [Download Node.js](https://nodejs.org/en/download/) to install Node.js,
+or use an alternate Node.js version manager of your choice.
+This allows you to switch between different versions of Node.js easily.
+
+Note that the [Node.js Snap for Linux](https://github.com/nodejs/snap) version manager is not recommended for use with Cypress.
+Attempting to use it as a non-root user may result in permissions errors.
 
 :::
+
+If you are using a [Cypress Docker image](../continuous-integration/overview#Cypress-Docker-variants),
+you will find a fixed version of Node.js is pre-installed in the image.
+You select the Node.js version using the Docker image tag.
 
 ### Hardware
 


### PR DESCRIPTION
## Issue

[App > Get Started > Install Cypress > System requirements > Installing Node.js](https://docs.cypress.io/app/get-started/install-cypress#Installing-Nodejs) contains text:

> Best Practice
>
> Use a [Node.js package manager](https://nodejs.org/en/download/package-manager/all) to install Node.js. Package managers for Node.js allow you to switch between different versions easily.

The link to "Node.js package manager" https://nodejs.org/en/download/package-manager/all is no longer in use by the https://nodejs.org website and so its contents, which is a list of various Node.js version managers,  need to be regarded as no longer maintained even if the page is currently still visible. Its local language translations have all been deleted.

Node.js redesigned their [Download Node.js](https://nodejs.org/en/download/) landing page and no longer link to the list [Installing Node.js via Package Managers](https://nodejs.org/en/download/package-manager/all).

Instead, [Download Node.js](https://nodejs.org/en/download/) suggests using specific Node.js version managers depending on the target operating system (Windows, macOS or Linux).

The current suggestions from Node.js no longer include [Node.js Snap for Linux](https://github.com/nodejs/snap).

Node.js Snap for Linux is not suitable for use with Cypress due to its limited permissions. Several issues arise: Unless `node` is run as root with `sudo`, Cypress installation with npm fails. Global installation of pnpm fails. Corepack is not installed by default by the snap package, making it different to Node.js installations by other means. To remedy this and install Corepack manually requires root permissions.

## Change

- Remove the link on [App > Get Started > Install Cypress > System requirements > Installing Node.js](https://docs.cypress.io/app/get-started/install-cypress#Installing-Nodejs) to [Node.js package manager](https://nodejs.org/en/download/package-manager/all) and move the Best Practice section up on the page.

- Change the terms
  - "Node.js package manager" to "Node.js version manager"
  - "Node.js Snap for Linux package manager" to "Node.js Snap for Linux version manager"

  to align with the term change on the [Download Node.js](https://nodejs.org/en/download/) site.

- Recommend against using the [Node.js Snap for Linux](https://github.com/nodejs/snap) version manager

