### PR TITLE
Add details for user .gitignore configuration

### DIFF
--- a/docs/app/core-concepts/writing-and-organizing-tests.mdx
+++ b/docs/app/core-concepts/writing-and-organizing-tests.mdx
@@ -93,12 +93,15 @@ detail.
 
 <strong>What files should I add to my '.gitignore file' ?</strong>
 
-Cypress will create a
-[`screenshotsFolder`](/app/references/configuration#Screenshots) and a
-[`videosFolder`](/app/references/configuration#Videos) to store the
-screenshots and videos taken during the testing of your application. Many users
-will opt to add these folders to their `.gitignore` file. Additionally, if you
-are storing sensitive environment variables in your
+Cypress may create
+[asset files](#Asset-Files) in a
+[`downloadsFolder`](#Download-Files), a
+[`screenshotsFolder`](#Screenshot-Files) or a
+[`videosFolder`](#Video-Files) to store any downloads,
+screenshots or videos created during the testing of your application.
+Many users will opt to add these folders to their
+[.gitignore](https://git-scm.com/docs/gitignore) file (see [below](#Asset-Files) for an example).
+Additionally, if you are storing sensitive environment variables in your
 [Cypress configuration](/app/references/configuration) or
 [`cypress.env.json`](/app/references/environment-variables#Option-2-cypressenvjson),
 these should also be ignored when you check into source control.
@@ -151,8 +154,16 @@ command and most often when you're stubbing
 There are some folders that may be generated after a test run, containing assets
 that were generated during the test run.
 
-You may consider adding these folders to your `.gitignore` file to ignore
-checking these files into source control.
+You may consider adding these folders to your
+[.gitignore](https://git-scm.com/docs/gitignore) file to prevent
+checking files in these folders into source control, for example, using the default folder locations:
+
+```text
+# Cypress asset folders to exclude from source control
+cypress/downloads/
+cypress/screenshots/
+cypress/videos/
+```
 
 #### Download Files
 


### PR DESCRIPTION
## Situation

In [Core Concepts > Writing and Organizing Tests](https://docs.cypress.io/app/core-concepts/writing-and-organizing-tests#Configuring-Folder-Structure) the `.gitignore` advice is fragmented into two sections:

- [Configuring Folder Structure](https://docs.cypress.io/app/core-concepts/writing-and-organizing-tests#Configuring-Folder-Structure)
- [Asset Files](https://docs.cypress.io/app/core-concepts/writing-and-organizing-tests#Asset-Files)

The following aspects could be improved:

- The first section does not mention the [downloadsFolder](downloadsFolder)
- The first section is not linked to the second section
- A concrete example is missing

## Change

In [Core Concepts > Writing and Organizing Tests](https://docs.cypress.io/app/core-concepts/writing-and-organizing-tests)

- [Configuring Folder Structure](https://docs.cypress.io/app/core-concepts/writing-and-organizing-tests#Configuring-Folder-Structure)
  - expand description and link to [Asset Files](https://docs.cypress.io/app/core-concepts/writing-and-organizing-tests#Asset-Files) on the same page
- [Asset Files](https://docs.cypress.io/app/core-concepts/writing-and-organizing-tests#Asset-Files)
  - provide an example using default asset file folder locations
