### PR TITLE
Adjust trial period and announce cy.prompt

### DIFF
--- a/docs/cloud/get-started/free-trial.mdx
+++ b/docs/cloud/get-started/free-trial.mdx
@@ -18,7 +18,7 @@ sidebar_position: 15
 
 :::
 
-Your free trial of Cypress Cloud provides a 14 day all-access pass to Cypress Cloud features.
+Your free trial of Cypress Cloud provides a 30 day all-access pass to Cypress Cloud features.
 This is the same list of Cloud features available in our Enterprise plan as described on the
 [Cypress Cloud pricing page](https://www.cypress.io/pricing). 50,000 test results are included!
 
@@ -27,7 +27,7 @@ that your testing life wouldn't be the same without it! After starting your tria
 and subscribe to a Cypress Cloud plan at any time.
 
 However, if you determine that subscribing to a Cloud plan is
-not workable at the end of 14 days, rest assured that your account will remain available to you
+not workable at the end of 30 days, rest assured that your account will remain available to you
 and revert to our _Starter_ plan. The _Starter_ plan is free, but does not have the same
 set of features. The _Starter_ plan will also limit data retention to 30 days and test results
 to 500 per monthly period. Details of the _Starter_ plan are available on the
@@ -138,7 +138,7 @@ If you click the progress indicator you will be presented with an onboarding
 guide that will introduce and showcase the features of Cypress Cloud using your
 own Cypress tests that have been recorded to Cloud. Progress through the
 exploration of Cypress Cloud at your own pace as you and the other members of
-your organization have **2 weeks** to experience **all** of the capabilities
+your organization have **30 days** to experience **all** of the capabilities
 that Cypress Cloud provides!
 
 <DocsImage

--- a/docs/partials/_cloud_free_plan.mdx
+++ b/docs/partials/_cloud_free_plan.mdx
@@ -1,4 +1,4 @@
 To get started with Cypress Cloud,
-[sign up](https://cloud.cypress.io/signup) to start your **2 week free trial** - including all
+[sign up](https://cloud.cypress.io/signup) to start your **30 day free trial** - including all
 premium Cypress Cloud features and plenty of test results
 to let you experience the power of Cypress Cloud!

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -156,8 +156,8 @@ const config = {
       // Styles for this are controlled in src/css/announcement-bar.scss
       announcementBar: {
         //give id a unique value to get a new announcement bar to appear
-        id: 'ga-ui-cov-a11y',
-        content: `📢 NEW! Improve app quality with instant insights using <a href="https://www.cypress.io/accessibility?utm_medium=accouncement-banner&utm_source=docs.cypress.io&utm_content=Cypress Accessibility">Cypress Accessibility</a> or <a href="https://www.cypress.io/ui-coverage?utm_medium=announcement-banner&utm_source=docs.cypress.io&utm_content=UI Coverage">UI Coverage</a>.`,
+        id: 'cy-prompt-experimental-live',
+        content: `📢 NEW! cy.prompt() natural language and self-healing tests <a href="https://www.cypress.io/blog/cy-prompt-experimental-launch?utm_source=docs.cypress.io&utm_medium=cyconf&utm_campaign=cypressconf">now available</a> in the Cypress App.`,
         isCloseable: true,
       },
       footer: {


### PR DESCRIPTION
Extend free trials from 14 days to 30 days. Announce in a banner that cy.prompt is now available, and provide a blog link for more info and access to Studio AI early access registration form.