### PR TITLE
Add browser support section

### DIFF
--- a/docs/app/get-started/install-cypress.mdx
+++ b/docs/app/get-started/install-cypress.mdx
@@ -179,6 +179,20 @@ In [pnpm@10.4.0](https://github.com/pnpm/pnpm/releases/tag/v10.4.0) and above, t
 pnpm --allow-build=cypress add --save-dev cypress
 ```
 
+### Browsers
+
+Each Cypress release includes the Electron-bundled Chromium [browser](/app/references/launching-browsers#Electron-Browser).
+
+The latest 3 major versions of the following browsers are also supported:
+
+- [Google Chrome](/app/references/launching-browsers#Chrome-Browsers)
+- [Microsoft Edge](/app/references/launching-browsers#Edge-Browsers)
+- [Mozilla Firefox](/app/references/launching-browsers#Firefox-Browsers) (_release Firefox [141.0](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/141) and above requires a minimum Cypress [14.1.0](https://docs.cypress.io/app/references/changelog#14-1-0)_)
+
+Additionally:
+
+- [WebKit](https://docs.cypress.io/app/references/launching-browsers#WebKit-Experimental) is experimentally supported
+
 ### Hardware
 
 When running Cypress locally, it should run comfortably on any machine that is


### PR DESCRIPTION
- closes https://github.com/cypress-io/cypress/issues/32148

## Situation

Firefox `141.0` and above is not compatible with versions of Cypress below [14.1.0](https://docs.cypress.io/app/references/changelog#14-1-0) and this is not specifically mentioned on https://docs.cypress.io/ (see https://github.com/cypress-io/cypress/issues/32148).

The [Get Started > Install Cypress > System requirements](https://docs.cypress.io/app/get-started/install-cypress#System-requirements) section lists only base system requirements without mentioning browsers. For browser information, readers have to find and consult with the page [References > Launching Browsers](https://docs.cypress.io/app/references/launching-browsers) where the Firefox version restriction is however not mentioned.

The related section [References > Launching Browsers > Browsers > Firefox Browsers > Webdriver BiDi and CDP Deprecation](https://docs.cypress.io/app/references/launching-browsers#Webdriver-BiDi-and-CDP-Deprecation) is planned for removal in Cypress 15.

## Change

Add a "Browsers" section to the page [Get Started > Install Cypress > System requirements](http://localhost:3000/app/get-started/install-cypress#System-requirements) section.

## Suggestion

Review the plans to remove the section [References > Launching Browsers > Browsers > Firefox Browsers > Webdriver BiDi and CDP Deprecation](https://docs.cypress.io/app/references/launching-browsers#Webdriver-BiDi-and-CDP-Deprecation) in Cypress 15 and consider reworking it based on the current situation. Perhaps retitle to "Webdriver CDP to BiDi Migration" given that CDP is no longer just deprecated, but removed entirely?

## Reference

| Source                                                                                                                                     | Date         |
| ------------------------------------------------------------------------------------------------------------------------------------------ | ------------ |
| [Bugzilla 1882096 - Remove CDP support from Remote Agent](https://bugzilla.mozilla.org/show_bug.cgi?id=1882096)                            | Feb 26, 2024 |
| [Cypress 14.1.0 - changelog](https://docs.cypress.io/app/references/changelog#14-1-0)                                                                  | Feb 25, 2025 |
| [WebDriver BiDi Becomes the Default for Cypress with Firefox](https://fxdx.dev/webdriver-bidi-becomes-the-default-for-cypress-in-firefox/) | Feb 26, 2025 |
| [CDP Retirement in Firefox](https://fxdx.dev/cdp-retirement-in-firefox/)                                                                   | Jun 2, 2025   |
| [Firefox 141 for developers - release notes](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/141)                                        | Jul 22, 2025 |

