### PR TITLE
Note abut Selector Priority

### DIFF
--- a/docs/api/cypress-api/element-selector-api.mdx
+++ b/docs/api/cypress-api/element-selector-api.mdx
@@ -68,6 +68,10 @@ With the default selector priority, Cypress prioritizes `id`, so the selector wo
 
 The [jQuery element](http://api.jquery.com/Types/#jQuery) for which you want to retrieve a selector.
 
+## Where to configure
+
+Call `Cypress.ElementSelector.defaults()` **once at the top level** in the **browser** (not from `cypress.config` or other Node-only scripts). Put it in the file set by [`supportFile`](/app/references/configuration), outside `describe`, `it`, and hooks, so it runs when support loads.
+
 ## Examples
 
 ### Set custom selector priority

--- a/docs/api/cypress-api/element-selector-api.mdx
+++ b/docs/api/cypress-api/element-selector-api.mdx
@@ -70,7 +70,9 @@ The [jQuery element](http://api.jquery.com/Types/#jQuery) for which you want to 
 
 ## Where to configure
 
-Call `Cypress.ElementSelector.defaults()` **once at the top level** in the **browser** (not from `cypress.config` or other Node-only scripts). Put it in the file set by [`supportFile`](/app/references/configuration), outside `describe`, `it`, and hooks, so it runs when support loads.
+Call `Cypress.ElementSelector.defaults({ ... })` once in your [support file](/app/references/configuration). You want this to load before your specs and do **not** want to set this inside `describe`, `it`, `before`, `beforeEach`, or similar test hooks.
+
+`Cypress.ElementSelector` is only available in support and spec code, not in the Node process that loads your cypress configuration.
 
 ## Examples
 

--- a/docs/app/tooling/ai-skills.mdx
+++ b/docs/app/tooling/ai-skills.mdx
@@ -58,7 +58,7 @@ Before writing a single line, the cypress-author skill reads your project: your 
 
 In practice, that means:
 
-- **Selectors that hold up.** The skill follows a defined hierarchy (`data-cy`, `data-test`, `data-testid`) and flags selectors that are likely to break under normal maintenance.
+- **Selectors that hold up.** The skill attempts to follow the selector priority configured with [`Cypress.ElementSelector`](/api/cypress-api/element-selector-api) and flags selectors that are likely to break under normal maintenance.
 - **Code that fits your project.** It matches your language (TypeScript or JavaScript) and existing type patterns, and reuses your existing helpers and custom commands rather than reinventing them.
 - **Only APIs your Cypress version supports.** The skill checks your Cypress version and limits suggestions to what is actually available to your project.
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only updates that clarify where `Cypress.ElementSelector.defaults()` can be configured and how AI skills choose selectors; no runtime or API behavior changes.
> 
> **Overview**
> Adds a **"Where to configure"** section to `Cypress.ElementSelector` docs, clarifying that `Cypress.ElementSelector.defaults({ ... })` should be called once from the support/spec context (not Node config) and loaded before specs.
> 
> Updates the `cypress-author` AI Skills documentation to state it *attempts to follow the project’s configured* `Cypress.ElementSelector` selector priority rather than a fixed `data-*` hierarchy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b64207bab88a0c2ea590e61ecb80eddb31ab18fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->