### PR TITLE
Make macOS 13.5 minimum supported OS version

### DIFF
--- a/docs/app/get-started/install-cypress.mdx
+++ b/docs/app/get-started/install-cypress.mdx
@@ -39,7 +39,7 @@ sidebar_position: 30
 
 Cypress supports running under these operating systems:
 
-- **macOS** >=11 _(Intel or Apple Silicon 64-bit (x64 or arm64))_
+- **macOS** >=13.5 _(Intel or Apple Silicon 64-bit (x64 or arm64))_
 - **Linux** _(x64 or arm64)_ see also [Linux Prerequisites](#Linux-Prerequisites) down below
   - Ubuntu >=22.04
   - Debian >=11


### PR DESCRIPTION
## Situation

macOS `13.5` is the minimum compatible version across currently supported versions of Node.js 20, 22, 24 and 25.

| Node.js                                                                   | minimum macOS x64 | minimum macOS arm64 |
| ------------------------------------------------------------------------- | ----------------- | ----------------- |
| [20](https://github.com/nodejs/node/blob/v20.x/BUILDING.md#platform-list) | `>=10.15`         | `>=11`            |
| [22](https://github.com/nodejs/node/blob/v22.x/BUILDING.md#platform-list) | `>=11`            | `>=11`            |
| [24](https://github.com/nodejs/node/blob/v24.x/BUILDING.md#platform-list) | `>=13.5`          | `>=13.5`          |
| [25](https://github.com/nodejs/node/blob/v25.x/BUILDING.md#platform-list) | `>=13.5`          | `>=13.5`          |

See [Node.js 24.x > BUILDING > Platform list](https://github.com/nodejs/node/blob/v24.x/BUILDING.md#platform-list) and [Migration Guide Node.js v22 to v24](https://nodejs.org/en/blog/migrations/v22-to-v24)

Apple generally supports the latest 3 major releases, which are currently macOS 26 (Tahoe), macOS 15 (Sequoia) and macOS 14 (Sonoma).

The minimum non-deprecated version of macOS available in [GitHub Actions runner images](https://github.com/actions/runner-images) is currently macOS 14.

## Change

Update the minimum macOS version listed on [Get Started > Install Cypress > System requirements > Operating System](https://docs.cypress.io/app/get-started/install-cypress#Operating-System) from

macOS `>=11`

to

macOS `>=13.5`
