### PR TITLE
TypeScript support for v5 only

### DIFF
--- a/docs/app/tooling/typescript-support.mdx
+++ b/docs/app/tooling/typescript-support.mdx
@@ -29,7 +29,7 @@ tests in TypeScript.
 
 ### Install TypeScript
 
-To use TypeScript with Cypress, you will need TypeScript 5.0+. If you do not
+To use TypeScript with Cypress, you will need TypeScript 5.x. If you do not
 already have TypeScript installed as a part of your framework, you will need to
 install it:
 


### PR DESCRIPTION
## Situation

The [Tooling > TypeScript](https://docs.cypress.io/app/tooling/typescript-support) documentation section states:

> To use TypeScript with Cypress, you will need TypeScript 5.0+.

This implies support of TypeScript 5 and versions above, including TypeScript 6.

The TypeScript 6 beta was [announced](https://devblogs.microsoft.com/typescript/announcing-typescript-6-0-beta/) on Feb 11, 2026 and includes a list of [Breaking Changes and Deprecations](https://devblogs.microsoft.com/typescript/announcing-typescript-6-0-beta/#breaking-changes-and-deprecations-in-typescript-6.0).

## Assessment

Cypress issue https://github.com/cypress-io/cypress/issues/33385 demonstrates that Cypress E2E testing with TypeScript 6 beta does not work out of the box using Cypress documentation [Configure tsconfig.json](https://docs.cypress.io/app/tooling/typescript-support#Configure-tsconfigjson) recommendations.

Component testing frameworks, such as [Angular@21.0.x](https://angular.dev/reference/versions#actively-supported-versions) (TypeScript `>=5.9.0 <6.0.0`) do not yet support TypeScript 6.

The definition "TypeScript 5.0+" can be ambiguously interpreted as meaning `typescript >=5.0.0` including TypeScript 6 (and later 7).

To support TypeScript 6 at a later stage, due to the [Breaking Changes and Deprecations](https://devblogs.microsoft.com/typescript/announcing-typescript-6-0-beta/#breaking-changes-and-deprecations-in-typescript-6.0), changes to Cypress software and Cypress documentation will be necessary. This will need to be revisited after TypeScript 6 becomes available in a non-beta version.

## Change

Specify TypeScript `5.x` instead of `5.0+`, which would be `>=5.0.0 <6.0.0` using SemVer range terminology, clearly excluding TypeScript 6 from current support.