### PR TITLE
Fix: fix pnpm --allow-build command example to actually work as is.

### DIFF
--- a/docs/app/get-started/install-cypress.mdx
+++ b/docs/app/get-started/install-cypress.mdx
@@ -175,7 +175,7 @@ Refer to the [pnpm settings](https://pnpm.io/settings) documentation for additio
 In [pnpm@10.4.0](https://github.com/pnpm/pnpm/releases/tag/v10.4.0) and above, the CLI `add` option [--allow-build](https://pnpm.io/cli/add#--allow-build) can be used, for example:
 
 ```shell
-pnpm --allow-build cypress add --save-dev cypress
+pnpm --allow-build=cypress add --save-dev cypress
 ```
 
 ### Hardware


### PR DESCRIPTION
Tried copy-pasting the command as-is, but didn't work on `pnpm 10.11.0`. Hence update to match the [docs](https://pnpm.io/cli/add#--allow-build)

```sh
~/src/nitor/nitor-com-web (run-with-kubernetes*) » pnpm --version
10.11.0
~/src/repo » pnpm --allow-build cypress add --save-dev cypress
 ERR_PNPM_ALLOW_BUILD_MISSING_PACKAGE  The --allow-build flag is missing a package name. Please specify the package name(s) that are allowed to run installation scripts.
~/src/repo » pnpm --allow-build=cypress add --save-dev cypress
# works
```