### PR TITLE
Add missing hash character on PR 31631 references

### DIFF
--- a/docs/app/references/changelog.mdx
+++ b/docs/app/references/changelog.mdx
@@ -19,7 +19,7 @@ _Released 5/6/2025_
 **Bugfixes:**
 
 - Fixed an issue where the configuration setting `trashAssetsBeforeRuns=false` was ignored for assets in the `videosFolder`. These assets were incorrectly deleted before running tests with `cypress run`. Addresses [#8280](https://github.com/cypress-io/cypress/issues/8280).
-- Fixed a potential hang condition when `@cypress/grep` would match many files and `stdout`/`stderr` was piped to a file. Fixes [#31625](https://github.com/cypress-io/cypress/issues/31625). Addressed in [31631](https://github.com/cypress-io/cypress/pull/31631).
+- Fixed a potential hang condition when `@cypress/grep` would match many files and `stdout`/`stderr` was piped to a file. Fixes [#31625](https://github.com/cypress-io/cypress/issues/31625). Addressed in [#31631](https://github.com/cypress-io/cypress/pull/31631).
 - Fixed a potential hang condition when navigating to `about:blank`. Addressed in [#31634](https://github.com/cypress-io/cypress/pull/31634).
 
 **Misc:**
@@ -29,7 +29,7 @@ _Released 5/6/2025_
 
 **Dependency Updates:**
 
-- Downgraded `cli-table3` to 0.6.1. Addressed in [31631](https://github.com/cypress-io/cypress/pull/31631).
+- Downgraded `cli-table3` to 0.6.1. Addressed in [#31631](https://github.com/cypress-io/cypress/pull/31631).
 
 ## 14.3.2
 


### PR DESCRIPTION
## Situation

- [Writing Guidelines](https://github.com/cypress-io/cypress/blob/develop/guides/writing-the-cypress-changelog.md#writing-guidelines) specifies prepending the hash (`#`) character to GitHub issue and PR references

- The [Cypress Changelog 14.3.3](https://docs.cypress.io/app/references/changelog#14-3-3) contains links to PR https://github.com/cypress-io/cypress/pull/31631 that are missing the hash (`#`) character

## Change

Add the hash (`#`) to links for PR https://github.com/cypress-io/cypress/pull/31631 in the [Cypress Changelog 14.3.3](https://docs.cypress.io/app/references/changelog#14-3-3)