### PR TITLE
Update changelog dates with leading zeros

### DIFF
--- a/docs/app/references/changelog.mdx
+++ b/docs/app/references/changelog.mdx
@@ -10,7 +10,7 @@ sidebar_label: Changelog
 
 ## 15.7.1
 
-_Released 12/2/2025_
+_Released 12/02/2025_
 
 **Performance:**
 
@@ -50,7 +50,7 @@ _Released 11/19/2025_
 
 ## 15.6.0
 
-_Released 11/4/2025_
+_Released 11/04/2025_
 
 **Features:**
 
@@ -106,7 +106,7 @@ _Released 10/17/2025_
 
 ## 15.4.0
 
-_Released 10/7/2025_
+_Released 10/07/2025_
 
 **Features:**
 
@@ -136,7 +136,7 @@ _Released 10/7/2025_
 
 ## 15.3.0
 
-_Released 9/23/2025_
+_Released 09/23/2025_
 
 **Features:**
 
@@ -161,7 +161,7 @@ _Released 9/23/2025_
 
 ## 15.2.0
 
-_Released 9/9/2025_
+_Released 09/09/2025_
 
 **Features:**
 
@@ -279,7 +279,7 @@ Refer to the [v15 Migration Guide](/app/references/migration-guide#Migrating-to-
 
 ## 14.5.4
 
-_Released 8/07/2025_
+_Released 08/07/2025_
 
 **Dependency Updates:**
 
@@ -287,7 +287,7 @@ _Released 8/07/2025_
 
 ## 14.5.3
 
-_Released 7/25/2025_
+_Released 07/25/2025_
 
 **Bugfixes:**
 
@@ -301,7 +301,7 @@ _Released 7/25/2025_
 
 ## 14.5.2
 
-_Released 7/15/2025_
+_Released 07/15/2025_
 
 **Bugfixes:**
 
@@ -310,7 +310,7 @@ _Released 7/15/2025_
 
 ## 14.5.1
 
-_Released 7/01/2025_
+_Released 07/01/2025_
 
 **Bugfixes:**
 
@@ -322,7 +322,7 @@ _Released 7/01/2025_
 
 ## 14.5.0
 
-_Released 6/17/2025_
+_Released 06/17/2025_
 
 **Features:**
 
@@ -334,7 +334,7 @@ _Released 6/17/2025_
 
 ## 14.4.1
 
-_Released 6/3/2025_
+_Released 06/03/2025_
 
 **Bugfixes:**
 
@@ -350,7 +350,7 @@ _Released 6/3/2025_
 
 ## 14.4.0
 
-_Released 5/20/2025_
+_Released 05/20/2025_
 
 **Features:**
 
@@ -376,7 +376,7 @@ _Released 5/20/2025_
 
 ## 14.3.3
 
-_Released 5/6/2025_
+_Released 05/06/2025_
 
 **Performance:**
 
@@ -399,7 +399,7 @@ _Released 5/6/2025_
 
 ## 14.3.2
 
-_Released 4/22/2025_
+_Released 04/22/2025_
 
 **Bugfixes:**
 
@@ -408,7 +408,7 @@ _Released 4/22/2025_
 
 ## 14.3.1
 
-_Released 4/17/2025_
+_Released 04/17/2025_
 
 **Performance:**
 
@@ -427,7 +427,7 @@ _Released 4/17/2025_
 
 ## 14.3.0
 
-_Released 4/8/2025_
+_Released 04/08/2025_
 
 **Features:**
 
@@ -452,7 +452,7 @@ _Released 4/8/2025_
 
 ## 14.2.1
 
-_Released 3/26/2025_
+_Released 03/26/2025_
 
 **Bugfixes:**
 
@@ -475,7 +475,7 @@ _Released 3/26/2025_
 
 ## 14.2.0
 
-_Released 3/12/2025_
+_Released 03/12/2025_
 
 **Features:**
 
@@ -494,7 +494,7 @@ _Released 3/12/2025_
 
 ## 14.1.0
 
-_Released 2/25/2025_
+_Released 02/25/2025_
 
 **Features:**
 
@@ -518,7 +518,7 @@ _Released 2/25/2025_
 
 ## 14.0.3
 
-_Released 2/11/2025_
+_Released 02/11/2025_
 
 **Bugfixes:**
 
@@ -531,7 +531,7 @@ _Released 2/11/2025_
 
 ## 14.0.2
 
-_Released 2/05/2025_
+_Released 02/05/2025_
 
 **Bugfixes:**
 
@@ -550,7 +550,7 @@ _Released 2/05/2025_
 
 ## 14.0.1
 
-_Released 1/28/2025_
+_Released 01/28/2025_
 
 **Bugfixes:**
 
@@ -567,7 +567,7 @@ _Released 1/28/2025_
 
 ## 14.0.0
 
-_Released 1/16/2025_
+_Released 01/16/2025_
 
 **Summary:**
 
@@ -707,7 +707,7 @@ _Released 11/19/2024_
 
 ## 13.15.2
 
-_Released 11/5/2024_
+_Released 11/05/2024_
 
 **Bugfixes:**
 
@@ -743,7 +743,7 @@ _Released 10/24/2024_
 
 ## 13.15.0
 
-_Released 9/25/2024_
+_Released 09/25/2024_
 
 **Features:**
 
@@ -768,7 +768,7 @@ _Released 9/25/2024_
 
 ## 13.14.2
 
-_Released 9/4/2024_
+_Released 09/04/2024_
 
 **Bugfixes:**
 
@@ -777,7 +777,7 @@ _Released 9/4/2024_
 
 ## 13.14.1
 
-_Released 8/29/2024_
+_Released 08/29/2024_
 
 **Bugfixes:**
 
@@ -785,7 +785,7 @@ _Released 8/29/2024_
 
 ## 13.14.0
 
-_Released 8/27/2024_
+_Released 08/27/2024_
 
 **Performance:**
 
@@ -819,7 +819,7 @@ _Released 8/27/2024_
 
 ## 13.13.3
 
-_Released 8/14/2024_
+_Released 08/14/2024_
 
 **Bugfixes:**
 
@@ -836,7 +836,7 @@ _Released 8/14/2024_
 
 ## 13.13.2
 
-_Released 7/31/2024_
+_Released 07/31/2024_
 
 **Performance:**
 
@@ -856,7 +856,7 @@ _Released 7/31/2024_
 
 ## 13.13.1
 
-_Released 7/16/2024_
+_Released 07/16/2024_
 
 **Bugfixes:**
 
@@ -873,7 +873,7 @@ _Released 7/16/2024_
 
 ## 13.13.0
 
-_Released 7/02/2024_
+_Released 07/02/2024_
 
 **Performance:**
 
@@ -897,7 +897,7 @@ _Released 7/02/2024_
 
 ## 13.12.0
 
-_Released 6/18/2024_
+_Released 06/18/2024_
 
 **Features:**
 
@@ -923,7 +923,7 @@ _Released 6/18/2024_
 
 ## 13.11.0
 
-_Released 6/4/2024_
+_Released 06/04/2024_
 
 **Performance:**
 
@@ -945,7 +945,7 @@ _Released 6/4/2024_
 
 ## 13.10.0
 
-_Released 5/21/2024_
+_Released 05/21/2024_
 
 **Features:**
 
@@ -966,7 +966,7 @@ _Released 5/21/2024_
 
 ## 13.9.0
 
-_Released 5/7/2024_
+_Released 05/07/2024_
 
 **Features:**
 
@@ -989,7 +989,7 @@ _Released 5/7/2024_
 
 ## 13.8.1
 
-_Released 4/23/2024_
+_Released 04/23/2024_
 
 **Performance:**
 
@@ -1010,7 +1010,7 @@ _Released 4/23/2024_
 
 ## 13.8.0
 
-_Released 4/18/2024_
+_Released 04/18/2024_
 
 **Features:**
 
@@ -1026,7 +1026,7 @@ _Released 4/18/2024_
 
 ## 13.7.3
 
-_Released 4/11/2024_
+_Released 04/11/2024_
 
 **Bugfixes:**
 
@@ -1040,7 +1040,7 @@ _Released 4/11/2024_
 
 ## 13.7.2
 
-_Released 4/2/2024_
+_Released 04/02/2024_
 
 **Performance:**
 
@@ -1059,7 +1059,7 @@ _Released 4/2/2024_
 
 ## 13.7.1
 
-_Released 3/21/2024_
+_Released 03/21/2024_
 
 **Bugfixes:**
 
@@ -1072,7 +1072,7 @@ _Released 3/21/2024_
 
 ## 13.7.0
 
-_Released 3/13/2024_
+_Released 03/13/2024_
 
 **Features:**
 
@@ -1105,7 +1105,7 @@ _Released 3/13/2024_
 
 ## 13.6.6
 
-_Released 2/22/2024_
+_Released 02/22/2024_
 
 **Bugfixes:**
 
@@ -1113,7 +1113,7 @@ _Released 2/22/2024_
 
 ## 13.6.5
 
-_Released 2/20/2024_
+_Released 02/20/2024_
 
 **Bugfixes:**
 
@@ -1139,7 +1139,7 @@ _Released 2/20/2024_
 
 ## 13.6.4
 
-_Released 1/30/2024_
+_Released 01/30/2024_
 
 **Performance:**
 
@@ -1155,7 +1155,7 @@ _Released 1/30/2024_
 
 ## 13.6.3
 
-_Released 1/16/2024_
+_Released 01/16/2024_
 
 **Bugfixes:**
 
@@ -1207,7 +1207,7 @@ _Released 12/26/2023_
 
 ## 13.6.1
 
-_Released 12/5/2023_
+_Released 12/05/2023_
 
 **Bugfixes:**
 
@@ -1259,7 +1259,7 @@ _Released 11/14/2023_
 
 ## 13.5.0
 
-_Released 11/8/2023_
+_Released 11/08/2023_
 
 **Features:**
 
@@ -2023,7 +2023,7 @@ _Released 02/15/2023_
 
 ## 12.5.1
 
-_Released 02/2/2023_
+_Released 02/02/2023_
 
 **Bugfixes:**
 
@@ -2097,7 +2097,7 @@ _Released 01/27/2023_
 
 ## 12.4.0
 
-_Released 1/24/2023_
+_Released 01/24/2023_
 
 **Features:**
 
@@ -2164,7 +2164,7 @@ _Released 1/24/2023_
 
 ## 12.3.0
 
-_Released 1/03/2023_
+_Released 01/03/2023_
 
 **Features:**
 
@@ -2898,7 +2898,7 @@ _Released 10/11/2022_
 
 ## 10.9.0
 
-_Released 9/27/2022_
+_Released 09/27/2022_
 
 **Features:**
 
@@ -2968,7 +2968,7 @@ _Released 9/27/2022_
 
 ## 10.8.0
 
-_Released 9/13/2022_
+_Released 09/13/2022_
 
 **Features:**
 
@@ -3082,7 +3082,7 @@ _Released 9/13/2022_
 
 ## 10.7.0
 
-_Released 8/30/2022_
+_Released 08/30/2022_
 
 **Features:**
 
@@ -3164,7 +3164,7 @@ _Released 8/30/2022_
 
 ## 10.6.0
 
-_Released 8/16/2022_
+_Released 08/16/2022_
 
 **Features:**
 
@@ -3204,7 +3204,7 @@ _Released 8/16/2022_
 
 ## 10.5.0
 
-_Released 8/15/2022_
+_Released 08/15/2022_
 
 **Features:**
 
@@ -3292,7 +3292,7 @@ _Released 8/15/2022_
 
 ## 10.4.0
 
-_Released 8/2/2022_
+_Released 08/02/2022_
 
 **Features:**
 
@@ -3358,7 +3358,7 @@ _Released 8/2/2022_
 
 ## 10.3.1
 
-_Released 7/19/2022_
+_Released 07/19/2022_
 
 **Bugfixes:**
 
@@ -3437,7 +3437,7 @@ _Released 7/19/2022_
 
 ## 10.3.0
 
-_Released 6/28/2022_
+_Released 06/28/2022_
 
 **Features:**
 
@@ -3481,7 +3481,7 @@ _Released 6/28/2022_
 
 ## 10.2.0
 
-_Released 6/21/2022_
+_Released 06/21/2022_
 
 **Features:**
 
@@ -3531,7 +3531,7 @@ _Released 6/21/2022_
 
 ## 10.1.0
 
-_Released 6/10/2022_
+_Released 06/10/2022_
 
 **Features:**
 
@@ -3568,7 +3568,7 @@ _Released 6/10/2022_
 
 ## 10.0.3
 
-_Released 6/3/2022_
+_Released 06/03/2022_
 
 **Bugfixes:**
 
@@ -3593,7 +3593,7 @@ _Released 6/3/2022_
 
 ## 10.0.2
 
-_Released 6/2/2022_
+_Released 06/02/2022_
 
 **Bugfixes:**
 
@@ -3620,7 +3620,7 @@ _Released 6/2/2022_
 
 ## 10.0.1
 
-_Released 6/1/2022_
+_Released 06/01/2022_
 
 **Bugfixes:**
 
@@ -3654,7 +3654,7 @@ _Released 6/1/2022_
 
 ## 10.0.0
 
-_Released 6/1/2022_
+_Released 06/01/2022_
 
 **Summary:**
 
@@ -3987,7 +3987,7 @@ which explains some breaking changes in more detail.**
 
 ## 9.7.0
 
-_Released 5/23/2022_
+_Released 05/23/2022_
 
 **Features:**
 
@@ -4032,7 +4032,7 @@ _Released 5/23/2022_
 
 ## 9.6.1
 
-_Released 5/9/2022_
+_Released 05/09/2022_
 
 **Bugfixes:**
 
@@ -4057,7 +4057,7 @@ _Released 5/9/2022_
 
 ## 9.6.0
 
-_Released 4/25/2022_
+_Released 04/25/2022_
 
 **Features:**
 
@@ -4111,7 +4111,7 @@ _Released 4/25/2022_
 
 ## 9.5.4
 
-_Released 4/11/2022_
+_Released 04/11/2022_
 
 **Bugfixes:**
 
@@ -4182,7 +4182,7 @@ _Released 4/11/2022_
 
 ## 9.5.3
 
-_Released 3/28/2022_
+_Released 03/28/2022_
 
 **Bugfixes:**
 
@@ -4226,7 +4226,7 @@ _Released 3/28/2022_
 
 ## 9.5.2
 
-_Released 3/14/2022_
+_Released 03/14/2022_
 
 **Bugfixes:**
 
@@ -4269,7 +4269,7 @@ _Released 3/14/2022_
 
 ## 9.5.1
 
-_Released 2/28/2022_
+_Released 02/28/2022_
 
 **Bugfixes:**
 
@@ -4304,7 +4304,7 @@ _Released 2/28/2022_
 
 ## 9.5.0
 
-_Released 2/15/2022_
+_Released 02/15/2022_
 
 **Features:**
 
@@ -4339,7 +4339,7 @@ _Released 2/15/2022_
 
 ## 9.4.1
 
-_Released 1/31/2022_
+_Released 01/31/2022_
 
 **Bugfixes:**
 
@@ -4349,7 +4349,7 @@ _Released 1/31/2022_
 
 ## 9.4.0
 
-_Released 1/31/2022_
+_Released 01/31/2022_
 
 **Features**
 
@@ -4387,7 +4387,7 @@ _Released 1/31/2022_
 
 ## 9.3.1
 
-_Released 1/19/2022_
+_Released 01/19/2022_
 
 **Bugfixes:**
 
@@ -4396,7 +4396,7 @@ _Released 1/19/2022_
 
 ## 9.3.0
 
-_Released 1/18/2022_
+_Released 01/18/2022_
 
 **Features:**
 
@@ -4448,7 +4448,7 @@ _Released 1/18/2022_
 
 ## 9.2.1
 
-_Released 1/10/2022_
+_Released 01/10/2022_
 
 **Bugfixes:**
 
@@ -5718,7 +5718,7 @@ to Cypress 7.0.**
 
 ## 6.9.1
 
-_Released 4/5/2021_
+_Released 04/05/2021_
 
 This release contains the same features as [6.8.0](#6-8-0). It was published to provide a
 non-breaking alternative to [6.9.0](#6-9-0), which was mistakenly published with breaking
@@ -5726,14 +5726,14 @@ changes.
 
 ## 6.9.0
 
-_Released 4/5/2021_
+_Released 04/05/2021_
 
 This release was mistakenly published with breaking changes, is deprecated, and
 should not be used. Upgrade to [6.9.1](#6-9-1) or [7.0.0](#7-0-0), or stay on [6.8.0](#6-8-0).
 
 ## 6.8.0
 
-_Released 3/17/2021_
+_Released 03/17/2021_
 
 **User Experience:**
 
@@ -5754,7 +5754,7 @@ _Released 3/17/2021_
 
 ## 6.7.1
 
-_Released 3/15/2021_
+_Released 03/15/2021_
 
 **Bugfixes:**
 
@@ -5768,7 +5768,7 @@ _Released 3/15/2021_
 
 ## 6.7.0
 
-_Released 3/15/2021_
+_Released 03/15/2021_
 
 **Features:**
 
@@ -5842,7 +5842,7 @@ _Released 3/15/2021_
 
 ## 6.6.0
 
-_Released 2/18/2021_
+_Released 02/18/2021_
 
 **Features:**
 
@@ -5857,7 +5857,7 @@ _Released 2/18/2021_
 
 ## 6.5.0
 
-_Released 2/15/2021_
+_Released 02/15/2021_
 
 **Performance:**
 
@@ -5902,7 +5902,7 @@ _Released 2/15/2021_
 
 ## 6.4.0
 
-_Released 2/1/2021_
+_Released 02/01/2021_
 
 **Features:**
 
@@ -5988,7 +5988,7 @@ _Released 2/1/2021_
 
 ## 6.3.0
 
-_Released 1/19/2021_
+_Released 01/19/2021_
 
 **Features:**
 
@@ -6059,7 +6059,7 @@ _Released 1/19/2021_
 
 ## 6.2.1
 
-_Released 1/4/2021_
+_Released 01/04/2021_
 
 **Bugfixes:**
 
@@ -6643,7 +6643,7 @@ _Released 10/14/2020_
 
 ## 5.3.0
 
-_Released 9/28/2020_
+_Released 09/28/2020_
 
 **Features:**
 
@@ -6700,7 +6700,7 @@ _Released 9/28/2020_
 
 ## 5.2.0
 
-_Released 9/15/2020_
+_Released 09/15/2020_
 
 **Features:**
 
@@ -6785,7 +6785,7 @@ _Released 9/15/2020_
 
 ## 5.1.0
 
-_Released 9/1/2020_
+_Released 09/01/2020_
 
 **Features:**
 
@@ -6856,7 +6856,7 @@ _Released 9/1/2020_
 
 ## 5.0.0
 
-_Released 8/19/2020_
+_Released 08/19/2020_
 
 **Summary:**
 
@@ -7028,7 +7028,7 @@ to Cypress 5.0.**
 
 ## 4.12.1
 
-_Released 8/5/2020_
+_Released 08/05/2020_
 
 **Bugfixes:**
 
@@ -7048,7 +7048,7 @@ _Released 8/5/2020_
 
 ## 4.12.0
 
-_Released 8/3/2020_
+_Released 08/03/2020_
 
 **Features:**
 
@@ -7128,7 +7128,7 @@ _Released 8/3/2020_
 
 ## 4.11.0
 
-_Released 7/21/2020_
+_Released 07/21/2020_
 
 **Features:**
 
@@ -7215,7 +7215,7 @@ _Released 7/21/2020_
 
 ## 4.10.0
 
-_Released 7/7/2020_
+_Released 07/07/2020_
 
 **Features:**
 
@@ -7267,7 +7267,7 @@ _Released 7/7/2020_
 
 ## 4.9.0
 
-_Released 6/23/2020_
+_Released 06/23/2020_
 
 **Features:**
 
@@ -7358,7 +7358,7 @@ _Released 6/23/2020_
 
 ## 4.8.0
 
-_Released 6/8/2020_
+_Released 06/08/2020_
 
 **Features:**
 
@@ -7464,7 +7464,7 @@ _Released 6/8/2020_
 
 ## 4.7.0
 
-_Released 5/26/2020_
+_Released 05/26/2020_
 
 **Features:**
 
@@ -7492,7 +7492,7 @@ _Released 5/26/2020_
 
 ## 4.6.0
 
-_Released 5/20/2020_
+_Released 05/20/2020_
 
 **Features:**
 
@@ -7637,7 +7637,7 @@ _Released 5/20/2020_
 
 ## 4.5.0
 
-_Released 4/28/2020_
+_Released 04/28/2020_
 
 **Features:**
 
@@ -7680,7 +7680,7 @@ _Released 4/28/2020_
 
 ## 4.4.1
 
-_Released 4/20/2020_
+_Released 04/20/2020_
 
 **Bugfixes:**
 
@@ -7715,7 +7715,7 @@ _Released 4/20/2020_
 
 ## 4.4.0
 
-_Released 4/13/2020_
+_Released 04/13/2020_
 
 **Features:**
 
@@ -7759,7 +7759,7 @@ _Released 4/13/2020_
 
 ## 4.3.0
 
-_Released 3/30/2020_
+_Released 03/30/2020_
 
 **Features:**
 
@@ -7875,7 +7875,7 @@ _Released 3/30/2020_
 
 ## 4.2.0
 
-_Released 3/16/2020_
+_Released 03/16/2020_
 
 **Features:**
 
@@ -7962,7 +7962,7 @@ _Released 3/16/2020_
 
 ## 4.1.0
 
-_Released 2/28/2020_
+_Released 02/28/2020_
 
 **Features:**
 
@@ -8038,7 +8038,7 @@ _Released 2/28/2020_
 
 ## 4.0.2
 
-_Released 2/14/2020_
+_Released 02/14/2020_
 
 **Bugfixes:**
 
@@ -8074,7 +8074,7 @@ _Released 2/14/2020_
 
 ## 4.0.1
 
-_Released 2/7/2020_
+_Released 02/07/2020_
 
 **Bugfixes:**
 
@@ -8102,7 +8102,7 @@ _Released 2/7/2020_
 
 ## 4.0.0
 
-_Released 2/6/2020_
+_Released 02/06/2020_
 
 **Summary:**
 
@@ -8275,7 +8275,7 @@ to Cypress 4.0.**
 
 ## 3.8.3
 
-_Released 1/24/2020_
+_Released 01/24/2020_
 
 **Bugfixes:**
 
@@ -9068,7 +9068,7 @@ _Released 10/23/2019_
 
 ## 3.4.1
 
-_Released 7/29/2019_
+_Released 07/29/2019_
 
 **Dashboard Features:**
 
@@ -9212,7 +9212,7 @@ _Released 7/29/2019_
 
 ## 3.4.0
 
-_Released 7/9/2019_
+_Released 07/09/2019_
 
 **Features:**
 
@@ -9304,7 +9304,7 @@ _Released 7/9/2019_
 
 ## 3.3.2
 
-_Released 6/27/2019_
+_Released 06/27/2019_
 
 **Performance Improvements:**
 
@@ -9506,7 +9506,7 @@ _Released 6/27/2019_
 
 ## 3.3.1
 
-_Released 5/23/2019_
+_Released 05/23/2019_
 
 **News:**
 
@@ -9559,7 +9559,7 @@ _Released 5/23/2019_
 
 ## 3.3.0
 
-_Released 5/17/2019_
+_Released 05/17/2019_
 
 **News:**
 
@@ -9842,7 +9842,7 @@ _Released 5/17/2019_
 
 ## 3.2.0
 
-_Released 3/15/2019_
+_Released 03/15/2019_
 
 **Features:**
 
@@ -10078,7 +10078,7 @@ _Released 3/15/2019_
 
 ## 3.1.5
 
-_Released 1/30/2019_
+_Released 01/30/2019_
 
 **Bugfixes:**
 
@@ -10317,7 +10317,7 @@ _Released 11/18/2018_
 
 ## 3.1.1
 
-_Released 11/2/2018_
+_Released 11/02/2018_
 
 **Features:**
 
@@ -10451,7 +10451,7 @@ _Released 11/2/2018_
 
 ## 3.1.0
 
-_Released 8/13/2018_
+_Released 08/13/2018_
 
 **Summary:**
 
@@ -10572,7 +10572,7 @@ _Released 8/13/2018_
 
 ## 3.0.3
 
-_Released 7/30/2018_
+_Released 07/30/2018_
 
 **Bugfixes:**
 
@@ -10733,7 +10733,7 @@ _Released 7/30/2018_
 
 ## 3.0.2
 
-_Released 6/28/2018_
+_Released 06/28/2018_
 
 **Bugfixes:**
 
@@ -10906,7 +10906,7 @@ _Released 6/28/2018_
 
 ## 3.0.1
 
-_Released 5/30/2018_
+_Released 05/30/2018_
 
 **Bugfixes:**
 
@@ -10925,7 +10925,7 @@ _Released 5/30/2018_
 
 ## 3.0.0
 
-_Released 5/29/2018_
+_Released 05/29/2018_
 
 **Summary:**
 
@@ -11174,7 +11174,7 @@ _Released 5/29/2018_
 
 ## 2.1.0
 
-_Released 3/1/2018_
+_Released 03/01/2018_
 
 **Bugfixes:**
 
@@ -11206,7 +11206,7 @@ _Released 3/1/2018_
 
 ## 2.0.4
 
-_Released 2/25/2018_
+_Released 02/25/2018_
 
 **Bugfixes:**
 
@@ -11217,7 +11217,7 @@ _Released 2/25/2018_
 
 ## 2.0.3
 
-_Released 2/21/2018_
+_Released 02/21/2018_
 
 **Bugfixes:**
 
@@ -11237,7 +11237,7 @@ _Released 2/21/2018_
 
 ## 2.0.2
 
-_Released 2/17/2018_
+_Released 02/17/2018_
 
 **Bugfixes:**
 
@@ -11257,7 +11257,7 @@ _Released 2/17/2018_
 
 ## 2.0.1
 
-_Released 2/16/2018_
+_Released 02/16/2018_
 
 **Bugfixes:**
 
@@ -11273,7 +11273,7 @@ _Released 2/16/2018_
 
 ## 2.0.0
 
-_Released 2/15/2018_
+_Released 02/15/2018_
 
 **Breaking Changes:**
 
@@ -11369,7 +11369,7 @@ _Released 2/15/2018_
 
 ## 1.4.2
 
-_Released 2/4/2018_
+_Released 02/04/2018_
 
 **Bugfixes:**
 
@@ -11566,7 +11566,7 @@ _Released 12/14/2017_
 
 ## 1.1.4
 
-_Released 12/6/2017_
+_Released 12/06/2017_
 
 **Bugfixes:**
 
@@ -11601,7 +11601,7 @@ _Released 12/6/2017_
 
 ## 1.1.3
 
-_Released 12/3/2017_
+_Released 12/03/2017_
 
 **Bugfixes:**
 
@@ -14572,7 +14572,7 @@ _Released 12/11/2015_
 
 ## 0.13.0
 
-_Released 12/9/2015_
+_Released 12/09/2015_
 
 **Summary:**
 
@@ -14617,7 +14617,7 @@ _Released 12/9/2015_
 
 ## 0.12.8
 
-_Released 12/2/2015_
+_Released 12/02/2015_
 
 **Features:**
 


### PR DESCRIPTION
Relates to:

- https://github.com/cypress-io/cypress/issues/32655
- https://github.com/cypress-io/cypress/pull/33070

## Situation

Release dates in the [App > References > changelog](https://docs.cypress.io/app/references/changelog) are inconsistently formatted concerning leading zeros for day and month.

- PR https://github.com/cypress-io/cypress/pull/33070 proposes adding a guide rule to use the date format `MM/DD/YYYY` with 2 digit months and days, padded with leading zeros where necessary.

## Change

Update release dates in [App > References > changelog](https://docs.cypress.io/app/references/changelog) to consistently use the  `MM/DD/YYYY` format.