### PR TITLE
Remove mention of iframe support being on our current roadmap

### DIFF
--- a/docs/api/commands/origin.mdx
+++ b/docs/api/commands/origin.mdx
@@ -555,9 +555,6 @@ There are other testing scenarios which are not currently covered by
 - It cannot run commands
   [inside an `<iframe>` element](/app/faq#How-do-I-test-elements-inside-an-iframe)
 
-However, `<iframe>` support is on [our roadmap](/app/references/roadmap) for
-inclusion in a future version of Cypress.
-
 ## History
 
 | Version                                     | Changes                                                                                                     |


### PR DESCRIPTION
This was added a while ago. Our actual Roadmap page reflects reality - that we can update as priorities change.