### PR TITLE
chore: fix spacing issue in cy.mount tooltip

### DIFF
--- a/docs/app/component-testing/angular/examples.mdx
+++ b/docs/app/component-testing/angular/examples.mdx
@@ -17,7 +17,7 @@ sidebar_label: Examples
 - How to pass data to an Angular component
 - How to test multiple scenarios of Angular components
 - How to test Angular signals
-- How to customize the`cy.mount()` for Angular
+- How to customize the `cy.mount()` for Angular
 
 :::
 


### PR DESCRIPTION
noticed this inconsistency when QA the examples