### PR TITLE
chore: add changelog entry for #33617 in 15.14.1

### DIFF
--- a/docs/app/references/changelog.mdx
+++ b/docs/app/references/changelog.mdx
@@ -20,6 +20,7 @@ _Released 04/21/2026_
 
 - Increased the limit for decrypted payloads to support large [`cy.prompt`](/api/commands/prompt) requests and responses. Fixed in [#33619](https://github.com/cypress-io/cypress/pull/33619).
 - Fixed a race condition in `@cypress/vite-dev-server` where the Cypress iframe could attempt to import the support file before Vite had finished serving it, causing intermittent "Failed to fetch dynamically imported module" errors in component tests. The dev server now waits until the support file URL returns a successful response before signaling that it is ready. Addressed in [#33487](https://github.com/cypress-io/cypress/pull/33487).
+- Fixed an issue where early-exit crashes (such as config errors or renderer crashes) left the in-flight test with a generic failure instead of the actual fatal error. The fatal error is now attached to the failing test attempt so Cypress Cloud displays the underlying cause. Addressed in [#33617](https://github.com/cypress-io/cypress/pull/33617).
 
 ## 15.14.0
 


### PR DESCRIPTION
## Summary

Adds a 15.14.1 changelog entry for [cypress#33617](https://github.com/cypress-io/cypress/pull/33617), which fixes how early-exit crashes are reported so the fatal error is attached to the failing test attempt and displayed in Cypress Cloud.

## Test plan

- [ ] Verify changelog renders correctly on the 15.14.1 section

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change adding a release note; no runtime code paths are modified, so risk is minimal.
> 
> **Overview**
> Adds a new `15.14.1` **Bugfixes** changelog entry documenting that early-exit crashes (e.g., config or renderer failures) now attach the fatal error to the failing test attempt so Cypress Cloud shows the underlying cause (refs `#33617`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86777503ef87ed37b499bb8c09cbc4a76a5bedd0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->