### PR TITLE
Add Plugins: cypress-plugin-grep-boxes & cypress-cli-select

### DIFF
--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -147,11 +147,25 @@
           "keywords": ["auditory", "ui", "results", "duration"],
           "badge": "community"
         },
-        {
+      {
           "name": "cypress-plugin-last-failed",
-          "description": "A companion Cypress plugin for `cy-grep` that re-runs the last failed test(s).",
+          "description": "A companion Cypress plugin for `cy-grep` that re-runs the last failed test(s).",
           "link": "https://github.com/dennisbergevin/cypress-plugin-last-failed",
           "keywords": ["grep", "ui", "failure", "results"],
+          "badge": "community"
+        },
+        {
+          "name": "cypress-plugin-grep-boxes",
+          "description": "A companion Cypress plugin for `cy-grep` that allows users to run specific test(s) in open mode.",
+          "link": "https://github.com/dennisbergevin/cypress-plugin-grep-boxes",
+          "keywords": ["grep", "ui"],
+          "badge": "community"
+        },
+        {
+          "name": "cypress-cli-select",
+          "description": "Cypress interactive cli prompt to select and run specific specs, tests or tags",
+          "link": "https://github.com/dennisbergevin/cypress-cli-select",
+          "keywords": ["grep", "cli", "tags"],
           "badge": "community"
         },
         {

--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -147,7 +147,7 @@
           "keywords": ["auditory", "ui", "results", "duration"],
           "badge": "community"
         },
-      {
+        {
           "name": "cypress-plugin-last-failed",
           "description": "A companion Cypress plugin for `cy-grep` that re-runs the last failed test(s).",
           "link": "https://github.com/dennisbergevin/cypress-plugin-last-failed",


### PR DESCRIPTION
Adding two new, fantastic plugins that support expanded grep/test select functionality. 

- [cypress-plugin-grep-boxes](https://github.com/dennisbergevin/cypress-plugin-grep-boxes)
- [cypress-cli-select-plugins](https://github.com/dennisbergevin/cypress-cli-select)

@dennisbergevin 