### PR TITLE
electron33 doesn't support macOS 10.15

### DIFF
--- a/docs/app/get-started/install-cypress.mdx
+++ b/docs/app/get-started/install-cypress.mdx
@@ -103,7 +103,7 @@ need prebuilt.
 
 Cypress supports running under these operating systems:
 
-- **macOS** 10.15 and above _(Intel or Apple Silicon 64-bit (x64 or arm64))_
+- **macOS** 11 and above _(Intel or Apple Silicon 64-bit (x64 or arm64))_
 - **Linux** Ubuntu 20.04 and above, Fedora 40 and above, and Debian 11 and above _(x64 or arm64)_
   (see [Linux Prerequisites](#Linux-Prerequisites) down below)
 - **Windows** 10 and above _(x64)_


### PR DESCRIPTION
https://www.electronjs.org/blog/electron-33-0#removed-macos-1015-support

Cypress 14 includes Electron 33