### PR TITLE
chore: add changelog to app version 15.14.1

### DIFF
--- a/docs/app/references/changelog.mdx
+++ b/docs/app/references/changelog.mdx
@@ -8,6 +8,19 @@ sidebar_label: Changelog
 
 # Changelog
 
+## 15.14.1
+
+_Released 04/21/2026_
+
+**Performance:**
+
+- Fixed a memory leak in `cypress open` where each spec rerun accumulated an additional `uncaughtException` listener, preventing the previous Mocha runner — and all the objects it retained (commands, snapshots, logs) — from being garbage collected. Fixed in [#33631](https://github.com/cypress-io/cypress/pull/33631).
+
+**Bugfixes:**
+
+- Increased the limit for decrypted payloads to support large [`cy.prompt`](/api/commands/prompt) requests and responses. Fixed in [#33619](https://github.com/cypress-io/cypress/pull/33619).
+- Fixed a race condition in `@cypress/vite-dev-server` where the Cypress iframe could attempt to import the support file before Vite had finished serving it, causing intermittent "Failed to fetch dynamically imported module" errors in component tests. The dev server now waits until the support file URL returns a successful response before signaling that it is ready. Addressed in [#33487](https://github.com/cypress-io/cypress/pull/33487).
+
 ## 15.14.0
 
 _Released 04/16/2026_


### PR DESCRIPTION
## Summary

- Adds changelog entries for Cypress app version 15.14.1


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds a new changelog section; no runtime code or behavior is modified.
> 
> **Overview**
> Adds a new `15.14.1` entry to the Cypress App changelog with release date, including notes on a `cypress open` memory leak fix, increased decrypted payload limits for large `cy.prompt` traffic, and a `@cypress/vite-dev-server` readiness/race-condition fix for component testing support-file loading.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc6ee62c26c9f2b66273bf0ce33f3efb1bf45941. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->