### PR TITLE
Fix "cy.visit() succeeded, but commands are timing out" error example

### DIFF
--- a/docs/app/references/error-messages.mdx
+++ b/docs/app/references/error-messages.mdx
@@ -498,18 +498,18 @@ as-is:
 ```javascript
 it('navigates to docs.cypress.io', () => {
   cy.visit('http://localhost:3000')
-  cy.visit('https://docs.cypress.io') // visit a different superdomain
+  cy.visit('https://docs.cypress.io') // visit a different domain
 })
 ```
 
-However, when the newly visited URL is not considered the same superdomain, the
+However, when the newly visited URL is not considered the same domain, the
 [`cy.origin()`](/api/commands/origin) command **must** be used to interact with
 the newly visited domain. The following test is incorrect:
 
 ```javascript
 it('navigates to docs.cypress.io and runs additional commands', () => {
   cy.visit('http://localhost:3000')
-  cy.visit('https://docs.cypress.io') // visit a different superdomain
+  cy.visit('https://docs.cypress.io') // visit a different domain
   cy.get('h1').should('contain', 'Why Cypress?') // fails
 })
 ```
@@ -525,10 +525,10 @@ In order to fix this, our `cy.get()` command **must** be wrapped with the
 [`cy.origin()`](/api/commands/origin) command, like so:
 
 ```javascript
-it('navigates to example.cypress.io and runs additional commands', () => {
+it('navigates to docs.cypress.io and runs additional commands', () => {
   cy.visit('http://localhost:3000')
-  cy.visit('https://example.cypress.io') // visit a different superdomain
-  cy.origin('https://example.cypress.io', () => {
+  cy.visit('https://docs.cypress.io') // visit a different domain
+  cy.origin('https://docs.cypress.io', () => {
     cy.get('h1').should('contain', 'Why Cypress?') // now succeeds!
   })
 })


### PR DESCRIPTION
## Status

https://on.cypress.io/cy-visit-succeeded-but-commands-fail forwards to the documentation page

[cy.visit() succeeded, but commands are timing out](https://docs.cypress.io/app/references/error-messages#cyvisit-succeeded-but-commands-are-timing-out)

where a failing example is given, visiting the following domains:
- http://localhost:3000
- https://docs.cypress.io

```js
it('navigates to docs.cypress.io and runs additional commands', () => {
  cy.visit('http://localhost:3000')
  cy.visit('https://docs.cypress.io') // visit a different superdomain
  cy.get('h1').should('contain', 'Why Cypress?') // fails
})
```

The solution is given as:

```js
it('navigates to example.cypress.io and runs additional commands', () => {
  cy.visit('http://localhost:3000')
  cy.visit('https://example.cypress.io') // visit a different superdomain
  cy.origin('https://example.cypress.io', () => {
    cy.get('h1').should('contain', 'Why Cypress?') // now succeeds!
  })
})
```

This is confusing because, without explanation, the secondary domain `example.cypress.io` in the solution differs from the secondary domain `docs.cypress.io` in the failing test spec.

Furthermore, since only https://docs.cypress.io contains a 'Why Cypress?', not https://example.cypress.io, the corrected example will fail if an attempt is made to run it.

The text refers to `superdomain`, however the [Cypress 14 Migration Guide](https://docs.cypress.io/app/references/migration-guide#Changes-to-cyorigin) explains that tests must be in the same domain. Being in the same superdomain is no longer sufficient.

## Change

1. Modify the solution in https://docs.cypress.io/app/references/error-messages#cyvisit-succeeded-but-commands-are-timing-out to use https://docs.cypress.io instead of https://example.cypress.io

    ```js
    it('navigates to docs.cypress.io and runs additional commands', () => {
      cy.visit('http://localhost:3000')
      cy.visit('https://docs.cypress.io') // visit a different domain
      cy.origin('https://docs.cypress.io', () => {
        cy.get('h1').should('contain', 'Why Cypress?') // now succeeds!
      })
    })
    ```

2. Change "superdomain" to "domain" in the text

## Verify

```shell
git clone --branch test/origin https://github.com/MikeMcC399/cypress-documentation
cd cypress-documentation
npm ci
npm start
```

In a separate terminal window, execute:

```shell
npx cypress run -s cypress/e2e/visit-timeout-correction.cy.ts
```
