### PR TITLE
Remove AppVeyor CI link

### DIFF
--- a/docs/app/continuous-integration/overview.mdx
+++ b/docs/app/continuous-integration/overview.mdx
@@ -288,10 +288,6 @@ You can find examples that use Cypress Docker images below
 
 ## CI Examples
 
-### AppVeyor
-
-- [Basic Example (appveyor.yml)](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/appveyor.yml)
-
 ### AWS Amplify Console
 
 - [Basic Example (amplify.yml)](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/amplify.yml)


### PR DESCRIPTION
## Situation

- PR https://github.com/cypress-io/cypress-example-kitchensink/pull/1096 removes the live AppVeyor example

## Change

Remove AppVeyor reference from https://docs.cypress.io/app/continuous-integration/overview#CI-Examples section

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change that removes a dead AppVeyor reference; no runtime or API behavior affected.
> 
> **Overview**
> Removes the `AppVeyor` subsection/link from the `CI Examples` section in `docs/app/continuous-integration/overview.mdx` now that the referenced example no longer exists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10940cb1558f5991620c9d2110c5133fe873ae33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->