### PR TITLE
chore: Fix vercel builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ cypress/videos
 # Generated files
 .docusaurus
 .cache-loader
+.vercel
 
 .nuxt
 .husky

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
       "devDependencies": {
         "@docusaurus/module-type-aliases": "^3.1.1",
         "@docusaurus/tsconfig": "3.1.1",
-        "@prettier/sync": "^0.5.1",
+        "@prettier/sync": "^0.6.1",
         "cypress": "^13.15.0",
         "node-fetch": "^3.3.2",
         "patch-package": "^8.0.0",
@@ -3265,12 +3265,13 @@
       "integrity": "sha512-2LuNTFBIO0m7kKIQvvPHN6UE63VjpmL9rnEEaOOaiSPbZK+zUOYIzBAWcED+3XYzhYsd/0mD57VdxAEqqV52CQ=="
     },
     "node_modules/@prettier/sync": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@prettier/sync/-/sync-0.5.1.tgz",
-      "integrity": "sha512-tpF+A1e4ynO2U4fTH21Sjgm9EYENmqg4zmJCMLrmLVfzIzuDc1cKGXyxrxbFgcH8qQRfowyDCZFAUukwhiZlsw==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@prettier/sync/-/sync-0.6.1.tgz",
+      "integrity": "sha512-yF9G8vK/LYUTF3Cijd7VC9La3b20F20/J/fgoR4H0B8JGOWnZVZX6+I6+vODPosjmMcpdlUV+gUqJQZp3kLOcw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "make-synchronized": "^0.2.8"
+        "make-synchronized": "^0.8.0"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier-synchronized?sponsor=1"
@@ -9542,10 +9543,11 @@
       }
     },
     "node_modules/make-synchronized": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/make-synchronized/-/make-synchronized-0.2.8.tgz",
-      "integrity": "sha512-jtXnKYCxjmGaXiZhXbDbGPbh4YyTvIIbOgcQjtAboc4RSm9k3nyhTFvFQB0cfs7QFKuZXKe2D2RvOkv1c+vpxg==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/make-synchronized/-/make-synchronized-0.8.0.tgz",
+      "integrity": "sha512-DZu4lwc0ffoFz581BSQa/BJl+1ZqIkoRQ+VejMlH0VrP4E86StAODnZujZ4sepumQj8rcP7wUnUBGM8Gu+zKUA==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/fisker/make-synchronized?sponsor=1"
       }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "devDependencies": {
     "@docusaurus/module-type-aliases": "^3.1.1",
     "@docusaurus/tsconfig": "3.1.1",
-    "@prettier/sync": "^0.5.1",
+    "@prettier/sync": "^0.6.1",
     "cypress": "^13.15.0",
     "node-fetch": "^3.3.2",
     "patch-package": "^8.0.0",


### PR DESCRIPTION
chore: add .vercel to gitignore and update @prettier/sync to transiently update make-synchronized so process args are no longer passed into child processes neded by prettier incorrectly