### PR TITLE
docs: Update shadow query command to correct command signature

### DIFF
--- a/docs/api/commands/shadow.mdx
+++ b/docs/api/commands/shadow.mdx
@@ -34,6 +34,17 @@ cy.exec('npm start').shadow() // Errors, 'exec' does not yield DOM element
 cy.get('.not-a-shadow-host').shadow() // Errors, subject must host a shadow root
 ```
 
+### Arguments
+
+<Icon name="angle-right" /> **options _(Object)_**
+
+Pass in an options object to change the default behavior of `.shadow()`.
+
+| Option             | Default                                                                        | Description                                                                                                  |
+| ------------------ | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
+| `log`              | `true`                                                                         | Displays the command in the [Command log](/app/core-concepts/open-mode#Command-Log)                          |
+| `timeout`          | [`defaultCommandTimeout`](/app/references/configuration#Timeouts)              | Time to wait for `cy.get()` to resolve before [timing out](#Timeouts)                                        |
+
 <HeaderYields />
 
 - `.shadow()` yields the new DOM element(s) it found.

--- a/docs/api/commands/shadow.mdx
+++ b/docs/api/commands/shadow.mdx
@@ -40,10 +40,10 @@ cy.get('.not-a-shadow-host').shadow() // Errors, subject must host a shadow root
 
 Pass in an options object to change the default behavior of `.shadow()`.
 
-| Option             | Default                                                                        | Description                                                                                                  |
-| ------------------ | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
-| `log`              | `true`                                                                         | Displays the command in the [Command log](/app/core-concepts/open-mode#Command-Log)                          |
-| `timeout`          | [`defaultCommandTimeout`](/app/references/configuration#Timeouts)              | Time to wait for `cy.get()` to resolve before [timing out](#Timeouts)                                        |
+| Option    | Default                                                           | Description                                                                         |
+| --------- | ----------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| `log`     | `true`                                                            | Displays the command in the [Command log](/app/core-concepts/open-mode#Command-Log) |
+| `timeout` | [`defaultCommandTimeout`](/app/references/configuration#Timeouts) | Time to wait for `cy.get()` to resolve before [timing out](#Timeouts)               |
 
 <HeaderYields />
 

--- a/docs/api/commands/shadow.mdx
+++ b/docs/api/commands/shadow.mdx
@@ -14,8 +14,8 @@ Traverse into the shadow DOM of an element.
 ## Syntax
 
 ```javascript
-.shadow(selector)
-.shadow(selector, options)
+.shadow()
+.shadow(options)
 ```
 
 ### Usage


### PR DESCRIPTION
This signature is just...wrong. I looked at the implementation. The .shadow command does not accept a selector.

Also added the options that are supported.