### PR TITLE
Remove Linux OS and Node.js deprecation notes

### DIFF
--- a/docs/app/get-started/install-cypress.mdx
+++ b/docs/app/get-started/install-cypress.mdx
@@ -110,13 +110,11 @@ need prebuilt.
 
 Cypress supports running under these operating systems:
 
-- **macOS** 10.15 and above _(Intel or Apple Silicon 64-bit (x64 or arm64))_.
-- **Linux** Ubuntu 20.04 and above, Fedora 40 and above, and Debian 11 and above _(x64 or arm64)_ (see [Linux Prerequisites](#Linux-Prerequisites) down
-  below).
-  - Cypress deprecated the use of Node.js `16.x` in Cypress [`13.0.0`](/app/references/changelog#13-0-0). We recommend that users update to at least Node.js `18.x`.
-    For related reasons, Cypress deprecates the use of Linux operating systems with library [`glibc`](https://www.gnu.org/software/libc/) versions `2.17` - `2.27`. The Linux CLI command `ldd --version` displays your glibc version.
-- **Windows** 10 and above _(x64)_.
-- **Windows Server** 2019 and 2022 _(x64)_.
+- **macOS** 10.15 and above _(Intel or Apple Silicon 64-bit (x64 or arm64))_
+- **Linux** Ubuntu 20.04 and above, Fedora 40 and above, and Debian 11 and above _(x64 or arm64)_
+  (see [Linux Prerequisites](#Linux-Prerequisites) down below)
+- **Windows** 10 and above _(x64)_
+- **Windows Server** 2019 and 2022 _(x64)_
 
 ### Node.js
 
@@ -182,8 +180,6 @@ If you're using Linux, you'll want to have the required dependencies installed
 on your system. Depending on your system defaults, these dependencies may already be installed.
 If not, run the command line for your operating system listed below.
 See below under [Docker Prerequisites](#Docker-Prerequisites) for information on [Cypress Docker images](https://github.com/cypress-io/cypress-docker-images). These already include the necessary dependencies.
-
-It is worth noting that Cypress on Linux requires a minimum [`glibc`](https://www.gnu.org/software/libc/) version of `2.17`. This version is fixed as `glibc` is shipped with your operating system and cannot be changed.
 
 #### Ubuntu/Debian
 


### PR DESCRIPTION
## Issue

The Linux section of [App > Get Started > Install Cypress > System requirements > Operating System](https://docs.cypress.io/app/get-started/install-cypress#Operating-System) contains the following deprecation notices:

> - Cypress deprecated the use of Node.js `16.x` in Cypress [`13.0.0`](https://docs.cypress.io/app/references/changelog#13-0-0). We recommend that users update to at least Node.js `18.x`.
>    For related reasons, Cypress deprecates the use of Linux operating systems with library [`glibc`](https://www.gnu.org/software/libc/) versions `2.17` - `2.27`. The Linux CLI command `ldd --version` displays your glibc version.

With the release of [Cypress 14.0.0](https://docs.cypress.io/app/references/changelog#14-0-0) the deprecation notes are no longer necessary in this location as the information is now covered in the release notes. Leaving them here is likely to be confusing for readers, since Node.js `16.x` is not simply deprecated, it is now no longer supported.

Cypress documentation is not versioned and, apart from history lists, it only documents the latest major version of Cypress.

### Node.js min 18.x

1. [App > Get Started > Install Cypress > System requirements > Node.js](https://docs.cypress.io/app/get-started/install-cypress#Nodejs) lists a minimum of Node.js `18.x`
2. Release notes [Cypress 14.0.0 > Breaking Changes](https://docs.cypress.io/app/references/changelog#14-0-0) lists
    > Removed support for Node.js 16 and Node.js 21. Addresses [#29930](https://github.com/cypress-io/cypress/issues/29930).

### glib min 2.17

1. [App > Get Started > Install Cypress > System requirements > Linux Prerequisites](https://docs.cypress.io/app/get-started/install-cypress#Linux-Prerequisites) lists a minimum `glibc` >= `22.17`.
2. This is not consistent with a minimum of Node.js `18.x`. Node.js `18` requires a minimum of GLIBC `2.28` on `x64` Linux systems (see https://github.com/nodejs/node/blob/v18.0.0/BUILDING.md#unix-prerequisites). Node.js `18.0.0` and later versions output the error message and will not run:
  > node: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found (required by node)
3. See also note below where Cypress now requires `glibc` minimum `2.28`

### glibc min 2.28

1. The supported list of Linux operating systems under [App > Get Started > Install Cypress > System requirements > Operating System](https://docs.cypress.io/app/get-started/install-cypress#Operating-System) excludes versions which do not meet the minimum version requirement  `glibc` >= `22.28`
    > Ubuntu 20.04 and above, Fedora 40 and above, and Debian 11 and above
2. Release notes [Cypress 14.0.0 > Breaking Changes](https://docs.cypress.io/app/references/changelog#14-0-0) lists
    > Prebuilt binaries for Linux are no longer compatible with Linux distributions based on glibc `<2.28`, for example: Ubuntu 14-18, RHEL 7, CentOS 7, Amazon Linux 2. Addresses [#29601](https://github.com/cypress-io/cypress/issues/29601).

## Change

In the Linux section of [App > Get Started > Install Cypress > System requirements > Operating System](https://docs.cypress.io/app/get-started/install-cypress#Operating-System) remove the deprecation notices which are now covered in the [Cypress 14.0.0 > Breaking Changes](https://docs.cypress.io/app/references/changelog#14-0-0) release notes.

Remove the periods at the end of each operating system unordered list item to match formatting on the rest of the page for phrases which are not full sentences.

In the [App > Get Started > Install Cypress > System requirements > Linux Prerequisites](https://docs.cypress.io/app/get-started/install-cypress#Linux-Prerequisites) section, remove the outdated reference to `glibc` minimum of `22.17`.
