### PR TITLE
chore: add vite 8 support documentation

### DIFF
--- a/docs/app/component-testing/get-started.mdx
+++ b/docs/app/component-testing/get-started.mdx
@@ -42,13 +42,13 @@ following development servers and frameworks:
 
 | Framework                                                                                                          | UI Library    | Bundler   |
 | ------------------------------------------------------------------------------------------------------------------ | ------------- | --------- |
-| [React with Vite](/app/component-testing/react/overview#React-with-Vite)                                           | React 18-19   | Vite 5-7  |
+| [React with Vite](/app/component-testing/react/overview#React-with-Vite)                                           | React 18-19   | Vite 5-8  |
 | [React with Webpack](/app/component-testing/react/overview#React-with-Webpack)                                     | React 18-19   | Webpack 5 |
 | [Next.js 14-16](/app/component-testing/react/overview#Nextjs)                                                      | React 18-19   | Webpack 5 |
-| [Vue with Vite](/app/component-testing/vue/overview#Vue-with-Vite)                                                 | Vue 3         | Vite 5-7  |
+| [Vue with Vite](/app/component-testing/vue/overview#Vue-with-Vite)                                                 | Vue 3         | Vite 5-8  |
 | [Vue with Webpack](/app/component-testing/vue/overview#Vue-with-Webpack)                                           | Vue 3         | Webpack 5 |
 | [Angular](/app/component-testing/angular/overview#Framework-Configuration)                                         | Angular 18-21 | Webpack 5 |
-| [Svelte with Vite](/app/component-testing/svelte/overview#Svelte-with-Vite) <Badge type="info">Alpha</Badge>       | Svelte 5      | Vite 5-7  |
+| [Svelte with Vite](/app/component-testing/svelte/overview#Svelte-with-Vite) <Badge type="info">Alpha</Badge>       | Svelte 5      | Vite 5-8  |
 | [Svelte with Webpack](/app/component-testing/svelte/overview#Svelte-with-Webpack) <Badge type="info">Alpha</Badge> | Svelte 5      | Webpack 5 |
 
 The following integrations are built and maintained by Cypress community members.

--- a/docs/app/component-testing/svelte/overview.mdx
+++ b/docs/app/component-testing/svelte/overview.mdx
@@ -76,7 +76,7 @@ properly. The examples below are for reference purposes.
 
 ### Svelte with Vite
 
-Cypress Component Testing works with Svelte apps that use Vite 4+ as the
+Cypress Component Testing works with Svelte apps that use Vite 5+ as the
 bundler.
 
 #### Vite Configuration

--- a/docs/app/component-testing/vue/overview.mdx
+++ b/docs/app/component-testing/vue/overview.mdx
@@ -68,7 +68,7 @@ and configure them properly. The examples below are for reference purposes.
 
 ### Vue with Vite
 
-Cypress Component Testing works with Vue apps that use Vite 4+ as the bundler.
+Cypress Component Testing works with Vue apps that use Vite 5+ as the bundler.
 
 #### Vite Configuration
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change updating stated Vite support ranges; no runtime or API behavior changes.
> 
> **Overview**
> Updates Component Testing docs to reflect **Vite 8 support** for `React with Vite`, `Vue with Vite`, and `Svelte with Vite` by expanding the supported bundler range from `Vite 5-7` to `Vite 5-8`.
> 
> Aligns the `Vue` and `Svelte` overview pages to state that Vite support starts at `Vite 5+` (previously documented as `Vite 4+`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56af7226dec7667bb91b74789bf2f85d4ca68e42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->