### PR TITLE
Bump lowest supported to Fedora Linux 42

### DIFF
--- a/docs/app/get-started/install-cypress.mdx
+++ b/docs/app/get-started/install-cypress.mdx
@@ -43,7 +43,7 @@ Cypress supports running under these operating systems:
 - **Linux** _(x64 or arm64)_ see also [Linux Prerequisites](#Linux-Prerequisites) down below
   - Ubuntu >=22.04
   - Debian >=11
-  - Fedora >=41
+  - Fedora >=42
 - **Windows** 10 & 11 _(x64)_
 - **Windows** 11 24H2 _(arm64, runs in [x64 emulation](https://learn.microsoft.com/en-us/windows/arm/apps-on-arm-x86-emulation) mode, minimum Cypress [14.5.0](/app/references/changelog#14-5-0) required)_ - preview status
 - **Windows Server** 2019, 2022 and 2025 _(x64)_


### PR DESCRIPTION
## Issue

The [Fedora Linux Release Life Cycle](https://docs.fedoraproject.org/en-US/releases/lifecycle/) says:

> The Fedora Project releases a new version of Fedora Linux approximately every six months and provides updated packages (maintenance) to these releases for approximately 13 months.

- [F43 announcement](https://www.redhat.com/en/blog/announcing-fedora-43), released Oct 28, 2025
- [F43 schedule with F41 EOL](https://fedorapeople.org/groups/schedule/f-43/f-43-key-tasks.html), F41 EOL Nov 26, 2025

Reference [Fedora End of Life Releases](https://docs.fedoraproject.org/en-US/releases/eol/)

## Change

In the section [Install Cypress > Operating System](https://docs.cypress.io/app/get-started/install-cypress#Operating-System):

- Change the lowest supported version of Fedora Linux from `41` to `42`