### PR TITLE
Bump Cypress CircleCI Orb to v6 in examples

### DIFF
--- a/docs/app/continuous-integration/circleci.mdx
+++ b/docs/app/continuous-integration/circleci.mdx
@@ -40,11 +40,11 @@ A typical project can have:
 ```yaml title=".circleci/config.yml"
 version: 2.1
 orbs:
-  # "cypress-io/cypress@4" installs the latest published
+  # "cypress-io/cypress@6" installs the latest published
   # version "s.x.y" of the orb. We recommend you then use
-  # the strict explicit version "cypress-io/cypress@4.x.y"
+  # the strict explicit version "cypress-io/cypress@6.x.y"
   # to lock the version and prevent unexpected CI changes
-  cypress: cypress-io/cypress@4
+  cypress: cypress-io/cypress@6
 workflows:
   build:
     jobs:
@@ -64,7 +64,7 @@ run tests across 4 CI machines
 ```yaml title=".circleci/config.yml"
 version: 2.1
 orbs:
-  cypress: cypress-io/cypress@4
+  cypress: cypress-io/cypress@6
 workflows:
   build:
     jobs:
@@ -101,7 +101,7 @@ Check out the full <Icon name="github" inline="true" callout="RWA Circle CI conf
 ```yaml title=".circleci/config.yml"
 version: 2.1
 orbs:
-  cypress: cypress-io/cypress@4
+  cypress: cypress-io/cypress@6
 workflows:
   test:
     jobs:
@@ -114,7 +114,7 @@ workflows:
 ```yaml title=".circleci/config.yml"
 version: 2.1
 orbs:
-  cypress: cypress-io/cypress@4
+  cypress: cypress-io/cypress@6
 workflows:
   test:
     jobs:
@@ -132,7 +132,7 @@ This is only needed if you are passing the `--browser` flag in your `cypress-com
 ```yaml title=".circleci/config.yml"
 version: 2.1
 orbs:
-  cypress: cypress-io/cypress@4
+  cypress: cypress-io/cypress@6
 workflows:
   test:
     jobs:

--- a/docs/app/guides/cross-browser-testing.mdx
+++ b/docs/app/guides/cross-browser-testing.mdx
@@ -102,7 +102,7 @@ The following example demonstrates a nightly CI schedule against production
 ```yaml title='.circleci/config.yml'
 version: 2.1
 orbs:
-  cypress: cypress-io/cypress@4
+  cypress: cypress-io/cypress@6
 workflows:
   nightly:
     triggers:
@@ -132,7 +132,7 @@ Firefox issues can be caught before a production release:
 ```yaml title='.circleci/config.yml'
 version: 2.1
 orbs:
-  cypress: cypress-io/cypress@4
+  cypress: cypress-io/cypress@6
 workflows:
   test_develop:
     jobs:
@@ -174,7 +174,7 @@ Circle CI workflow UI to distinguish the jobs.
 ```yaml title='.circleci/config.yml'
 version: 2.1
 orbs:
-  cypress: cypress-io/cypress@4
+  cypress: cypress-io/cypress@6
 workflows:
   build:
     jobs:
@@ -211,7 +211,7 @@ named `firefox`.
 ```yaml title='.circleci/config.yml'
 version: 2.1
 orbs:
-  cypress: cypress-io/cypress@4
+  cypress: cypress-io/cypress@6
 workflows:
   build:
     jobs:


### PR DESCRIPTION
## Situation

Examples of using the [Cypress CircleCI Orb](https://circleci.com/developer/orbs/orb/cypress-io/cypress) refer to the v4 release [cypress-io/cypress@4.0.0](https://github.com/cypress-io/circleci-orb/releases/tag/v4.0.0) from April 2025.

The current version is [cypress-io/cypress@6.0.0](https://github.com/cypress-io/circleci-orb/releases/tag/v6.0.0), released on Oct 30, 2025.

Pages with outdated version references are:

- https://docs.cypress.io/app/continuous-integration/circleci
- https://docs.cypress.io/app/guides/cross-browser-testing

## Change

Update CircleCI pipeline examples to show `cypress: cypress-io/cypress@6` on the above pages.

## Note

No change is made to the internally used [.circleci/config.yml](https://github.com/cypress-io/cypress-documentation/blob/main/.circleci/config.yml) pipeline.

This should be addressed separately.