### PR TITLE
Update Banner for UI Cov Webinar

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -169,8 +169,9 @@ const config = {
       // Styles for this are controlled in src/css/announcement-bar.scss
       announcementBar: {
         //give id a unique value to get a new announcement bar to appear
-        id: 'cy-prompt-experimental-live',
-        content: `📢 NEW! cy.prompt() natural language and self-healing tests <a href="https://www.cypress.io/blog/cy-prompt-experimental-launch?utm_source=docs.cypress.io&utm_medium=cyconf&utm_campaign=cypressconf">now available</a> in the Cypress App.`,
+        id: 'webinar-agentic-confidence-april-2026',
+        // Visual content (including Cypress Design icon) is rendered in src/theme/AnnouncementBar/Content
+        content: `📢 Join us for our live webinar on April 26! <a href="https://cypress.registration.goldcast.io/webinar/5503143f-d40d-48ae-9b52-d132a0888ee3?utm_source=docs.cypress.io&utm_medium=announcement-bar">Closing the Agentic Confidence Gap: Quality Governance for AI-Accelerated Teams</a>`,
         isCloseable: true,
       },
       footer: {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -171,7 +171,7 @@ const config = {
         //give id a unique value to get a new announcement bar to appear
         id: 'webinar-agentic-confidence-april-2026',
         // Visual content (including Cypress Design icon) is rendered in src/theme/AnnouncementBar/Content
-        content: `📢 Join us for our live webinar on April 23rd! <a href="https://cypress.registration.goldcast.io/webinar/5503143f-d40d-48ae-9b52-d132a0888ee3?utm_source=docs.cypress.io&utm_medium=announcement-bar">Closing the Agentic Confidence Gap: Quality Governance for AI-Accelerated Teams</a>`,
+        content: `📢 Join us for our live webinar on April 23rd! <a href="https://cypress.registration.goldcast.io/webinar/5503143f-d40d-48ae-9b52-d132a0888ee3?utm_source=docs.cypress.io&utm_medium=announcement-bar&utm_campaign=webinar&utm_term=04-23-2026">Closing the Agentic Confidence Gap: Quality Governance for AI-Accelerated Teams</a>`,
         isCloseable: true,
       },
       footer: {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -171,7 +171,7 @@ const config = {
         //give id a unique value to get a new announcement bar to appear
         id: 'webinar-agentic-confidence-april-2026',
         // Visual content (including Cypress Design icon) is rendered in src/theme/AnnouncementBar/Content
-        content: `📢 Join us for our live webinar on April 26! <a href="https://cypress.registration.goldcast.io/webinar/5503143f-d40d-48ae-9b52-d132a0888ee3?utm_source=docs.cypress.io&utm_medium=announcement-bar">Closing the Agentic Confidence Gap: Quality Governance for AI-Accelerated Teams</a>`,
+        content: `📢 Join us for our live webinar on April 23rd! <a href="https://cypress.registration.goldcast.io/webinar/5503143f-d40d-48ae-9b52-d132a0888ee3?utm_source=docs.cypress.io&utm_medium=announcement-bar">Closing the Agentic Confidence Gap: Quality Governance for AI-Accelerated Teams</a>`,
         isCloseable: true,
       },
       footer: {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Static documentation-site config change limited to announcement banner text/link and an ID; no app logic or data handling changes.
> 
> **Overview**
> Updates the Docusaurus `announcementBar` messaging from the previous `cy.prompt()` promo to a new April 23, 2026 live webinar CTA, including a new `id` and updated tracking URL.
> 
> Adds a clarifying comment that the announcement bar’s visual/icon content is rendered by `src/theme/AnnouncementBar/Content`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cc4eb1504e3cb32fe714c8cbc3d4cb84d375f87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->