### PR TITLE
Add experimentalSessionAndOrigin removed comment to origin video

### DIFF
--- a/docs/api/commands/origin.mdx
+++ b/docs/api/commands/origin.mdx
@@ -367,6 +367,9 @@ Cypress.Commands.add('login', (username, password) => {
 In this video we walk through how to test multiple origins in a single test. We
 also look at how to use the `cy.session()` command to cache session information
 and reuse it across tests.
+The configuration option `experimentalSessionAndOrigin`, mentioned in the video, is not used
+since [Cypress 12.0.0](https://docs.cypress.io/app/references/changelog#12-0-0)
+and the associated functionality is enabled by default.
 
 ## Notes
 


### PR DESCRIPTION
## Situation

The [API > origin > How to Test Multiple Origins](https://docs.cypress.io/api/commands/origin#How-to-Test-Multiple-Origins) contains a link to a YouTube video

https://www.youtube.com/watch?v=8tYoopVaWLE

that says (4:53) `experimentalSessionAndOrigin` must be set to true.

`experimentalSessionAndOrigin` was however removed in release

12.0.0
Removed experimentalSessionAndOrigin and made it the default behavior. Added experimentalOriginDependencies.

## Change

Add note to refer to [Cypress 12.0.0 release notes](https://docs.cypress.io/app/references/changelog#12-0-0) that describe the removal of `experimentalSessionAndOrigin`.