### PR TITLE
Add Firefox to Linux/arm64 CI Cypress Docker usage

### DIFF
--- a/docs/app/continuous-integration/overview.mdx
+++ b/docs/app/continuous-integration/overview.mdx
@@ -260,8 +260,11 @@ Cypress Docker images are available from:
 - [cypress/browsers](https://github.com/cypress-io/cypress-docker-images/tree/master/browsers) builds on the
   [cypress/base](https://github.com/cypress-io/cypress-docker-images/tree/master/base) image.
   For `Linux/amd64` images it adds **Chrome**, **Firefox** and **Edge** browsers.
+  For `Linux/arm64` images it adds only **Firefox** browsers from version `136.0.2` and above.
+  Chrome and Edge browsers are currently not available for `Linux/arm64`.
   A corresponding image `<tag>` allows selection of the combined Node.js and browser versions.
-  (Currently `Linux/arm64` images do **not** contain browsers.)
+  The version tags for the unavailable Chrome and Edge browsers on the `Linux/arm64` platform are empty place-holders only,
+  required for multi-platform support compatibility.
 
 - [cypress/included](https://github.com/cypress-io/cypress-docker-images/tree/master/included) builds on the
   [cypress/browsers](https://github.com/cypress-io/cypress-docker-images/tree/master/browsers) image.


### PR DESCRIPTION
## Situation

Cypress Docker images for the `Linux/arm64` platform include Firefox >= `136.0.2` , see [cypress-io/cypress-docker-images > README](https://github.com/cypress-io/cypress-docker-images/blob/master/README.md#browsers):

- `cypress/browsers:node-22.14.0-chrome-134.0.6998.88-1-ff-136.0.2-edge-134.0.3124.68-1`
- `cypress/included:cypress-14.2.0-node-22.14.0-chrome-134.0.6998.88-1-ff-136.0.2-edge-134.0.3124.68-1`

[Continuous Integration > Cypress Docker Images > Cypress Docker Variants](https://docs.cypress.io/app/continuous-integration/overview#Cypress-Docker-variants) is now outdated, as it states:

> Currently Linux/arm64 images do not contain browsers.

## Change

Modify the text in https://github.com/cypress-io/cypress-documentation/blob/main/docs/app/continuous-integration/overview.mdx#cypress-docker-variants to introduce Firefox 136.0.2 and above to `cypress/browsers` and thus also to `cypress/included` Cypress Docker images.
