### PR TITLE
Update Ubuntu/Debian t64 Year 2038 Linux module choices

### DIFF
--- a/docs/app/get-started/install-cypress.mdx
+++ b/docs/app/get-started/install-cypress.mdx
@@ -235,11 +235,13 @@ See below under [Docker Prerequisites](#Docker-Prerequisites) for information on
 
 #### Ubuntu/Debian
 
+For Ubuntu below 24.04 and Debian below 13:
+
 ```shell
 apt-get install libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libnss3 libxss1 libasound2 libxtst6 xauth xvfb
 ```
 
-For Ubuntu 24.04, and above, use the following command:
+For Ubuntu 24.04, and above, and Debian 13, use the following command:
 
 ```shell
 apt-get install libgtk2.0-0t64 libgtk-3-0t64 libgbm-dev libnotify-dev libnss3 libxss1 libasound2t64 libxtst6 xauth xvfb


### PR DESCRIPTION
## Situation

The section [Get Started > Install Cypress > System requirements > Linux Prerequisites > Ubuntu/Debian](https://docs.cypress.io/app/get-started/install-cypress#UbuntuDebian) provides two sets of Linux prerequisite recommendations for modules depending on whether the underlying operating system releases have been converted to support the Year 2038. Since the release of [Debian 13 (Trixie)](https://www.debian.org/News/2025/20250809), the labels for which implementation to use are no longer correct for Debian because Debian 13, like previously Ubuntu 24.04, has been converted to modules with `t64` appended to their names. This indicates support for 64-bit time.

## Assessment

The following Ubuntu / Debian operating system releases are [supported by Cypress](https://docs.cypress.io/app/get-started/install-cypress#Operating-System)

- Ubuntu 20.04 and above
- Debian 11 and above

The [Ubuntu release cycle](https://ubuntu.com/about/release-cycle) shows the following releases covered by standard support, with detailed information in the [Ubuntu wiki releases page](https://wiki.ubuntu.com/Releases?_gl=1*xo17wk*_gcl_au*MjA5ODA2ODcwMC4xNzUwMTUzMzU1LjExODYwMDkwNDAuMTc1MDE1MzQzOC4xNzUwMTUzNDM3):

- Ubuntu 22.04 (Jammy Jellyfish)
- Ubuntu 24.04 (Noble Numbat)
- Ubuntu 25.04 (Plucky Puffin)

The [Debian Releases](https://www.debian.org/releases/) includes the following releases within End of Life and End of Long Term Support that are also covered by Cypress support:

- Debian 11 (Bullseye)
- Debian 12 (Bookworm)
- Debian 13 (Trixie)

[Ubuntu 24.04 (Noble Numbat) Release Notes](https://discourse.ubuntu.com/t/ubuntu-24-04-lts-noble-numbat-release-notes/39890) section "Year 2038 support for the armhf architecture" explains that "packages have been updated to handle time using a 64-bit value rather than a 32-bit one"

[Debian 13 (trixie) Release Notes](https://www.debian.org/releases/trixie/release-notes/whats-new.en.html#bit-time-t-abi-transition) states All architectures other than i386 now use a 64-bit time_t ABI, supporting dates beyond 2038."


| Operating system               | pre-t64 | post-t64 |
| ------------------------------ | ------- | -------- |
| Ubuntu 22.04 (Jammy Jellyfish) | ✅       |          |
| Ubuntu 24.04 (Noble Numbat)    |         | ✅        |
| Ubuntu 25.04 (Plucky Puffin)   |         | ✅        |
| Debian 11 (Bullseye)           | ✅       |          |
| Debian 12 (Bookworm)           | ✅       |          |
| Debian 13 (Trixie)             |         | ✅        |

## Change

Add Debian 13 to the t64 section.

## Verification

### pre-t64 OS

Check that the following can be successfully executed in each Docker container:

```bash
apt-get update
apt-get install libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libnss3 libxss1 libasound2 libxtst6 xauth xvfb
```

```shell
docker run -it --rm ubuntu:22.04
docker run -it --rm debian:11
docker run -it --rm debian:12
```

### post-t64 OS

Check that the following can be successfully executed in each Docker container:

```bash
apt-get update
apt-get install libgtk2.0-0t64 libgtk-3-0t64 libgbm-dev libnotify-dev libnss3 libxss1 libasound2t64 libxtst6 xauth xvfb
```

```shell
docker run -it --rm ubuntu:24.04
docker run -it --rm ubuntu:25.04
docker run -it --rm debian:13
```
