### PR TITLE
docs: harmonize on injectDocumentDomain removal in future version

### DIFF
--- a/docs/app/references/configuration.mdx
+++ b/docs/app/references/configuration.mdx
@@ -599,7 +599,7 @@ or [`component`](#component) testing-specific options.
 
 ### injectDocumentDomain
 
-This option is <Badge type="caution">deprecated</Badge>, and will be removed in Cypress. 15
+This option is <Badge type="caution">deprecated</Badge>, and will be removed in a future version of Cypress.
 
 Set this configuration option to `true` to instruct Cypress to
 [inject document.domain](/app/guides/cross-origin-testing#What-Cypress-does-under-the-hood)
@@ -608,7 +608,7 @@ between subdomains](/app/guides/cross-origin-testing), but comes with compatibil
 caveats for some sites.
 
 This configuration option is provided to ease the transition between `cy.origin()`'s behavior
-in Cypress 13 and the default behavior in Cypress 14. It will be removed in a future version of Cypress.
+in Cypress 13 and the default behavior in Cypress 14.
 [Read the Cypress 14 migration guide](/app/references/migration-guide#Migrating-to-Cypress-140) to understand how to update your tests to remove
 the need to set this flag.
 

--- a/docs/app/references/migration-guide.mdx
+++ b/docs/app/references/migration-guide.mdx
@@ -83,8 +83,8 @@ is set to true, `cy.origin()` will not be required to navigate between origins, 
 <Icon name="exclamation-triangle" /> If `injectDocumentDomain` is set to `true`,
 Cypress will warn that this option is deprecated.
 
-<Icon name="exclamation-triangle" /> `injectDocumentDomain` will be removed in Cypress
-15.
+<Icon name="exclamation-triangle" /> `injectDocumentDomain` will be removed in a
+future version of Cypress.
 
 <Icon name="exclamation-triangle" /> Setting `injectDocumentDomain` to `true` may
 cause certain sites to stop working in Cypress. Please read the [configuration notes](/app/references/configuration#injectDocumentDomain)


### PR DESCRIPTION
## Issue

- PR https://github.com/cypress-io/cypress-documentation/pull/6131 changed the planning statement that the configuration option [injectDocumentDomain](https://docs.cypress.io/app/references/configuration#injectDocumentDomain) would be removed in Cypress 15 to instead state that it would be removed in a future version.

This has led to some inconsistencies in the statements:

1. The [References > Configuration > injectDocumentDomain](https://docs.cypress.io/app/references/configuration#injectDocumentDomain) section contains contradictory statements:

    > This option is deprecated, and will be removed in Cypress. 15

    ...
    > This configuration option is provided to ease the transition between cy.origin()'s behavior in Cypress 13 and the default behavior in Cypress 14. It will be removed in a future version of Cypress.

2. The [Migration Guide > Migrating to Cypress 14.0 > Changes to cy.origin()](https://docs.cypress.io/app/references/migration-guide#Changes-to-cyorigin) contains the outdated statement:

    > injectDocumentDomain will be removed in Cypress 15.

## Change

For

- [References > Configuration > injectDocumentDomain](https://docs.cypress.io/app/references/configuration#injectDocumentDomain) section
- [Migration Guide > Migrating to Cypress 14.0 > Changes to cy.origin()](https://docs.cypress.io/app/references/migration-guide#Changes-to-cyorigin)

consolidate the removal statements and harmonize on a statement that the removal of the configuration option `injectDocumentDomain` occurs in a future version of Cypress instead of the specific version Cypress 15.
