### PR TITLE
Remove reference to `experimentalInteractiveRunEvents` flag

### DIFF
--- a/docs/api/node-events/after-spec-api.mdx
+++ b/docs/api/node-events/after-spec-api.mdx
@@ -15,12 +15,6 @@ The `after:spec` event fires after a spec file is run. When running cypress via
 
 <WarningSetupNodeEvents />
 
-:::caution
-
-⚠️ When running via `cypress open`, the `after:spec` event only fires if the
-[experimentalInteractiveRunEvents flag](/app/references/configuration#Experiments)
-is enabled.
-
 :::
 
 :::cypress-config-plugin-example


### PR DESCRIPTION
It looks like this flag doesn't exist at the link destination. I'm not 100% sure it's gone, but the docs link is dead.

I figured I'd submit this PR even though I'm not sure - if I'm correct, this can be approved and merged. If not, consider this a bug report and update the PR to reflect the true state of the flags.