### PR TITLE
chore: add the cypress 14.0.3 changelog

### DIFF
--- a/docs/app/references/changelog.mdx
+++ b/docs/app/references/changelog.mdx
@@ -8,6 +8,19 @@ sidebar_label: Changelog
 
 # Changelog
 
+## 14.0.3
+
+_Released 2/11/2025_
+
+**Bugfixes:**
+
+- Fixed an issue in Cypress [`14.0.2`](#14-0-2) where privileged commands did not run correctly when a spec file or support file contained certain encoded characters. Fixes [#31034](https://github.com/cypress-io/cypress/issues/31034) and [#31060](https://github.com/cypress-io/cypress/issues/31060).
+
+**Dependency Updates:**
+
+- Upgraded `@cypress/request` from `3.0.6` to `3.0.7`. Addressed in [#31063](https://github.com/cypress-io/cypress/pull/31063).
+- Upgraded `compression` from `1.7.4` to `1.7.5`. Addressed in [#31004](https://github.com/cypress-io/cypress/pull/31004).
+
 ## 14.0.2
 
 _Released 2/05/2025_


### PR DESCRIPTION
Adds the Cypress `14.0.3` changelog