### PR TITLE
fix: Algolia scraper import json syntax

### DIFF
--- a/scripts/search/scrape-and-compare-algolia-index.mjs
+++ b/scripts/search/scrape-and-compare-algolia-index.mjs
@@ -23,7 +23,7 @@ import util from 'util'
 import { exec as execOriginal } from 'child_process'
 const exec = util.promisify(execOriginal)
 import { AlgoliaClient } from './algolia-client.mjs'
-import config from './config.json' assert { type: 'json' }
+import config from './config.json' with { type: 'json' }
 
 // Required environment variables
 const API_KEY = process.env.ALGOLIA_API_KEY


### PR DESCRIPTION
## Situation

The CircleCI job "Run Algolia scraper" fails to run.

The error is

```text
import config from './config.json' assert { type: 'json' }
                                   ^^^^^^

SyntaxError: Unexpected identifier 'assert'
```

## Logs

See https://app.circleci.com/pipelines/github/cypress-io/cypress-documentation/26567/workflows/94363567-384d-4e59-9a5b-88987d84c5f1/jobs/67593

```text
Scraping...
babel.config.js    docusaurus.config.js  patches      static
CONTRIBUTING.md    LICENSE.md            plugins      tailwind.config.js
cypress            netlify.toml          README.md    tsconfig.json
cypress.config.ts  node_modules          scripts      vercel.json
dist               package.json          sidebars.js
docs               package-lock.json     src
file:///home/circleci/repo/scripts/search/scrape-and-compare-algolia-index.mjs:26
import config from './config.json' assert { type: 'json' }
                                   ^^^^^^

SyntaxError: Unexpected identifier 'assert'
    at compileSourceTextModule (node:internal/modules/esm/utils:344:16)
    at ModuleLoader.moduleStrategy (node:internal/modules/esm/translators:105:18)
    at #translate (node:internal/modules/esm/loader:534:12)
    at ModuleLoader.loadAndTranslate (node:internal/modules/esm/loader:581:27)
    at async ModuleJob._link (node:internal/modules/esm/module_job:116:19)

Node.js v22.15.1

Exited with code exit status 1
```

## Assessment

https://github.com/cypress-io/cypress-documentation/blob/4b29f22b6d6d667f9c9316eb1bfc52f970938c03/scripts/search/scrape-and-compare-algolia-index.mjs#L26

uses `import ... assert { type: 'json' }`

In Node.js 22.x only [Import attributes](https://nodejs.org/docs/latest-v22.x/api/esm.html#import-attributes) are available. The experimental [Import assertions](https://nodejs.org/docs/v18.17.1/api/esm.html) from Node.js `18.17.1` are no longer supported. This was announced in the [Node.js 22.0.0 release notes](https://nodejs.org/en/blog/release/v22.0.0).

## Change

In [scripts/search/scrape-and-compare-algolia-index.mjs](https://github.com/cypress-io/cypress-documentation/blob/main/scripts/search/scrape-and-compare-algolia-index.mjs) change from experimental [Import assertions](https://nodejs.org/docs/v18.17.1/api/esm.html) to [Import attributes](https://nodejs.org/docs/latest-v22.x/api/esm.html#import-attributes) in the import statement for compatibility with Node.js `22.x`:

`import config from './config.json' with { type: 'json' }`

## Verification

Monitor the success of the CircleCI job "Run Algolia scraper" after PR merge into `main` branch.
