### PR TITLE
Update Windows 11 arm version compatibility to 25H2

### DIFF
--- a/docs/app/get-started/install-cypress.mdx
+++ b/docs/app/get-started/install-cypress.mdx
@@ -45,7 +45,7 @@ Cypress supports running under these operating systems:
   - Debian >=11
   - Fedora >=42
 - **Windows** 10 & 11 _(x64)_
-- **Windows** 11 24H2 _(arm64, runs in [x64 emulation](https://learn.microsoft.com/en-us/windows/arm/apps-on-arm-x86-emulation) mode, minimum Cypress [14.5.0](/app/references/changelog#14-5-0) required)_ - preview status
+- **Windows** 11 25H2 _(arm64, runs in [x64 emulation](https://learn.microsoft.com/en-us/windows/arm/apps-on-arm-x86-emulation) mode, minimum Cypress [14.5.0](/app/references/changelog#14-5-0) required)_ - preview status
 - **Windows Server** 2019, 2022 and 2025 _(x64)_
 
 ### Node.js


### PR DESCRIPTION
## Situation

https://docs.cypress.io/app/get-started/install-cypress#Operating-System lists:

> Windows 11 24H2 (arm64, runs in x64 emulation mode, minimum Cypress [14.5.0](https://docs.cypress.io/app/references/changelog#14-5-0) required) - preview status

[GitHub Actions Partner Runner Images](https://github.com/actions/partner-runner-images) offers [windows-11-arm](https://github.com/actions/partner-runner-images/blob/main/images/arm-windows-11-image.md) with Windows 11 Enterprise 25H2. A runner image based on Windows 11 24H2 is no longer available.

Support End Dates are taken from [Windows 11 Home & Pro Lifecycle](https://learn.microsoft.com/en-us/lifecycle/products/windows-11-home-and-pro):

| Windows 11 Version | Available in GitHub Actions | Support End Date |
| ------------------ | --------------------------- | ---------------- |
| 25H2               | yes                         | Oct 12, 2027     |
| 24H2               | no                          | Oct 13, 2026     |

## Usage

Cypress support for Windows on Arm (WoA) was introduced through PR https://github.com/cypress-io/cypress/pull/31784. There has not been any noticeable feedback since the availability was announced in the Changelog - neither positive nor negative. It's therefore unclear what the size of the user base of Cypress on WoA might be (unless there is some telemetry data available).

## Testing

I successfully tested Cypress 15.14.0 in https://github.com/MikeMcC399/cypress-example-kitchensink/actions/runs/24611434833 running under `windows-11-arm` (Microsoft Windows 11 Desktop by Arm Limited - Windows 11 Enterprise 10.0.26200 arm64) using the workflow [chrome-windows-arm.yml](https://github.com/MikeMcC399/cypress-example-kitchensink/blob/use/windows-11-25h2-arm/.github/workflows/chrome-windows-arm.yml)

## Change

Update in https://docs.cypress.io/app/get-started/install-cypress#Operating-System changing only the release from 24H2 to 25H2:

| Before                  | After                   |
| ----------------------- | ----------------------- |
| Windows 11 24H2 (arm64) | Windows 11 25H2 (arm64) |

## Other

Unlike GitHub Actions, CircleCI does not offer any Windows ARM CI environment - see unanswered post https://discuss.circleci.com/t/windows-on-arm-support/52106 Oct 2024.

Regarding Windows 11 26H1, which is not available in GitHub Actions, this only targets new devices with select new silicon, for example Qualcomm Snapdragon® X2 Series processors. This version diverges from mainstream Windows 11, and will not offer an upgrade path to Windows 11 26H2 when this is released. See article https://techcommunity.microsoft.com/blog/windows-itpro-blog/what-to-know-about-windows-11-version-26h1/4491941.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change updating the stated Windows 11 Arm (WoA) version; no runtime, build, or security-sensitive code is affected.
> 
> **Overview**
> Updates the installation system requirements docs to list **Windows 11 25H2 (arm64 via x64 emulation)** as the supported/preview WoA version instead of 24H2, keeping the same minimum Cypress version requirement (`14.5.0`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f2117ebb9aaf6dd520be97149f7727dae9affd7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->