### PR TITLE
Remove link to obsolete yarn-cypress-cache example repo

### DIFF
--- a/docs/app/continuous-integration/overview.mdx
+++ b/docs/app/continuous-integration/overview.mdx
@@ -646,11 +646,6 @@ following:
    to your CI script. If there is a binary already present, it should finish
    quickly.
 
-See
-[bahmutov/yarn-cypress-cache](https://github.com/bahmutov/yarn-cypress-cache)
-for an example that runs the `npx cypress install` command to ensure the Cypress
-binary is always present before the tests begin.
-
 ### Xvfb
 
 When running on Linux, Cypress needs an X11 server; otherwise it spawns its own


### PR DESCRIPTION
## Issue

In [Continuous Integration > Common problems and solutions > Missing binary](https://docs.cypress.io/app/continuous-integration/overview#Missing-binary) the linked example:

https://github.com/bahmutov/yarn-cypress-cache

is obsolete and fails to run. It was last updated 6 years ago in Nov 2019.

- The example is based on the legacy Cypress `3.6.1` version
- The action versions are outdated and are no longer available
- The application under test http://todomvc.com/examples/vue/ no longer exists and has moved to a different page
- The example CI is Travis and the build status https://travis-ci.org/bahmutov/yarn-cypress-cache no longer exists

## Change

Remove the paragraph from the [Continuous Integration > Common problems and solutions > Missing binary](https://docs.cypress.io/app/continuous-integration/overview#Missing-binary) section that refers to the obsolete example:

> See [bahmutov/yarn-cypress-cache](https://github.com/bahmutov/yarn-cypress-cache) for an example that runs the npx cypress install command to ensure the Cypress binary is always present before the tests begin.