### PR TITLE
chore: add documentation on recommended TypeScript sourcemap option

### DIFF
--- a/docs/api/node-events/overview.mdx
+++ b/docs/api/node-events/overview.mdx
@@ -141,7 +141,7 @@ You can use the `file:preprocessor` event to do things like:
 - Write your test code in ClojureScript.
 - Customize the Babel settings to add your own plugins.
 - Customize the options for compiling TypeScript.
-- Swap out webpack for Browserify or anything else.
+- Swap out Webpack for Vite or anything else.
 
 Check out our [File Preprocessor API docs](/api/node-events/preprocessors-api) which
 describe how to use this event.

--- a/docs/app/tooling/typescript-support.mdx
+++ b/docs/app/tooling/typescript-support.mdx
@@ -63,6 +63,7 @@ with the following configuration:
   "compilerOptions": {
     "target": "es5",
     "lib": ["es5", "dom"],
+    "sourceMap": true,
     "types": ["cypress", "node"]
   },
   "include": ["**/*.ts"]

--- a/docs/partials/_source-maps.mdx
+++ b/docs/partials/_source-maps.mdx
@@ -27,3 +27,8 @@ source maps are enabled to get the same experience. Some examples of this includ
     option: `prettySourceMaps`, but this option is buggy and setting source maps on the esbuild
     bundler directly works better.
   - The other bundlers all default their source maps appropriately.
+
+If using [TypeScript](https://www.typescriptlang.org/) with any custom preprocessor, you will want to make sure that the [TypeScript](https://www.typescriptlang.org/)
+compiler is generating source maps. This can be done by setting the [`sourceMap`](https://www.typescriptlang.org/tsconfig/#sourceMap) option in your
+`tsconfig.json` to `true`. The [`inlineSourceMap`](https://www.typescriptlang.org/tsconfig/#inlineSourceMap) option is **not** recommended as it does not provide an accurate code frame.
+Please see our recommended [tsconfig.json](/app/tooling/typescript-support#Configure-tsconfigjson) as a reference.


### PR DESCRIPTION
Adds documentation on letting users know that the `sourceMap` option should be set to `true` for TypeScript if using a custom preprocessor