### PR TITLE
docs: remove references to cypress-example-todomvc which will be archived

### DIFF
--- a/docs/api/cypress-api/custom-commands.mdx
+++ b/docs/api/cypress-api/custom-commands.mdx
@@ -894,9 +894,7 @@ and unnecessary. Try to take as many shortcuts as possible.
 #### 5. Write TypeScript definitions
 
 You can describe the method signature for your custom command, allowing
-IntelliSense to show helpful documentation. See the
-[`cypress-example-todomvc`](https://github.com/cypress-io/cypress-example-todomvc#cypress-intellisense)
-repository for a working example.
+IntelliSense to show helpful documentation.
 
 #### 6. Create a function that adds the custom command
 

--- a/docs/app/tooling/IDE-integration.mdx
+++ b/docs/app/tooling/IDE-integration.mdx
@@ -163,10 +163,6 @@ them in `cypress/support/index.d.ts` use:
 /// <reference types="../support" />
 ```
 
-See the
-[`cypress-example-todomvc`](https://github.com/cypress-io/cypress-example-todomvc#cypress-intellisense)
-repository for a working example.
-
 If the triple slash directive does not work, please refer to your code editor in
 [TypeScript's Editor Support doc](https://github.com/Microsoft/TypeScript/wiki/TypeScript-Editor-Support)
 and follow the instructions for your IDE to get

--- a/docs/app/tooling/typescript-support.mdx
+++ b/docs/app/tooling/typescript-support.mdx
@@ -246,9 +246,6 @@ As you can see there are generic parameters `<'type', 'element'>` are used:
 - See
   [Adding Custom Commands (TS)](https://github.com/cypress-io/cypress-example-recipes#fundamentals)
   example recipe.
-- Example project
-  [cypress-example-todomvc custom commands](https://github.com/cypress-io/cypress-example-todomvc#custom-commands)
-  uses custom commands to avoid boilerplate code.
 
 ### Types for custom assertions
 


### PR DESCRIPTION
We're intending to archive this repo.