### PR TITLE
feat: (ui-coverage) add examples for protocol-agnostic views and viewFilters

### DIFF
--- a/docs/partials/_viewfilters.mdx
+++ b/docs/partials/_viewfilters.mdx
@@ -137,3 +137,32 @@ https://cypress.io/error/500
 ```
 https://cypress.io/home
 ```
+
+### Excluding URLs regardless of protocol
+
+#### Config
+
+```json
+{
+  "viewFilters": [
+    {
+      "pattern": "localhost:8888/admin/*",
+      "include": false
+    }
+  ]
+}
+```
+
+#### Visited URLs
+
+```
+http://localhost:8888/app
+http://localhost:8888/admin
+https://localhost:8888/admin
+```
+
+#### Views shown in UI
+
+```
+http://localhost:8888/app
+```

--- a/docs/partials/_views.mdx
+++ b/docs/partials/_views.mdx
@@ -59,7 +59,7 @@ The first pattern that a given URL matches is used as its view. If a URL doesn't
 {
   "views": [
     {
-      "pattern": "https://www.my-app.com/users/*"
+      "pattern": "www.my-app.com/users/*"
     }
   ]
 }
@@ -91,7 +91,7 @@ www.my-app.com/users/*
 {
   "views": [
     {
-      "pattern": "https://www.my-app.com/users/:name"
+      "pattern": "www.my-app.com/users/:name"
     }
   ]
 }
@@ -123,7 +123,7 @@ www.my-app.com/users/:name
 {
   "views": [
     {
-      "pattern": "https://www.my-app.com/analytics/:type/:id",
+      "pattern": "www.my-app.com/analytics/:type/:id",
       "groupBy": ["type"]
     }
   ]
@@ -156,7 +156,7 @@ www.my-app.com/analytics/usage/:id
 {
   "views": [
     {
-      "pattern": "https://www.my-app.com/home?*status=:status{&*}?#*",
+      "pattern": "www.my-app.com/home?*status=:status{&*}?#*",
       "groupBy": ["status"]
     }
   ]


### PR DESCRIPTION
Update UI coverage docs to show examples of specifying views and view patterns without a specific protocol.

See related PR https://github.com/cypress-io/cypress-services/pull/10437