### PR TITLE
add studio limitation regarding shadowdom

### DIFF
--- a/docs/app/guides/cypress-studio.mdx
+++ b/docs/app/guides/cypress-studio.mdx
@@ -46,6 +46,7 @@ attribute to your Cypress configuration.
   yet work with Component Testing.
 - Cypress Studio does not support writing tests that use domains of [multiple
   origins](/app/guides/cross-origin-testing).
+- Cypress Studio can not interact with elements within a ShadowDom directly, though it can still run tests that do.
 
 ## Overview
 


### PR DESCRIPTION
Cypress-Studio has known limitations regarding shadowdoms (https://github.com/cypress-io/cypress/issues/26146 ). The documentation should reflect that. 

This PR updates the documentation accordingly, I think. 