### PR TITLE
Added plugin for generating OTP tokens

### DIFF
--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -726,6 +726,18 @@
             "google"
           ],
           "badge": "community"
+        },
+        {
+          "name": "cypress-get-otp",
+          "description": "Cypress custom command for generating OTP codes.",
+          "link": "https://github.com/sergiubcn/cypress-get-otp",
+          "keywords": [
+            "authentication",
+            "hmac",
+            "otp",
+            "totp"
+          ],
+          "badge": "community"
         }
       ]
     },


### PR DESCRIPTION
- Added plugin which provides access to a custom command used to generate OTP tokens;
- Please let me know if the "Authentication" category is not suited for this plugin;
- Note*: I used AI to generate documentation for this plugin - I haven't seen rules which mandate mentioning this, but I think it's good practice;