### PR TITLE
chore: add Cypress 14.2.1 changelog

### DIFF
--- a/docs/app/references/changelog.mdx
+++ b/docs/app/references/changelog.mdx
@@ -8,6 +8,29 @@ sidebar_label: Changelog
 
 # Changelog
 
+## 14.2.1
+
+_Released 3/26/2025_
+
+**Bugfixes:**
+
+- Applies a fix from [#30730](https://github.com/cypress-io/cypress/pull/30730) and [#30099](https://github.com/cypress-io/cypress/pull/30099) related to Node.js turning on ESM flags by default in Node.js version `20.19.0`. Fixed in [#31308](https://github.com/cypress-io/cypress/pull/31308).
+- Fixed an issue where Firefox BiDi was not correctly removing prerequests on expected network request failures. Fixes [#31325](https://github.com/cypress-io/cypress/issues/31325).
+- Fixed an issue in `@cypress/webpack-batteries-included-preprocessor` and `@cypress/webpack-preprocessor` where sourceMaps were not being set correctly in TypeScript 5. This should now make error code frames accurate for TypeScript 5 users. Fixes [#29614](https://github.com/cypress-io/cypress/issues/29614).
+
+**Misc:**
+
+- The UI above the application under test now displays in dark mode. Addresses [#31106](https://github.com/cypress-io/cypress/issues/31106). Addressed in [#31360](https://github.com/cypress-io/cypress/pull/31360).
+
+**Dependency Updates:**
+
+- Upgraded `@cypress/request` from `3.0.7` to `3.0.8`. Addressed in [#31311](https://github.com/cypress-io/cypress/pull/31311).
+- Upgraded `cross-fetch` from `3.1.8` to `4.1.0`. Addressed in [#31327](https://github.com/cypress-io/cypress/pull/31327).
+- Upgraded `micromatch` from `4.0.6` to `4.0.8`. Addressed in [#31330](https://github.com/cypress-io/cypress/pull/31330).
+- Upgraded `resolve` from `1.17.0` to `1.22.10`. Addressed in [#31333](https://github.com/cypress-io/cypress/pull/31333).
+- Upgraded `semver` from `7.5.3` to `7.7.1`. Addressed in [#31341](https://github.com/cypress-io/cypress/pull/31341).
+- Upgraded `systeminformation` from `5.21.7` to `5.22.8`. Addressed in [#31281](https://github.com/cypress-io/cypress/pull/31281).
+
 ## 14.2.0
 
 _Released 3/12/2025_


### PR DESCRIPTION
Adds release `14.2.1` to the app changelog