### PR TITLE
Add "log" option to hide displayed log of cy.origin()

### DIFF
--- a/docs/api/commands/origin.mdx
+++ b/docs/api/commands/origin.mdx
@@ -123,6 +123,7 @@ Pass in an options object to control the behavior of `cy.origin()`.
 | option | description                                                                                                                                                                                                    |
 | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | args   | Plain JavaScript object which will be serialized and sent from the primary origin to the secondary origin, where it will be deserialized and passed into the callback function as its first and only argument. |
+| log    | (default `true`) Displays the command in the [Command log](/app/core-concepts/open-mode#Command-Log)                                                                                                                            |
 
 :::caution
 


### PR DESCRIPTION
This is the updated `cy.origin()` API documentation relative to the new `log: boolean` option added in this Cypress PR:  https://github.com/cypress-io/cypress/pull/31114