### PR TITLE
chore: add migration guide for built ins

### DIFF
--- a/docs/app/references/migration-guide.mdx
+++ b/docs/app/references/migration-guide.mdx
@@ -86,6 +86,33 @@ As stated earlier, this is likely unnecessary unless you are already using `@cyp
 
 Note that this package version is deprecated and no longer supported by Cypress and is intended as a workaround until you can migrate to Webpack `5`. More information on how to configure the preprocessor can be found in the [Preprocessors API documentation](/api/node-events/preprocessors-api#Usage) and [Webpack Preprocessor documentation](https://github.com/cypress-io/cypress/blob/@cypress/webpack-preprocessor-v6.0.4/npm/webpack-preprocessor/README.md).
 
+### `@cypress/webpack-batteries-included-preprocessor` no longer shims built-ins provided by `webpack` v4
+
+The default file preprocessor, `@cypress/webpack-batteries-included-preprocessor`, no longer shims built-ins. This is mainly to reduce security vulnerabilities and bundle size within the end-to-end file preprocessor. 
+
+If these built-ins are required, you can install `@cypress/webpack-batteries-included-preprocessor` independently and follow the webpack documentation described in [webpack's resolve.fallback](https://webpack.js.org/configuration/resolve/#resolvefallback) to configure which built-ins you need.
+
+For example, the following code shows how to provide the `path` built-in to the preprocessor:
+
+```javascript
+const webpackPreprocessor = require('@cypress/webpack-batteries-included-preprocessor')
+
+function getWebpackOptions () {
+  const options = webpackPreprocessor.getFullWebpackOptions()
+
+  // add built-ins as needed
+  options.resolve.fallback.path = require.resolve('path-browserify')
+
+  return options
+}
+
+module.exports = (on) => {
+  on('file:preprocessor', webpackPreprocessor({
+    webpackOptions: getWebpackOptions()
+  }))
+}
+```
+
 ### Angular `17` CT no longer supported
 
 With [LTS ending](https://angular.dev/reference/releases#actively-supported-versions) for Angular 17, the minimum required Angular version for component testing is now `18.0.0`.


### PR DESCRIPTION
adds migration guide for Cypress v15 `@cypress/webpack-batteries-included-preprocessor` if end-to-end users still need built-ins in their tests