### PR TITLE
fix: typo in UI Cov example code

### DIFF
--- a/docs/ui-coverage/configuration/allowedinteractioncommands.mdx
+++ b/docs/ui-coverage/configuration/allowedinteractioncommands.mdx
@@ -149,7 +149,7 @@ Note that because `allowedInteractionCommands` replaces the allowed interactions
 ```json
 {
   "uiCoverage": {
-    "additionalInteractionCommands": [
+    "allowedInteractionCommands": [
       {
         "selector": "button[data-no-explicit-interaction='true']",
         "commands": ["assert"]


### PR DESCRIPTION
A user ran into an issue copying this section from our documentation.