### PR TITLE
ci: update Cypress tests to Node.js 22.15.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  cypress: cypress-io/cypress@3
+  cypress: cypress-io/cypress@4
 
 executors:
   node-executor:
@@ -19,7 +19,7 @@ commands:
       - checkout
       - restore_cache:
           keys:
-            - npm-cache-{{ checksum "package-lock.json" }}            
+            - npm-cache-{{ checksum "package-lock.json" }}
       - run:
           name: Install Dependencies
           command: npm ci
@@ -56,7 +56,9 @@ jobs:
       - run: npm run lint
 
   install-and-persist:
-    executor: cypress/default
+    executor:
+      name: cypress/default
+      node-version: 22.15.1
     steps:
       - cypress/install
       - persist_to_workspace:
@@ -66,7 +68,9 @@ jobs:
             - project
 
   run-tests-in-parallel:
-    executor: cypress/default
+    executor:
+      name: cypress/default
+      node-version: 22.15.1
     parallelism: 6
     steps:
       - attach_workspace:
@@ -87,7 +91,7 @@ jobs:
           command: |
             echo "Scraping..."
             ls
-            node ./scripts/search/scrape-and-compare-algolia-index.mjs 
+            node ./scripts/search/scrape-and-compare-algolia-index.mjs
 
 workflows:
   build-and-test:
@@ -96,14 +100,14 @@ workflows:
       - lint:
           name: "Lint JS/CSS/Markdown"
           requires:
-            - build     
+            - build
       - install-and-persist:
           name: Install & Persist To Workspace
       - run-tests-in-parallel:
           name: Run Tests in Parallel
           requires:
             - build
-            - Install & Persist To Workspace      
+            - Install & Persist To Workspace
       # Run Algolia scraper only on main.
       - release:
           name: 'Run Algolia scraper'


### PR DESCRIPTION
## Situation

- PR https://github.com/cypress-io/cypress-documentation/pull/6223 includes the text
  > updates the node version in the repo to 22.15.1

Current CircleCI jobs are now running in two different Node.js environments `18.16.1` and `22.15.1`

| Job                            | image                                                   |
| ------------------------------ | ------------------------------------------------------- |
| build                          | `docker.io/cimg/node:22.15.1`                           |
| Run Algolia scraper            | `ubuntu-2204:2024.11.1` / `docker.io/cimg/node:22.15.1` |
| Lint JS/CSS/Markdown           | `docker.io/cimg/node:22.15.1`                           |
| Install & Persist To Workspace | `docker.io/cimg/node:18.16.1-browsers`                  |
| Run Tests in Parallel          | `docker.io/cimg/node:18.16.1-browsers`                  |

It doesn't seem like this would have been the intention. Node.js `18.x` is end-of-life and deprecated by Cypress. With the release of Cypress 15, this version of Node.js will transition into being unsupported by Cypress and the minimum Node.js will become version 20.

## Assessment

The configuration [.circleci/config.yml](https://github.com/cypress-io/cypress-documentation/blob/main/.circleci/config.yml) for the jobs:

- Install & Persist To Workspace
- Run Tests in Parallel

relies on `executor: cypress/default` taken from

https://github.com/cypress-io/cypress-documentation/blob/3a428ac5e53b94444b18e0ee63e2e2285781c4e3/.circleci/config.yml#L3-L4

- The default Node.js version for `cypress: cypress-io/cypress@3`, equivalent to [cypress-io/cypress@3.4.3](https://github.com/cypress-io/circleci-orb/releases/tag/v3.4.3), is [Node.js 18.16.1](https://circleci.com/developer/orbs/orb/cypress-io/cypress?version=3.4.3#executors-default)

- The default Node.js version for `cypress: cypress-io/cypress@4`, equivalent to [cypress-io/cypress@4.2.0](https://github.com/cypress-io/circleci-orb/releases/tag/v4.2.0), is [Node.js 22.15.0](https://circleci.com/developer/orbs/orb/cypress-io/cypress?version=4.2.0#executors-default)

## Change

In the configuration [.circleci/config.yml](https://github.com/cypress-io/cypress-documentation/blob/main/.circleci/config.yml):

- update the Cypress CircleCI Orb from `cypress: cypress-io/cypress@3` to `cypress: cypress-io/cypress@4` (current `latest`)

and in the jobs "Install & Persist To Workspace" and "Run Tests in Parallel"

- specify the [node-version](https://circleci.com/developer/orbs/orb/cypress-io/cypress?version=4.2.0#usage-node-version) parameter, set to `22.15.1`, to use exactly this version that is being used in the other jobs already
