### PR TITLE
Add quoting advice for PowerShell CLI options

### DIFF
--- a/docs/app/references/command-line.mdx
+++ b/docs/app/references/command-line.mdx
@@ -13,6 +13,13 @@ This guide assumes you've already read our
 installed Cypress as an `npm` module. After installing you'll be able to execute
 all of the commands in this document from your **project root**.
 
+:::info
+
+You can alternatively require and run Cypress as a node module using our
+[Module API](/app/references/module-api).
+
+:::
+
 ## How to run commands
 
 You can run Cypress from your **project root** using a command which
@@ -58,8 +65,9 @@ pnpm cypress run --record --spec "cypress/e2e/my-spec.cy.js"
 
 :::info
 
-You can alternatively require and run Cypress as a node module using our
-[Module API](/app/references/module-api).
+**PowerShell**
+
+When `cypress run` [options](#Options) or `cypress open` [options](#Options-1) are specified with multiple values separated by commas, such as for `--conf` or `--env` options, and you are using PowerShell on Windows, you may need to surround the key/value pairs with quotes, for example: `--env "host=api.dev.local,port=4222"`.
 
 :::
 


### PR DESCRIPTION
- closes https://github.com/cypress-io/cypress-documentation/issues/6166

## Situation

CLI options that include multiple values separated with commas, such as for `--config`, `--env` or `--reporter-options` may be misinterpreted when executing Cypress CLI in PowerShell on Windows.

The following documentation example [cypress run --config <config>](https://docs.cypress.io/app/references/command-line#cypress-run-config-lt-config-gt) generally fails to run in PowerShell `7.5.1` on Windows 11 24H2, Cypress `14.3.2` with package managers: npm, pnpm and Yarn:

```shell
cypress run --config pageLoadTimeout=100000,watchForFileChanges=false
```

The error is:

```text
An invalid configuration value was set.

Expected pageLoadTimeout to be a number.

Instead the value was: "100000 watchForFileChanges=false"
```

An exception is `npm@10.8.2` under Node.js `v20.19.1` using `npx cypress run` where it works correctly.

Using PowerShell `7.5.1` on Ubuntu `24.04.2` LTS shows no issues with executing the above command in each of the package managers (npm, pnpm and Yarn).

## Change

Add an info admonition to https://docs.cypress.io/app/references/command-line to advise enclosing the options in quotes:

> When  `cypress run` [options](https://docs.cypress.io/app/references/command-line#Options) or `cypress open` [options](https://docs.cypress.io/app/references/command-line#Options-1) are specified with multiple values separated by commas, such as for `--conf` or `--env` options, and you are using PowerShell on Windows, you may need to surround the key/value pairs with quotes, for example: `--env "host=api.dev.local,port=4222"`.