### PR TITLE
Cross-link cy.origin and injectDocumentDomain

### DIFF
--- a/docs/api/commands/origin.mdx
+++ b/docs/api/commands/origin.mdx
@@ -40,9 +40,11 @@ doc.
 
 Cypress no longer injects `document.domain` by default, which means `cy.origin()`
 must now be used to navigate between any two origins in the same test, even if
-the two origins are in the same superdomain. This behavior can be disabled by setting
-the `injectDocumentDomain` configuration option to `true`, to allow a smooth transition
-of tests to the new behavior. This configuration option will be removed in a future version of Cypress.
+the two origins are in the same superdomain.
+This behavior can be disabled by setting the
+[injectDocumentDomain](/app/references/configuration#injectDocumentDomain) configuration option to `true`,
+to allow a smooth transition of tests to the new behavior.
+This configuration option will be removed in a future version of Cypress.
 
 :::
 

--- a/docs/app/references/configuration.mdx
+++ b/docs/app/references/configuration.mdx
@@ -603,17 +603,18 @@ This option is <Badge type="caution">deprecated</Badge>, and will be removed in 
 
 Set this configuration option to `true` to instruct Cypress to
 [inject document.domain](/app/guides/cross-origin-testing#What-Cypress-does-under-the-hood)
-into your test application. This can reduce the need for `cy.origin()` when [navigating
-between subdomains](/app/guides/cross-origin-testing), but comes with compatibility
-caveats for some sites.
+into your test application.
+This can reduce the need for [`cy.origin()`](/api/commands/origin)
+when [navigating between subdomains](/app/guides/cross-origin-testing),
+but comes with compatibility caveats for some sites.
 
-This configuration option is provided to ease the transition between `cy.origin()`'s behavior
+This configuration option is provided to ease the transition between [`cy.origin()`](/api/commands/origin)'s behavior
 in Cypress 13 and the default behavior in Cypress 14.
 [Read the Cypress 14 migration guide](/app/references/migration-guide#Migrating-to-Cypress-140) to understand how to update your tests to remove
 the need to set this flag.
 
 This configuration value _must_ be set to true if you are running tests with experimental
-WebKit support, as `cy.origin` is not yet supported in WebKit.
+WebKit support, as [`cy.origin()`](/api/commands/origin) is not yet supported in WebKit.
 
 :::caution
 

--- a/docs/partials/_document-domain-workaround.mdx
+++ b/docs/partials/_document-domain-workaround.mdx
@@ -9,8 +9,9 @@ This means you must now use `cy.origin()` when navigating between different _ori
 in the same test. Previously, `cy.origin()` was only necessary when navigating between
 different [superdomains](/app/guides/cross-origin-testing#Parts-of-a-URL) in the same test.
 
-By setting the `injectDocumentDomain` configuration option to `true`, Cypress will
-attempt to inject `document.domain` into `text/html` pages.
+By setting the
+[injectDocumentDomain](/app/references/configuration#injectDocumentDomain) configuration option to `true`,
+Cypress will attempt to inject `document.domain` into `text/html` pages.
 
 A superdomain is comprised of the trailing two elements of the hostname, delimited by
 a `.` (period). Given `https://www.cypress.io`, the superdomain is determined to be


### PR DESCRIPTION
## Status

The [API commands origin](https://docs.cypress.io/api/commands/origin) page refers to the configuration option `injectDocumentDomain` without linking to the [Configuration > injectDocumentDomain](https://docs.cypress.io/app/references/configuration#injectDocumentDomain) section, where additional important information, such as "Known Incompatibilities" is provided.

Similarly the [Configuration > injectDocumentDomain](https://docs.cypress.io/app/references/configuration#injectDocumentDomain) section does not link to the [cy.origin](https://docs.cypress.io/api/commands/origin) page.

## Change

Cross-link the usage of

- `injectDocumentDomain`
- `cy.origin()`

on the pages / sections

- [API commands origin](https://docs.cypress.io/api/commands/origin)
- [Configuration > injectDocumentDomain](https://docs.cypress.io/app/references/configuration#injectDocumentDomain)
