### PR TITLE
Change Happo plugin badge from community to verified

### DIFF
--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -937,7 +937,7 @@
           "description": "Catch unexpected visual and accessibility changes and UI bugs",
           "link": "https://docs.happo.io/docs/cypress",
           "keywords": ["screenshots", "visual regression"],
-          "badge": "community"
+          "badge": "verified"
         },
         {
           "name": "Cypress Image Snapshot",


### PR DESCRIPTION
I'd like to upgrade the status of this plugin from community to verified. I was unable to find information about a process for this kind of change, and looking through some other pull requests it seems that the process is fairly informal.