### PR TITLE
Make macOS 11 minimum supported OS version

### DIFF
--- a/docs/app/get-started/install-cypress.mdx
+++ b/docs/app/get-started/install-cypress.mdx
@@ -103,7 +103,7 @@ need prebuilt.
 
 Cypress supports running under these operating systems:
 
-- **macOS** 10.15 and above _(Intel or Apple Silicon 64-bit (x64 or arm64))_
+- **macOS** 11 and above _(Intel or Apple Silicon 64-bit (x64 or arm64))_
 - **Linux** Ubuntu 20.04 and above, Fedora 40 and above, and Debian 11 and above _(x64 or arm64)_
   (see [Linux Prerequisites](#Linux-Prerequisites) down below)
 - **Windows** 10 and above _(x64)_

--- a/docs/app/references/migration-guide.mdx
+++ b/docs/app/references/migration-guide.mdx
@@ -33,6 +33,13 @@ This support is in line with Node.js's support for Linux in 18+.
 If you're using a Linux distribution based on glibc `<2.28`, for example, Ubuntu 14-18, RHEL 7, CentOS 7, Amazon Linux 2, you'll need to
 update your system to a newer version to install Cypress 14+.
 
+### Minimum macOS 11 (Big Sur)
+
+[Cypress 14.0](/app/references/changelog#14-0-0) upgrades Electron to `33.2.1`.
+On macOS this requires a minimum version of macOS 11 (Big Sur).
+
+If you're using a lower version of macOS make sure that you update.
+
 ### Updated Browser Support
 
 Starting in Cypress 14, Cypress will officially support [the latest 3 major versions of Chrome, Firefox, and Edge](/app/references/launching-browsers#Browser-versions-supported).
@@ -50,21 +57,21 @@ are in the same superdomain. This means you must now use `cy.origin()` in more s
 
 {/* prettier-ignore-start */}
 <Icon name="exclamation-triangle" color="red" /> **Failing Test**
-```js 
+```js
 cy.visit('https://www.cypress.io')
 cy.visit('https://docs.cypress.io')
-// Cypress will not be able to interact with the page, causing the test to fail 
+// Cypress will not be able to interact with the page, causing the test to fail
 cy.get('[role="banner"]').should('be.visible')
 ```
 
-<Icon name="check-circle" color="green" /> **Fixed Test** 
+<Icon name="check-circle" color="green" /> **Fixed Test**
 
-```js 
+```js
 cy.visit('https://www.cypress.io')
 cy.visit('https://docs.cypress.io')
 cy.origin('https://docs.cypress.io', () => {
   cy.get('[role="banner"]').should('be.visible')
-}) 
+})
 ```
 {/* prettier-ignore-end */}
 


### PR DESCRIPTION
## Situation

[cypress@14.0.0](https://docs.cypress.io/app/references/changelog#14-0-0) updated to `electron@33.2.1`

```text
$ npx cypress version
Cypress package version: 14.2.0
Cypress binary version: 14.2.0
Electron version: 33.2.1
Bundled Node version:
20.18.1
```

https://www.electronjs.org/docs/latest/breaking-changes#removed-macos-1015-support says:

![image](https://github.com/user-attachments/assets/84dd360f-43b3-48c6-8fed-5642c0c4e591)

https://www.electronjs.org/docs/latest/tutorial/electron-timelines lists Electron 33.0.0 as the lowest version supported.

![image](https://github.com/user-attachments/assets/fafa3c76-7b45-4f09-8e76-40dc7b96aee5)

https://docs.cypress.io/app/get-started/install-cypress#Operating-System needs to be updated to the reflect the above:

![image](https://github.com/user-attachments/assets/8a92edaf-ad3a-4320-91b2-e52f784de7fb)

## Change

- Make macOS 11 (Big Sur) the minimum version on https://github.com/cypress-io/cypress-documentation/blob/main/docs/app/get-started/install-cypress.mdx
- Add a section to https://github.com/cypress-io/cypress-documentation/blob/main/docs/app/references/migration-guide.mdx to describe that macOS 10.15 (Catalina) is no longer supported