### PR TITLE
Remove binary download introduction reference to Cypress 3.0

### DIFF
--- a/docs/app/continuous-integration/overview.mdx
+++ b/docs/app/continuous-integration/overview.mdx
@@ -431,8 +431,7 @@ If you see a message about a missing dependency when you run Cypress in a Linux 
 
 ### Caching
 
-As of [Cypress version 3.0](/app/references/changelog#3-0-0), Cypress
-downloads its binary to the global system cache - on linux that is
+Cypress downloads its binary to the global system cache - on Linux that is
 `~/.cache/Cypress`. By ensuring this cache persists across builds you can save
 minutes off install time by preventing a large binary download.
 

--- a/docs/app/references/advanced-installation.mdx
+++ b/docs/app/references/advanced-installation.mdx
@@ -147,7 +147,7 @@ DEBUG=cypress:cli* pnpm cypress install
 
 ## Binary cache
 
-As of version `3.0`, Cypress downloads the matching Cypress binary to the global
+Cypress downloads the matching Cypress binary to the global
 system cache, so that the binary can be shared between projects. By default,
 global cache folders are:
 


### PR DESCRIPTION
## Situation

Reference is made to the introduction of the Cypress binary downloaded to the global system cache in Cypress `3.0` in:
- https://docs.cypress.io/app/references/advanced-installation#Binary-cache
- https://docs.cypress.io/app/continuous-integration/overview#Caching

The documentation concerns itself specifically with the current version of Cypress, 14, and in general only with non-legacy versions Cypress 10 and later. Describing the introduction of a feature within the stream of legacy releases < Cypress 10 is no longer relevant or necessary.

The information regarding introduction of a global binary cache per version is available for reference in the [Cypress 3.0.0 changelog](https://docs.cypress.io/app/references/changelog#3-0-0).

## Change

Remove the reference "As of version 3.0" from https://docs.cypress.io/app/references/advanced-installation#Binary-cache
