### PR TITLE
Correct command syntax

### DIFF
--- a/docs/api/cypress-api/custom-commands.mdx
+++ b/docs/api/cypress-api/custom-commands.mdx
@@ -17,7 +17,7 @@ There are two API available for adding custom commands:
 
 - [`Cypress.Commands.add()`](#Syntax) - use to add a custom command to use when
   writing tests
-- [`Cypress.Command.overwrite()`](#Overwrite-Existing-Commands) - use to
+- [`Cypress.Commands.overwrite()`](#Overwrite-Existing-Commands) - use to
   override an existing built-in Cypress command or reserved internal function.
   **Caution:** this overrides it for Cypress as well and could impact how
   Cypress behaves.


### PR DESCRIPTION
Adds the missing `s` to `Cypress.Command.overwrite()`