### PR TITLE
Add Chrome for Testing and Edge to CircleCI browsers

### DIFF
--- a/docs/app/continuous-integration/circleci.mdx
+++ b/docs/app/continuous-integration/circleci.mdx
@@ -126,8 +126,8 @@ workflows:
 ### Chrome Example
 
 Cypress uses Electron by default to run your tests. The `install-browsers` flag
-is used to install Firefox and Chrome to run your tests. This is only needed if
-you are passing the `--browser` flag in your `cypress-command`
+is used to install Chrome, Chrome for Testing, Edge, Firefox and the geckodriver to run your tests.
+This is only needed if you are passing the `--browser` flag in your `cypress-command`.
 
 ```yaml title=".circleci/config.yml"
 version: 2.1


### PR DESCRIPTION
## Situation

- The [Continuous Integration > CircleCI > Chrome Example](https://docs.cypress.io/app/continuous-integration/circleci#Chrome-Example) currently states:
  > The `install-browsers` flag is used to install Firefox and Chrome to run your tests.

- Using `install-browsers: true` from the Cypress CircleCI Orb [cypress-io/cypress@4.2.0](https://circleci.com/developer/orbs/orb/cypress-io/cypress?version=4.2.0) release, and above, installs Chrome, Chrome for Testing, Edge, Firefox and the geckodriver

## Change

Update the browser list in [Continuous Integration > CircleCI > Chrome Example](https://docs.cypress.io/app/continuous-integration/circleci#Chrome-Example) to include Chrome, Chrome for Testing, Edge, Firefox and the geckodriver.
