### PR TITLE
extend pnpm config instructions

### DIFF
--- a/docs/app/get-started/install-cypress.mdx
+++ b/docs/app/get-started/install-cypress.mdx
@@ -157,10 +157,23 @@ is preferred. Cypress [Component Testing](/app/core-concepts/testing-types#What-
 
 #### pnpm Configuration
 
+The following configuration options enable Cypress to execute its `postinstall` script so it can install the Cypress binary into the [binary cache](/app/references/advanced-installation#Binary-cache).
+If these configuration options are not set, then Cypress may skip the `postinstall` script execution and Cypress will not run.
+
+The pnpm [side effects cache](https://pnpm.io/settings#sideeffectscache) uses and caches the results of (pre/post)install hooks and is not compatible with Cypress' own caching.
+Disable the pnpm [side effects cache](https://pnpm.io/settings#sideeffectscache), for example using the following command, executed in the root of your Cypress project:
+
+```shell
+pnpm config set side-effects-cache false --location project
+```
+
 [pnpm@10.0.0](https://github.com/pnpm/pnpm/releases/tag/v10.0.0) and above require allowlisting `cypress`.
-This enables Cypress to execute its `postinstall` script so it can install the Cypress binary into the [binary cache](/app/references/advanced-installation#Binary-cache).
-Refer to the [pnpm](https://pnpm.io/) configuration file documentation for additional information.
-[pnpm@10.4.0](https://github.com/pnpm/pnpm/releases/tag/v10.4.0) introduced the CLI add option [--allow-build](https://pnpm.io/cli/add#--allow-build) to add the allowed build configuration directly through the command line.
+Refer to the [pnpm settings](https://pnpm.io/settings) documentation for additional information.
+In [pnpm@10.4.0](https://github.com/pnpm/pnpm/releases/tag/v10.4.0) and above, the CLI `add` option [--allow-build](https://pnpm.io/cli/add#--allow-build) can be used, for example:
+
+```shell
+pnpm --allow-build cypress add --save-dev cypress
+```
 
 ### Hardware
 


### PR DESCRIPTION
- partially resolves issue https://github.com/cypress-io/cypress-documentation/issues/6147

## Issue

pnpm implements a [side effects cache](https://pnpm.io/npmrc#side-effects-cache) that uses and caches the results of (pre/post)-install hooks. This does not work if the effects of running the hook are outside the package's module. This is the case for the Cypress `postinstall` hook which installs the Cypress binary in a separate cache location (see [Binary cache](https://docs.cypress.io/app/references/advanced-installation#Binary-cache)). pnpm believes that it is unnecessary to run the Cypress `postinstall` hook and skips it if the Cypress npm module is already present in the pnpm store cache.

This is not documented on https://docs.cypress.io/ and it is only briefly referred to on https://pnpm.io/settings#sideeffectscache.

Cypress will not run if the Cypress binary is not installed.

## Change

Recommend the configuration related commands:

```yaml
pnpm config set side-effects-cache false --location project
pnpm --allow-build cypress add --save-dev cypress
```

and rework the section https://docs.cypress.io/app/get-started/install-cypress#pnpm-Configuration.
