### PR TITLE
Bump Cypress Docker versions in examples to Node.js 22.15.0 LTS

### DIFF
--- a/docs/accessibility/results-api.mdx
+++ b/docs/accessibility/results-api.mdx
@@ -322,7 +322,7 @@ run-cypress:
 pipeline {
   agent {
     docker {
-      image 'cypress/base:22.12.0'
+      image 'cypress/base:22.15.0'
     }
   }
 
@@ -393,7 +393,7 @@ version: 2.1
 jobs:
   linux-test:
     docker:
-      - image: cypress/base:22.12.0
+      - image: cypress/base:22.15.0
 
     working_directory: ~/repo
     steps:

--- a/docs/app/continuous-integration/aws-codebuild.mdx
+++ b/docs/app/continuous-integration/aws-codebuild.mdx
@@ -138,14 +138,14 @@ version: 0.2
 ## https://docs.aws.amazon.com/codebuild/latest/userguide/batch-build-buildspec.html
 
 ## Define build to run using the
-## "cypress/browsers:22.12.0" image
+## "cypress/browsers:22.15.0" image
 ## from the Cypress Amazon ECR Public Gallery
 batch:
   fast-fail: false
   build-list:
     - identifier: cypress-e2e-tests
       env:
-        image: public.ecr.aws/cypress-io/cypress/browsers:22.12.0
+        image: public.ecr.aws/cypress-io/cypress/browsers:22.15.0
 
 phases:
   install:

--- a/docs/app/continuous-integration/bitbucket-pipelines.mdx
+++ b/docs/app/continuous-integration/bitbucket-pipelines.mdx
@@ -43,7 +43,7 @@ example, this allows us to run the tests in Firefox by passing the
 Read about [Cypress Docker variants](/app/continuous-integration/overview#Cypress-Docker-variants) to decide which image is best for your project.
 
 ```yaml title="bitbucket-pipelines.yml"
-image: cypress/browsers:22.12.0
+image: cypress/browsers:22.15.0
 
 pipelines:
   default:
@@ -82,7 +82,7 @@ Artifacts from a job can be defined by providing paths to the `artifacts`
 attribute.
 
 ```yaml title="bitbucket-pipelines.yml"
-image: cypress/browsers:22.12.0
+image: cypress/browsers:22.15.0
 
 pipelines:
   default:
@@ -146,7 +146,7 @@ recording test results to [Cypress Cloud](/cloud/get-started/introduction).
 :::
 
 ```yaml title="bitbucket-pipelines.yml"
-image: cypress/base:22.12.0
+image: cypress/base:22.15.0
 
 ## job definition for running E2E tests in parallel
 e2e: &e2e
@@ -205,7 +205,7 @@ definitions:
 The complete `bitbucket-pipelines.yml` is below:
 
 ```yaml title="bitbucket-pipelines.yml"
-image: cypress/base:22.12.0
+image: cypress/base:22.15.0
 
 ## job definition for running E2E tests in parallel
 e2e: &e2e

--- a/docs/app/continuous-integration/github-actions.mdx
+++ b/docs/app/continuous-integration/github-actions.mdx
@@ -188,7 +188,7 @@ jobs:
   cypress-run:
     runs-on: ubuntu-24.04
     container:
-      image: cypress/browsers:22.12.0
+      image: cypress/browsers:22.15.0
       options: --user 1001
     steps:
       - name: Checkout

--- a/docs/app/continuous-integration/gitlab-ci.mdx
+++ b/docs/app/continuous-integration/gitlab-ci.mdx
@@ -74,7 +74,7 @@ stages:
   - test
 
 test:
-  image: cypress/browsers:22.12.0
+  image: cypress/browsers:22.15.0
   stage: test
   script:
     # install dependencies
@@ -105,7 +105,7 @@ cache:
     - .npm/
 
 test:
-  image: cypress/browsers:22.12.0
+  image: cypress/browsers:22.15.0
   stage: test
   script:
     # install dependencies
@@ -172,7 +172,7 @@ cache:
 
 ## Install npm dependencies and Cypress
 install:
-  image: cypress/browsers:22.12.0
+  image: cypress/browsers:22.15.0
   stage: build
   script:
     - npm ci
@@ -217,13 +217,13 @@ cache:
 
 ## Install npm dependencies and Cypress
 install:
-  image: cypress/browsers:22.12.0
+  image: cypress/browsers:22.15.0
   stage: build
   script:
     - npm ci
 
 ui-chrome-tests:
-  image: cypress/browsers:22.12.0
+  image: cypress/browsers:22.15.0
   stage: test
   parallel: 5
   script:

--- a/docs/ui-coverage/results-api.mdx
+++ b/docs/ui-coverage/results-api.mdx
@@ -236,7 +236,7 @@ run-cypress:
 pipeline {
   agent {
     docker {
-      image 'cypress/base:22.12.0'
+      image 'cypress/base:22.15.0'
     }
   }
 
@@ -307,7 +307,7 @@ version: 2.1
 jobs:
   linux-test:
     docker:
-      - image: cypress/base:22.12.0
+      - image: cypress/base:22.15.0
 
     working_directory: ~/repo
     steps:


### PR DESCRIPTION
## Situation

Documentation examples are using the Cypress Docker image:

- `cypress/base:22.12.0`
- `cypress/browsers:22.12.0`

This version of the `browsers` image is no longer supported.

In [Cypress 14.0.0](https://docs.cypress.io/app/references/changelog#14-0-0)

> Cypress now only officially supports the latest 3 major versions of Chrome, Firefox, and Edge - older browser versions may still work, but we recommend keeping your browsers up to date to ensure compatibility with Cypress.

| Browser | Current major version | lowest supported |
| ------- | --------------------- | ---------------- |
| Chrome  | 135                   | 133              |
| Firefox | 135                   | 133              |
| Edge    | 137                   | 135              |

The lowest Cypress Docker image which meets this criteria is `cypress/browsers:node-22.14.0-chrome-133.0.6943.53-1-ff-135.0-edge-133.0.3065.59-1`.

## Change

Update all Cypress Docker image tags in examples to Node.js `22.15.0` for supportability and consistency:

- `cypress/base:22.15.0`
- `cypress/browsers:22.15.0`

## Note

The image `cypress/browsers:node18.12.0-chrome106-ff106` used internally in [.circleci/config.yml](https://github.com/cypress-io/cypress-documentation/blob/main/.circleci/config.yml) is left unchanged.