### PR TITLE
chore: fix headers

### DIFF
--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -122,8 +122,6 @@
   --ifm-heading-font-family: Poppins;
   --ifm-heading-font-weight: var(--ifm-font-weight-bold);
   --ifm-line-height-base: 1.6;
-  --ifm-heading-color: theme(colors.gray.1000);
-  --ifm-code-font-size: 95%;
   --ifm-pre-line-height: 1.5em;
 
   --ifm-code-background-color: #282a36;


### PR DESCRIPTION
fixes header styles that were working before due to `15.4.0` fixing a syntax error, which in turn applied a style we do not want

#### Before
<img width="1882" height="753" alt="Screenshot 2025-10-07 at 4 13 43 PM" src="https://github.com/user-attachments/assets/171a2299-84e9-46f0-bb07-952c4828cb48" />

#### After
<img width="709" height="753" alt="Screenshot 2025-10-07 at 4 24 11 PM" src="https://github.com/user-attachments/assets/8d47f38f-e01c-48aa-b86c-28f03730a7aa" />
