### PR TITLE
Remove stranded legacy plugin links

### DIFF
--- a/docs/api/node-events/overview.mdx
+++ b/docs/api/node-events/overview.mdx
@@ -233,7 +233,7 @@ You can use the `task` event to do things like:
 ## Execution context
 
 The [`setupNodeEvents`](/app/references/configuration#setupNodeEvents)
-function (or deprecated [plugins file][legacypluginsfile] function) is invoked
+function is invoked
 when Cypress opens a project.
 
 Cypress does this by spawning an independent `child_process` which then
@@ -246,7 +246,7 @@ This code will be executed using the Node version that launched Cypress.
 
 When Cypress executes the
 [`setupNodeEvents`](/app/references/configuration#setupNodeEvents) function
-(or deprecated [plugins file][legacypluginsfile] function) it will execute with
+it will execute with
 `process.cwd()` set to your project's path. Additionally - you will be able to
 `require` **any node module** you have installed, including local files inside
 your project.
@@ -289,7 +289,7 @@ itself runs in. That means you cannot accidentally modify or change Cypress's
 own execution in any way.
 
 If your [`setupNodeEvents`](/app/references/configuration#setupNodeEvents)
-function (or deprecated [plugins file][legacypluginsfile] function) has an
+function has an
 uncaught exception, an unhandled rejection from a promise, or a syntax error -
 Cypress will automatically catch those and display them to you inside of the
 console and even in Cypress itself.


### PR DESCRIPTION
## Issue

[API > Node Events Overview](https://docs.cypress.io/api/node-events/overview) refers to a missing markdown link to deleted documentation `[legacypluginsfile]`

## Change

Remove obsolete references to legacy configurations. This documentation is no longer available.