### PR TITLE
docs: add note in CI overview about how to disable dbus

### DIFF
--- a/docs/app/continuous-integration/overview.mdx
+++ b/docs/app/continuous-integration/overview.mdx
@@ -709,6 +709,14 @@ colors are not properly formatted in your CI.
 NO_COLOR=1 cypress run
 ```
 
+### `Failed to connect to the bus: Failed to connect to socket /run/dbus/system_bus_socket`
+
+This error message indicates that Electron is attempting to connect to `dbus`, a desktop environment service, when there is no `dbus` present.
+
+Cypress does its best to detect non-interactive shells and disable `dbus` by setting the `DBUS_SESSION_BUS_ADDRESS` environment variable to `disabled:`.
+
+If you see these error messages, setting the `DBUS_SESSION_BUS_ADDRESS` environment variable to `disabled:` should resolve them.
+
 ## See also
 
 - [Cypress Real World App](https://github.com/cypress-io/cypress-realworld-app)


### PR DESCRIPTION
This documentation relates to:

- https://github.com/cypress-io/cypress/pull/32479 , which attempts to detect non-interactive shells (likely candidates for missing a desktop environment) and disables `dbus` if it does
- https://github.com/cypress-io/cypress-docker-images/pull/1415 , which defaults to disabling `dbus` in the official Cypress images

Ultimately, `dbus` error messages are typically a configuration issue - not a bug.