### PR TITLE
Write GitHub consistently

### DIFF
--- a/docs/accessibility/guides/block-pull-requests.mdx
+++ b/docs/accessibility/guides/block-pull-requests.mdx
@@ -18,7 +18,7 @@ The [Cypress Accessibility Results API](/accessibility/results-api) allows you t
 <DocsImage
   src="/img/accessibility/guides/github-actions-a11y-block.png"
   width="75%"
-  alt="On the left hand side, a list of Github Actions jobs is presented related to building, testing and deploying a website. Everything has a green checkmark except the `verify-accessibility-results` job, and the 'test' job that is its parents. On the right hand side we see the terminal output for that job which warns us that the 'button-name' rule has been broken, and that it was previously passing."
+  alt="On the left hand side, a list of GitHub Actions jobs is presented related to building, testing and deploying a website. Everything has a green checkmark except the `verify-accessibility-results` job, and the 'test' job that is its parents. On the right hand side we see the terminal output for that job which warns us that the 'button-name' rule has been broken, and that it was previously passing."
   noBorder={true}
 />
 

--- a/docs/app/guides/authentication-testing/azure-active-directory-authentication.mdx
+++ b/docs/app/guides/authentication-testing/azure-active-directory-authentication.mdx
@@ -252,7 +252,7 @@ We hope this guide was able to get you up and running with
 [`cy.origin()`](/api/commands/origin) and
 [`cy.session()`](/api/commands/session). If you ran into any issues while
 following this guide, or have any feedback, please let us know and submit a
-[Github issue](https://github.com/cypress-io/cypress-documentation/issues/new/choose).
+[GitHub issue](https://github.com/cypress-io/cypress-documentation/issues/new/choose).
 Happy testing!
 
 ## See also

--- a/docs/app/guides/authentication-testing/social-authentication.mdx
+++ b/docs/app/guides/authentication-testing/social-authentication.mdx
@@ -431,7 +431,7 @@ We hope this guide was able to get you up and running with
 [`cy.origin()`](/api/commands/origin) and
 [`cy.session()`](/api/commands/session). If you ran into any issues while
 following this guide, or have any feedback, please let us know and submit a
-[Github issue](https://github.com/cypress-io/cypress-documentation/issues/new/choose).
+[GitHub issue](https://github.com/cypress-io/cypress-documentation/issues/new/choose).
 Happy testing!
 
 ## See also

--- a/docs/app/references/changelog.mdx
+++ b/docs/app/references/changelog.mdx
@@ -2994,7 +2994,7 @@ _Released 8/30/2022_
 - Fixed an issue where snapshots performed in XHR requests could reflect the
   primary domain instead of current domain. Fixes
   [#21496](https://github.com/cypress-io/cypress/issues/21496).
-- An update was made to correctly track Github Actions retries in the Cypress
+- An update was made to correctly track GitHub Actions retries in the Cypress
   Dashboard. Previously retries data was not being recorded. Addressed in
   [#23445](https://github.com/cypress-io/cypress/pull/23445).
 - Fixed an issue where an internal TypeScript type was exposed globally. Fixes

--- a/docs/cloud/faq.mdx
+++ b/docs/cloud/faq.mdx
@@ -114,7 +114,7 @@ Please see our [Pricing Page](https://www.cypress.io/pricing) for more details.
 ### <Icon name="angle-right" /> What is the difference between public and private projects?
 
 **A public project** means that anyone can see the recorded runs for it. It's
-similar to how public projects on Github, Travis, or CircleCI are handled.
+similar to how public projects on GitHub, Travis, or CircleCI are handled.
 Anyone who knows your `projectId` will be able to see the recorded runs,
 screenshots, and videos for public projects.
 

--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -99,7 +99,7 @@
           "badge": "official"
         },
         {
-          "name": "Cypress Github Actions",
+          "name": "Cypress GitHub Actions",
           "description": "GitHub Action for running Cypress end-to-end and component tests. Includes npm, pnpm and Yarn installation, custom caching and lots of configuration options.",
           "link": "https://github.com/cypress-io/github-action",
           "keywords": ["continuous-integration", "github-actions"],
@@ -1117,7 +1117,7 @@
           "link":"https://github.com/pushpak1300/cypress-mailpit",
           "keywords":["mailpit", "email", "test", "commands", "email"],
           "badge":"community"
-        }, 
+        },
         {
           "name":"cypress-sql",
           "description":"The @dankieu/cypress-sql package supports the following database connections Sql server, Mysql, OracleDB, Postgress",


### PR DESCRIPTION
## Situation

In several places, GitHub (mixed case) is incorrectly written as Github, with only the first letter capitalized.

## Change

Change text usage to consistently refer to GitHub (mixed case).

## Reference

- https://github.com/why-github