### PR TITLE
Lint before commit / push

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+npx lint-staged

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+npm run lint

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+# Agent Instructions
+
+## Required checks after edits
+
+- After making code or documentation changes, run `npm run lint:fix` before finalizing.
+- If lint fails, fix issues introduced by your changes before finishing.

--- a/docs/accessibility/changelog.mdx
+++ b/docs/accessibility/changelog.mdx
@@ -10,118 +10,152 @@ sidebar_position: 200
 # Changelog
 
 ## Week of Feb 06, 2026
+
 - We now support fetching Accessibility results from Buildkite CI with the [Results API](/accessibility/results-api).
 
 ## Week of Jan 16, 2026
+
 - We've upgraded our axe-core version to [4.11.0](https://docs.deque.com/axe-release-impact/4.11.0/en/release-notes).
 - We now support fetching Accessibility results from Bitbucket CI with the [Results API](/accessibility/results-api).
 
 ## Week of Dec 19, 2025
+
 - The `elementFilters` configuration property now supports an optional `documentScope` field that allows you to scope selectors to specific document hosts (iframes or shadow DOM hosts). This enables you to filter elements within nested document contexts without requiring DOM changes. For example, you can filter all elements within a specific shadow DOM component or iframe by combining a selector with `documentScope`. See the [Element Filters](/accessibility/configuration/elementfilters) documentation for more details and examples.
 
 ## Week of Dec 12, 2025
+
 - You can now create Jira issues directly from accessibility violations in the detail view. This allows you to quickly track and prioritize accessibility issues within your existing Jira workflow. The created Jira issue will include a link back to the accessibility violation in Cypress Cloud. [Learn more about creating Jira issues](/accessibility/core-concepts/inspecting-violation-details#Create-Jira-issue).
 
 ## Week of Dec 01, 2025
+
 - The `profiles` configuration property allows you to use different configuration settings for different runs based on [run tags](/app/references/command-line#cypress-run-tag-lt-tag-gt). This enables you to customize accessibility testing behavior for different environments, branches, or test scenarios. See the [Profiles](/accessibility/configuration/profiles) guide for more details.
 - All configuration objects now support an optional `comment` property that you can use to provide context and explanations for why certain values are set. This helps make your configuration easier to understand and maintain, especially when working in teams or revisiting configuration after some time.
 
 ## Week of Oct 13, 2025
+
 - Individual rules, or set of rules, can now be ignored for specific elements using [a `data-a11y-ignore` attribute](/accessibility/configuration/ignoring-rules-per-element).
 
 ## Week of Oct 06, 2025
+
 - False positives in ["Interactive elements should be semantically correct"](/accessibility/core-concepts/cypress-rules#Interactive-elements-should-be-semantically-correct) related to elements using the `contenteditable` attribute have been addressed.
 
 ## Week of Jul 07, 2025
+
 - A new custom accessibility rule, ["Interactive elements should be semantically correct"](/accessibility/core-concepts/cypress-rules#Interactive-elements-should-be-semantically-correct), is now available. This rule is based on the interactions that take place during your test execution, and helps detect accessibility issues that are not a part of typical DOM-based accessibility scans.
 
 ## Week of Jun 02, 2025
+
 - We now support fetching Accessibility results from Drone CI with the [Results API](/accessibility/results-api).
 
 ## Week of May 26, 2025
+
 - A new [element identification](/accessibility/core-concepts/element-identification) algorithm is now available for Cypress Accessibility. This produces improved element deduplication across different snapshots and runs, and incorporates testing-specific attributes like Test IDs into the element recognition and deduplication process. This replaces the default Axe-Core® element identification behavior.
 - Two new configuration options are available in Cypress Accessibility - [`significantAttributes`](/accessibility/configuration/significantattributes) and [`attributeFilters`](/accessibility/configuration/attributefilters). These allow you to fine-tune Cypress's element identification behavior to ensure stable and relevant locators are used.
 - Branch Review for Cypress Accessibility is now generally available, with an updated interface for displaying new and resolved violations, based on feedback during the Beta period. Thank you all for hitting the feedback button! [Learn more about comparing reports](/accessibility/core-concepts/compare-reports).
 
 ## Week of May 12, 2025
+
 - We now support fetching Accessibility results from AWS CodeBuild with the [Results API](/accessibility/results-api).
 
 ## Week of Mar 24, 2025
+
 - Cypress Accessibility results are now included in the [Data Extract API](/cloud/integrations/data-extract-api) so that you can retrieve data over time.
 
 ## Week of Mar 10, 2025
+
 - The [Cypress Accessibility Results API](/accessibility/results-api) has been updated with additional details about accessibility scores and failed element counts at the run level. Also, view-level reporting has been added, breaking out accessibility report data by the pages and components covered in the report. These improvements support more advanced workflows based on the accessibility data in the API, such as alerting a specific team about violations in a part of the app they own, or implementing different standards for different parts of the application.
 
 ## Week of Mar 03, 2025
+
 - We've upgraded our axe-core version to [4.10.2](https://docs.deque.com/axe-release-impact/4.10.2/en/release-notes).
 - The axe-core version used to generate a report can now be viewed in the Run Properties tab.
 
 ## Week of Feb 24, 2025
+
 - [Cypress Accessibility Branch Review](/accessibility/core-concepts/compare-reports) has entered beta. Read the docs to learn how to compare runs and automatically spot newly introduced issues.
 
 ## Week of Jan 13, 2025
+
 - Cypress Accessibility results are now included in the Enterprise Reporting area of Cypress Cloud. Filter by project and branch and see trends over time.
 
 ## Week of Nov 11, 2024
+
 - A "Share Issue" button has been added to the element details section for each reported rule violation. This allows for easily copying the key details and related links for a particular issue into your clipboard to add to a message or to a ticket in your issue tracking system.
 
 ## Week of Oct 28, 2024
+
 - Our [Axe Core® versioning policy](/accessibility/core-concepts/how-it-works#Axe-Core-updates) has been published, providing a 30-day buffer between any Axe Core® releases and the adoption of those releases in Cypress Cloud.
 
 ## Week of Sep 30, 2024
+
 - Cypress Accessibility results are now included in Slack messages alongside test results. [Learn more about our Slack integration here](/cloud/integrations/slack).
 
 ## Week of Sep 20, 2024
+
 - A minor bugfix was released for score calculations, to fix a scenario where some snapshots could be counted more than once if they appeared in multiple tests. This may result in a small difference in the total score for runs before and after the change.
 - Documentation updates to reflect recently released features and capabilities.
 
 ## Week of Sep 09, 2024
+
 - We have introduced the new "Rules" tab for all users. This allows you to more easily review the outcome of all the rules that were tested for, across the entire run, and see which rules have the most failing elements. This also helps you understand the exact effect of any underlying configuration on rule outcomes.
 - We have introduced new element statuses, beyond just failures. This allows Cypress Accessibility to surface any inconclusive or "manual review" items from Axe Core, as well as track and display elements whose results were explicitly ignored. Learn more in the [run-level reports](/accessibility/core-concepts/run-level-reports) [Elements section](/accessibility/core-concepts/run-level-reports#Elements).
 - Elements ignored by configuration will have results captured, but these results will not affect your score. This ensures you can use filters to peek behind the curtain and understand exactly what is being excluded from a given run's results.
 - The Detail View that displays failing elements will now also display inconclusive and (optionally) ignored elements for each rule. Inconclusive and ignored elements have distinct orange and gray icons and highlights respectively.
 
 ## Week of Aug 19, 2024
+
 - iFrames are now supported for accessibility checks. iFrame processing is _opt-in_ for existing customers, but new customers will begin with iFrames enabled and can choose to opt out instead. This is to avoid disrupting existing pipelines, especially because iFrame content is not _always_ something you want to include in your reports.
 - Cypress Accessibility results will now appear in [GitHub](/cloud/integrations/source-control/github), [GitLab](/cloud/integrations/source-control/gitlab) and [Bitbucket](/cloud/integrations/source-control/bitbucket) pull request and merge request comments alongside test results. Integrations can be installed and comments can be enabled in Project Settings.
 
 ## Week of Aug 05, 2024
+
 - We now support fetching Accessibility results from CircleCI workflows with the [Results API](/accessibility/results-api).
 
 ## Week of Jul 29, 2024
+
 - Fetching results in Azure and Jenkins is now supported in the new [Results API](/accessibility/results-api), which enables you to programmatically fetch your run's Accessibility results in a CI environment.
 
 ## Week of Jul 15, 2024
+
 - The new [Results API](/accessibility/results-api), which enables you to programmatically fetch your run's Accessibility results in a CI environment, now supports fetching results in GitLab CI workflows.
 
 ## Week of Jun 24, 2024
+
 - We have added the new [Results API](/accessibility/results-api) which enables you to programmatically fetch your run's Accessibility results in a CI environment. This allows you to review the results within CI and to determine if the results are acceptable or need to be addressed before code changes can merge.
 - View [configuration information for each run](/accessibility/configuration/overview#Viewing-Configuration-for-a-Run) in the properties tab. There, you'll find the configuration set for the project at the start of the run. This will help you understand what factors might be driving a score change. This helps distinguish config criteria changes from other factors such as changes to your application, tests, Cypress versions, and more.
 
 ## Week of May 20, 2024
+
 - Shadow DOM elements are now visible and highlighted in A11y report snapshots. By highlighting shadow DOM elements in snapshots, developers can identify and address all accessibility violations, including those within encapsulated components, thus enhancing the overall accessibility of the web application.
 - You can now click directly into the accessibility report from any respective run from the "Latest Runs" page in Cypress Cloud. This improvement streamlines access and navigation to accessibility reports, saving you time and reducing the number of steps needed to view the details.
 - We've added the ability to configure and customize your Accessibility report in Project Settings. You can set configuration through our editor equipped with linting and IntelliSense code completion. Control what should be tested or ignored in your score calculations to ensure your team is capturing what's relevant to your organization's goals.
 
 ## Week of Apr 15, 2024
+
 - We've added full depth axe-core® details for each element flagged with an accessibility violation, providing comprehensive context to help developers accurately identify and resolve issues.
 
 ## Week of Mar 25, 2024
+
 - The new Violation Severity Breakdown displays a small bar graph indicating the severity level of accessibility violations across the entire run, or on the level of individual pages or components. This gives users more information at a glance about what pages have the most severe problems, and the overall makeup of their accessibility report. Pages with more severe problems will now be more obvious when scanning the report, helping users decide what pages need more investigation or which pages have the fewest problems.
 
 ## Week of Mar 18, 2024
+
 - You can now refine your Views list by severity or specific rule sets. For instance, isolate pages featuring "Critical" violations only, or focus solely on WCAG 2.1 A violations. If your project has varying levels of accessibility, filtering pages or components with specific types of violations can serve as an initial step to comprehend and prioritize areas with the most severe issues.
 - Cypress will now conduct accessibility checks within the Shadow DOM on all runs, expanding the accessibility testing scope.
 
 ## Week of Feb 25, 2024
+
 - We've introduced text filtering so that users can filter the "Views" list by name, making it effortless to search and locate specific items.
 - To improve clarity and context, we've also implemented a tooltip-style feature that displays the position of the highlighted elements. This means that when an accessibility violation is reported and is associated with a specific element on the screen, it's a lot easier to locate.
 
 ## Week of Jan 15, 2024
+
 - We've introduced a new feature that streamlines accessibility management - the aggregation of all violations into a single comprehensive report. Look for the "View all" link next to the violations count at the top of the accessibility tab. This will show you all violations detected across an entire run, regardless of what page or component they are detected on.
 
 ## Week of Dec 31, 2023
+
 - Users can now discover and address accessibility violations swiftly by utilizing the newly integrated "Print Elements to Console" button within your browser's developer tools.
 
 ## Week of Dec 17, 2023
+
 - Users can now view a detailed breakdown of the total number of Views (pages and/or components) and Violations detected during a specific run.

--- a/docs/accessibility/changelog.mdx
+++ b/docs/accessibility/changelog.mdx
@@ -9,153 +9,119 @@ sidebar_position: 200
 
 # Changelog
 
-## Week of 2/6/2026
-
+## Week of Feb 06, 2026
 - We now support fetching Accessibility results from Buildkite CI with the [Results API](/accessibility/results-api).
 
-## Week of 1/16/2026
-
+## Week of Jan 16, 2026
 - We've upgraded our axe-core version to [4.11.0](https://docs.deque.com/axe-release-impact/4.11.0/en/release-notes).
 - We now support fetching Accessibility results from Bitbucket CI with the [Results API](/accessibility/results-api).
 
-## Week of 12/19/2025
-
+## Week of Dec 19, 2025
 - The `elementFilters` configuration property now supports an optional `documentScope` field that allows you to scope selectors to specific document hosts (iframes or shadow DOM hosts). This enables you to filter elements within nested document contexts without requiring DOM changes. For example, you can filter all elements within a specific shadow DOM component or iframe by combining a selector with `documentScope`. See the [Element Filters](/accessibility/configuration/elementfilters) documentation for more details and examples.
 
-## Week of 12/12/2025
-
+## Week of Dec 12, 2025
 - You can now create Jira issues directly from accessibility violations in the detail view. This allows you to quickly track and prioritize accessibility issues within your existing Jira workflow. The created Jira issue will include a link back to the accessibility violation in Cypress Cloud. [Learn more about creating Jira issues](/accessibility/core-concepts/inspecting-violation-details#Create-Jira-issue).
 
-## Week of 12/1/2025
-
+## Week of Dec 01, 2025
 - The `profiles` configuration property allows you to use different configuration settings for different runs based on [run tags](/app/references/command-line#cypress-run-tag-lt-tag-gt). This enables you to customize accessibility testing behavior for different environments, branches, or test scenarios. See the [Profiles](/accessibility/configuration/profiles) guide for more details.
 - All configuration objects now support an optional `comment` property that you can use to provide context and explanations for why certain values are set. This helps make your configuration easier to understand and maintain, especially when working in teams or revisiting configuration after some time.
 
-## Week of 10/13/2025
-
+## Week of Oct 13, 2025
 - Individual rules, or set of rules, can now be ignored for specific elements using [a `data-a11y-ignore` attribute](/accessibility/configuration/ignoring-rules-per-element).
 
-## Week of 10/6/2025
-
+## Week of Oct 06, 2025
 - False positives in ["Interactive elements should be semantically correct"](/accessibility/core-concepts/cypress-rules#Interactive-elements-should-be-semantically-correct) related to elements using the `contenteditable` attribute have been addressed.
 
-## Week of 7/7/2025
-
+## Week of Jul 07, 2025
 - A new custom accessibility rule, ["Interactive elements should be semantically correct"](/accessibility/core-concepts/cypress-rules#Interactive-elements-should-be-semantically-correct), is now available. This rule is based on the interactions that take place during your test execution, and helps detect accessibility issues that are not a part of typical DOM-based accessibility scans.
 
-## Week of 6/2/2025
-
+## Week of Jun 02, 2025
 - We now support fetching Accessibility results from Drone CI with the [Results API](/accessibility/results-api).
 
-## Week of 5/26/2025
-
+## Week of May 26, 2025
 - A new [element identification](/accessibility/core-concepts/element-identification) algorithm is now available for Cypress Accessibility. This produces improved element deduplication across different snapshots and runs, and incorporates testing-specific attributes like Test IDs into the element recognition and deduplication process. This replaces the default Axe-Core® element identification behavior.
 - Two new configuration options are available in Cypress Accessibility - [`significantAttributes`](/accessibility/configuration/significantattributes) and [`attributeFilters`](/accessibility/configuration/attributefilters). These allow you to fine-tune Cypress's element identification behavior to ensure stable and relevant locators are used.
 - Branch Review for Cypress Accessibility is now generally available, with an updated interface for displaying new and resolved violations, based on feedback during the Beta period. Thank you all for hitting the feedback button! [Learn more about comparing reports](/accessibility/core-concepts/compare-reports).
 
-## Week of 5/12/2025
-
+## Week of May 12, 2025
 - We now support fetching Accessibility results from AWS CodeBuild with the [Results API](/accessibility/results-api).
 
-## Week of 3/24/2025
-
+## Week of Mar 24, 2025
 - Cypress Accessibility results are now included in the [Data Extract API](/cloud/integrations/data-extract-api) so that you can retrieve data over time.
 
-## Week of 3/10/2025
-
+## Week of Mar 10, 2025
 - The [Cypress Accessibility Results API](/accessibility/results-api) has been updated with additional details about accessibility scores and failed element counts at the run level. Also, view-level reporting has been added, breaking out accessibility report data by the pages and components covered in the report. These improvements support more advanced workflows based on the accessibility data in the API, such as alerting a specific team about violations in a part of the app they own, or implementing different standards for different parts of the application.
 
-## Week of 3/03/2025
-
+## Week of Mar 03, 2025
 - We've upgraded our axe-core version to [4.10.2](https://docs.deque.com/axe-release-impact/4.10.2/en/release-notes).
 - The axe-core version used to generate a report can now be viewed in the Run Properties tab.
 
-## Week of 2/24/2025
-
+## Week of Feb 24, 2025
 - [Cypress Accessibility Branch Review](/accessibility/core-concepts/compare-reports) has entered beta. Read the docs to learn how to compare runs and automatically spot newly introduced issues.
 
-## Week of 1/13/2025
-
+## Week of Jan 13, 2025
 - Cypress Accessibility results are now included in the Enterprise Reporting area of Cypress Cloud. Filter by project and branch and see trends over time.
 
-## Week of 11/11/2024
-
+## Week of Nov 11, 2024
 - A "Share Issue" button has been added to the element details section for each reported rule violation. This allows for easily copying the key details and related links for a particular issue into your clipboard to add to a message or to a ticket in your issue tracking system.
 
-## Week of 10/28/2024
-
+## Week of Oct 28, 2024
 - Our [Axe Core® versioning policy](/accessibility/core-concepts/how-it-works#Axe-Core-updates) has been published, providing a 30-day buffer between any Axe Core® releases and the adoption of those releases in Cypress Cloud.
 
-## Week of 9/30/2024
-
+## Week of Sep 30, 2024
 - Cypress Accessibility results are now included in Slack messages alongside test results. [Learn more about our Slack integration here](/cloud/integrations/slack).
 
-## Week of 9/20/2024
-
+## Week of Sep 20, 2024
 - A minor bugfix was released for score calculations, to fix a scenario where some snapshots could be counted more than once if they appeared in multiple tests. This may result in a small difference in the total score for runs before and after the change.
 - Documentation updates to reflect recently released features and capabilities.
 
-## Week of 9/9/2024
-
+## Week of Sep 09, 2024
 - We have introduced the new "Rules" tab for all users. This allows you to more easily review the outcome of all the rules that were tested for, across the entire run, and see which rules have the most failing elements. This also helps you understand the exact effect of any underlying configuration on rule outcomes.
 - We have introduced new element statuses, beyond just failures. This allows Cypress Accessibility to surface any inconclusive or "manual review" items from Axe Core, as well as track and display elements whose results were explicitly ignored. Learn more in the [run-level reports](/accessibility/core-concepts/run-level-reports) [Elements section](/accessibility/core-concepts/run-level-reports#Elements).
 - Elements ignored by configuration will have results captured, but these results will not affect your score. This ensures you can use filters to peek behind the curtain and understand exactly what is being excluded from a given run's results.
 - The Detail View that displays failing elements will now also display inconclusive and (optionally) ignored elements for each rule. Inconclusive and ignored elements have distinct orange and gray icons and highlights respectively.
 
-## Week of 8/19/2024
-
+## Week of Aug 19, 2024
 - iFrames are now supported for accessibility checks. iFrame processing is _opt-in_ for existing customers, but new customers will begin with iFrames enabled and can choose to opt out instead. This is to avoid disrupting existing pipelines, especially because iFrame content is not _always_ something you want to include in your reports.
 - Cypress Accessibility results will now appear in [GitHub](/cloud/integrations/source-control/github), [GitLab](/cloud/integrations/source-control/gitlab) and [Bitbucket](/cloud/integrations/source-control/bitbucket) pull request and merge request comments alongside test results. Integrations can be installed and comments can be enabled in Project Settings.
 
-## Week of 8/5/2024
-
+## Week of Aug 05, 2024
 - We now support fetching Accessibility results from CircleCI workflows with the [Results API](/accessibility/results-api).
 
-## Week of 7/29/2024
-
+## Week of Jul 29, 2024
 - Fetching results in Azure and Jenkins is now supported in the new [Results API](/accessibility/results-api), which enables you to programmatically fetch your run's Accessibility results in a CI environment.
 
-## Week of 7/15/2024
-
+## Week of Jul 15, 2024
 - The new [Results API](/accessibility/results-api), which enables you to programmatically fetch your run's Accessibility results in a CI environment, now supports fetching results in GitLab CI workflows.
 
-## Week of 6/24/2024
-
+## Week of Jun 24, 2024
 - We have added the new [Results API](/accessibility/results-api) which enables you to programmatically fetch your run's Accessibility results in a CI environment. This allows you to review the results within CI and to determine if the results are acceptable or need to be addressed before code changes can merge.
 - View [configuration information for each run](/accessibility/configuration/overview#Viewing-Configuration-for-a-Run) in the properties tab. There, you'll find the configuration set for the project at the start of the run. This will help you understand what factors might be driving a score change. This helps distinguish config criteria changes from other factors such as changes to your application, tests, Cypress versions, and more.
 
-## Week of 5/20/2024
-
+## Week of May 20, 2024
 - Shadow DOM elements are now visible and highlighted in A11y report snapshots. By highlighting shadow DOM elements in snapshots, developers can identify and address all accessibility violations, including those within encapsulated components, thus enhancing the overall accessibility of the web application.
 - You can now click directly into the accessibility report from any respective run from the "Latest Runs" page in Cypress Cloud. This improvement streamlines access and navigation to accessibility reports, saving you time and reducing the number of steps needed to view the details.
 - We've added the ability to configure and customize your Accessibility report in Project Settings. You can set configuration through our editor equipped with linting and IntelliSense code completion. Control what should be tested or ignored in your score calculations to ensure your team is capturing what's relevant to your organization's goals.
 
-## Week of 4/15/2024
-
+## Week of Apr 15, 2024
 - We've added full depth axe-core® details for each element flagged with an accessibility violation, providing comprehensive context to help developers accurately identify and resolve issues.
 
-## Week of 3/25/2024
-
+## Week of Mar 25, 2024
 - The new Violation Severity Breakdown displays a small bar graph indicating the severity level of accessibility violations across the entire run, or on the level of individual pages or components. This gives users more information at a glance about what pages have the most severe problems, and the overall makeup of their accessibility report. Pages with more severe problems will now be more obvious when scanning the report, helping users decide what pages need more investigation or which pages have the fewest problems.
 
-## Week of 3/18/2024
-
+## Week of Mar 18, 2024
 - You can now refine your Views list by severity or specific rule sets. For instance, isolate pages featuring "Critical" violations only, or focus solely on WCAG 2.1 A violations. If your project has varying levels of accessibility, filtering pages or components with specific types of violations can serve as an initial step to comprehend and prioritize areas with the most severe issues.
 - Cypress will now conduct accessibility checks within the Shadow DOM on all runs, expanding the accessibility testing scope.
 
-## Week of 2/25/2024
-
+## Week of Feb 25, 2024
 - We've introduced text filtering so that users can filter the "Views" list by name, making it effortless to search and locate specific items.
 - To improve clarity and context, we've also implemented a tooltip-style feature that displays the position of the highlighted elements. This means that when an accessibility violation is reported and is associated with a specific element on the screen, it's a lot easier to locate.
 
-## Week of 1/15/2024
-
+## Week of Jan 15, 2024
 - We've introduced a new feature that streamlines accessibility management - the aggregation of all violations into a single comprehensive report. Look for the "View all" link next to the violations count at the top of the accessibility tab. This will show you all violations detected across an entire run, regardless of what page or component they are detected on.
 
-## Week of 12/31/2023
-
+## Week of Dec 31, 2023
 - Users can now discover and address accessibility violations swiftly by utilizing the newly integrated "Print Elements to Console" button within your browser's developer tools.
 
-## Week of 12/17/2023
-
+## Week of Dec 17, 2023
 - Users can now view a detailed breakdown of the total number of Views (pages and/or components) and Violations detected during a specific run.

--- a/docs/app/references/changelog.mdx
+++ b/docs/app/references/changelog.mdx
@@ -10,7 +10,7 @@ sidebar_label: Changelog
 
 ## 15.13.0
 
-_Released 03/24/2026_
+_Released Mar 24, 2026_
 
 **Features:**
 
@@ -35,7 +35,7 @@ _Released 03/24/2026_
 
 ## 15.12.0
 
-_Released 03/13/2026_
+_Released Mar 13, 2026_
 
 **Features:**
 
@@ -55,7 +55,7 @@ _Released 03/13/2026_
 
 ## 15.11.0
 
-_Released 02/25/2026_
+_Released Feb 25, 2026_
 
 **Features:**
 
@@ -84,7 +84,7 @@ _Released 02/25/2026_
 
 ## 15.10.0
 
-_Released 02/03/2026_
+_Released Feb 03, 2026_
 
 **Deprecations:**
 
@@ -113,7 +113,7 @@ _Released 02/03/2026_
 
 ## 15.9.0
 
-_Released 01/13/2026_
+_Released Jan 13, 2026_
 
 **Features:**
 
@@ -121,7 +121,7 @@ _Released 01/13/2026_
 
 ## 15.8.2
 
-_Released 01/06/2026_
+_Released Jan 06, 2026_
 
 **Bugfixes:**
 
@@ -134,7 +134,7 @@ _Released 01/06/2026_
 
 ## 15.8.1
 
-_Released 12/18/2025_
+_Released Dec 18, 2025_
 
 **Dependency Updates:**
 
@@ -142,7 +142,7 @@ _Released 12/18/2025_
 
 ## 15.8.0
 
-_Released 12/16/2025_
+_Released Dec 16, 2025_
 
 **Performance:**
 
@@ -170,7 +170,7 @@ _Released 12/16/2025_
 
 ## 15.7.1
 
-_Released 12/02/2025_
+_Released Dec 02, 2025_
 
 **Performance:**
 
@@ -186,7 +186,7 @@ _Released 12/02/2025_
 
 ## 15.7.0
 
-_Released 11/19/2025_
+_Released Nov 19, 2025_
 
 **Performance:**
 
@@ -210,7 +210,7 @@ _Released 11/19/2025_
 
 ## 15.6.0
 
-_Released 11/04/2025_
+_Released Nov 04, 2025_
 
 **Features:**
 
@@ -243,7 +243,7 @@ _Released 11/04/2025_
 
 ## 15.5.0
 
-_Released 10/17/2025_
+_Released Oct 17, 2025_
 
 **Features:**
 
@@ -266,7 +266,7 @@ _Released 10/17/2025_
 
 ## 15.4.0
 
-_Released 10/07/2025_
+_Released Oct 07, 2025_
 
 **Features:**
 
@@ -296,7 +296,7 @@ _Released 10/07/2025_
 
 ## 15.3.0
 
-_Released 09/23/2025_
+_Released Sep 23, 2025_
 
 **Features:**
 
@@ -321,7 +321,7 @@ _Released 09/23/2025_
 
 ## 15.2.0
 
-_Released 09/09/2025_
+_Released Sep 09, 2025_
 
 **Features:**
 
@@ -337,7 +337,7 @@ _Released 09/09/2025_
 
 ## 15.1.0
 
-_Released 09/02/2025_
+_Released Sep 02, 2025_
 
 **Features:**
 
@@ -364,7 +364,7 @@ _Released 09/02/2025_
 
 ## 15.0.0
 
-_Released 08/20/2025_
+_Released Aug 20, 2025_
 
 **Summary**
 
@@ -439,7 +439,7 @@ Refer to the [v15 Migration Guide](/app/references/migration-guide#Migrating-to-
 
 ## 14.5.4
 
-_Released 08/07/2025_
+_Released Aug 07, 2025_
 
 **Dependency Updates:**
 
@@ -447,7 +447,7 @@ _Released 08/07/2025_
 
 ## 14.5.3
 
-_Released 07/25/2025_
+_Released Jul 25, 2025_
 
 **Bugfixes:**
 
@@ -461,7 +461,7 @@ _Released 07/25/2025_
 
 ## 14.5.2
 
-_Released 07/15/2025_
+_Released Jul 15, 2025_
 
 **Bugfixes:**
 
@@ -470,7 +470,7 @@ _Released 07/15/2025_
 
 ## 14.5.1
 
-_Released 07/01/2025_
+_Released Jul 01, 2025_
 
 **Bugfixes:**
 
@@ -482,7 +482,7 @@ _Released 07/01/2025_
 
 ## 14.5.0
 
-_Released 06/17/2025_
+_Released Jun 17, 2025_
 
 **Features:**
 
@@ -494,7 +494,7 @@ _Released 06/17/2025_
 
 ## 14.4.1
 
-_Released 06/03/2025_
+_Released Jun 03, 2025_
 
 **Bugfixes:**
 
@@ -510,7 +510,7 @@ _Released 06/03/2025_
 
 ## 14.4.0
 
-_Released 05/20/2025_
+_Released May 20, 2025_
 
 **Features:**
 
@@ -536,7 +536,7 @@ _Released 05/20/2025_
 
 ## 14.3.3
 
-_Released 05/06/2025_
+_Released May 06, 2025_
 
 **Performance:**
 
@@ -559,7 +559,7 @@ _Released 05/06/2025_
 
 ## 14.3.2
 
-_Released 04/22/2025_
+_Released Apr 22, 2025_
 
 **Bugfixes:**
 
@@ -568,7 +568,7 @@ _Released 04/22/2025_
 
 ## 14.3.1
 
-_Released 04/17/2025_
+_Released Apr 17, 2025_
 
 **Performance:**
 
@@ -587,7 +587,7 @@ _Released 04/17/2025_
 
 ## 14.3.0
 
-_Released 04/08/2025_
+_Released Apr 08, 2025_
 
 **Features:**
 
@@ -612,7 +612,7 @@ _Released 04/08/2025_
 
 ## 14.2.1
 
-_Released 03/26/2025_
+_Released Mar 26, 2025_
 
 **Bugfixes:**
 
@@ -635,7 +635,7 @@ _Released 03/26/2025_
 
 ## 14.2.0
 
-_Released 03/12/2025_
+_Released Mar 12, 2025_
 
 **Features:**
 
@@ -654,7 +654,7 @@ _Released 03/12/2025_
 
 ## 14.1.0
 
-_Released 02/25/2025_
+_Released Feb 25, 2025_
 
 **Features:**
 
@@ -678,7 +678,7 @@ _Released 02/25/2025_
 
 ## 14.0.3
 
-_Released 02/11/2025_
+_Released Feb 11, 2025_
 
 **Bugfixes:**
 
@@ -691,7 +691,7 @@ _Released 02/11/2025_
 
 ## 14.0.2
 
-_Released 02/05/2025_
+_Released Feb 05, 2025_
 
 **Bugfixes:**
 
@@ -710,7 +710,7 @@ _Released 02/05/2025_
 
 ## 14.0.1
 
-_Released 01/28/2025_
+_Released Jan 28, 2025_
 
 **Bugfixes:**
 
@@ -727,7 +727,7 @@ _Released 01/28/2025_
 
 ## 14.0.0
 
-_Released 01/16/2025_
+_Released Jan 16, 2025_
 
 **Summary:**
 
@@ -821,7 +821,7 @@ Refer to the [v14 Migration Guide](/app/references/migration-guide#Migrating-to-
 
 ## 13.17.0
 
-_Released 12/17/2024_
+_Released Dec 17, 2024_
 
 **Features:**
 
@@ -843,7 +843,7 @@ _Released 12/17/2024_
 
 ## 13.16.1
 
-_Released 12/04/2024_
+_Released Dec 04, 2024_
 
 **Bugfixes:**
 
@@ -851,7 +851,7 @@ _Released 12/04/2024_
 
 ## 13.16.0
 
-_Released 11/19/2024_
+_Released Nov 19, 2024_
 
 **Features:**
 
@@ -867,7 +867,7 @@ _Released 11/19/2024_
 
 ## 13.15.2
 
-_Released 11/05/2024_
+_Released Nov 05, 2024_
 
 **Bugfixes:**
 
@@ -884,7 +884,7 @@ _Released 11/05/2024_
 
 ## 13.15.1
 
-_Released 10/24/2024_
+_Released Oct 24, 2024_
 
 **Bugfixes:**
 
@@ -903,7 +903,7 @@ _Released 10/24/2024_
 
 ## 13.15.0
 
-_Released 09/25/2024_
+_Released Sep 25, 2024_
 
 **Features:**
 
@@ -928,7 +928,7 @@ _Released 09/25/2024_
 
 ## 13.14.2
 
-_Released 09/04/2024_
+_Released Sep 04, 2024_
 
 **Bugfixes:**
 
@@ -937,7 +937,7 @@ _Released 09/04/2024_
 
 ## 13.14.1
 
-_Released 08/29/2024_
+_Released Aug 29, 2024_
 
 **Bugfixes:**
 
@@ -945,7 +945,7 @@ _Released 08/29/2024_
 
 ## 13.14.0
 
-_Released 08/27/2024_
+_Released Aug 27, 2024_
 
 **Performance:**
 
@@ -979,7 +979,7 @@ _Released 08/27/2024_
 
 ## 13.13.3
 
-_Released 08/14/2024_
+_Released Aug 14, 2024_
 
 **Bugfixes:**
 
@@ -996,7 +996,7 @@ _Released 08/14/2024_
 
 ## 13.13.2
 
-_Released 07/31/2024_
+_Released Jul 31, 2024_
 
 **Performance:**
 
@@ -1016,7 +1016,7 @@ _Released 07/31/2024_
 
 ## 13.13.1
 
-_Released 07/16/2024_
+_Released Jul 16, 2024_
 
 **Bugfixes:**
 
@@ -1033,7 +1033,7 @@ _Released 07/16/2024_
 
 ## 13.13.0
 
-_Released 07/02/2024_
+_Released Jul 02, 2024_
 
 **Performance:**
 
@@ -1057,7 +1057,7 @@ _Released 07/02/2024_
 
 ## 13.12.0
 
-_Released 06/18/2024_
+_Released Jun 18, 2024_
 
 **Features:**
 
@@ -1083,7 +1083,7 @@ _Released 06/18/2024_
 
 ## 13.11.0
 
-_Released 06/04/2024_
+_Released Jun 04, 2024_
 
 **Performance:**
 
@@ -1105,7 +1105,7 @@ _Released 06/04/2024_
 
 ## 13.10.0
 
-_Released 05/21/2024_
+_Released May 21, 2024_
 
 **Features:**
 
@@ -1126,7 +1126,7 @@ _Released 05/21/2024_
 
 ## 13.9.0
 
-_Released 05/07/2024_
+_Released May 07, 2024_
 
 **Features:**
 
@@ -1149,7 +1149,7 @@ _Released 05/07/2024_
 
 ## 13.8.1
 
-_Released 04/23/2024_
+_Released Apr 23, 2024_
 
 **Performance:**
 
@@ -1170,7 +1170,7 @@ _Released 04/23/2024_
 
 ## 13.8.0
 
-_Released 04/18/2024_
+_Released Apr 18, 2024_
 
 **Features:**
 
@@ -1186,7 +1186,7 @@ _Released 04/18/2024_
 
 ## 13.7.3
 
-_Released 04/11/2024_
+_Released Apr 11, 2024_
 
 **Bugfixes:**
 
@@ -1200,7 +1200,7 @@ _Released 04/11/2024_
 
 ## 13.7.2
 
-_Released 04/02/2024_
+_Released Apr 02, 2024_
 
 **Performance:**
 
@@ -1219,7 +1219,7 @@ _Released 04/02/2024_
 
 ## 13.7.1
 
-_Released 03/21/2024_
+_Released Mar 21, 2024_
 
 **Bugfixes:**
 
@@ -1232,7 +1232,7 @@ _Released 03/21/2024_
 
 ## 13.7.0
 
-_Released 03/13/2024_
+_Released Mar 13, 2024_
 
 **Features:**
 
@@ -1265,7 +1265,7 @@ _Released 03/13/2024_
 
 ## 13.6.6
 
-_Released 02/22/2024_
+_Released Feb 22, 2024_
 
 **Bugfixes:**
 
@@ -1273,7 +1273,7 @@ _Released 02/22/2024_
 
 ## 13.6.5
 
-_Released 02/20/2024_
+_Released Feb 20, 2024_
 
 **Bugfixes:**
 
@@ -1299,7 +1299,7 @@ _Released 02/20/2024_
 
 ## 13.6.4
 
-_Released 01/30/2024_
+_Released Jan 30, 2024_
 
 **Performance:**
 
@@ -1315,7 +1315,7 @@ _Released 01/30/2024_
 
 ## 13.6.3
 
-_Released 01/16/2024_
+_Released Jan 16, 2024_
 
 **Bugfixes:**
 
@@ -1350,7 +1350,7 @@ _Released 01/16/2024_
 
 ## 13.6.2
 
-_Released 12/26/2023_
+_Released Dec 26, 2023_
 
 **Bugfixes:**
 
@@ -1367,7 +1367,7 @@ _Released 12/26/2023_
 
 ## 13.6.1
 
-_Released 12/05/2023_
+_Released Dec 05, 2023_
 
 **Bugfixes:**
 
@@ -1383,7 +1383,7 @@ _Released 12/05/2023_
 
 ## 13.6.0
 
-_Released 11/21/2023_
+_Released Nov 21, 2023_
 
 **Features:**
 
@@ -1409,7 +1409,7 @@ _Released 11/21/2023_
 
 ## 13.5.1
 
-_Released 11/14/2023_
+_Released Nov 14, 2023_
 
 **Bugfixes:**
 
@@ -1419,7 +1419,7 @@ _Released 11/14/2023_
 
 ## 13.5.0
 
-_Released 11/08/2023_
+_Released Nov 08, 2023_
 
 **Features:**
 
@@ -1439,7 +1439,7 @@ _Released 11/08/2023_
 
 ## 13.4.0
 
-_Released 10/30/2023_
+_Released Oct 30, 2023_
 
 **Features:**
 
@@ -1451,7 +1451,7 @@ _Released 10/30/2023_
 
 ## 13.3.3
 
-_Released 10/24/2023_
+_Released Oct 24, 2023_
 
 **Bugfixes:**
 
@@ -1461,7 +1461,7 @@ _Released 10/24/2023_
 
 ## 13.3.2
 
-_Released 10/18/2023_
+_Released Oct 18, 2023_
 
 **Bugfixes:**
 
@@ -1478,7 +1478,7 @@ _Released 10/18/2023_
 
 ## 13.3.1
 
-_Released 10/11/2023_
+_Released Oct 11, 2023_
 
 **Bugfixes:**
 
@@ -1491,7 +1491,7 @@ _Released 10/11/2023_
 
 ## 13.3.0
 
-_Released 09/27/2023_
+_Released Sep 27, 2023_
 
 **Features:**
 
@@ -1504,7 +1504,7 @@ _Released 09/27/2023_
 
 ## 13.2.0
 
-_Released 09/12/2023_
+_Released Sep 12, 2023_
 
 **Features:**
 
@@ -1524,7 +1524,7 @@ _Released 09/12/2023_
 
 ## 13.1.0
 
-_Released 08/31/2023_
+_Released Aug 31, 2023_
 
 **Features:**
 
@@ -1540,7 +1540,7 @@ _Released 08/31/2023_
 
 ## 13.0.0
 
-_Released 08/29/2023_
+_Released Aug 29, 2023_
 
 **Summary:**
 
@@ -1596,7 +1596,7 @@ Refer to the [v13 Migration Guide](/app/references/migration-guide#Migrating-to-
 
 ## 12.17.4
 
-_Released 08/15/2023_
+_Released Aug 15, 2023_
 
 **Bugfixes:**
 
@@ -1609,7 +1609,7 @@ _Released 08/15/2023_
 
 ## 12.17.3
 
-_Released 08/01/2023_
+_Released Aug 01, 2023_
 
 **Bugfixes:**
 
@@ -1621,7 +1621,7 @@ _Released 08/01/2023_
 
 ## 12.17.2
 
-_Released 07/20/2023_
+_Released Jul 20, 2023_
 
 **Bugfixes:**
 
@@ -1631,7 +1631,7 @@ _Released 07/20/2023_
 
 ## 12.17.1
 
-_Released 07/10/2023_
+_Released Jul 10, 2023_
 
 **Bugfixes:**
 
@@ -1644,7 +1644,7 @@ _Released 07/10/2023_
 
 ## 12.17.0
 
-_Released 07/06/2023_
+_Released Jul 06, 2023_
 
 **Features:**
 
@@ -1666,7 +1666,7 @@ _Released 07/06/2023_
 
 ## 12.16.0
 
-_Released 06/26/2023_
+_Released Jun 26, 2023_
 
 **Features:**
 
@@ -1678,7 +1678,7 @@ _Released 06/26/2023_
 
 ## 12.15.0
 
-_Released 06/20/2023_
+_Released Jun 20, 2023_
 
 **Features:**
 
@@ -1722,7 +1722,7 @@ _Released 06/20/2023_
 
 ## 12.14.0
 
-_Released 06/07/2023_
+_Released Jun 07, 2023_
 
 **Features:**
 
@@ -1762,7 +1762,7 @@ _Released 06/07/2023_
 
 ## 12.13.0
 
-_Released 05/23/2023_
+_Released May 23, 2023_
 
 **Features:**
 
@@ -1805,7 +1805,7 @@ _Released 05/23/2023_
 
 ## 12.12.0
 
-_Released 05/09/2023_
+_Released May 09, 2023_
 
 **Features:**
 
@@ -1842,7 +1842,7 @@ _Released 05/09/2023_
 
 ## 12.11.0
 
-_Released 04/26/2023_
+_Released Apr 26, 2023_
 
 **Features:**
 
@@ -1877,7 +1877,7 @@ _Released 04/26/2023_
 
 ## 12.10.0
 
-_Released 04/17/2023_
+_Released Apr 17, 2023_
 
 **Features:**
 
@@ -1936,7 +1936,7 @@ _Released 04/17/2023_
 
 ## 12.9.0
 
-_Released 03/28/2023_
+_Released Mar 28, 2023_
 
 **Features:**
 
@@ -1972,7 +1972,7 @@ _Released 03/28/2023_
 
 ## 12.8.1
 
-_Released 03/15/2023_
+_Released Mar 15, 2023_
 
 **Bugfixes:**
 
@@ -1993,7 +1993,7 @@ _Released 03/15/2023_
 
 ## 12.8.0
 
-_Released 03/14/2023_
+_Released Mar 14, 2023_
 
 **Features:**
 
@@ -2059,7 +2059,7 @@ _Released 03/14/2023_
 
 ## 12.7.0
 
-_Released 02/24/2023_
+_Released Feb 24, 2023_
 
 **Features:**
 
@@ -2117,7 +2117,7 @@ _Released 02/24/2023_
 
 ## 12.6.0
 
-_Released 02/15/2023_
+_Released Feb 15, 2023_
 
 **Features:**
 
@@ -2183,7 +2183,7 @@ _Released 02/15/2023_
 
 ## 12.5.1
 
-_Released 02/02/2023_
+_Released Feb 02, 2023_
 
 **Bugfixes:**
 
@@ -2203,7 +2203,7 @@ _Released 02/02/2023_
 
 ## 12.5.0
 
-_Released 01/31/2023_
+_Released Jan 31, 2023_
 
 **Features:**
 
@@ -2236,7 +2236,7 @@ _Released 01/31/2023_
 
 ## 12.4.1
 
-_Released 01/27/2023_
+_Released Jan 27, 2023_
 
 **Bugfixes:**
 
@@ -2257,7 +2257,7 @@ _Released 01/27/2023_
 
 ## 12.4.0
 
-_Released 01/24/2023_
+_Released Jan 24, 2023_
 
 **Features:**
 
@@ -2324,7 +2324,7 @@ _Released 01/24/2023_
 
 ## 12.3.0
 
-_Released 01/03/2023_
+_Released Jan 03, 2023_
 
 **Features:**
 
@@ -2408,7 +2408,7 @@ _Released 01/03/2023_
 
 ## 12.2.0
 
-_Released 12/20/2022_
+_Released Dec 20, 2022_
 
 **Features:**
 
@@ -2460,7 +2460,7 @@ _Released 12/20/2022_
 
 ## 12.1.0
 
-_Released 12/12/2022_
+_Released Dec 12, 2022_
 
 **Features:**
 
@@ -2505,7 +2505,7 @@ _Released 12/12/2022_
 
 ## 12.0.2
 
-_Released 12/08/2022_
+_Released Dec 08, 2022_
 
 **Bugfixes:**
 
@@ -2521,7 +2521,7 @@ _Released 12/08/2022_
 
 ## 12.0.1
 
-_Released 12/06/2022_
+_Released Dec 06, 2022_
 
 **Bugfixes:**
 
@@ -2541,7 +2541,7 @@ _Released 12/06/2022_
 
 ## 12.0.0
 
-_Released 12/06/2022_
+_Released Dec 06, 2022_
 
 **Summary:**
 
@@ -2734,7 +2734,7 @@ Read more about 12.0 in
 
 ## 11.2.0
 
-_Released 11/22/2022_
+_Released Nov 22, 2022_
 
 **Features:**
 
@@ -2763,7 +2763,7 @@ _Released 11/22/2022_
 
 ## 11.1.0
 
-_Released 11/14/2022_
+_Released Nov 14, 2022_
 
 **Features:**
 
@@ -2798,7 +2798,7 @@ _Released 11/14/2022_
 
 ## 11.0.1
 
-_Released 11/09/2022_
+_Released Nov 09, 2022_
 
 **Bugfixes:**
 
@@ -2821,7 +2821,7 @@ _Released 11/09/2022_
 
 ## 11.0.0
 
-_Released 11/08/2022_
+_Released Nov 08, 2022_
 
 **Summary:**
 
@@ -2942,7 +2942,7 @@ which explains the breaking changes in more detail.**
 
 ## 10.11.0
 
-_Released 10/25/2022_
+_Released Oct 25, 2022_
 
 **Features:**
 
@@ -3009,7 +3009,7 @@ _Released 10/25/2022_
 
 ## 10.10.0
 
-_Released 10/11/2022_
+_Released Oct 11, 2022_
 
 **Features:**
 
@@ -3058,7 +3058,7 @@ _Released 10/11/2022_
 
 ## 10.9.0
 
-_Released 09/27/2022_
+_Released Sep 27, 2022_
 
 **Features:**
 
@@ -3128,7 +3128,7 @@ _Released 09/27/2022_
 
 ## 10.8.0
 
-_Released 09/13/2022_
+_Released Sep 13, 2022_
 
 **Features:**
 
@@ -3242,7 +3242,7 @@ _Released 09/13/2022_
 
 ## 10.7.0
 
-_Released 08/30/2022_
+_Released Aug 30, 2022_
 
 **Features:**
 
@@ -3324,7 +3324,7 @@ _Released 08/30/2022_
 
 ## 10.6.0
 
-_Released 08/16/2022_
+_Released Aug 16, 2022_
 
 **Features:**
 
@@ -3364,7 +3364,7 @@ _Released 08/16/2022_
 
 ## 10.5.0
 
-_Released 08/15/2022_
+_Released Aug 15, 2022_
 
 **Features:**
 
@@ -3452,7 +3452,7 @@ _Released 08/15/2022_
 
 ## 10.4.0
 
-_Released 08/02/2022_
+_Released Aug 02, 2022_
 
 **Features:**
 
@@ -3518,7 +3518,7 @@ _Released 08/02/2022_
 
 ## 10.3.1
 
-_Released 07/19/2022_
+_Released Jul 19, 2022_
 
 **Bugfixes:**
 
@@ -3597,7 +3597,7 @@ _Released 07/19/2022_
 
 ## 10.3.0
 
-_Released 06/28/2022_
+_Released Jun 28, 2022_
 
 **Features:**
 
@@ -3641,7 +3641,7 @@ _Released 06/28/2022_
 
 ## 10.2.0
 
-_Released 06/21/2022_
+_Released Jun 21, 2022_
 
 **Features:**
 
@@ -3691,7 +3691,7 @@ _Released 06/21/2022_
 
 ## 10.1.0
 
-_Released 06/10/2022_
+_Released Jun 10, 2022_
 
 **Features:**
 
@@ -3728,7 +3728,7 @@ _Released 06/10/2022_
 
 ## 10.0.3
 
-_Released 06/03/2022_
+_Released Jun 03, 2022_
 
 **Bugfixes:**
 
@@ -3753,7 +3753,7 @@ _Released 06/03/2022_
 
 ## 10.0.2
 
-_Released 06/02/2022_
+_Released Jun 02, 2022_
 
 **Bugfixes:**
 
@@ -3780,7 +3780,7 @@ _Released 06/02/2022_
 
 ## 10.0.1
 
-_Released 06/01/2022_
+_Released Jun 01, 2022_
 
 **Bugfixes:**
 
@@ -3814,7 +3814,7 @@ _Released 06/01/2022_
 
 ## 10.0.0
 
-_Released 06/01/2022_
+_Released Jun 01, 2022_
 
 **Summary:**
 
@@ -4139,7 +4139,7 @@ more detail.**
 
 ## 9.7.0
 
-_Released 05/23/2022_
+_Released May 23, 2022_
 
 **Features:**
 
@@ -4184,7 +4184,7 @@ _Released 05/23/2022_
 
 ## 9.6.1
 
-_Released 05/09/2022_
+_Released May 09, 2022_
 
 **Bugfixes:**
 
@@ -4209,7 +4209,7 @@ _Released 05/09/2022_
 
 ## 9.6.0
 
-_Released 04/25/2022_
+_Released Apr 25, 2022_
 
 **Features:**
 
@@ -4263,7 +4263,7 @@ _Released 04/25/2022_
 
 ## 9.5.4
 
-_Released 04/11/2022_
+_Released Apr 11, 2022_
 
 **Bugfixes:**
 
@@ -4334,7 +4334,7 @@ _Released 04/11/2022_
 
 ## 9.5.3
 
-_Released 03/28/2022_
+_Released Mar 28, 2022_
 
 **Bugfixes:**
 
@@ -4378,7 +4378,7 @@ _Released 03/28/2022_
 
 ## 9.5.2
 
-_Released 03/14/2022_
+_Released Mar 14, 2022_
 
 **Bugfixes:**
 
@@ -4421,7 +4421,7 @@ _Released 03/14/2022_
 
 ## 9.5.1
 
-_Released 02/28/2022_
+_Released Feb 28, 2022_
 
 **Bugfixes:**
 
@@ -4456,7 +4456,7 @@ _Released 02/28/2022_
 
 ## 9.5.0
 
-_Released 02/15/2022_
+_Released Feb 15, 2022_
 
 **Features:**
 
@@ -4491,7 +4491,7 @@ _Released 02/15/2022_
 
 ## 9.4.1
 
-_Released 01/31/2022_
+_Released Jan 31, 2022_
 
 **Bugfixes:**
 
@@ -4501,7 +4501,7 @@ _Released 01/31/2022_
 
 ## 9.4.0
 
-_Released 01/31/2022_
+_Released Jan 31, 2022_
 
 **Features**
 
@@ -4539,7 +4539,7 @@ _Released 01/31/2022_
 
 ## 9.3.1
 
-_Released 01/19/2022_
+_Released Jan 19, 2022_
 
 **Bugfixes:**
 
@@ -4548,7 +4548,7 @@ _Released 01/19/2022_
 
 ## 9.3.0
 
-_Released 01/18/2022_
+_Released Jan 18, 2022_
 
 **Features:**
 
@@ -4600,7 +4600,7 @@ _Released 01/18/2022_
 
 ## 9.2.1
 
-_Released 01/10/2022_
+_Released Jan 10, 2022_
 
 **Bugfixes:**
 
@@ -4627,7 +4627,7 @@ _Released 01/10/2022_
 
 ## 9.2.0
 
-_Released 12/20/2021_
+_Released Dec 20, 2021_
 
 **Features:**
 
@@ -4703,7 +4703,7 @@ _Released 12/20/2021_
 
 ## 9.1.1
 
-_Released 12/03/2021_
+_Released Dec 03, 2021_
 
 **Bugfixes:**
 
@@ -4744,7 +4744,7 @@ _Released 12/03/2021_
 
 ## 9.1.0
 
-_Released 11/22/2021_
+_Released Nov 22, 2021_
 
 **Features:**
 
@@ -4774,7 +4774,7 @@ _Released 11/22/2021_
 
 ## 9.0.0
 
-_Released 11/10/2021_
+_Released Nov 10, 2021_
 
 **Breaking Changes:**
 
@@ -4846,7 +4846,7 @@ _Released 11/10/2021_
 
 ## 8.7.0
 
-_Released 10/25/2021_
+_Released Oct 25, 2021_
 
 **Features:**
 
@@ -4893,7 +4893,7 @@ _Released 10/25/2021_
 
 ## 8.6.0
 
-_Released 10/11/2021_
+_Released Oct 11, 2021_
 
 **Features:**
 
@@ -4940,7 +4940,7 @@ _Released 10/11/2021_
 
 ## 8.5.0
 
-_Released 09/27/2021_
+_Released Sep 27, 2021_
 
 **Features:**
 
@@ -4973,7 +4973,7 @@ _Released 09/27/2021_
 
 ## 8.4.1
 
-_Released 09/17/2021_
+_Released Sep 17, 2021_
 
 **Bugfixes:**
 
@@ -4986,7 +4986,7 @@ _Released 09/17/2021_
 
 ## 8.4.0
 
-_Released 09/13/2021_
+_Released Sep 13, 2021_
 
 **Features:**
 
@@ -5010,7 +5010,7 @@ _Released 09/13/2021_
 
 ## 8.3.1
 
-_Released 08/27/2021_
+_Released Aug 27, 2021_
 
 **Performance:**
 
@@ -5048,7 +5048,7 @@ _Released 08/27/2021_
 
 ## 8.3.0
 
-_Released 08/16/2021_
+_Released Aug 16, 2021_
 
 **Features:**
 
@@ -5095,7 +5095,7 @@ _Released 08/16/2021_
 
 ## 8.2.0
 
-_Released 08/04/2021_
+_Released Aug 04, 2021_
 
 **Features:**
 
@@ -5151,7 +5151,7 @@ _Released 08/04/2021_
 
 ## 8.1.0
 
-_Released 07/29/2021_
+_Released Jul 29, 2021_
 
 **Features:**
 
@@ -5183,7 +5183,7 @@ _Released 07/29/2021_
 
 ## 8.0.0
 
-_Released 07/19/2021_
+_Released Jul 19, 2021_
 
 **Summary:**
 
@@ -5259,7 +5259,7 @@ detail and how to change your code to migrate to Cypress 8.0.**
 
 ## 7.7.0
 
-_Released 07/07/2021_
+_Released Jul 07, 2021_
 
 **Features:**
 
@@ -5291,7 +5291,7 @@ _Released 07/07/2021_
 
 ## 7.6.0
 
-_Released 06/23/2021_
+_Released Jun 23, 2021_
 
 **Features:**
 
@@ -5351,7 +5351,7 @@ _Released 06/23/2021_
 
 ## 7.5.0
 
-_Released 06/07/2021_
+_Released Jun 07, 2021_
 
 **Features:**
 
@@ -5386,7 +5386,7 @@ _Released 06/07/2021_
 
 ## 7.4.0
 
-_Released 05/24/2021_
+_Released May 24, 2021_
 
 **Features:**
 
@@ -5442,7 +5442,7 @@ _Released 05/24/2021_
 
 ## 7.3.0
 
-_Released 05/10/2021_
+_Released May 10, 2021_
 
 **Features:**
 
@@ -5544,7 +5544,7 @@ _Released 05/10/2021_
 
 ## 7.2.0
 
-_Released 04/26/2021_
+_Released Apr 26, 2021_
 
 **Features:**
 
@@ -5618,7 +5618,7 @@ _Released 04/26/2021_
 
 ## 7.1.0
 
-_Released 04/12/2021_
+_Released Apr 12, 2021_
 
 **Features:**
 
@@ -5644,7 +5644,7 @@ _Released 04/12/2021_
 
 ## 7.0.1
 
-_Released 04/07/2021_
+_Released Apr 07, 2021_
 
 **Bugfixes:**
 
@@ -5676,7 +5676,7 @@ _Released 04/07/2021_
 
 ## 7.0.0
 
-_Released 04/05/2021_
+_Released Apr 05, 2021_
 
 **Summary:**
 
@@ -5870,7 +5870,7 @@ detail and how to change your code to migrate to Cypress 7.0.**
 
 ## 6.9.1
 
-_Released 04/05/2021_
+_Released Apr 05, 2021_
 
 This release contains the same features as [6.8.0](#6-8-0). It was published to provide a
 non-breaking alternative to [6.9.0](#6-9-0), which was mistakenly published with breaking
@@ -5878,14 +5878,14 @@ changes.
 
 ## 6.9.0
 
-_Released 04/05/2021_
+_Released Apr 05, 2021_
 
 This release was mistakenly published with breaking changes, is deprecated, and
 should not be used. Upgrade to [6.9.1](#6-9-1) or [7.0.0](#7-0-0), or stay on [6.8.0](#6-8-0).
 
 ## 6.8.0
 
-_Released 03/17/2021_
+_Released Mar 17, 2021_
 
 **User Experience:**
 
@@ -5906,7 +5906,7 @@ _Released 03/17/2021_
 
 ## 6.7.1
 
-_Released 03/15/2021_
+_Released Mar 15, 2021_
 
 **Bugfixes:**
 
@@ -5920,7 +5920,7 @@ _Released 03/15/2021_
 
 ## 6.7.0
 
-_Released 03/15/2021_
+_Released Mar 15, 2021_
 
 **Features:**
 
@@ -5994,7 +5994,7 @@ _Released 03/15/2021_
 
 ## 6.6.0
 
-_Released 02/18/2021_
+_Released Feb 18, 2021_
 
 **Features:**
 
@@ -6009,7 +6009,7 @@ _Released 02/18/2021_
 
 ## 6.5.0
 
-_Released 02/15/2021_
+_Released Feb 15, 2021_
 
 **Performance:**
 
@@ -6054,7 +6054,7 @@ _Released 02/15/2021_
 
 ## 6.4.0
 
-_Released 02/01/2021_
+_Released Feb 01, 2021_
 
 **Features:**
 
@@ -6140,7 +6140,7 @@ _Released 02/01/2021_
 
 ## 6.3.0
 
-_Released 01/19/2021_
+_Released Jan 19, 2021_
 
 **Features:**
 
@@ -6211,7 +6211,7 @@ _Released 01/19/2021_
 
 ## 6.2.1
 
-_Released 01/04/2021_
+_Released Jan 04, 2021_
 
 **Bugfixes:**
 
@@ -6255,7 +6255,7 @@ _Released 01/04/2021_
 
 ## 6.2.0
 
-_Released 12/21/2020_
+_Released Dec 21, 2020_
 
 **Features:**
 
@@ -6329,7 +6329,7 @@ _Released 12/21/2020_
 
 ## 6.1.0
 
-_Released 12/07/2020_
+_Released Dec 07, 2020_
 
 **Features:**
 
@@ -6400,7 +6400,7 @@ deprecations.
 
 ## 6.0.1
 
-_Released 11/30/2020_
+_Released Nov 30, 2020_
 
 **Bugfixes:**
 
@@ -6424,7 +6424,7 @@ _Released 11/30/2020_
 
 ## 6.0.0
 
-_Released 11/23/2020_
+_Released Nov 23, 2020_
 
 **Summary:**
 
@@ -6558,7 +6558,7 @@ deprecations.
 
 ## 5.6.0
 
-_Released 11/09/2020_
+_Released Nov 09, 2020_
 
 **Features:**
 
@@ -6636,7 +6636,7 @@ _Released 11/09/2020_
 
 ## 5.5.0
 
-_Released 10/26/2020_
+_Released Oct 26, 2020_
 
 **Features:**
 
@@ -6695,7 +6695,7 @@ _Released 10/26/2020_
 
 ## 5.4.0
 
-_Released 10/14/2020_
+_Released Oct 14, 2020_
 
 **Features:**
 
@@ -6795,7 +6795,7 @@ _Released 10/14/2020_
 
 ## 5.3.0
 
-_Released 09/28/2020_
+_Released Sep 28, 2020_
 
 **Features:**
 
@@ -6852,7 +6852,7 @@ _Released 09/28/2020_
 
 ## 5.2.0
 
-_Released 09/15/2020_
+_Released Sep 15, 2020_
 
 **Features:**
 
@@ -6937,7 +6937,7 @@ _Released 09/15/2020_
 
 ## 5.1.0
 
-_Released 09/01/2020_
+_Released Sep 01, 2020_
 
 **Features:**
 
@@ -7008,7 +7008,7 @@ _Released 09/01/2020_
 
 ## 5.0.0
 
-_Released 08/19/2020_
+_Released Aug 19, 2020_
 
 **Summary:**
 
@@ -7180,7 +7180,7 @@ detail and how to change your code to migrate to Cypress 5.0.**
 
 ## 4.12.1
 
-_Released 08/05/2020_
+_Released Aug 05, 2020_
 
 **Bugfixes:**
 
@@ -7200,7 +7200,7 @@ _Released 08/05/2020_
 
 ## 4.12.0
 
-_Released 08/03/2020_
+_Released Aug 03, 2020_
 
 **Features:**
 
@@ -7280,7 +7280,7 @@ _Released 08/03/2020_
 
 ## 4.11.0
 
-_Released 07/21/2020_
+_Released Jul 21, 2020_
 
 **Features:**
 
@@ -7367,7 +7367,7 @@ _Released 07/21/2020_
 
 ## 4.10.0
 
-_Released 07/07/2020_
+_Released Jul 07, 2020_
 
 **Features:**
 
@@ -7419,7 +7419,7 @@ _Released 07/07/2020_
 
 ## 4.9.0
 
-_Released 06/23/2020_
+_Released Jun 23, 2020_
 
 **Features:**
 
@@ -7510,7 +7510,7 @@ _Released 06/23/2020_
 
 ## 4.8.0
 
-_Released 06/08/2020_
+_Released Jun 08, 2020_
 
 **Features:**
 
@@ -7616,7 +7616,7 @@ _Released 06/08/2020_
 
 ## 4.7.0
 
-_Released 05/26/2020_
+_Released May 26, 2020_
 
 **Features:**
 
@@ -7644,7 +7644,7 @@ _Released 05/26/2020_
 
 ## 4.6.0
 
-_Released 05/20/2020_
+_Released May 20, 2020_
 
 **Features:**
 
@@ -7789,7 +7789,7 @@ _Released 05/20/2020_
 
 ## 4.5.0
 
-_Released 04/28/2020_
+_Released Apr 28, 2020_
 
 **Features:**
 
@@ -7832,7 +7832,7 @@ _Released 04/28/2020_
 
 ## 4.4.1
 
-_Released 04/20/2020_
+_Released Apr 20, 2020_
 
 **Bugfixes:**
 
@@ -7867,7 +7867,7 @@ _Released 04/20/2020_
 
 ## 4.4.0
 
-_Released 04/13/2020_
+_Released Apr 13, 2020_
 
 **Features:**
 
@@ -7911,7 +7911,7 @@ _Released 04/13/2020_
 
 ## 4.3.0
 
-_Released 03/30/2020_
+_Released Mar 30, 2020_
 
 **Features:**
 
@@ -8027,7 +8027,7 @@ _Released 03/30/2020_
 
 ## 4.2.0
 
-_Released 03/16/2020_
+_Released Mar 16, 2020_
 
 **Features:**
 
@@ -8114,7 +8114,7 @@ _Released 03/16/2020_
 
 ## 4.1.0
 
-_Released 02/28/2020_
+_Released Feb 28, 2020_
 
 **Features:**
 
@@ -8190,7 +8190,7 @@ _Released 02/28/2020_
 
 ## 4.0.2
 
-_Released 02/14/2020_
+_Released Feb 14, 2020_
 
 **Bugfixes:**
 
@@ -8226,7 +8226,7 @@ _Released 02/14/2020_
 
 ## 4.0.1
 
-_Released 02/07/2020_
+_Released Feb 07, 2020_
 
 **Bugfixes:**
 
@@ -8254,7 +8254,7 @@ _Released 02/07/2020_
 
 ## 4.0.0
 
-_Released 02/06/2020_
+_Released Feb 06, 2020_
 
 **Summary:**
 
@@ -8427,7 +8427,7 @@ detail and how to change your code to migrate to Cypress 4.0.**
 
 ## 3.8.3
 
-_Released 01/24/2020_
+_Released Jan 24, 2020_
 
 **Bugfixes:**
 
@@ -8467,7 +8467,7 @@ _Released 01/24/2020_
 
 ## 3.8.2
 
-_Released 01/10/2020_
+_Released Jan 10, 2020_
 
 **Bugfixes:**
 
@@ -8523,7 +8523,7 @@ _Released 01/10/2020_
 
 ## 3.8.1
 
-_Released 12/26/2019_
+_Released Dec 26, 2019_
 
 **Bugfixes:**
 
@@ -8578,7 +8578,7 @@ _Released 12/26/2019_
 
 ## 3.8.0
 
-_Released 12/12/2019_
+_Released Dec 12, 2019_
 
 **Features:**
 
@@ -8666,7 +8666,7 @@ _Released 12/12/2019_
 
 ## 3.7.0
 
-_Released 11/27/2019_
+_Released Nov 27, 2019_
 
 **Features:**
 
@@ -8771,7 +8771,7 @@ _Released 11/27/2019_
 
 ## 3.6.1
 
-_Released 11/08/2019_
+_Released Nov 08, 2019_
 
 **Bugfixes:**
 
@@ -8844,7 +8844,7 @@ _Released 11/08/2019_
 
 ## 3.6.0
 
-_Released 10/31/2019_
+_Released Oct 31, 2019_
 
 **Features:**
 
@@ -8918,7 +8918,7 @@ _Released 10/31/2019_
 
 ## 3.5.0
 
-_Released 10/23/2019_
+_Released Oct 23, 2019_
 
 **Features:**
 
@@ -9220,7 +9220,7 @@ _Released 10/23/2019_
 
 ## 3.4.1
 
-_Released 07/29/2019_
+_Released Jul 29, 2019_
 
 **Dashboard Features:**
 
@@ -9364,7 +9364,7 @@ _Released 07/29/2019_
 
 ## 3.4.0
 
-_Released 07/09/2019_
+_Released Jul 09, 2019_
 
 **Features:**
 
@@ -9456,7 +9456,7 @@ _Released 07/09/2019_
 
 ## 3.3.2
 
-_Released 06/27/2019_
+_Released Jun 27, 2019_
 
 **Performance Improvements:**
 
@@ -9658,7 +9658,7 @@ _Released 06/27/2019_
 
 ## 3.3.1
 
-_Released 05/23/2019_
+_Released May 23, 2019_
 
 **News:**
 
@@ -9711,7 +9711,7 @@ _Released 05/23/2019_
 
 ## 3.3.0
 
-_Released 05/17/2019_
+_Released May 17, 2019_
 
 **News:**
 
@@ -9994,7 +9994,7 @@ _Released 05/17/2019_
 
 ## 3.2.0
 
-_Released 03/15/2019_
+_Released Mar 15, 2019_
 
 **Features:**
 
@@ -10230,7 +10230,7 @@ _Released 03/15/2019_
 
 ## 3.1.5
 
-_Released 01/30/2019_
+_Released Jan 30, 2019_
 
 **Bugfixes:**
 
@@ -10327,7 +10327,7 @@ _Released 01/30/2019_
 
 ## 3.1.4
 
-_Released 12/25/2018_
+_Released Dec 25, 2018_
 
 Merry Christmas everyone!
 
@@ -10376,7 +10376,7 @@ Merry Christmas everyone!
 
 ## 3.1.3
 
-_Released 12/03/2018_
+_Released Dec 03, 2018_
 
 **Bugfixes:**
 
@@ -10428,7 +10428,7 @@ _Released 12/03/2018_
 
 ## 3.1.2
 
-_Released 11/18/2018_
+_Released Nov 18, 2018_
 
 **Bugfixes:**
 
@@ -10469,7 +10469,7 @@ _Released 11/18/2018_
 
 ## 3.1.1
 
-_Released 11/02/2018_
+_Released Nov 02, 2018_
 
 **Features:**
 
@@ -10603,7 +10603,7 @@ _Released 11/02/2018_
 
 ## 3.1.0
 
-_Released 08/13/2018_
+_Released Aug 13, 2018_
 
 **Summary:**
 
@@ -10724,7 +10724,7 @@ _Released 08/13/2018_
 
 ## 3.0.3
 
-_Released 07/30/2018_
+_Released Jul 30, 2018_
 
 **Bugfixes:**
 
@@ -10885,7 +10885,7 @@ _Released 07/30/2018_
 
 ## 3.0.2
 
-_Released 06/28/2018_
+_Released Jun 28, 2018_
 
 **Bugfixes:**
 
@@ -11058,7 +11058,7 @@ _Released 06/28/2018_
 
 ## 3.0.1
 
-_Released 05/30/2018_
+_Released May 30, 2018_
 
 **Bugfixes:**
 
@@ -11077,7 +11077,7 @@ _Released 05/30/2018_
 
 ## 3.0.0
 
-_Released 05/29/2018_
+_Released May 29, 2018_
 
 **Summary:**
 
@@ -11326,7 +11326,7 @@ _Released 05/29/2018_
 
 ## 2.1.0
 
-_Released 03/01/2018_
+_Released Mar 01, 2018_
 
 **Bugfixes:**
 
@@ -11358,7 +11358,7 @@ _Released 03/01/2018_
 
 ## 2.0.4
 
-_Released 02/25/2018_
+_Released Feb 25, 2018_
 
 **Bugfixes:**
 
@@ -11369,7 +11369,7 @@ _Released 02/25/2018_
 
 ## 2.0.3
 
-_Released 02/21/2018_
+_Released Feb 21, 2018_
 
 **Bugfixes:**
 
@@ -11389,7 +11389,7 @@ _Released 02/21/2018_
 
 ## 2.0.2
 
-_Released 02/17/2018_
+_Released Feb 17, 2018_
 
 **Bugfixes:**
 
@@ -11409,7 +11409,7 @@ _Released 02/17/2018_
 
 ## 2.0.1
 
-_Released 02/16/2018_
+_Released Feb 16, 2018_
 
 **Bugfixes:**
 
@@ -11425,7 +11425,7 @@ _Released 02/16/2018_
 
 ## 2.0.0
 
-_Released 02/15/2018_
+_Released Feb 15, 2018_
 
 **Breaking Changes:**
 
@@ -11521,7 +11521,7 @@ _Released 02/15/2018_
 
 ## 1.4.2
 
-_Released 02/04/2018_
+_Released Feb 04, 2018_
 
 **Bugfixes:**
 
@@ -11569,7 +11569,7 @@ _Released 02/04/2018_
 
 ## 1.4.1
 
-_Released 12/26/2017_
+_Released Dec 26, 2017_
 
 **Bugfixes:**
 
@@ -11606,7 +11606,7 @@ _Released 12/26/2017_
 
 ## 1.4.0
 
-_Released 12/19/2017_
+_Released Dec 19, 2017_
 
 **Features:**
 
@@ -11631,7 +11631,7 @@ _Released 12/19/2017_
 
 ## 1.3.0
 
-_Released 12/17/2017_
+_Released Dec 17, 2017_
 
 **Features:**
 
@@ -11663,7 +11663,7 @@ Documentation Changes:
 
 ## 1.2.0
 
-_Released 12/14/2017_
+_Released Dec 14, 2017_
 
 **Features:**
 
@@ -11718,7 +11718,7 @@ _Released 12/14/2017_
 
 ## 1.1.4
 
-_Released 12/06/2017_
+_Released Dec 06, 2017_
 
 **Bugfixes:**
 
@@ -11753,7 +11753,7 @@ _Released 12/06/2017_
 
 ## 1.1.3
 
-_Released 12/03/2017_
+_Released Dec 03, 2017_
 
 **Bugfixes:**
 
@@ -11801,7 +11801,7 @@ _Released 12/03/2017_
 
 ## 1.1.2
 
-_Released 11/26/2017_
+_Released Nov 26, 2017_
 
 **Bugfixes:**
 
@@ -11826,7 +11826,7 @@ _Released 11/26/2017_
 
 ## 1.1.1
 
-_Released 11/20/2017_
+_Released Nov 20, 2017_
 
 **Bugfixes:**
 
@@ -11838,7 +11838,7 @@ _Released 11/20/2017_
 
 ## 1.1.0
 
-_Released 11/19/2017_
+_Released Nov 19, 2017_
 
 **Summary:**
 
@@ -11918,7 +11918,7 @@ _Released 11/19/2017_
 
 ## 1.0.3
 
-_Released 10/29/2017_
+_Released Oct 29, 2017_
 
 **Features:**
 
@@ -11967,7 +11967,7 @@ _Released 10/29/2017_
 
 ## 1.0.2
 
-_Released 10/13/2017_
+_Released Oct 13, 2017_
 
 **Bugfixes:**
 
@@ -11995,7 +11995,7 @@ _Released 10/13/2017_
 
 ## 1.0.1
 
-_Released 10/10/2017_
+_Released Oct 10, 2017_
 
 **Bugfixes:**
 
@@ -12006,7 +12006,7 @@ _Released 10/10/2017_
 
 ## 1.0.0
 
-_Released 10/09/2017_
+_Released Oct 09, 2017_
 
 **Summary:**
 
@@ -12064,14 +12064,14 @@ _Released 10/09/2017_
 
 ## 0.20.3
 
-_Released 10/06/2017_
+_Released Oct 06, 2017_
 
 - Improved verifying the binary for the first time after an `npm install`. Fixes
   [#709](https://github.com/cypress-io/cypress/issues/709).
 
 ## 0.20.2
 
-_Released 10/06/2017_
+_Released Oct 06, 2017_
 
 **Possibly Breaking Changes:**
 
@@ -12102,7 +12102,7 @@ _Released 10/06/2017_
 
 ## 0.20.1
 
-_Released 09/17/2017_
+_Released Sep 17, 2017_
 
 **Features:**
 
@@ -12155,7 +12155,7 @@ _Released 09/17/2017_
 
 ## 0.20.0
 
-_Released 09/10/2017_
+_Released Sep 10, 2017_
 
 **Summary:**
 
@@ -12561,7 +12561,7 @@ Note: we are still updating all of the docs to reflect all the `0.20.0` changes.
 
 ## 0.19.4
 
-_Released 06/18/2017_
+_Released Jun 18, 2017_
 
 **Bugfixes:**
 
@@ -12571,7 +12571,7 @@ Fixed [.type()](/api/commands/type) not firing `input` event for
 
 ## 0.19.3
 
-_Released 06/14/2017_
+_Released Jun 14, 2017_
 
 **Bugfixes:**
 
@@ -12581,7 +12581,7 @@ _Released 06/14/2017_
 
 ## 0.19.2
 
-_Released 04/16/2017_
+_Released Apr 16, 2017_
 
 **Features:**
 
@@ -12630,7 +12630,7 @@ _Released 04/16/2017_
 
 ## 0.19.1
 
-_Released 03/09/2017_
+_Released Mar 09, 2017_
 
 **Features:**
 
@@ -12674,7 +12674,7 @@ _Released 03/09/2017_
 
 ## 0.19.0
 
-_Released 02/11/2017_
+_Released Feb 11, 2017_
 
 **Notes:**
 
@@ -12759,7 +12759,7 @@ _Released 02/11/2017_
 
 ## 0.18.8
 
-_Released 02/05/2017_
+_Released Feb 05, 2017_
 
 **Overview:**
 
@@ -12809,7 +12809,7 @@ _Released 02/05/2017_
 
 ## 0.18.7
 
-_Released 01/30/2017_
+_Released Jan 30, 2017_
 
 **Bugfixes:**
 
@@ -12819,7 +12819,7 @@ _Released 01/30/2017_
 
 ## 0.18.6
 
-_Released 01/29/2017_
+_Released Jan 29, 2017_
 
 **Features:**
 
@@ -12857,7 +12857,7 @@ _Released 01/29/2017_
 
 ## 0.18.5
 
-_Released 01/08/2017_
+_Released Jan 08, 2017_
 
 **Features:**
 
@@ -12884,7 +12884,7 @@ _Released 01/08/2017_
 
 ## 0.18.4
 
-_Released 12/28/2016_
+_Released Dec 28, 2016_
 
 **Bugfixes:**
 
@@ -12909,7 +12909,7 @@ _Released 12/28/2016_
 
 ## 0.18.3
 
-_Released 12/18/2016_
+_Released Dec 18, 2016_
 
 **Features:**
 
@@ -12936,7 +12936,7 @@ _Released 12/18/2016_
 
 ## 0.18.2
 
-_Released 12/15/2016_
+_Released Dec 15, 2016_
 
 **Bugfixes:**
 
@@ -12960,7 +12960,7 @@ _Released 12/15/2016_
 
 ## 0.18.1
 
-_Released 12/11/2016_
+_Released Dec 11, 2016_
 
 **Notes:**
 
@@ -13038,7 +13038,7 @@ _Released 12/11/2016_
 
 ## 0.18.0
 
-_Released 11/27/2016_
+_Released Nov 27, 2016_
 
 **Notes:**
 
@@ -13105,7 +13105,7 @@ _Released 11/27/2016_
 
 ## 0.17.12
 
-_Released 11/21/2016_
+_Released Nov 21, 2016_
 
 **Bugfixes:**
 
@@ -13139,7 +13139,7 @@ _Released 11/21/2016_
 
 ## 0.17.11
 
-_Released 11/16/2016_
+_Released Nov 16, 2016_
 
 **Roadmap:**
 
@@ -13196,7 +13196,7 @@ _Released 11/16/2016_
 
 ## 0.17.10
 
-_Released 11/07/2016_
+_Released Nov 07, 2016_
 
 **Bugfixes:**
 
@@ -13219,7 +13219,7 @@ _Released 11/07/2016_
 
 ## 0.17.9
 
-_Released 10/22/2016_
+_Released Oct 22, 2016_
 
 **Bugfixes:**
 
@@ -13245,7 +13245,7 @@ _Released 10/22/2016_
 
 ## 0.17.8
 
-_Released 10/13/2016_
+_Released Oct 13, 2016_
 
 **Bugfixes:**
 
@@ -13275,7 +13275,7 @@ _Released 10/13/2016_
 
 ## 0.17.7
 
-_Released 10/12/2016_
+_Released Oct 12, 2016_
 
 **Features:**
 
@@ -13303,7 +13303,7 @@ _Released 10/12/2016_
 
 ## 0.17.6
 
-_Released 10/04/2016_
+_Released Oct 04, 2016_
 
 **Features:**
 
@@ -13334,7 +13334,7 @@ _Released 10/04/2016_
 
 ## 0.17.5
 
-_Released 10/02/2016_
+_Released Oct 02, 2016_
 
 **Features:**
 
@@ -13402,7 +13402,7 @@ _Released 10/02/2016_
 
 ## 0.17.4
 
-_Released 09/12/2016_
+_Released Sep 12, 2016_
 
 **Breaking Changes:**
 
@@ -13435,7 +13435,7 @@ _Released 09/12/2016_
 
 ## 0.17.3
 
-_Released 09/11/2016_
+_Released Sep 11, 2016_
 
 **Features:**
 
@@ -13462,7 +13462,7 @@ _Released 09/11/2016_
 
 ## 0.17.2
 
-_Released 09/06/2016_
+_Released Sep 06, 2016_
 
 **Notes:**
 
@@ -13526,7 +13526,7 @@ _Released 09/06/2016_
 
 ## 0.17.1
 
-_Released 08/31/2016_
+_Released Aug 31, 2016_
 
 **Features:**
 
@@ -13571,7 +13571,7 @@ _Released 08/31/2016_
 
 ## 0.17.0
 
-_Released 08/30/2016_
+_Released Aug 30, 2016_
 
 **Overview:**
 
@@ -13716,7 +13716,7 @@ _Released 08/30/2016_
 
 ## 0.16.5
 
-_Released 07/31/2016_
+_Released Jul 31, 2016_
 
 **Bugfixes:**
 
@@ -13725,7 +13725,7 @@ _Released 07/31/2016_
 
 ## 0.16.4
 
-_Released 06/17/2016_
+_Released Jun 17, 2016_
 
 **Bugfixes:**
 
@@ -13737,7 +13737,7 @@ _Released 06/17/2016_
 
 ## 0.16.3
 
-_Released 06/17/2016_
+_Released Jun 17, 2016_
 
 **Features:**
 
@@ -13793,7 +13793,7 @@ _Released 06/17/2016_
 
 ## 0.16.2
 
-_Released 06/11/2016_
+_Released Jun 11, 2016_
 
 **Features:**
 
@@ -13853,7 +13853,7 @@ _Released 06/11/2016_
 
 ## 0.16.1
 
-_Released 05/22/2016_
+_Released May 22, 2016_
 
 **Features:**
 
@@ -13882,7 +13882,7 @@ _Released 05/22/2016_
 
 ## 0.16.0
 
-_Released 05/17/2016_
+_Released May 17, 2016_
 
 **Notes:**
 
@@ -14019,7 +14019,7 @@ _Released 05/17/2016_
 
 ## 0.15.4
 
-_Released 04/22/2016_
+_Released Apr 22, 2016_
 
 **Notes:**
 
@@ -14066,7 +14066,7 @@ _Released 04/22/2016_
 
 ## 0.15.3
 
-_Released 04/10/2016_
+_Released Apr 10, 2016_
 
 **Features:**
 
@@ -14123,7 +14123,7 @@ _Released 04/10/2016_
 
 ## 0.15.2
 
-_Released 04/03/2016_
+_Released Apr 03, 2016_
 
 **Features:**
 
@@ -14150,7 +14150,7 @@ _Released 04/03/2016_
 
 ## 0.15.1
 
-_Released 04/01/2016_
+_Released Apr 01, 2016_
 
 **Features:**
 
@@ -14180,7 +14180,7 @@ _Released 04/01/2016_
 
 ## 0.15.0
 
-_Released 03/28/2016_
+_Released Mar 28, 2016_
 
 **Overview:**
 
@@ -14255,7 +14255,7 @@ More Info:
 
 ## 0.14.3
 
-_Released 03/20/2016_
+_Released Mar 20, 2016_
 
 **Features:**
 
@@ -14284,7 +14284,7 @@ _Released 03/20/2016_
 
 ## 0.14.2
 
-_Released 03/14/2016_
+_Released Mar 14, 2016_
 
 **Bugfixes:**
 
@@ -14308,7 +14308,7 @@ _Released 03/14/2016_
 
 ## 0.14.1
 
-_Released 03/13/2016_
+_Released Mar 13, 2016_
 
 **Features:**
 
@@ -14349,7 +14349,7 @@ _Released 03/13/2016_
 
 ## 0.14.0
 
-_Released 03/08/2016_
+_Released Mar 08, 2016_
 
 **Summary:**
 
@@ -14432,7 +14432,7 @@ Known Issues:
 
 ## 0.13.9
 
-_Released 01/28/2016_
+_Released Jan 28, 2016_
 
 **Bugfixes:**
 
@@ -14455,7 +14455,7 @@ _Released 01/28/2016_
 
 ## 0.13.8
 
-_Released 01/24/2016_
+_Released Jan 24, 2016_
 
 **Features:**
 
@@ -14483,7 +14483,7 @@ _Released 01/24/2016_
 
 ## 0.13.7
 
-_Released 01/17/2016_
+_Released Jan 17, 2016_
 
 **Bugfixes:**
 
@@ -14509,7 +14509,7 @@ _Released 01/17/2016_
 
 ## 0.13.6
 
-_Released 01/09/2016_
+_Released Jan 09, 2016_
 
 **Features:**
 
@@ -14532,7 +14532,7 @@ _Released 01/09/2016_
 
 ## 0.13.5
 
-_Released 01/03/2016_
+_Released Jan 03, 2016_
 
 **Features:**
 
@@ -14552,7 +14552,7 @@ _Released 01/03/2016_
 
 ## 0.13.4
 
-_Released 12/31/2015_
+_Released Dec 31, 2015_
 
 **Features:**
 
@@ -14592,7 +14592,7 @@ _Released 12/31/2015_
 
 ## 0.13.3
 
-_Released 12/25/2015_
+_Released Dec 25, 2015_
 
 **Notes:**
 
@@ -14650,7 +14650,7 @@ _Released 12/25/2015_
 
 ## 0.13.2
 
-_Released 12/20/2015_
+_Released Dec 20, 2015_
 
 **Notes:**
 
@@ -14704,7 +14704,7 @@ _Released 12/20/2015_
 
 ## 0.13.1
 
-_Released 12/11/2015_
+_Released Dec 11, 2015_
 
 **Notes:**
 
@@ -14724,7 +14724,7 @@ _Released 12/11/2015_
 
 ## 0.13.0
 
-_Released 12/09/2015_
+_Released Dec 09, 2015_
 
 **Summary:**
 
@@ -14769,7 +14769,7 @@ _Released 12/09/2015_
 
 ## 0.12.8
 
-_Released 12/02/2015_
+_Released Dec 02, 2015_
 
 **Features:**
 
@@ -14805,7 +14805,7 @@ _Released 12/02/2015_
 
 ## 0.12.7
 
-_Released 11/30/2015_
+_Released Nov 30, 2015_
 
 **Bugfixes:**
 
@@ -14818,7 +14818,7 @@ _Released 11/30/2015_
 
 ## 0.12.6
 
-_Released 11/29/2015_
+_Released Nov 29, 2015_
 
 **Features:**
 
@@ -14864,7 +14864,7 @@ _Released 11/29/2015_
 
 ## 0.12.5
 
-_Released 11/22/2015_
+_Released Nov 22, 2015_
 
 **Features:**
 
@@ -14884,7 +14884,7 @@ _Released 11/22/2015_
 
 ## 0.12.4
 
-_Released 11/19/2015_
+_Released Nov 19, 2015_
 
 **Features:**
 
@@ -14918,7 +14918,7 @@ _Released 11/19/2015_
 
 ## 0.12.3
 
-_Released 11/04/2015_
+_Released Nov 04, 2015_
 
 **Bugfixes:**
 
@@ -14929,7 +14929,7 @@ _Released 11/04/2015_
 
 ## 0.12.2
 
-_Released 11/01/2015_
+_Released Nov 01, 2015_
 
 **Features:**
 
@@ -14951,7 +14951,7 @@ _Released 11/01/2015_
 
 ## 0.12.1
 
-_Released 10/28/2015_
+_Released Oct 28, 2015_
 
 **Bugfixes:**
 
@@ -14966,7 +14966,7 @@ _Released 10/28/2015_
 
 ## 0.12.0
 
-_Released 10/23/2015_
+_Released Oct 23, 2015_
 
 **Summary:**
 
@@ -15070,7 +15070,7 @@ _Released 10/23/2015_
 
 ## 0.11.13
 
-_Released 10/08/2015_
+_Released Oct 08, 2015_
 
 **Bugfixes:**
 
@@ -15083,7 +15083,7 @@ _Released 10/08/2015_
 
 ## 0.11.12
 
-_Released 10/07/2015_
+_Released Oct 07, 2015_
 
 **Features:**
 
@@ -15109,7 +15109,7 @@ _Released 10/07/2015_
 
 ## 0.11.11
 
-_Released 10/04/2015_
+_Released Oct 04, 2015_
 
 **Bugfixes:**
 
@@ -15131,7 +15131,7 @@ _Released 10/04/2015_
 
 ## 0.11.10
 
-_Released 10/04/2015_
+_Released Oct 04, 2015_
 
 **Features:**
 
@@ -15151,7 +15151,7 @@ _Released 10/04/2015_
 
 ## 0.11.9
 
-_Released 10/03/2015_
+_Released Oct 03, 2015_
 
 **Features:**
 
@@ -15180,7 +15180,7 @@ _Released 10/03/2015_
 
 ## 0.11.8
 
-_Released 09/25/2015_
+_Released Sep 25, 2015_
 
 **Features:**
 
@@ -15197,7 +15197,7 @@ _Released 09/25/2015_
 
 ## 0.11.7
 
-_Released 09/25/2015_
+_Released Sep 25, 2015_
 
 **Bugfixes:**
 
@@ -15208,7 +15208,7 @@ _Released 09/25/2015_
 
 ## 0.11.6
 
-_Released 09/25/2015_
+_Released Sep 25, 2015_
 
 **Bugfixes:**
 
@@ -15237,7 +15237,7 @@ _Released 09/25/2015_
 
 ## 0.11.5
 
-_Released 09/20/2015_
+_Released Sep 20, 2015_
 
 **Features:**
 
@@ -15272,7 +15272,7 @@ _Released 09/20/2015_
 
 ## 0.11.4
 
-_Released 09/17/2015_
+_Released Sep 17, 2015_
 
 **Features:**
 
@@ -15297,7 +15297,7 @@ _Released 09/17/2015_
 
 ## 0.11.3
 
-_Released 09/16/2015_
+_Released Sep 16, 2015_
 
 **Features:**
 
@@ -15317,7 +15317,7 @@ _Released 09/16/2015_
 
 ## 0.11.2
 
-_Released 09/14/2015_
+_Released Sep 14, 2015_
 
 **Bugfixes:**
 
@@ -15331,7 +15331,7 @@ _Released 09/14/2015_
 
 ## 0.11.1
 
-_Released 09/14/2015_
+_Released Sep 14, 2015_
 
 **Bugfixes:**
 
@@ -15351,7 +15351,7 @@ _Released 09/14/2015_
 
 ## 0.11.0
 
-_Released 09/13/2015_
+_Released Sep 13, 2015_
 
 **Summary:**
 
@@ -15466,7 +15466,7 @@ _Released 09/13/2015_
 
 ## 0.10.8
 
-_Released 08/21/2015_
+_Released Aug 21, 2015_
 
 **Features:**
 
@@ -15475,7 +15475,7 @@ _Released 08/21/2015_
 
 ## 0.10.7
 
-_Released 08/16/2015_
+_Released Aug 16, 2015_
 
 **Features:**
 
@@ -15490,7 +15490,7 @@ _Released 08/16/2015_
 
 ## 0.10.6
 
-_Released 08/15/2015_
+_Released Aug 15, 2015_
 
 **Bugfixes:**
 
@@ -15504,7 +15504,7 @@ _Released 08/15/2015_
 
 ## 0.10.5
 
-_Released 08/13/2015_
+_Released Aug 13, 2015_
 
 **Bugfixes:**
 
@@ -15527,7 +15527,7 @@ _Released 08/13/2015_
 
 ## 0.10.4
 
-_Released 08/11/2015_
+_Released Aug 11, 2015_
 
 **Bugfixes:**
 
@@ -15541,7 +15541,7 @@ _Released 08/11/2015_
 
 ## 0.10.3
 
-_Released 08/10/2015_
+_Released Aug 10, 2015_
 
 **Bugfixes:**
 
@@ -15563,7 +15563,7 @@ _Released 08/10/2015_
 
 ## 0.10.2
 
-_Released 08/10/2015_
+_Released Aug 10, 2015_
 
 **Bugfixes:**
 
@@ -15577,7 +15577,7 @@ _Released 08/10/2015_
 
 ## 0.10.1
 
-_Released 08/07/2015_
+_Released Aug 07, 2015_
 
 **Bugfixes:**
 
@@ -15589,7 +15589,7 @@ _Released 08/07/2015_
 
 ## 0.10.0
 
-_Released 08/06/2015_
+_Released Aug 06, 2015_
 
 **Summary:**
 
@@ -15662,7 +15662,7 @@ _Released 08/06/2015_
 
 ## 0.9.6
 
-_Released 07/27/2015_
+_Released Jul 27, 2015_
 
 **Bugfixes:**
 
@@ -15672,7 +15672,7 @@ _Released 07/27/2015_
 
 ## 0.9.5
 
-_Released 07/14/2015_
+_Released Jul 14, 2015_
 
 **Features:**
 
@@ -15689,7 +15689,7 @@ _Released 07/14/2015_
 
 ## 0.9.4
 
-_Released 07/06/2015_
+_Released Jul 06, 2015_
 
 **Features:**
 
@@ -15713,7 +15713,7 @@ _Released 07/06/2015_
 
 ## 0.9.3
 
-_Released 07/06/2015_
+_Released Jul 06, 2015_
 
 **Features:**
 
@@ -15742,7 +15742,7 @@ _Released 07/06/2015_
 
 ## 0.9.2
 
-_Released 07/04/2015_
+_Released Jul 04, 2015_
 
 **Features:**
 
@@ -15759,7 +15759,7 @@ _Released 07/04/2015_
 
 ## 0.9.1
 
-_Released 07/03/2015_
+_Released Jul 03, 2015_
 
 **Features:**
 
@@ -15796,7 +15796,7 @@ _Released 07/03/2015_
 
 ## 0.9.0
 
-_Released 07/02/2015_
+_Released Jul 02, 2015_
 
 **Summary:**
 
@@ -15834,7 +15834,7 @@ _Released 07/02/2015_
 
 ## 0.8.1
 
-_Released 06/30/2015_
+_Released Jun 30, 2015_
 
 **Bugfixes:**
 
@@ -15850,7 +15850,7 @@ _Released 06/30/2015_
 
 ## 0.8.0
 
-_Released 06/26/2015_
+_Released Jun 26, 2015_
 
 **Summary:**
 
@@ -15910,7 +15910,7 @@ _Released 06/26/2015_
 
 ## 0.7.6
 
-_Released 06/23/2015_
+_Released Jun 23, 2015_
 
 **Bugfixes:**
 
@@ -15921,7 +15921,7 @@ _Released 06/23/2015_
 
 ## 0.7.5
 
-_Released 06/19/2015_
+_Released Jun 19, 2015_
 
 **Bugfixes:**
 
@@ -15937,7 +15937,7 @@ _Released 06/19/2015_
 
 ## 0.7.4
 
-_Released 06/18/2015_
+_Released Jun 18, 2015_
 
 **Misc:**
 
@@ -15952,7 +15952,7 @@ _Released 06/18/2015_
 
 ## 0.7.3
 
-_Released 06/17/2015_
+_Released Jun 17, 2015_
 
 **Features:**
 
@@ -15978,7 +15978,7 @@ _Released 06/17/2015_
 
 ## 0.7.2
 
-_Released 06/17/2015_
+_Released Jun 17, 2015_
 
 **Bugfixes:**
 
@@ -15988,7 +15988,7 @@ _Released 06/17/2015_
 
 ## 0.7.1
 
-_Released 06/16/2015_
+_Released Jun 16, 2015_
 
 **Bugfixes:**
 
@@ -16006,7 +16006,7 @@ _Released 06/16/2015_
 
 ## 0.7.0
 
-_Released 06/15/2015_
+_Released Jun 15, 2015_
 
 **Features:**
 
@@ -16037,7 +16037,7 @@ _Released 06/15/2015_
 
 ## 0.6.14
 
-_Released 06/11/2015_
+_Released Jun 11, 2015_
 
 **Features:**
 
@@ -16066,7 +16066,7 @@ _Released 06/11/2015_
 
 ## 0.6.13
 
-_Released 06/09/2015_
+_Released Jun 09, 2015_
 
 **Bugfixes:**
 
@@ -16079,7 +16079,7 @@ _Released 06/09/2015_
 
 ## 0.6.12
 
-_Released 06/09/2015_
+_Released Jun 09, 2015_
 
 **Bugfixes:**
 
@@ -16102,7 +16102,7 @@ _Released 06/09/2015_
 
 ## 0.6.11
 
-_Released 06/08/2015_
+_Released Jun 08, 2015_
 
 **Bugfixes:**
 
@@ -16121,7 +16121,7 @@ _Released 06/08/2015_
 
 ## 0.6.10
 
-_Released 06/06/2015_
+_Released Jun 06, 2015_
 
 **Bugfixes:**
 
@@ -16145,7 +16145,7 @@ _Released 06/06/2015_
 
 ## 0.6.9
 
-_Released 06/06/2015_
+_Released Jun 06, 2015_
 
 **Bugfixes:**
 
@@ -16153,7 +16153,7 @@ _Released 06/06/2015_
 
 ## 0.6.8
 
-_Released 06/05/2015_
+_Released Jun 05, 2015_
 
 **Features:**
 
@@ -16182,7 +16182,7 @@ _Released 06/05/2015_
 
 ## 0.6.7
 
-_Released 06/04/2015_
+_Released Jun 04, 2015_
 
 **Features:**
 
@@ -16223,7 +16223,7 @@ _Released 06/04/2015_
 
 ## 0.6.6
 
-_Released 05/31/2015_
+_Released May 31, 2015_
 
 **Bugfixes:**
 
@@ -16232,7 +16232,7 @@ _Released 05/31/2015_
 
 ## 0.6.5
 
-_Released 05/23/2015_
+_Released May 23, 2015_
 
 **Features:**
 
@@ -16259,7 +16259,7 @@ _Released 05/23/2015_
 
 ## 0.6.4
 
-_Released 05/21/2015_
+_Released May 21, 2015_
 
 **Bugfixes:**
 
@@ -16269,7 +16269,7 @@ _Released 05/21/2015_
 
 ## 0.6.3
 
-_Released 05/20/2015_
+_Released May 20, 2015_
 
 **Misc:**
 
@@ -16277,7 +16277,7 @@ _Released 05/20/2015_
 
 ## 0.6.2
 
-_Released 05/20/2015_
+_Released May 20, 2015_
 
 **Bugfixes:**
 
@@ -16290,7 +16290,7 @@ _Released 05/20/2015_
 
 ## 0.6.1
 
-_Released 05/15/2015_
+_Released May 15, 2015_
 
 **Bugfixes:**
 
@@ -16308,7 +16308,7 @@ _Released 05/15/2015_
 
 ## 0.6.0
 
-_Released 05/14/2015_
+_Released May 14, 2015_
 
 **Features:**
 
@@ -16349,7 +16349,7 @@ _Released 05/14/2015_
 
 ## 0.5.15
 
-_Released 05/07/2015_
+_Released May 07, 2015_
 
 **Bugfixes:**
 
@@ -16360,7 +16360,7 @@ _Released 05/07/2015_
 
 ## 0.5.14
 
-_Released 05/06/2015_
+_Released May 06, 2015_
 
 **Features:**
 
@@ -16390,7 +16390,7 @@ _Released 05/06/2015_
 
 ## 0.5.13
 
-_Released 05/04/2015_
+_Released May 04, 2015_
 
 **Features:**
 
@@ -16415,7 +16415,7 @@ _Released 05/04/2015_
 
 ## 0.5.12
 
-_Released 04/30/2015_
+_Released Apr 30, 2015_
 
 **Features:**
 
@@ -16437,7 +16437,7 @@ _Released 04/30/2015_
 
 ## 0.5.11
 
-_Released 04/29/2015_
+_Released Apr 29, 2015_
 
 **Bugfixes:**
 
@@ -16451,7 +16451,7 @@ _Released 04/29/2015_
 
 ## 0.5.10
 
-_Released 04/28/2015_
+_Released Apr 28, 2015_
 
 **Features:**
 
@@ -16480,7 +16480,7 @@ _Released 04/28/2015_
 
 ## 0.5.9
 
-_Released 04/26/2015_
+_Released Apr 26, 2015_
 
 **Features:**
 
@@ -16504,7 +16504,7 @@ _Released 04/26/2015_
 
 ## 0.5.8
 
-_Released 04/24/2015_
+_Released Apr 24, 2015_
 
 **Features:**
 
@@ -16535,7 +16535,7 @@ _Released 04/24/2015_
 
 ## 0.5.7
 
-_Released 04/23/2015_
+_Released Apr 23, 2015_
 
 **Features:**
 
@@ -16556,7 +16556,7 @@ _Released 04/23/2015_
 
 ## 0.5.6
 
-_Released 04/22/2015_
+_Released Apr 22, 2015_
 
 **Features:**
 
@@ -16584,7 +16584,7 @@ _Released 04/22/2015_
 
 ## 0.5.5
 
-_Released 04/20/2015_
+_Released Apr 20, 2015_
 
 **Features:**
 
@@ -16601,7 +16601,7 @@ _Released 04/20/2015_
 
 ## 0.5.4
 
-_Released 04/20/2015_
+_Released Apr 20, 2015_
 
 **Features:**
 
@@ -16616,7 +16616,7 @@ _Released 04/20/2015_
 
 ## 0.5.3
 
-_Released 04/19/2015_
+_Released Apr 19, 2015_
 
 **Bugfixes:**
 
@@ -16634,7 +16634,7 @@ Misc
 
 ## 0.5.2
 
-_Released 04/17/2015_
+_Released Apr 17, 2015_
 
 **Bugfixes:**
 
@@ -16642,7 +16642,7 @@ _Released 04/17/2015_
 
 ## 0.5.1
 
-_Released 04/16/2015_
+_Released Apr 16, 2015_
 
 **Misc:**
 
@@ -16651,7 +16651,7 @@ _Released 04/16/2015_
 
 ## 0.5.0
 
-_Released 04/15/2015_
+_Released Apr 15, 2015_
 
 **Misc:**
 
@@ -16659,7 +16659,7 @@ _Released 04/15/2015_
 
 ## 0.4.7
 
-_Released 04/15/2015_
+_Released Apr 15, 2015_
 
 **Misc:**
 
@@ -16668,7 +16668,7 @@ _Released 04/15/2015_
 
 ## 0.4.6
 
-_Released 04/11/2015_
+_Released Apr 11, 2015_
 
 **Features:**
 
@@ -16679,7 +16679,7 @@ _Released 04/11/2015_
 
 ## 0.4.5
 
-_Released 04/10/2015_
+_Released Apr 10, 2015_
 
 **Features:**
 
@@ -16692,7 +16692,7 @@ _Released 04/10/2015_
 
 ## 0.4.4
 
-_Released 04/09/2015_
+_Released Apr 09, 2015_
 
 **Features:**
 
@@ -16709,7 +16709,7 @@ _Released 04/09/2015_
 
 ## 0.4.3
 
-_Released 04/09/2015_
+_Released Apr 09, 2015_
 
 **Features:**
 
@@ -16730,7 +16730,7 @@ _Released 04/09/2015_
 
 ## 0.4.2
 
-_Released 04/09/2015_
+_Released Apr 09, 2015_
 
 **Bugfixes:**
 
@@ -16744,7 +16744,7 @@ _Released 04/09/2015_
 
 ## 0.4.1
 
-_Released 04/08/2015_
+_Released Apr 08, 2015_
 
 **Features:**
 
@@ -16768,7 +16768,7 @@ _Released 04/08/2015_
 
 ## 0.4.0
 
-_Released 04/02/2015_
+_Released Apr 02, 2015_
 
 **Features:**
 
@@ -16803,7 +16803,7 @@ _Released 04/02/2015_
 
 ## 0.3.15
 
-_Released 03/28/2015_
+_Released Mar 28, 2015_
 
 **Misc:**
 
@@ -16813,7 +16813,7 @@ _Released 03/28/2015_
 
 ## 0.3.14
 
-_Released 03/27/2015_
+_Released Mar 27, 2015_
 
 **Bugfixes:**
 
@@ -16823,7 +16823,7 @@ _Released 03/27/2015_
 
 ## 0.3.13
 
-_Released 03/27/2015_
+_Released Mar 27, 2015_
 
 **Features:**
 
@@ -16852,7 +16852,7 @@ _Released 03/27/2015_
 
 ## 0.3.12
 
-_Released 03/26/2015_
+_Released Mar 26, 2015_
 
 **Bugfixes:**
 
@@ -16874,7 +16874,7 @@ _Released 03/26/2015_
 
 ## 0.3.11
 
-_Released 03/25/2015_
+_Released Mar 25, 2015_
 
 **Bugfixes:**
 
@@ -16888,7 +16888,7 @@ _Released 03/25/2015_
 
 ## 0.3.10
 
-_Released 03/24/2015_
+_Released Mar 24, 2015_
 
 **Bugfixes:**
 
@@ -16903,7 +16903,7 @@ _Released 03/24/2015_
 
 ## 0.3.9
 
-_Released 03/24/2015_
+_Released Mar 24, 2015_
 
 **Features:**
 
@@ -16934,7 +16934,7 @@ _Released 03/24/2015_
 
 ## 0.3.8
 
-_Released 03/22/2015_
+_Released Mar 22, 2015_
 
 **Features:**
 
@@ -16947,7 +16947,7 @@ _Released 03/22/2015_
 
 ## 0.3.7
 
-_Released 03/21/2015_
+_Released Mar 21, 2015_
 
 **Features:**
 
@@ -16955,7 +16955,7 @@ _Released 03/21/2015_
 
 ## 0.3.6
 
-_Released 03/20/2015_
+_Released Mar 20, 2015_
 
 **Features:**
 
@@ -16970,7 +16970,7 @@ _Released 03/20/2015_
 
 ## 0.3.5
 
-_Released 03/20/2015_
+_Released Mar 20, 2015_
 
 **Bugfixes:**
 
@@ -16985,7 +16985,7 @@ _Released 03/20/2015_
 
 ## 0.3.4
 
-_Released 03/19/2015_
+_Released Mar 19, 2015_
 
 **Features:**
 
@@ -17011,7 +17011,7 @@ _Released 03/19/2015_
 
 ## 0.3.3
 
-_Released 03/18/2015_
+_Released Mar 18, 2015_
 
 **Features:**
 

--- a/docs/ui-coverage/changelog.mdx
+++ b/docs/ui-coverage/changelog.mdx
@@ -9,104 +9,82 @@ sidebar_position: 200
 
 # Changelog
 
-## Week of 2/6/2026
-
+## Week of Feb 06, 2026
 - We now support fetching UI Coverage results from Buildkite CI with the [Results API](/ui-coverage/results-api).
 
-## Week of 1/16/2026
-
+## Week of Jan 16, 2026
 - We now support fetching UI Coverage results from Bitbucket CI with the [Results API](/ui-coverage/results-api).
 
-## Week of 12/19/2025
-
+## Week of Dec 19, 2025
 - The `elementFilters`, `elements`, `elementGroups`, and `allowedInteractionCommands` configuration properties now support an optional `documentScope` field that allows you to scope selectors to specific document hosts (iframes or shadow DOM hosts). This enables you to target elements within nested document contexts without requiring DOM changes. For example, you can filter, identify, group, or restrict interactions for elements within a specific shadow DOM component or iframe by combining a selector with `documentScope`. Multiple document hosts can be chained in the array to target elements within nested documents (e.g., an iframe containing a shadow DOM component). See the [Element Filters](/ui-coverage/configuration/elementfilters), [Elements](/ui-coverage/configuration/elements), [Element Groups](/ui-coverage/configuration/elementgroups), and [Allowed Interaction Commands](/ui-coverage/configuration/allowedinteractioncommands) documentation for more details and examples.
 
-## Week of 12/12/2025
-
+## Week of Dec 12, 2025
 - The `profiles` configuration property allows you to use different configuration settings for different runs based on [run tags](/app/references/command-line#cypress-run-tag-lt-tag-gt). This enables you to customize UI Coverage behavior for different environments, branches, or test scenarios. See the [Profiles](/ui-coverage/configuration/profiles) guide for more details.
 - All configuration objects now support an optional `comment` property that you can use to provide context and explanations for why certain values are set. This helps make your configuration easier to understand and maintain, especially when working in teams or revisiting configuration after some time.
 - A new guide on [blocking pull requests and setting policies](/ui-coverage/guides/block-pull-requests) is now available. This guide demonstrates how to use the Results API to enforce test coverage standards, compare results against baselines, and automatically block pull requests when coverage thresholds are not met.
 
-## Week of 6/23/25
-
+## Week of Jun 23, 2025
 UI Coverage now supports defining custom commands that will count towards coverage scores, restricting which kinds of interactions are allowed for certain elements, and including assertions in the UI Coverage calculations. See the following new properties for more details:
 
 - [`additionalInteractionCommands`](/ui-coverage/configuration/additionalinteractioncommands)
 - [`allowedInteractionCommands`](/ui-coverage/configuration/allowedinteractioncommands)
 
-## Week of 6/2/2025
-
+## Week of Jun 02, 2025
 - We now support fetching UI Coverage results from Drone CI with the [Results API](/ui-coverage/results-api).
 
-## Week of 5/26/2025
-
+## Week of May 26, 2025
 - Launched AI-powered Test Generation in Cypress Cloud, to help you quickly add tests for the untested elements detected in UI Coverage reports, in a way that follows your existing practices and conventions. For more details, read [our blog post](https://www.cypress.io/blog/add-your-missing-tests-faster-with-test-generation-in-ui-coverage).
 
-## Week of 5/12/2025
-
+## Week of May 12, 2025
 - We now support fetching UI Coverage results from AWS CodeBuild with the [Results API](/ui-coverage/results-api).
 
-## Week of 4/1/2024
-
+## Week of Apr 01, 2024
 - **Shadow DOM and iFrame Support:** UI Coverage now supports Shadow DOM and iFrames for reporting on interactions. Both of these settings are off by default. Please contact your Cypress representative to opt in.
 
-## Week of 3/24/2025
-
+## Week of Mar 24, 2025
 - UI Coverage results are now included in the [Data Extract API](/cloud/integrations/data-extract-api) so that you can retrieve data over time.
 
-## Week of 1/15/2024
-
+## Week of Jan 15, 2024
 - **Branch Review Integration (Beta):** Added UI Coverage comparisons to Branch Review, enabling teams to see how code changes impact test coverage across branches. Available for all Git providers and includes manual run selection for customized comparisons.
 
-## Week of 12/16/2023
-
+## Week of Dec 16, 2023
 - **URL Handling:** Fixed issues with URLs containing special characters (like parentheses) that could break view generation.
 - **Performance Improvements:** Optimized rendering performance for reports containing large numbers of elements and snapshots.
 
-## Week of 10/7/2024
-
+## Week of Oct 07, 2024
 - **Improved Table Grouping:** The default grouping rules have been updated to more accurately identify and group elements in tables.
 
-## Week of 9/30/2024
-
+## Week of Sep 30, 2024
 - **Slack Messages:** UI Coverage results results are now included in Slack messages alongside test results. [Learn more about our Slack integration here](/cloud/integrations/slack).
 
-## Week of 9/23/2024
-
+## Week of Sep 23, 2024
 - **Improved Link Display Logic:** Links will now more consistently display across the reports, matching defined views more closely.
 
-## Week of 9/9/2024
-
+## Week of Sep 09, 2024
 - **Element Tooltips:** We have improved the user experience of UI Coverage by adding tooltips for elements, emphasizing their selectors, making it easier to navigate coverage reports and identify elements.
 
-## Week of 8/19/2024
-
+## Week of Aug 19, 2024
 - **Results API:** We have added the new [Results API](/ui-coverage/results-api) which enables you to programmatically fetch your run's UI Coverage results in a CI environment. This allows you to act the results within CI by allowing you to determine if the results are acceptable or need to be addressed before code changes can merge.
 - **Pull and Merge Request Comments:** UI Coverage results will now appear in [GitHub](/cloud/integrations/source-control/github), [GitLab](/cloud/integrations/source-control/gitlab) and [Bitbucket](/cloud/integrations/source-control/bitbucket) pull request and merge request comments alongside test results. Integrations can be installed and comments can be enabled in Project Settings.
 
-## Week of 8/12/2024
-
+## Week of Aug 12, 2024
 - **Improved attributeFilters Behavior:** When matching against class attributes, the [attributeFilters](/ui-coverage/configuration/attributefilters) configuration option now targets and filters individual class names rather than the entire value of the class attribute.
 
-## Week of 8/5/2024
-
+## Week of Aug 05, 2024
 - **View Untested Elements:** You can now quickly access all of the untested elements across all views in the "Untested elements" section.
   Save time and improve your coverage by testing these areas of your application, or use
   [elementFilters](/ui-coverage/configuration/elementfilters) in UI Coverage [configuration](/ui-coverage/configuration/overview) to ignore certain elements.
 - **View Tested Elements:** You can now quickly access all of the tested elements across all views in the "Tested elements" section. Identify potential redundant coverage by looking through the elements with the highest numbers of interactions and tests.
 
-## Week of 7/22/2024
-
+## Week of Jul 22, 2024
 - **View Untested Links:** You can now quickly access all of the untested links across all views in the "Untested links" section. Save time and improve your coverage by testing these areas of your application,
   or use [viewFilters](/ui-coverage/configuration/viewfilters) in UI Coverage [configuration](/ui-coverage/configuration/overview) to ignore certain links.
 
-## Week of 6/24/2024
-
+## Week of Jun 24, 2024
 - **View** [**configuration information for each run**](/accessibility/configuration/overview#Viewing-Configuration-for-a-Run) **in the properties tab:** There, you'll find the configuration set for the project at the start of the run. This will help you understand what factors might be driving a score change. This helps distinguish config criteria changes from other factors such as changes to your application, tests, Cypress versions, and more.
 - **Anchor elements considered interactive:** Anchor elements (`a` tags) are now considered interactive even when they do not have an `href` attribute.
 
-## Week of 5/20/2024
-
+## Week of May 20, 2024
 - **Manage Configuration in Project Settings:** Added the ability to configure what should be tested or ignored in your score calculations to ensure your team is capturing what's relevant to your testing strategy. This feature allows owners and admins to easily update and manage settings using an editor within Project Settings.
   - `elementFilters`: Exclude specific elements by CSS selector.
   - `views`: Define URL patterns for grouping in the UI.
@@ -115,19 +93,15 @@ UI Coverage now supports defining custom commands that will count towards covera
   - `elementGroups`: Create custom rules for grouping elements to reduce noise in scores.
   - `significantAttributes`: Prioritize custom attributes over defaults for element identification and grouping.
 
-## Week of 3/25/2024
-
+## Week of Mar 25, 2024
 - **Project-Level Configuration Options:** UI Coverage now supports project-level configuration, enabling users to customize UI Coverage settings without updating their HTML. Users can exclude specific URLs and elements by selector and group elements to simplify coverage analysis. For configuration assistance, contact your Account Executive.
 
-## Week of 3/4/2024
-
+## Week of Mar 04, 2024
 - **Element Interaction Details:** UI Coverage now provides detailed insights into the testing status of every interactive element, including interaction types, frequency, and locations within the UI. A new tracking system shows where each element has been identified and tested, and link details indicate visit frequency.
 
-## Week of 2/26/2024
-
+## Week of Feb 26, 2024
 - **Element Grouping Improvements:** Introduced "cascade" behavior for the `data-cy-ui-group` attribute, which now allows users to place the attribute on a wrapper or parent element, so that it pass grouping values to child interactive elements.
 - **Text Filter:** Text filtering has been added to UI Coverage reports, allowing users to filter the "Views" list by name for easy searching.
 
-## Week of 12/31/2023
-
+## Week of Dec 31, 2023
 - **URL Grouping:** UI Coverage reports now intelligently group repeated URLs to reduce duplicate Views. This update simplifies reports, making it easier to identify and prioritize issues by minimizing duplicate Views, resulting in a more polished and user-friendly experience.

--- a/docs/ui-coverage/changelog.mdx
+++ b/docs/ui-coverage/changelog.mdx
@@ -10,81 +10,103 @@ sidebar_position: 200
 # Changelog
 
 ## Week of Feb 06, 2026
+
 - We now support fetching UI Coverage results from Buildkite CI with the [Results API](/ui-coverage/results-api).
 
 ## Week of Jan 16, 2026
+
 - We now support fetching UI Coverage results from Bitbucket CI with the [Results API](/ui-coverage/results-api).
 
 ## Week of Dec 19, 2025
+
 - The `elementFilters`, `elements`, `elementGroups`, and `allowedInteractionCommands` configuration properties now support an optional `documentScope` field that allows you to scope selectors to specific document hosts (iframes or shadow DOM hosts). This enables you to target elements within nested document contexts without requiring DOM changes. For example, you can filter, identify, group, or restrict interactions for elements within a specific shadow DOM component or iframe by combining a selector with `documentScope`. Multiple document hosts can be chained in the array to target elements within nested documents (e.g., an iframe containing a shadow DOM component). See the [Element Filters](/ui-coverage/configuration/elementfilters), [Elements](/ui-coverage/configuration/elements), [Element Groups](/ui-coverage/configuration/elementgroups), and [Allowed Interaction Commands](/ui-coverage/configuration/allowedinteractioncommands) documentation for more details and examples.
 
 ## Week of Dec 12, 2025
+
 - The `profiles` configuration property allows you to use different configuration settings for different runs based on [run tags](/app/references/command-line#cypress-run-tag-lt-tag-gt). This enables you to customize UI Coverage behavior for different environments, branches, or test scenarios. See the [Profiles](/ui-coverage/configuration/profiles) guide for more details.
 - All configuration objects now support an optional `comment` property that you can use to provide context and explanations for why certain values are set. This helps make your configuration easier to understand and maintain, especially when working in teams or revisiting configuration after some time.
 - A new guide on [blocking pull requests and setting policies](/ui-coverage/guides/block-pull-requests) is now available. This guide demonstrates how to use the Results API to enforce test coverage standards, compare results against baselines, and automatically block pull requests when coverage thresholds are not met.
 
 ## Week of Jun 23, 2025
+
 UI Coverage now supports defining custom commands that will count towards coverage scores, restricting which kinds of interactions are allowed for certain elements, and including assertions in the UI Coverage calculations. See the following new properties for more details:
 
 - [`additionalInteractionCommands`](/ui-coverage/configuration/additionalinteractioncommands)
 - [`allowedInteractionCommands`](/ui-coverage/configuration/allowedinteractioncommands)
 
 ## Week of Jun 02, 2025
+
 - We now support fetching UI Coverage results from Drone CI with the [Results API](/ui-coverage/results-api).
 
 ## Week of May 26, 2025
+
 - Launched AI-powered Test Generation in Cypress Cloud, to help you quickly add tests for the untested elements detected in UI Coverage reports, in a way that follows your existing practices and conventions. For more details, read [our blog post](https://www.cypress.io/blog/add-your-missing-tests-faster-with-test-generation-in-ui-coverage).
 
 ## Week of May 12, 2025
+
 - We now support fetching UI Coverage results from AWS CodeBuild with the [Results API](/ui-coverage/results-api).
 
 ## Week of Apr 01, 2024
+
 - **Shadow DOM and iFrame Support:** UI Coverage now supports Shadow DOM and iFrames for reporting on interactions. Both of these settings are off by default. Please contact your Cypress representative to opt in.
 
 ## Week of Mar 24, 2025
+
 - UI Coverage results are now included in the [Data Extract API](/cloud/integrations/data-extract-api) so that you can retrieve data over time.
 
 ## Week of Jan 15, 2024
+
 - **Branch Review Integration (Beta):** Added UI Coverage comparisons to Branch Review, enabling teams to see how code changes impact test coverage across branches. Available for all Git providers and includes manual run selection for customized comparisons.
 
 ## Week of Dec 16, 2023
+
 - **URL Handling:** Fixed issues with URLs containing special characters (like parentheses) that could break view generation.
 - **Performance Improvements:** Optimized rendering performance for reports containing large numbers of elements and snapshots.
 
 ## Week of Oct 07, 2024
+
 - **Improved Table Grouping:** The default grouping rules have been updated to more accurately identify and group elements in tables.
 
 ## Week of Sep 30, 2024
+
 - **Slack Messages:** UI Coverage results results are now included in Slack messages alongside test results. [Learn more about our Slack integration here](/cloud/integrations/slack).
 
 ## Week of Sep 23, 2024
+
 - **Improved Link Display Logic:** Links will now more consistently display across the reports, matching defined views more closely.
 
 ## Week of Sep 09, 2024
+
 - **Element Tooltips:** We have improved the user experience of UI Coverage by adding tooltips for elements, emphasizing their selectors, making it easier to navigate coverage reports and identify elements.
 
 ## Week of Aug 19, 2024
+
 - **Results API:** We have added the new [Results API](/ui-coverage/results-api) which enables you to programmatically fetch your run's UI Coverage results in a CI environment. This allows you to act the results within CI by allowing you to determine if the results are acceptable or need to be addressed before code changes can merge.
 - **Pull and Merge Request Comments:** UI Coverage results will now appear in [GitHub](/cloud/integrations/source-control/github), [GitLab](/cloud/integrations/source-control/gitlab) and [Bitbucket](/cloud/integrations/source-control/bitbucket) pull request and merge request comments alongside test results. Integrations can be installed and comments can be enabled in Project Settings.
 
 ## Week of Aug 12, 2024
+
 - **Improved attributeFilters Behavior:** When matching against class attributes, the [attributeFilters](/ui-coverage/configuration/attributefilters) configuration option now targets and filters individual class names rather than the entire value of the class attribute.
 
 ## Week of Aug 05, 2024
+
 - **View Untested Elements:** You can now quickly access all of the untested elements across all views in the "Untested elements" section.
   Save time and improve your coverage by testing these areas of your application, or use
   [elementFilters](/ui-coverage/configuration/elementfilters) in UI Coverage [configuration](/ui-coverage/configuration/overview) to ignore certain elements.
 - **View Tested Elements:** You can now quickly access all of the tested elements across all views in the "Tested elements" section. Identify potential redundant coverage by looking through the elements with the highest numbers of interactions and tests.
 
 ## Week of Jul 22, 2024
+
 - **View Untested Links:** You can now quickly access all of the untested links across all views in the "Untested links" section. Save time and improve your coverage by testing these areas of your application,
   or use [viewFilters](/ui-coverage/configuration/viewfilters) in UI Coverage [configuration](/ui-coverage/configuration/overview) to ignore certain links.
 
 ## Week of Jun 24, 2024
+
 - **View** [**configuration information for each run**](/accessibility/configuration/overview#Viewing-Configuration-for-a-Run) **in the properties tab:** There, you'll find the configuration set for the project at the start of the run. This will help you understand what factors might be driving a score change. This helps distinguish config criteria changes from other factors such as changes to your application, tests, Cypress versions, and more.
 - **Anchor elements considered interactive:** Anchor elements (`a` tags) are now considered interactive even when they do not have an `href` attribute.
 
 ## Week of May 20, 2024
+
 - **Manage Configuration in Project Settings:** Added the ability to configure what should be tested or ignored in your score calculations to ensure your team is capturing what's relevant to your testing strategy. This feature allows owners and admins to easily update and manage settings using an editor within Project Settings.
   - `elementFilters`: Exclude specific elements by CSS selector.
   - `views`: Define URL patterns for grouping in the UI.
@@ -94,14 +116,18 @@ UI Coverage now supports defining custom commands that will count towards covera
   - `significantAttributes`: Prioritize custom attributes over defaults for element identification and grouping.
 
 ## Week of Mar 25, 2024
+
 - **Project-Level Configuration Options:** UI Coverage now supports project-level configuration, enabling users to customize UI Coverage settings without updating their HTML. Users can exclude specific URLs and elements by selector and group elements to simplify coverage analysis. For configuration assistance, contact your Account Executive.
 
 ## Week of Mar 04, 2024
+
 - **Element Interaction Details:** UI Coverage now provides detailed insights into the testing status of every interactive element, including interaction types, frequency, and locations within the UI. A new tracking system shows where each element has been identified and tested, and link details indicate visit frequency.
 
 ## Week of Feb 26, 2024
+
 - **Element Grouping Improvements:** Introduced "cascade" behavior for the `data-cy-ui-group` attribute, which now allows users to place the attribute on a wrapper or parent element, so that it pass grouping values to child interactive elements.
 - **Text Filter:** Text filtering has been added to UI Coverage reports, allowing users to filter the "Views" list by name for easy searching.
 
 ## Week of Dec 31, 2023
+
 - **URL Grouping:** UI Coverage reports now intelligently group repeated URLs to reduce duplicate Views. This update simplifies reports, making it easier to identify and prioritize issues by minimizing duplicate Views, resulting in a more polished and user-friendly experience.

--- a/package.json
+++ b/package.json
@@ -75,6 +75,6 @@
     ]
   },
   "lint-staged": {
-    "**/*.{md,mdx}": "prettier --write"
+    "**/*.{md,mdx}": "prettier --check"
   }
 }


### PR DESCRIPTION
I'm tired of CI failing because of link failures

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to developer tooling (Husky hooks) and markdown-only documentation formatting, with no runtime/app logic impact.
> 
> **Overview**
> **Prevents CI markdown lint failures earlier** by adding Husky hooks: `pre-commit` runs `lint-staged` and `pre-push` runs `npm run lint`.
> 
> Adds `AGENTS.md` guidance to run `npm run lint:fix` after edits, and reformats `docs/accessibility/changelog.mdx` headings to use consistent month-name date formatting (e.g., `Feb 06, 2026`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 415f3dac3a00c0f5e17b5a08c2e936897233214d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->