### PR TITLE
Correct parameter usage for click() in shadow.mdx

### DIFF
--- a/docs/api/commands/shadow.mdx
+++ b/docs/api/commands/shadow.mdx
@@ -96,13 +96,13 @@ When working with `cy.click()`, it sometimes won't click the right element in
 Chrome. It's happening because of
 [the ambiguity in spec](https://bugs.chromium.org/p/chromium/issues/detail?id=1188919&q=shadowRoot%20elementFromPoint&can=2).
 
-In this case, pass `{ position: 'top' }` to `cy.click()` like below:
+In this case, pass `'top` to `cy.click()` like below:
 
 ```js
 cy.get('#element')
   .shadow()
   .find('[data-test-id="my-button"]')
-  .click({ position: 'top' })
+  .click('top')
 ```
 
 ## Command Log

--- a/docs/api/commands/shadow.mdx
+++ b/docs/api/commands/shadow.mdx
@@ -99,10 +99,7 @@ Chrome. It's happening because of
 In this case, pass `'top'` to `cy.click()` like below:
 
 ```js
-cy.get('#element')
-  .shadow()
-  .find('[data-test-id="my-button"]')
-  .click('top')
+cy.get('#element').shadow().find('[data-test-id="my-button"]').click('top')
 ```
 
 ## Command Log

--- a/docs/api/commands/shadow.mdx
+++ b/docs/api/commands/shadow.mdx
@@ -96,7 +96,7 @@ When working with `cy.click()`, it sometimes won't click the right element in
 Chrome. It's happening because of
 [the ambiguity in spec](https://bugs.chromium.org/p/chromium/issues/detail?id=1188919&q=shadowRoot%20elementFromPoint&can=2).
 
-In this case, pass `'top` to `cy.click()` like below:
+In this case, pass `'top'` to `cy.click()` like below:
 
 ```js
 cy.get('#element')


### PR DESCRIPTION
The documentation for `Shadow` suggests that it's valid to pass `{position: 'top'}` to `cy.click()`, however `cy.click()`'s documentation suggests the `position` parameter should be passed as a standalone string outside of the `options` object, and the `options` object does not include a field for `position`.

- Update the suggestion to pass `'top'` to `cy.click()` using the API defined in `cy.click()`'s documentation.

See
https://docs.cypress.io/api/commands/click