### PR TITLE
Remove GTK2 Linux prerequisites

### DIFF
--- a/docs/app/get-started/install-cypress.mdx
+++ b/docs/app/get-started/install-cypress.mdx
@@ -130,19 +130,19 @@ Install required dependencies. See below under [Docker Prerequisites](#Docker-Pr
 For Ubuntu 22.04 and below, and Debian:
 
 ```shell
-apt-get install libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libnss3 libxss1 libasound2 libxtst6 xauth xvfb
+apt-get install libgtk-3-0 libgbm-dev libnotify-dev libnss3 libxss1 libasound2 libxtst6 xauth xvfb
 ```
 
 For Ubuntu >=24.04 and optionally for Debian 13:
 
 ```shell
-apt-get install libgtk2.0-0t64 libgtk-3-0t64 libgbm-dev libnotify-dev libnss3 libxss1 libasound2t64 libxtst6 xauth xvfb
+apt-get install libgtk-3-0t64 libgbm-dev libnotify-dev libnss3 libxss1 libasound2t64 libxtst6 xauth xvfb
 ```
 
 #### Arch
 
 ```shell
-pacman -S gtk2 gtk3 alsa-lib xorg-server-xvfb libxss nss libnotify
+pacman -S gtk3 alsa-lib xorg-server-xvfb libxss nss libnotify
 ```
 
 #### Amazon Linux 2023


### PR DESCRIPTION
## Situation

[Linux Prerequisites](https://docs.cypress.io/app/get-started/install-cypress#Linux-Prerequisites) lists both GTK 2 and GTK 3 packages for installation.

- PR https://github.com/cypress-io/cypress/pull/32372 locks Electron usage to GTK 3
- https://www.gtk.org/ supports only GTK 3 and GTK 4. GTK 2 reached end-of-life in 2020 according to https://blog.gtk.org/2020/12/16/gtk-4-0/
- Debian-based Cypress Docker images built using [factory/factory.Dockerfile](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/factory.Dockerfile) include only `libgtk-3-0`, not `libgtk2.0-0`

## Change

Remove GTK 2 prerequisites from [Linux Prerequisites](https://docs.cypress.io/app/get-started/install-cypress#Linux-Prerequisites)
