### PR TITLE
Add cypress-laravel plugin

### DIFF
--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -52,7 +52,14 @@
           "link": "https://github.com/mammadataei/cypress-vite",
           "keywords": ["vite"],
           "badge": "community"
-        }
+        },
+        {
+          "name": "cypress-laravel",
+          "description": "Add commands and hooks to test Laravel applications.",
+          "link": "https://github.com/noeldemartin/cypress-laravel",
+          "keywords": ["php", "laravel"],
+          "badge": "community"
+        },
       ]
     },
     {

--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -59,7 +59,7 @@
           "link": "https://github.com/noeldemartin/cypress-laravel",
           "keywords": ["php", "laravel"],
           "badge": "community"
-        },
+        }
       ]
     },
     {


### PR DESCRIPTION
I had already registered this plugin in #2250, but it was removed without my knowledge in #5946.

I also realized it had been marked as "deprecated" before, also without my knowledge. I suppose it was marked as such because it had Cypress 3 as a dependency, but that's something [I fixed 3 months ago](https://github.com/NoelDeMartin/cypress-laravel/releases/tag/v0.3.0). Would have fixed it sooner if anyone bothered to open an issue about it in my repo :).