### PR TITLE
Add geckodriver information

### DIFF
--- a/docs/app/references/launching-browsers.mdx
+++ b/docs/app/references/launching-browsers.mdx
@@ -188,6 +188,34 @@ of our [docker images](/app/continuous-integration/overview#Cypress-Docker-Image
 By default, we will launch Firefox headlessly during `cypress run`. To run
 Firefox headed, you can pass the `--headed` argument to `cypress run`.
 
+##### Mozilla geckodriver
+
+Cypress requires the
+[Mozilla geckodriver](https://github.com/mozilla/geckodriver) to launch Firefox.
+To meet this requirement, the Cypress binary uses the separate npm wrapper package
+[geckodriver](https://github.com/webdriverio-community/node-geckodriver)
+to provide the Mozilla geckodriver.
+The wrapper downloads the latest driver version if it does not find any driver version cached locally.
+
+:::info
+
+Retrieving the driver may fail if you are operating Cypress in an air-gapped environment without Internet connectivity and you do not have a cached driver version available.
+
+To avoid this issue, use a current
+[Cypress Docker image](/app/continuous-integration/overview#Cypress-Docker-Images) `cypress/browsers` or `cypress/included`, built with Firefox 139, or above.
+These images include a Mozilla geckodriver version pre-installed.
+Using `cypress/factory:5.9.0`, or above, you can also build your own custom Cypress Docker image that includes a Mozilla geckodriver version.
+Refer to the `cypress/factory`
+[documentation](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/README.md) for instructions on building custom images.
+
+If you need to work without Docker, refer to the npm wrapper package geckodriver
+[documentation](https://github.com/webdriverio-community/node-geckodriver) for information
+about how to define a custom path for the driver or how to refer to a local CDN mirror site.
+Download the Mozilla geckodriver from the
+[releases](https://github.com/mozilla/geckodriver/releases) location.
+
+:::
+
 ##### Webdriver BiDi and CDP Deprecation
 
 :::info


### PR DESCRIPTION
- closes https://github.com/cypress-io/cypress-documentation/issues/6188

## Situation

[cypress@13.15.1](https://docs.cypress.io/app/references/changelog#13-15-1) notes

> Cypress now consumes [geckodriver](https://firefox-source-docs.mozilla.org/testing/geckodriver/index.html) to help automate the Firefox browser instead of [marionette-client](https://github.com/cypress-io/marionette-client). Addresses [#30217](https://github.com/cypress-io/cypress/issues/30217).

The [mozilla/geckodriver](https://github.com/mozilla/geckodriver) is required to test Firefox. It is not part of the Firefox distribution, nor is it included in Cypress. If the driver is unavailable, then testing against Firefox fails.

This is not mentioned in [References > Launching Browsers > Firefox Browsers](https://docs.cypress.io/app/references/launching-browsers#Firefox-Browsers).

## Change

In [References > Launching Browsers > Firefox Browsers](https://docs.cypress.io/app/references/launching-browsers#Firefox-Browsers) add a new section "Mozilla geckodriver".
