### PR TITLE
chore: add firefox webdriver bidi docs

### DIFF
--- a/docs/api/cypress-api/browser.mdx
+++ b/docs/api/cypress-api/browser.mdx
@@ -19,18 +19,18 @@ Cypress.browser // returns browser object
 
 The object has the following properties:
 
-| Property       | Type      | Description                                                           |
-| -------------- | --------- | --------------------------------------------------------------------- |
-| `channel`      | `string`  | Release channel of the browser, such as `stable`, `dev`, or `canary`. |
-| `displayName`  | `string`  | Human-readable display name for the browser.                          |
-| `family`       | `string`  | Rendering engine being used. `chromium` or `firefox`.                 |
-| `isChosen`     | `boolean` | Whether the browser is selected in the browser selector of Cypress.   |
-| `majorVersion` | `number`  | The major version number of the browser.                              |
-| `name`         | `string`  | Machine-friendly name, like `chrome`, `electron`, or `firefox`.       |
-| `path`         | `string`  | Path to the browser on disk. Blank for Electron.                      |
-| `version`      | `string`  | Full version.                                                         |
-| `isHeadless`   | `boolean` | Whether the browser is running headlessly.                            |
-| `isHeaded`     | `boolean` | Whether the browser displays headed.                                  |
+| Property       | Type                 | Description                                                           |
+| -------------- | -------------------- | --------------------------------------------------------------------- |
+| `channel`      | `string`             | Release channel of the browser, such as `stable`, `dev`, or `canary`. |
+| `displayName`  | `string`             | Human-readable display name for the browser.                          |
+| `family`       | `string`             | Rendering engine being used. `chromium` or `firefox`.                 |
+| `isChosen`     | `boolean`            | Whether the browser is selected in the browser selector of Cypress.   |
+| `majorVersion` | `number` \| `string` | The major version number of the browser.                              |
+| `name`         | `string`             | Machine-friendly name, like `chrome`, `electron`, or `firefox`.       |
+| `path`         | `string`             | Path to the browser on disk. Blank for Electron.                      |
+| `version`      | `string`             | Full version.                                                         |
+| `isHeadless`   | `boolean`            | Whether the browser is running headlessly.                            |
+| `isHeaded`     | `boolean`            | Whether the browser displays headed.                                  |
 
 ## Examples
 

--- a/docs/api/cypress-api/isbrowser.mdx
+++ b/docs/api/cypress-api/isbrowser.mdx
@@ -38,17 +38,17 @@ Filter one or multiple browsers by the browser properties. You can inspect the
 current browser's properties by using the
 [Cypress.browser](/api/cypress-api/browser). Supported properties are:
 
-| Property       | Type      | Description                                                           |
-| -------------- | --------- | --------------------------------------------------------------------- |
-| `name`         | `string`  | Machine-friendly name, like `chrome`, `electron`, or `firefox`.       |
-| `family`       | `string`  | Rendering engine being used. `chromium` or `firefox`.                 |
-| `channel`      | `string`  | Release channel of the browser, such as `stable`, `dev`, or `canary`. |
-| `displayName`  | `string`  | Human-readable display name for the browser.                          |
-| `version`      | `string`  | Full version.                                                         |
-| `path`         | `string`  | Path to the browser on disk. Blank for Electron.                      |
-| `majorVersion` | `number`  | The major version number of the browser.                              |
-| `isHeadless`   | `boolean` | Whether the browser is running headlessly.                            |
-| `isHeaded`     | `boolean` | Whether the browser displays headed.                                  |
+| Property       | Type                 | Description                                                           |
+| -------------- | -------------------- | --------------------------------------------------------------------- |
+| `name`         | `string`             | Machine-friendly name, like `chrome`, `electron`, or `firefox`.       |
+| `family`       | `string`             | Rendering engine being used. `chromium` or `firefox`.                 |
+| `channel`      | `string`             | Release channel of the browser, such as `stable`, `dev`, or `canary`. |
+| `displayName`  | `string`             | Human-readable display name for the browser.                          |
+| `version`      | `string`             | Full version.                                                         |
+| `path`         | `string`             | Path to the browser on disk. Blank for Electron.                      |
+| `majorVersion` | `number` \| `string` | The major version number of the browser.                              |
+| `isHeadless`   | `boolean`            | Whether the browser is running headlessly.                            |
+| `isHeaded`     | `boolean`            | Whether the browser displays headed.                                  |
 
 ## Examples
 

--- a/docs/app/references/launching-browsers.mdx
+++ b/docs/app/references/launching-browsers.mdx
@@ -194,7 +194,10 @@ Firefox headed, you can pass the `--headed` argument to `cypress run`.
 
 :::info
 
-Since Firefox 129, Chrome DevTools Protocol (CDP) has been [deprecated in Firefox](https://fxdx.dev/deprecating-cdp-support-in-firefox-embracing-the-future-with-webdriver-bidi/). Cypress will default to automating the Firefox browser with WebDriver BiDi in Firefox 135. Cypress will no longer support CDP within Firefox in the future. Cypress CDP support within Firefox is planned to be removed in Cypress 15.
+Since Firefox 129, Chrome DevTools Protocol (CDP) has been [deprecated in Firefox](https://fxdx.dev/deprecating-cdp-support-in-firefox-embracing-the-future-with-webdriver-bidi/).
+In Firefox 135 and above, Cypress defaults to automating the Firefox browser with WebDriver BiDi.
+Cypress will no longer support CDP within Firefox in the future.
+Cypress CDP support within Firefox is planned to be removed in Cypress 15.
 
 If CDP still needs to be used, you can force enablement via the `FORCE_FIREFOX_CDP=1` environment variable, regardless of Firefox version. For example:
 

--- a/docs/app/references/launching-browsers.mdx
+++ b/docs/app/references/launching-browsers.mdx
@@ -190,6 +190,20 @@ of our [docker images](/app/continuous-integration/overview#Cypress-Docker-Image
 By default, we will launch Firefox headlessly during `cypress run`. To run
 Firefox headed, you can pass the `--headed` argument to `cypress run`.
 
+##### Webdriver BiDi and CDP Deprecation
+
+:::info
+
+Since Firefox 129, Chrome DevTools Protocol (CDP) has been [deprecated in Firefox](https://fxdx.dev/deprecating-cdp-support-in-firefox-embracing-the-future-with-webdriver-bidi/). Cypress will default to automating the Firefox browser with WebDriver BiDi in Firefox 135. Cypress will no longer support CDP within Firefox in the future. Cypress CDP support within Firefox is planned to be removed in Cypress 15.
+
+If CDP still needs to be used, you can force enablement via the `FORCE_FIREFOX_CDP=1` environment variable, regardless of Firefox version. For example:
+
+```bash
+FORCE_FIREFOX_CDP=1 npx cypress run --browser firefox
+```
+
+:::
+
 ### WebKit (Experimental)
 
 Cypress has [experimental](/app/references/experiments) support for WebKit,

--- a/docs/app/references/launching-browsers.mdx
+++ b/docs/app/references/launching-browsers.mdx
@@ -196,8 +196,7 @@ Firefox headed, you can pass the `--headed` argument to `cypress run`.
 
 Since Firefox 129, Chrome DevTools Protocol (CDP) has been [deprecated in Firefox](https://fxdx.dev/deprecating-cdp-support-in-firefox-embracing-the-future-with-webdriver-bidi/).
 In Firefox 135 and above, Cypress defaults to automating the Firefox browser with WebDriver BiDi.
-Cypress will no longer support CDP within Firefox in the future.
-Cypress CDP support within Firefox is planned to be removed in Cypress 15.
+Cypress will no longer support CDP within Firefox in the future and is planned for removal in Cypress 15.
 
 If CDP still needs to be used, you can force enablement via the `FORCE_FIREFOX_CDP=1` environment variable, regardless of Firefox version. For example:
 


### PR DESCRIPTION
adds docs around using firefox webdriver BiDi and CDP deprecation, as well as how to enable CDP if completely necessary. 