### PR TITLE
Fix gherkin keywords

### DIFF
--- a/docs/api/commands/prompt.mdx
+++ b/docs/api/commands/prompt.mdx
@@ -366,8 +366,8 @@ describe('Feature: User Registration', () => {
         'And the user enters {{password}} in the confirm password field',
         'And the user selects "admin" from the role dropdown',
         'And the user checks the terms and conditions checkbox',
-        'Then the user clicks the "Register User" button',
-        'And the user should see a success notification',
+        'And the user clicks the "Register User" button',
+        'Then the user should see a success notification',
         'And the user should be added to the user list',
       ],
       {


### PR DESCRIPTION
Since clicking the "Register User" button is still an action, we should use another `And`.

And as "the user should see a success notification" is the first assertion, here's where the `Then` keyword comes.

Cc @jennifer-shehane.