### PR TITLE
feat: Improve agentic access metadata

### DIFF
--- a/plugins/llm/src/MarkdownExporter.ts
+++ b/plugins/llm/src/MarkdownExporter.ts
@@ -116,7 +116,7 @@ export class MarkdownExporter {
     }
 
     const relFromRoot = toPosixPath('/'+path.relative(this.rootDir, dir))
-    const isRoot = relFromRoot === '/'
+    const isRoot = relFromRoot === '/llm/markdown'
     const dirName = isRoot ? 'Docs' : path.basename(dir)
     const lines: string[] = [`# ${dirName}`, '']
 

--- a/plugins/llm/src/catalog.ts
+++ b/plugins/llm/src/catalog.ts
@@ -1,0 +1,45 @@
+import fs from 'fs'
+import path from 'path'
+
+/**
+ * Writes a `/.well-known/api-catalog` file that supplies additional pointers to alternate formats of our docs
+ * @param url 
+ * @param distRoot 
+ */
+export function writeApiCatalog(url: string, distRoot: string) {
+  const normalizedUrl = url.replace(/\/$/, '')
+  const catalog = {
+    linkset: [
+      {
+        anchor: `${normalizedUrl}`,
+        'service-doc': [
+          {
+            href: `${normalizedUrl}`,
+            type: 'text/html',
+          },
+          {
+            href: `${normalizedUrl}/llm/markdown/index.md`,
+            type: 'text/markdown',
+          },
+          {
+            href: `${normalizedUrl}/llm/json/chunked/index.json`,
+            type: 'application/json',
+          },
+          {
+            href: `${normalizedUrl}/llm/json/full/index.json`,
+            type: 'application/json',
+          },
+        ],
+      },
+    ],
+  }
+
+  fs.mkdirSync(path.join(distRoot, '.well-known'), { recursive: true })
+
+  // Walk all files under /llm, write all to a `catalog.txt` file.
+  fs.writeFileSync(
+    path.join(distRoot, '.well-known', 'api-catalog'),
+    JSON.stringify(catalog, null, 2),
+    'utf8'
+  )
+}

--- a/plugins/llm/src/export-llm-docs.ts
+++ b/plugins/llm/src/export-llm-docs.ts
@@ -27,6 +27,8 @@ import {
 } from './utils'
 import { PartialsRegistry } from './PartialsRegistry'
 import { writeSitemap } from './sitemap'
+import { writeApiCatalog } from './catalog'
+import { writeSkillsIndex } from './skills'
 
 export async function runLlmExport(options?: LlmExportRunOptions): Promise<void> {
   console.log('Running LLM export...')
@@ -89,6 +91,10 @@ export async function runLlmExport(options?: LlmExportRunOptions): Promise<void>
   manifestWriter.write(config)
 
   writeSitemap(config.url, distRoot)
+
+  writeApiCatalog(config.url, distRoot)
+
+  writeSkillsIndex(distRoot)
 
   const elapsedMs = Math.round(performance.now() - startedAt)
   const { markdown: outMarkdown, json: outJson } = countMarkdownAndJsonFiles(exportRoot)

--- a/plugins/llm/src/index.ts
+++ b/plugins/llm/src/index.ts
@@ -22,6 +22,14 @@ function llmExportPlugin(context: any, _options: any) {
               href: '/llms.txt',
             },
           },
+          {
+            tagName: 'link',
+            attributes: {
+              rel: 'api-catalog',
+              type: 'application/linkset+json',
+              href: '/.well-known/api-catalog',
+            }
+          },
         ],
       }
     },

--- a/plugins/llm/src/skills.ts
+++ b/plugins/llm/src/skills.ts
@@ -1,0 +1,42 @@
+import fs from 'fs'
+import path from 'path'
+
+/**
+ * Writes a `/.well-known/agent-skills/index.json` file that lists all the available Cypress AI skills.
+ * For now this will just be manually updated as new skills aren't being added very quickly, but eventually
+ * we may want to automatically scan `cypress-io/ai-toolkit/skills` for new skills.
+ * @param distRoot
+ */
+export function writeSkillsIndex(distRoot: string) {
+  const skills = [
+    {
+      name: 'cypress-author',
+      type: 'skill-md',
+      description:
+        'Improves how AI tools create, update, and fix Cypress tests.',
+      url: 'https://github.com/cypress-io/ai-toolkit/tree/main/skills/cypress-author',
+    },
+    {
+      name: 'cypress-explain',
+      type: 'skill-md',
+      description:
+        'Explains Cypress tests and provides feedback on their quality.',
+      url: 'https://github.com/cypress-io/ai-toolkit/tree/main/skills/cypress-explain',
+    },
+  ]
+
+  const skillsIndex = {
+    $schema: 'https://schemas.agentskills.io/discovery/0.2.0/schema.json',
+    skills: skills,
+  }
+
+  const dir = path.join(distRoot, '.well-known', 'agent-skills')
+
+  fs.mkdirSync(dir, { recursive: true })
+
+  fs.writeFileSync(
+    path.join(dir, 'index.json'),
+    JSON.stringify(skillsIndex, null, 2),
+    'utf8'
+  )
+}

--- a/src/theme/DocItem/Layout/index.tsx
+++ b/src/theme/DocItem/Layout/index.tsx
@@ -11,7 +11,7 @@ export default function LayoutWrapper(props: Props): ReactNode {
   const { pathname } = useLocation();
   // Add LLM alternate links to all pages - using this swizzled layout wrapper is a workaround
   // since Docusaurus don't support adding route-dynamic tags from inside a plugin
-  const normalized = pathname.replace(/\/$/, '').replace(/^\//, '') || ''
+  const normalized = pathname.replace(/\/$/, '').replace(/^\//, '') || 'index'
   const fullJsonHref = `/llm/json/full/${normalized}.json`
   const markdownHref = `/llm/markdown/${normalized}.md`
   return (

--- a/src/theme/DocItem/Layout/index.tsx
+++ b/src/theme/DocItem/Layout/index.tsx
@@ -1,0 +1,26 @@
+import React, {type ReactNode} from 'react';
+import Layout from '@theme-original/DocItem/Layout';
+import type LayoutType from '@theme/DocItem/Layout';
+import type {WrapperProps} from '@docusaurus/types';
+import Head from '@docusaurus/Head';
+import {useLocation} from '@docusaurus/router';
+
+type Props = WrapperProps<typeof LayoutType>;
+
+export default function LayoutWrapper(props: Props): ReactNode {
+  const { pathname } = useLocation();
+  // Add LLM alternate links to all pages - using this swizzled layout wrapper is a workaround
+  // since Docusaurus don't support adding route-dynamic tags from inside a plugin
+  const normalized = pathname.replace(/\/$/, '').replace(/^\//, '') || ''
+  const fullJsonHref = `/llm/json/full/${normalized}.json`
+  const markdownHref = `/llm/markdown/${normalized}.md`
+  return (
+    <>
+      <Head>
+        <link rel="alternate" type="application/json" href={fullJsonHref} />
+        <link rel="alternate" type="text/markdown" href={markdownHref} />
+      </Head>
+      <Layout {...props} />
+    </>
+  );
+}

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,17 @@
+# Allow all user agents
+User-agent: *
+# Explicitly allow common AI crawlers (duplicative with `*` above, but including for clarity)
+User-agent: GPTBot
+User-agent: ChatGPT-User
+User-agent: OAI-SearchBot
+User-agent: Google-Extended
+User-agent: CCBot
+User-agent: anthropic-ai
+User-agent: ClaudeBot
+User-agent: Claude-Web
+# Signal allowable AI consumption
+Content-Signal: ai-train=yes, search=yes, ai-input=yes
+Allow: /
+
+# Sitemap index (primary entry point for all sitemaps)
+Sitemap: https://docs.cypress.io/sitemap-index.xml


### PR DESCRIPTION
* Add `robots.txt`
* Add more `link` hints for alternate formats
* Add `api-catalog` and `agent-skills` files

[Updated IsItAgentReady Scan](https://isitagentready.com/deploy-preview-6420--cypress-docs.netlify.app?checks=robotsTxt%2Csitemap%2ClinkHeaders%2CmarkdownNegotiation%2CrobotsTxtAiRules%2CcontentSignals%2CwebBotAuth%2CapiCatalog%2CmcpServerCard%2CagentSkills%2CwebMcp)

This bumps us from a score of 8 to 60.

By default, that cloudflare tool includes checks that aren't strictly related to our docs site (for instance publishing an OpenAPI spec and linking to it, and OIDC login steps) which are more suited to a pure API tool. I've unchecked those on the link above, leaving only the following failing checks:

- Provide HTTP `link` headers to our `/.well-known/*` files - can't do that with pure Docusaurus, will have to look at doing with Cloudflare. Pending that, I *am* including `link` tags (rather than headers) which accomplish the same
- Markdown content negotiation: We could likely do this with Cloudflare now that we have static Markdown content without relying on their "auto markdown" beta feature
- MCP content: This "standard" is still an open PR, didn't want to chase it until it's settled a bit. Also will be somewhat dynamic as we add more capabilities to the MCP and didn't want to churn on it too much

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk build/output metadata changes that add new `.well-known` discovery files and HTML head `link` hints; main risk is incorrect URLs/paths causing broken discovery links.
> 
> **Overview**
> Improves *agent/LLM discoverability* of the docs output by emitting new discovery metadata during the LLM export.
> 
> The build now writes `/.well-known/api-catalog` (linkset JSON pointing to HTML/Markdown/JSON doc formats) and `/.well-known/agent-skills/index.json` (a manually curated skill list), and injects a corresponding `rel="api-catalog"` head link.
> 
> Docs pages also now include per-route `link rel="alternate"` hints to the exported `/llm/json/full/...` and `/llm/markdown/...` variants via a swizzled `DocItem` layout, and `MarkdownExporter` treats `/llm/markdown` as the root for naming the top-level index. Adds a permissive `static/robots.txt` that includes an AI `Content-Signal` and sitemap pointer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de70ae3d08721d48a23ad576f54e79ee5c88af55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->