### PR TITLE
Fix typo on Branch Review page

### DIFF
--- a/docs/cloud/features/branch-review.mdx
+++ b/docs/cloud/features/branch-review.mdx
@@ -24,7 +24,7 @@ Compare which tests are failing, flaky, pending, added, or modified between the 
 UI Coverage or Cypress Accessibility changes between runs will also appear here.
 
 Branch Review is useful even if you do not have a Pull Request workflow, because it allows you to compare any two runs of your choice.
-These might might represent different builds of the application, changes in test code, or results from nightly runs. This page will use
+These might represent different builds of the application, changes in test code, or results from nightly runs. This page will use
 the example of a Pull Request made using the GitHub integration, but this integration is not required in order to use Branch Review.
 
 A common scenario throughout the software development lifecycle (SDLC) is an engineer's **feature** branch that will be merged into the


### PR DESCRIPTION
Fix "These might might represent different builds of the application [...]"