### PR TITLE
docs: drop Next.js 14 from component testing support matrix

### DIFF
--- a/docs/app/component-testing/get-started.mdx
+++ b/docs/app/component-testing/get-started.mdx
@@ -44,7 +44,7 @@ following development servers and frameworks:
 | ------------------------------------------------------------------------------------------------------------------ | ------------- | --------- |
 | [React with Vite](/app/component-testing/react/overview#React-with-Vite)                                           | React 18-19   | Vite 5-8  |
 | [React with Webpack](/app/component-testing/react/overview#React-with-Webpack)                                     | React 18-19   | Webpack 5 |
-| [Next.js 14-16](/app/component-testing/react/overview#Nextjs)                                                      | React 18-19   | Webpack 5 |
+| [Next.js 15-16](/app/component-testing/react/overview#Nextjs)                                                      | React 18-19   | Webpack 5 |
 | [Vue with Vite](/app/component-testing/vue/overview#Vue-with-Vite)                                                 | Vue 3         | Vite 5-8  |
 | [Vue with Webpack](/app/component-testing/vue/overview#Vue-with-Webpack)                                           | Vue 3         | Webpack 5 |
 | [Angular](/app/component-testing/angular/overview#Framework-Configuration)                                         | Angular 18-21 | Webpack 5 |

--- a/docs/app/component-testing/react/overview.mdx
+++ b/docs/app/component-testing/react/overview.mdx
@@ -151,7 +151,7 @@ it via the `webpackConfig` option.
 
 ### Next.js
 
-Cypress Component Testing works with Next.js 14, 15 and 16.
+Cypress Component Testing works with Next.js 15 and 16.
 
 #### Next.js Configuration
 


### PR DESCRIPTION
## Summary

- Next.js 14 is being dropped from the Cypress Component Testing supported version matrix in 16.x.
- Updated `docs/app/component-testing/react/overview.mdx` to state CT works with Next.js 15 and 16.
- Updated the framework support table in `docs/app/component-testing/get-started.mdx` to show Next.js 15-16.
- Historical changelog entries referencing Next.js 14 were intentionally left untouched.

## Test plan

- [x] `npm run lint:markdown` passes.
- [x] `npm start` and confirm `/app/component-testing/react/overview#Nextjs` reads "Next.js 15 and 16".
- [x] Confirm the framework table on `/app/component-testing/get-started` shows "Next.js 15-16" and the link still resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only update that narrows the stated supported Next.js versions; no runtime or API behavior changes.
> 
> **Overview**
> Updates Cypress Component Testing docs to **drop Next.js 14** from the supported-version matrix.
> 
> The Get Started support table and the React CT overview now state Next.js support as **15–16** (previously **14–16**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ba7ca0cead93ab496089cb4f286e2eccddfa6dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->