### PR TITLE
chore: add Cypress 14.5.0 changelog

### DIFF
--- a/docs/app/references/changelog.mdx
+++ b/docs/app/references/changelog.mdx
@@ -8,6 +8,18 @@ sidebar_label: Changelog
 
 # Changelog
 
+## 14.5.0
+
+_Released 6/17/2025_
+
+**Features:**
+
+- Install Cypress `win32-x64` binary on Windows `win32-arm64` systems. Cypress runs in emulation. Addresses [#30252](https://github.com/cypress-io/cypress/issues/30252).
+
+**Bugfixes:**
+
+- Fixed an issue when using `Cypress.stop()` where a run may be aborted prior to receiving the required runner events causing Test Replay to not be available. Addresses [#31781](https://github.com/cypress-io/cypress/issues/31781).
+
 ## 14.4.1
 
 _Released 6/3/2025_


### PR DESCRIPTION
Adds the Cypress `14.5.0` changelog