### PR TITLE
chore: add beginning of migration guide for Cypress 15

### DIFF
--- a/docs/app/references/migration-guide.mdx
+++ b/docs/app/references/migration-guide.mdx
@@ -16,14 +16,9 @@ version 15.
 
 ### Node.js 20 and 22+ support
 
-Cypress comes bundled with its own
-[Node.js version](https://github.com/cypress-io/cypress/blob/develop/.node-version).
-However, installing the `cypress` npm package uses the Node.js version installed
-on your system.
-
-[See Node's release schedule](https://github.com/nodejs/Release). Node.js
-version 18 and 23 are no longer supported when installing Cypress. The supported Node.js
-versions to install Cypress are now Node.js 20 and 22+.
+Cypress requires [Node.js](https://nodejs.org/en) in order to install the Cypress binary and the supported versions are now Node.js 20 and 22+.
+Node.js versions 18 and 23 are no longer supported.
+[See Node's release schedule](https://github.com/nodejs/Release).
 
 ### Angular `17` CT no longer supported
 

--- a/docs/app/references/migration-guide.mdx
+++ b/docs/app/references/migration-guide.mdx
@@ -12,7 +12,7 @@ sidebar_label: 'Migration Guide'
 
 This guide details the code changes needed to migrate to Cypress
 version 15.
-[See the full changelog for version v14.0](/app/references/changelog#15-0-0).
+[See the full changelog for version v15.0](/app/references/changelog#15-0-0).
 
 ### Node.js 20 and 22+ support
 

--- a/docs/app/references/migration-guide.mdx
+++ b/docs/app/references/migration-guide.mdx
@@ -22,8 +22,8 @@ However, installing the `cypress` npm package uses the Node.js version installed
 on your system.
 
 [See Node's release schedule](https://github.com/nodejs/Release). Node.js
-version 18 and 23 will no longer be supported when installing Cypress. The minimum Node.js
-version supported to install Cypress is Node.js 20 and 22+.
+version 18 and 23 are no longer supported when installing Cypress. The supported Node.js
+versions to install Cypress are now Node.js 20 and 22+.
 
 ### Angular `17` CT no longer supported
 

--- a/docs/app/references/migration-guide.mdx
+++ b/docs/app/references/migration-guide.mdx
@@ -8,6 +8,51 @@ sidebar_label: 'Migration Guide'
 
 # Migration Guide
 
+## Migrating to Cypress 15.0
+
+This guide details the code changes needed to migrate to Cypress
+version 15.
+[See the full changelog for version v14.0](/app/references/changelog#15-0-0).
+
+### Node.js 20 and 22+ support
+
+Cypress comes bundled with its own
+[Node.js version](https://github.com/cypress-io/cypress/blob/develop/.node-version).
+However, installing the `cypress` npm package uses the Node.js version installed
+on your system.
+
+[See Node's release schedule](https://github.com/nodejs/Release). Node.js
+version 18 and 23 will no longer be supported when installing Cypress. The minimum Node.js
+version supported to install Cypress is Node.js 20 and 22+.
+
+### Angular `17` CT no longer supported
+
+With [LTS ending](https://angular.dev/reference/releases#actively-supported-versions) for Angular 17, the minimum required Angular version for component testing is now `18.0.0`.
+
+#### To continue using Angular below 18.0.0
+
+If you haven't been able to migrate away from an older Angular version and still need that test harness, it can be installed independently via the [`@cypress/angular`](https://www.npmjs.com/package/@cypress/angular) `3.x.x` package from `npm`.
+
+Note that this test harness version is deprecated and no longer supported by Cypress. This version is intended to serve as a temporary workaround to migrate your project to Angular v18.0.0+.
+
+```sh
+npm install --save-dev @cypress/angular@3
+```
+
+Inside your support file (ex: `./cypress/support/component.(js|ts)`), or wherever your mount function is imported, make the following update to add `@`.
+
+<Badge type="danger">Before</Badge>{' '}
+
+```ts
+import { mount } from `cypress/angular`
+```
+
+<Badge type="success">After</Badge>
+
+```ts
+import { mount } from `@cypress/angular`
+```
+
 ## Migrating to Cypress 14.0
 
 This guide details the code changes needed to migrate to Cypress


### PR DESCRIPTION
Begins the migration guide for Cypress 15, which includes the node deprecations and angular 17 CT support removal and work arounds