### PR TITLE
Remove example of disabling headless new

### DIFF
--- a/docs/api/node-events/browser-launch-api.mdx
+++ b/docs/api/node-events/browser-launch-api.mdx
@@ -394,27 +394,6 @@ on('before:browser:launch', (browser, options) => {
 
 :::
 
-### Disable `--headless=new` for Chrome
-
-Starting in Chrome 112, you can change the value of the `--headless` flag to the
-old value before the `--headless=new` flag was introduced.
-
-```ts
-on('before:browser:launch', (browser = {}, launchOptions) => {
-  if (browser.name === 'chrome' && browser.isHeadless) {
-    launchOptions.args = launchOptions.args.map((arg) => {
-      if (arg === '--headless=new') {
-        return '--headless'
-      }
-
-      return arg
-    })
-  }
-
-  return launchOptions
-})
-```
-
 ### Set a Firefox flag
 
 If we need to set a particular Firefox flag, like `browser.send_pings` we can do


### PR DESCRIPTION
In Chrome 132, Chrome completely removed the old `--headless` flag, so this workaround is no longer available to users.