### PR TITLE
Add "cypress-dragndrop-kit" to list of plugins

### DIFF
--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -460,6 +460,13 @@
           "badge": "community"
         },
         {
+          "name": "cypress-dragndrop-kit",
+          "description": "A lightweight, Cypress-native plugin that simplifies drag‑and‑drop and movement interactions in end-to-end tests. Perfect for testing sortable lists, draggable elements, and custom UI components.",
+          "link": "https://github.com/vergjor/cypress-dragndrop-kit",
+          "keywords": ["dragndrop", "drag-and-drop", "drag", "drop", "commands"],
+          "badge": "community"
+        },
+        {
           "name": "cypress-fill-command",
           "description": "A Cypress command for fill inputs.",
           "link": "https://github.com/DanielFerrariR/cypress-fill-command",


### PR DESCRIPTION
Hi all 👋 

Since we were faced with difficulties during our test implementation for a drag and drop related functionality, and after a lot of effort, we managed to find a solution that I thought would be great to share with the community. This plugin is especially useful when faced with problems such as:
- Trying to scroll an item within a virtual list where not all of the items are visible without scrolling
- React applications which use `react-beautiful-dnd` or similar packages which do not always pick up on mouse events (even though this package also implements a solution with mouse events, it does offer a way to consistently trigger the drag and drop functionality)


The plugin is made with an MIT license and offers two commands:

- `dragTo(targetElementLocator)`: Custom child command for dragging and dropping a chained element to a specified element location
- `dragAndDrop(sourceElementLocator, targetElementLocator)`: Custom command for dragging and dropping from one element location to another
