### PR TITLE
Remove YouTube link to obsolete todomvc video

### DIFF
--- a/docs/app/continuous-integration/github-actions.mdx
+++ b/docs/app/continuous-integration/github-actions.mdx
@@ -29,12 +29,11 @@ in the [GitHub Action Documentation](https://docs.github.com/en/actions).
 ## GitHub Actions + Cypress Screencasts
 
 1. [What is Continuous Integration?](https://youtu.be/USX6AntcPyg)
-2. [Actions & Workflows](https://youtu.be/N0TOFWy1Xvg)
-3. [Example App Overview](https://youtu.be/zGrAhZkCoUE)
-4. [Understanding how to configure a workflow](https://youtu.be/vVr7DXDdUks)
-5. [Running Tests in GitHub Actions CI/CD Workflow](https://youtu.be/23ZGSrmbV_4)
-6. [Debugging Test Failures in CI](https://youtu.be/Oqq-_QZWzhg)
-7. [Running Tests in Parallel](https://youtu.be/96Yn_IiQUJI)
+1. [Actions & Workflows](https://youtu.be/N0TOFWy1Xvg)
+1. [Understanding how to configure a workflow](https://youtu.be/vVr7DXDdUks)
+1. [Running Tests in GitHub Actions CI/CD Workflow](https://youtu.be/23ZGSrmbV_4)
+1. [Debugging Test Failures in CI](https://youtu.be/Oqq-_QZWzhg)
+1. [Running Tests in Parallel](https://youtu.be/96Yn_IiQUJI)
 
 :::
 


### PR DESCRIPTION
- closes #5126

## Situation

Regarding YouTube video https://youtu.be/zGrAhZkCoUE

- [Continuous Integration > GitHub Actions](https://docs.cypress.io/app/continuous-integration/github-actions) links to [Example App Overview](https://youtu.be/zGrAhZkCoUE) which is a YouTube Video from June 2021 with the title "GitHub Actions + Cypress: Example App Overview" that describes using the repo https://github.com/cypress-io/todomvc
- The repo https://github.com/cypress-io/todomvc is based on the legacy Cypress 7.0.0 version and was archived on May 16, 2024.
- There is no other reference to the todomvc app on the above documentation page
- Although there is an active replacement repo https://github.com/cypress-io/cypress-example-todomvc the differences between this newer repo and the archived https://github.com/cypress-io/todomvc are so many that the YouTube video does not fit anymore

## Change

Remove the [Example App Overview](https://youtu.be/zGrAhZkCoUE) obsolete YouTube video link from the page [Continuous Integration > GitHub Actions](https://docs.cypress.io/app/continuous-integration/github-actions)