### PR TITLE
doc: update typescript support to include 6.x

### DIFF
--- a/docs/app/references/changelog.mdx
+++ b/docs/app/references/changelog.mdx
@@ -12,8 +12,6 @@ sidebar_label: Changelog
 
 _Released 04/21/2026_
 
-# Changelog
-
 ## 15.13.1
 
 _Released 04/07/2026_

--- a/docs/app/references/changelog.mdx
+++ b/docs/app/references/changelog.mdx
@@ -8,6 +8,12 @@ sidebar_label: Changelog
 
 # Changelog
 
+## 15.14.0
+
+_Released 04/21/2026_
+
+# Changelog
+
 ## 15.13.1
 
 _Released 04/07/2026_

--- a/docs/app/tooling/typescript-support.mdx
+++ b/docs/app/tooling/typescript-support.mdx
@@ -363,13 +363,14 @@ root `tsconfig.json` file.
 
 ## History
 
-| Version                                    | Changes                                                                                                                                       |
-| ------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| [15.0.0](/app/references/changelog#15-0-0) | Raised minimum required TypeScript version from 4.0+ to 5.0+ and replaced `ts-node` with `tsx` to parse and run the `cypress.config.ts` file. |
-| [13.0.0](/app/references/changelog#13-0-0) | Raised minimum required TypeScript version from 3.4+ to 4.0+                                                                                  |
-| [10.0.0](/app/references/changelog#10-0-0) | Update guide to cover TypeScript setup for component testing                                                                                  |
-| [5.0.0](/app/references/changelog#5-0-0)   | Raised minimum required TypeScript version from 2.9+ to 3.4+                                                                                  |
-| [4.4.0](/app/references/changelog#4-4-0)   | Added support for TypeScript without needing your own transpilation through preprocessors.                                                    |
+| Version                                      | Changes                                                                                                                                       |
+| -------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| [15.14.0](/app/references/changelog#15-14-0) | Added support for TypeScript 6.0+                                                                                                             |
+| [15.0.0](/app/references/changelog#15-0-0)   | Raised minimum required TypeScript version from 4.0+ to 5.0+ and replaced `ts-node` with `tsx` to parse and run the `cypress.config.ts` file. |
+| [13.0.0](/app/references/changelog#13-0-0)   | Raised minimum required TypeScript version from 3.4+ to 4.0+                                                                                  |
+| [10.0.0](/app/references/changelog#10-0-0)   | Update guide to cover TypeScript setup for component testing                                                                                  |
+| [5.0.0](/app/references/changelog#5-0-0)     | Raised minimum required TypeScript version from 2.9+ to 3.4+                                                                                  |
+| [4.4.0](/app/references/changelog#4-4-0)     | Added support for TypeScript without needing your own transpilation through preprocessors.                                                    |
 
 ## See also
 

--- a/docs/app/tooling/typescript-support.mdx
+++ b/docs/app/tooling/typescript-support.mdx
@@ -365,7 +365,7 @@ root `tsconfig.json` file.
 
 | Version                                      | Changes                                                                                                                                       |
 | -------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| [15.14.0](/app/references/changelog#15-14-0) | Added support for TypeScript 6.0+                                                                                                             |
+| [15.14.0](/app/references/changelog#15-14-0) | Added support for TypeScript 6.0                                                                                                              |
 | [15.0.0](/app/references/changelog#15-0-0)   | Raised minimum required TypeScript version from 4.0+ to 5.0+ and replaced `ts-node` with `tsx` to parse and run the `cypress.config.ts` file. |
 | [13.0.0](/app/references/changelog#13-0-0)   | Raised minimum required TypeScript version from 3.4+ to 4.0+                                                                                  |
 | [10.0.0](/app/references/changelog#10-0-0)   | Update guide to cover TypeScript setup for component testing                                                                                  |

--- a/docs/app/tooling/typescript-support.mdx
+++ b/docs/app/tooling/typescript-support.mdx
@@ -29,7 +29,7 @@ tests in TypeScript.
 
 ### Install TypeScript
 
-To use TypeScript with Cypress, you will need TypeScript 5.x. If you do not
+To use TypeScript with Cypress, you will need TypeScript 5.x or TypeScript 6.x. If you do not
 already have TypeScript installed as a part of your framework, you will need to
 install it:
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only updates announcing TypeScript 6 support and a new changelog entry; no runtime or API behavior changes.
> 
> **Overview**
> Adds a new `15.14.0` section (release date only) to the Cypress App changelog.
> 
> Updates the TypeScript support guide to state Cypress supports TypeScript `5.x` *and* `6.x`, and records this as a `15.14.0` history entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9c4b5969e799be4607dfbee27f797c2540b6802. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->