### PR TITLE
Fix typo: remove duplicate "the"

### DIFF
--- a/docs/app/core-concepts/interacting-with-elements.mdx
+++ b/docs/app/core-concepts/interacting-with-elements.mdx
@@ -85,7 +85,7 @@ When `experimentalFastVisibility` is enabled, an element is considered hidden if
   - _this is a known compatibility issue with the legacy visibility algorithm_ when it comes to asserting visibility. It will be addressed during the course of this experiment.
 - It is fully covered or clipped by another element
 
-Keep up-to-date with the the progress of this experiment in the [Cypress repository](https://github.com/cypress-io/cypress/issues/33043).
+Keep up-to-date with the progress of this experiment in the [Cypress repository](https://github.com/cypress-io/cypress/issues/33043).
 
 #### Limitations
 


### PR DESCRIPTION
Removed duplicate word in experimental fast visibility section.