### PR TITLE
Correct miscellaneous changelog formatting typos

### DIFF
--- a/docs/app/references/changelog.mdx
+++ b/docs/app/references/changelog.mdx
@@ -21,7 +21,7 @@ _Released 10/7/2025_
 
 **Bugfixes:**
 
-- Fixed a regression introduced in [`15.0.0`](#15-0-0) where `dbus` connection error messages appear in docker containers when launching Cypress. Fixes [#32290](https://github.com/cypress-io/cypress/issues/32290).
+- Fixed a regression introduced in [15.0.0](#15-0-0) where `dbus` connection error messages appear in docker containers when launching Cypress. Fixes [#32290](https://github.com/cypress-io/cypress/issues/32290).
 - Fixed code frames in [`cy.origin()`](/api/commands/origin) so that failed commands will show the correct line/column within the corresponding spec file. Addressed in [#32597](https://github.com/cypress-io/cypress/pull/32597).
 - Fixed Cypress cloud requests so that they properly verify SSL certificates. Addressed in [#32629](https://github.com/cypress-io/cypress/pull/32629).
 
@@ -44,11 +44,11 @@ _Released 9/23/2025_
 
 **Features:**
 
-- Added Escape key support to [`cy.press()`](http://on.cypress.io/api/press). Addresses[#32429](https://github.com/cypress-io/cypress/issues/32429). Addressed in [#32545](https://github.com/cypress-io/cypress/pull/32545).
+- Added Escape key support to [`cy.press()`](http://on.cypress.io/api/press). Addresses [#32429](https://github.com/cypress-io/cypress/issues/32429). Addressed in [#32545](https://github.com/cypress-io/cypress/pull/32545).
 
 **Bugfixes:**
 
-- In development mode, Electron `stderr` is piped directly to Cypress' `stderr` to make it clear why Electron failed to start, if it fails to start. Fixes [#32358](https://github.com/cypress-io/cypress/issues/32358). Addressed in [32468](https://github.com/cypress-io/cypress/pull/32468).
+- In development mode, Electron `stderr` is piped directly to Cypress' `stderr` to make it clear why Electron failed to start, if it fails to start. Fixes [#32358](https://github.com/cypress-io/cypress/issues/32358). Addressed in [#32468](https://github.com/cypress-io/cypress/pull/32468).
 - Fixed an issue where ESM Cypress configurations were not being interpreted correctly. Fixes [#32493](https://github.com/cypress-io/cypress/issues/32493). Fixed in [#32515](https://github.com/cypress-io/cypress/pull/32515).
 
 **Misc:**
@@ -1329,7 +1329,7 @@ Refer to the [v13 Migration Guide](/app/references/migration-guide#Migrating-to-
 
 - Fixed an issue where Cypress's internal `tsconfig` would conflict with properties set in the user's `tsconfig.json` such as `module` and `moduleResolution`. Fixes [#26308](https://github.com/cypress-io/cypress/issues/26308) and [#27448](https://github.com/cypress-io/cypress/issues/27448).
 - Clarified Svelte 4 works correctly with Component Testing and updated dependencies checks to reflect this. It was incorrectly flagged as not supported. Fixes [#27465](https://github.com/cypress-io/cypress/issues/27465).
-- Resolve the `process/browser` global inside `@cypress/webpack-batteries-included-preprocessor` to resolve to `process/browser.js` in order to explicitly provide the file extension. File resolution must include the extension for `.mjs` and `.js` files inside ESM packages in order to resolve correctly. Fixes[#27599](https://github.com/cypress-io/cypress/issues/27599).
+- Resolve the `process/browser` global inside `@cypress/webpack-batteries-included-preprocessor` to resolve to `process/browser.js` in order to explicitly provide the file extension. File resolution must include the extension for `.mjs` and `.js` files inside ESM packages in order to resolve correctly. Fixes [#27599](https://github.com/cypress-io/cypress/issues/27599).
 - Fixed an issue where the correct `pnp` process was not being discovered. Fixes [#27562](https://github.com/cypress-io/cypress/issues/27562).
 - Fixed incorrect type declarations for Cypress and Chai globals that asserted them to be local variables of the global scope rather than properties on the global object. Fixes [#27539](https://github.com/cypress-io/cypress/issues/27539). Fixed in [#27540](https://github.com/cypress-io/cypress/pull/27540).
 - Dev Servers will now respect and use the `port` configuration option if present. Fixes [#27675](https://github.com/cypress-io/cypress/issues/27675).
@@ -3441,7 +3441,7 @@ _Released 6/10/2022_
 
 - Cypress will show an improved error message when running `cypress run --ct`
   when component testing has not been configured.
-  Fixed[#21909](https://github.com/cypress-io/cypress/issues/21909)
+  Fixed [#21909](https://github.com/cypress-io/cypress/issues/21909)
 
 **Bugfixes:**
 
@@ -4753,7 +4753,7 @@ _Released 09/13/2021_
   [#3852](https://github.com/cypress-io/cypress/issues/3852).
 - A clearer error message is now thrown for `.check()` or `.uncheck()` when
   there are no matching value attributes found.
-  Fixes[#7379](https://github.com/cypress-io/cypress/issues/7379).
+  Fixes [#7379](https://github.com/cypress-io/cypress/issues/7379).
 - Hooks will no longer rerun on unrelated tests in some situations after a
   domain navigation. Fixes
   [#17705](https://github.com/cypress-io/cypress/issues/17705).


### PR DESCRIPTION
In https://docs.cypress.io/app/references/changelog some formatting inconsistencies, such as missing spaces, are corrected.

## Reference

- https://github.com/cypress-io/cypress/blob/develop/guides/writing-the-cypress-changelog.md