### PR TITLE
Remove Chrome 64 and 80 minimum references

### DIFF
--- a/docs/app/references/launching-browsers.mdx
+++ b/docs/app/references/launching-browsers.mdx
@@ -99,9 +99,7 @@ seeing failures in CI, to easily debug them you may want to run locally with the
 
 ### Chrome Browsers
 
-All Chrome\* flavored browsers will be detected and are supported above
-Chrome 64, with the restriction that a minimum of Chrome 80 is required to use
-`cypress open`.
+All Chrome\* flavored browsers are detected and supported by Cypress.
 
 You can launch Chrome like this:
 
@@ -112,7 +110,7 @@ cypress run --browser chrome
 To use this command in CI, you need to install the browser you want - or use one
 of our [docker images](/app/continuous-integration/overview#Cypress-Docker-Images).
 
-By default, we will launch Chrome in headlessly during `cypress run`. To run
+By default, we will launch Chrome headlessly during `cypress run`. To run
 Chrome headed, you can pass the `--headed` argument to `cypress run`.
 
 You can also launch Chromium:


### PR DESCRIPTION
## Situation

[References > Launching Browsers > Chrome Browsers](https://docs.cypress.io/app/references/launching-browsers#Chrome-Browsers) states:

> All Chrome* flavored browsers will be detected and are supported above Chrome 64, with the restriction that a minimum of Chrome 80 is required to use cypress open.

Higher up, on the same page, under [Browser versions supported](https://docs.cypress.io/app/references/launching-browsers#Browser-versions-supported) it states:

> Cypress officially supports the latest 3 major versions of Chrome, Firefox, and Edge. (For example, if the stable release of Chrome was 130, Cypress would officially support Chrome 128, 129, and 130.)

Given that the current [stable version of Chrome](https://chromereleases.googleblog.com/) is now `136`, the lowest version of Chrome supported by Cypress would be `134`.

References to minimum versions of Chrome `64` and Chrome `80` are now irrelevant and superfluous.

## Change

- Remove the specific references to Chrome 64 and 80 in [References > Launching Browsers > Chrome Browsers](https://docs.cypress.io/app/references/launching-browsers#Chrome-Browsers) and align with support statements for other browsers.

- Fix a typo in the section [References > Launching Browsers > Chrome Browsers](https://docs.cypress.io/app/references/launching-browsers#Chrome-Browsers)