### PR TITLE
Rework instructions for missing Cypress binary in CI

### DIFF
--- a/docs/app/references/error-messages.mdx
+++ b/docs/app/references/error-messages.mdx
@@ -610,6 +610,9 @@ if you've exhausted all other possibilities.
 
 ## CLI Errors
 
+Errors in this section may occur when using the [Cypress command line (CLI)](/app/references/command-line).
+They may also apply to running Cypress programmatically through the [Cypress Module API](/app/references/module-api).
+
 ### <Icon name="exclamation-triangle" color="red" /> You passed the `--record` flag but did not provide us your Record Key.
 
 You may receive this error when trying to run Cypress tests in
@@ -659,12 +662,18 @@ We will automatically apply the record key environment variable.
 
 ### <Icon name="exclamation-triangle" color="red" /> A Cached Cypress Binary Could not be found
 
-This error occurs in CI when using `cypress run` without a valid Cypress binary
-cache installed on the system (on linux that's `~/.cache/Cypress`).
+This error occurs in CI when attempting to use `cypress run` or `cypress verify` CLI commands
+without having a valid Cypress binary cache installed on the system.
 
-To fix this error, follow instructions on
-[caching the cypress binary in CI](/app/continuous-integration/overview#Caching),
-then bump the version of your CI cache to ensure a clean build.
+The Cypress binary is downloaded and installed into a [global cache folder](/app/references/advanced-installation#Binary-cache)
+with a package manager install command (such as `npm ci`, `npm install`, `yarn install` or `pnpm install`).
+The Cypress cache can also be loaded from a CI cache that was saved from a previous CI run.
+
+If you are using pnpm, ensure you are following the [pnpm configuration](/app/get-started/install-cypress#pnpm-Configuration)
+instructions, otherwise pnpm may skip the Cypress binary installation.
+
+If you are using CI caches, then review also the recommendations for
+[caching the Cypress binary in CI](/app/continuous-integration/overview#Caching).
 
 ### <Icon name="exclamation-triangle" color="red" /> Incorrect usage of `--ci-build-id` flag
 


### PR DESCRIPTION
## Situation

If an attempt is made to run Cypress in CI and the Cypress binary is not present, an error message from [notInstalledCI](https://github.com/cypress-io/cypress/blob/8254b9452fec7d7051d5a8a688cd07036aaab371/cli/lib/errors.js#L95C7-L114) is output:

```text
The cypress npm package is installed, but the Cypress binary is missing.

We expected the binary to be installed here: xxx

Reasons it may be missing:

- You're caching 'node_modules' but are not caching this path: xxx
- You ran 'npm install' at an earlier build step but did not persist: xxx

Properly caching the binary will fix this error and avoid downloading and unzipping Cypress.

Alternatively, you can run 'cypress install' to download the binary again.

https://on.cypress.io/not-installed-ci-error

----------

Platform: linux-x64 (Ubuntu - 24.04)
Cypress Version: 14.3.2
```

The link
https://on.cypress.io/not-installed-ci-error forwards to
https://docs.cypress.io/app/references/error-messages#A-Cached-Cypress-Binary-Could-not-be-found which refers to
https://docs.cypress.io/app/continuous-integration/overview#Caching

The related texts do not cover the situation where pnpm has not installed the Cypress binary due to:

1. the workflow caching the pnpm store without disabling the the [pnpm sideEffectsCache](https://pnpm.io/settings#sideeffectscache) (default setting is enabled)
2. use of pnpm >10 where running the Cypress postinstall script is not enabled (default is disabled)

Instructions for configuring pnpm to avoid the above two situations are shown in [Get Started > Install Cypress > System requirements > Package Manager > pnpm Configuration](https://docs.cypress.io/app/get-started/install-cypress#pnpm-Configuration).

## Change

In https://docs.cypress.io/app/references/error-messages#A-Cached-Cypress-Binary-Could-not-be-found

- Expand the description to cover the case where the CI workflow is not generally using caches.

- Add a description to cover the pnpm configuration issues.
