### PR TITLE
chore: add cypress 14.3.2 changelog

### DIFF
--- a/docs/app/references/changelog.mdx
+++ b/docs/app/references/changelog.mdx
@@ -8,6 +8,15 @@ sidebar_label: Changelog
 
 # Changelog
 
+## 14.3.2
+
+_Released 4/22/2025_
+
+**Bugfixes:**
+
+- Fixed an issue where auto scroll in the Cypress Command Log was not scrolling correctly. Fixes [#31530](https://github.com/cypress-io/cypress/issues/31530).
+- Fixed an issue where a message pointing users to the Cypress Cloud was not displaying on runs with failures in CI. Fixes [#31550](https://github.com/cypress-io/cypress/issues/31550).
+
 ## 14.3.1
 
 _Released 4/17/2025_


### PR DESCRIPTION
adds the Cypress `14.3.2` changelog