### PR TITLE
Add Windows 2025 to supported OS list

### DIFF
--- a/docs/app/get-started/install-cypress.mdx
+++ b/docs/app/get-started/install-cypress.mdx
@@ -107,7 +107,7 @@ Cypress supports running under these operating systems:
 - **Linux** Ubuntu 20.04 and above, Fedora 40 and above, and Debian 11 and above _(x64 or arm64)_
   (see [Linux Prerequisites](#Linux-Prerequisites) down below)
 - **Windows** 10 and above _(x64)_
-- **Windows Server** 2019 and 2022 _(x64)_
+- **Windows Server** 2019, 2022 and 2025 _(x64)_
 
 ### Node.js
 


### PR DESCRIPTION
- closes https://github.com/cypress-io/cypress/issues/30821

## Situation

[Get Started > System requirements > Operating System](https://docs.cypress.io/app/get-started/install-cypress#Operating-System) currently lists:

> Windows Server 2019 and 2022 (x64)

According to Microsoft's [Windows Server major versions by servicing option](https://learn.microsoft.com/en-us/windows/release-health/windows-server-release-info#windows-server-major-versions-by-servicing-option--)

- Windows Server 2025 was released for general availability on Nov 1, 2024

[GitHub Actions Runner Images](https://github.com/actions/runner-images) lists the availability of Windows Server 2025 with the YAML label `windows-2025`

## Change

Add Windows Server 2025 (x64) to [Get Started > System requirements > Operating System](https://docs.cypress.io/app/get-started/install-cypress#Operating-System)

