### PR TITLE
Bump lowest supported to Fedora Linux 41

### DIFF
--- a/docs/app/get-started/install-cypress.mdx
+++ b/docs/app/get-started/install-cypress.mdx
@@ -104,8 +104,10 @@ need prebuilt.
 Cypress supports running under these operating systems:
 
 - **macOS** 11 and above _(Intel or Apple Silicon 64-bit (x64 or arm64))_
-- **Linux** Ubuntu 20.04 and above, Fedora 40 and above, and Debian 11 and above _(x64 or arm64)_
-  (see [Linux Prerequisites](#Linux-Prerequisites) down below)
+- **Linux** _(x64 or arm64)_ see also [Linux Prerequisites](#Linux-Prerequisites) down below
+  - Ubuntu 20.04 and above
+  - Debian 11 and above
+  - Fedora 41 and above
 - **Windows** 10 and above _(x64)_
 - **Windows Server** 2019, 2022 and 2025 _(x64)_
 


### PR DESCRIPTION
## Issue

The [Fedora Linux Release Life Cycle](https://docs.fedoraproject.org/en-US/releases/lifecycle/) says:

> The Fedora Project releases a new version of Fedora Linux approximately every six months and provides updated packages (maintenance) to these releases for approximately 13 months.

| Fedora Linux release                                       | Status                |
| ---------------------------------------------------------- | --------------------- |
| [F42](https://www.redhat.com/en/blog/announcing-fedora-42) | Released Apr 15, 2025 |
| [F41](https://docs.fedoraproject.org/en-US/releases/f41/)  | Supported             |
| [F40](https://docs.fedoraproject.org/en-US/releases/f40/)  | EOL May 13, 2025      |

Reference [End of Life Releases](https://docs.fedoraproject.org/en-US/releases/eol/)

## Change

In the section [Install Cypress > Operating System](https://docs.cypress.io/app/get-started/install-cypress#Operating-System)

- Change the lowest supported version of Fedora Linux from `40` to `41`
- Reformat the list vertically for better readability and maintainability, reordering by OS popularity (highest to lowest) as gauged by the number of Cypress issues recorded per OS.