### PR TITLE
fix cy.origin() "yielding a value" example

### DIFF
--- a/docs/api/commands/origin.mdx
+++ b/docs/api/commands/origin.mdx
@@ -191,7 +191,7 @@ will not work:
 cy.origin('https://example.cypress.io', () => {
   cy.visit('/')
   cy.get('h1') // Yields an element, which can't be serialized...
-}).contains('CYPRESS') // ...so this will fail
+}).contains('Kitchen Sink') // ...so this will fail
 ```
 
 Instead, you must explicitly yield a serializable value:
@@ -201,8 +201,8 @@ Instead, you must explicitly yield a serializable value:
 ```js
 cy.origin('https://example.cypress.io', () => {
   cy.visit('/')
-  cy.get('h1').invoke('textContent') // Yields a string...
-}).should('equal', 'CYPRESS') // 👍
+  cy.get('h1').invoke('text') // Yields a string...
+}).should('equal', 'Kitchen Sink') // 👍
 ```
 
 ### Navigating to secondary origin with cy.visit


### PR DESCRIPTION
### Description

The [cy.origin() API documentation](https://docs.cypress.io/api/commands/origin) section [Yielding a value](https://docs.cypress.io/api/commands/origin#Yielding-a-value) contains the following example code:

---

### Yielding a value

Values returned or yielded from the callback function **must** be serializable
or they will not be returned to the primary origin. For example, the following
will not work:

**Incorrect Usage**

```js
cy.origin('https://example.cypress.io', () => {
  cy.visit('/')
  cy.get('h1') // Yields an element, which can't be serialized...
}).contains('CYPRESS') // ...so this will fail
```

Instead, you must explicitly yield a serializable value:

**Correct Usage**

```js
cy.origin('https://example.cypress.io', () => {
  cy.visit('/')
  cy.get('h1').invoke('textContent') // Yields a string...
}).should('equal', 'CYPRESS') // 👍
```
---

## Issues

1. The `h1` content for https://example.cypress.io comes from https://github.com/cypress-io/cypress-example-kitchensink/blob/991fc11ad87379f6bd57c381bed167dc24727fd8/app/index.html#L65 and is "Kitchen Sink" not "CYPRESS"
2. `.invoke('textContent')` provokes the error message:

    ```text
        CypressError: Timed out retrying after 4000ms: `cy.invoke()` errored because the property: `textContent` does not exist on your subject.

    `cy.invoke()` waited for the specified property `textContent` to exist, but it never did.

    If you do not expect the property `textContent` to exist, then add an assertion such as:

    `cy.wrap({ foo: 'bar' }).its('quux').should('not.exist')`

    https://on.cypress.io/invoke
    ```

## Change

In [Yielding a value](https://docs.cypress.io/api/commands/origin#Yielding-a-value)

1. Change the `h1` value to "Kitchen Sink"
2. Change the invoked method to [JQuery .text()](https://api.jquery.com/text/)

## Verification

Execute the following test and confirm that it is successful:

```js
describe('yielding a value', () => {
  it('example', () => {
    cy.origin('https://example.cypress.io', () => {
      cy.visit('/')
      cy.get('h1').invoke('text') // Yields a string...
    }).should('equal', 'Kitchen Sink') // 👍
  })
})
```

![image](https://github.com/user-attachments/assets/cbd53cd8-6838-4c01-8767-978b77005b00)
