### PR TITLE
docs: Update data-storage-and-masking.mdx

### DIFF
--- a/docs/cloud/account-management/data-storage-and-masking.mdx
+++ b/docs/cloud/account-management/data-storage-and-masking.mdx
@@ -154,7 +154,7 @@ You can pass `log: false` as an option to Cypress-specific commands in your test
 By default, Cypress logs all requests that match any [`cy.intercept()`](/api/commands/intercept) in the Cypress Command Log, as well as all XMLHttpRequests and fetch requests. You can use `cy.intercept()` to disable these logs by passing `{ log: false }` in the second parameter. See the [`cy.intercept()`](/api/commands/intercept#Disabling-logs-for-a-request) command for more information.
 
 ```js
-before(() => {
+beforeEach(() => {
   // disable Cypress's default behavior of logging all XMLHttpRequests and fetches
   cy.intercept({ resourceType: /xhr|fetch/ }, { log: false })
 })


### PR DESCRIPTION
Since intercepts are cleared before each test, update to use `beforeEach` instead of `before`.