### PR TITLE
Update incorrect links in plugins.json

### DIFF
--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -368,7 +368,7 @@
     },
     {
       "name": "Custom Commands",
-      "description": "Read the <a target=\"_blank\" href=\"/api/node-events/preprocessors-api\">Custom Commands</a> and <a target=\"_blank\" href=\"/api/node-events/preprocessors-api\">Custom Query</a> documentation to learn more.",
+      "description": "Read the <a target=\"_blank\" href=\"/api/cypress-api/custom-commands\">Custom Commands</a> and <a target=\"_blank\" href=\"/api/cypress-api/custom-queries\">Custom Query</a> documentation to learn more.",
       "plugins": [
         {
           "name": "Puppeteer",
@@ -698,7 +698,7 @@
     },
     {
       "name": "Authentication",
-      "description": "Take a look at our auth guides for <a href=\"/app/guides/authentication-testing/amazon-cognito-authentication\">Amazon Cognito</a>, <a href=\"/app/guides/authentication-testing/amazon-cognito-authentication\">Amazon Cognito</a>, <a href=\"/app/guides/authentication-testing/auth0-authentication\">Auth0</a>, <a href=\"/app/guides/authentication-testing/amazon-cognito-authentication\">Amazon Cognito</a>, <a href=\"/app/guides/authentication-testing/google-authentication\">Google</a>, <a href=\"/app/guides/authentication-testing/okta-authentication\">Okta Cognito</a>, and <a href=\"/app/guides/authentication-testing/social-authentication\">Social Logins</a>. Also checkout our <a target=\"_blank\" href=\"https://github.com/cypress-io/cypress-example-recipes#logging-in-recipes\">Logging in</a> recipes.",
+      "description": "Take a look at our auth guides for <a href=\"/app/guides/authentication-testing/amazon-cognito-authentication\">Amazon Cognito</a>, <a href=\"/app/guides/authentication-testing/auth0-authentication\">Auth0</a>, <a href=\"/app/guides/authentication-testing/azure-active-directory-authentication\">Azure Active Directory</a>, <a href=\"/app/guides/authentication-testing/google-authentication\">Google</a>, <a href=\"/app/guides/authentication-testing/okta-authentication\">Okta Cognito</a>, and <a href=\"/app/guides/authentication-testing/social-authentication\">Social Logins</a>. Also checkout our <a target=\"_blank\" href=\"https://github.com/cypress-io/cypress-example-recipes#logging-in-recipes\">Logging in</a> recipes.",
       "plugins": [
         {
           "name": "cypress-ntlm-auth",


### PR DESCRIPTION
* Fix `Custom Commands` and `Custom Queries` links in description for `Custom Commands` section that was incorrectly pointing to preprocessor API docs
* `Amazon Cognito` was listed 3 times in `Authentication` section, removed the 2 duplications and added missing `Azure Active Directory` link based on: https://github.com/cypress-io/cypress-documentation/tree/main/docs/app/guides/authentication-testing