### PR TITLE
Banner: remove webinar, replace with MCP

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -171,7 +171,7 @@ const config = {
         //give id a unique value to get a new announcement bar to appear
         id: 'cloud-mcp-april-2026',
         // Visual content (including Cypress Design icon) is rendered in src/theme/AnnouncementBar/Content
-        content: `🌟 Close the context gap. Bring real-time test data to your AI assistant with <a href="/cloud/integrations/cloud-mcp?utm_medium=announcement-bar">Cloud MCP</a>.`,
+        content: `🌟 Close the context gap. Bring real-time test data to your AI assistant with <a href="/cloud/integrations/cloud-mcp?utm_medium=announcement-bar&utm_campaign=cloud-mcp">Cloud MCP</a>.`,
         isCloseable: true,
       },
       footer: {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -169,9 +169,9 @@ const config = {
       // Styles for this are controlled in src/css/announcement-bar.scss
       announcementBar: {
         //give id a unique value to get a new announcement bar to appear
-        id: 'webinar-agentic-confidence-april-2026',
+        id: 'cloud-mcp-april-2026',
         // Visual content (including Cypress Design icon) is rendered in src/theme/AnnouncementBar/Content
-        content: `📢 Live Webinar: Closing the confidence gap for AI-accelerated teams - <a href="https://cypress.registration.goldcast.io/webinar/5503143f-d40d-48ae-9b52-d132a0888ee3?utm_source=docs.cypress.io&utm_medium=announcement-bar&utm_campaign=webinar&utm_term=04-23-2026">Join us April 23!</a>`,
+        content: `🌟 Close the context gap. Bring real-time test data to your AI assistant with <a href="/cloud/integrations/cloud-mcp?utm_medium=announcement-bar">Cloud MCP</a>.`,
         isCloseable: true,
       },
       footer: {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -171,7 +171,7 @@ const config = {
         //give id a unique value to get a new announcement bar to appear
         id: 'cloud-mcp-april-2026',
         // Visual content (including Cypress Design icon) is rendered in src/theme/AnnouncementBar/Content
-        content: `🌟 Close the context gap. Bring real-time test data to your AI assistant with <a href="/cloud/integrations/cloud-mcp?utm_medium=announcement-bar&utm_campaign=cloud-mcp">Cloud MCP</a>.`,
+        content: `🌟 Close the context gap. Bring real-time test data to your AI assistant with Cloud MCP &mdash; <a href="/cloud/integrations/cloud-mcp?utm_medium=announcement-bar&utm_campaign=cloud-mcp">Learn more</a>`,
         isCloseable: true,
       },
       footer: {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Static marketing copy/link changes in site config; no functional or security-sensitive logic is affected.
> 
> **Overview**
> Updates the Docusaurus `announcementBar` to retire the April 2026 webinar promo and replace it with a Cloud MCP promotion, including a new `id` and updated message/link (with UTM params) pointing to `/cloud/integrations/cloud-mcp`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 063ba3d64f81c85e493ffcf1f3036afa63ef3fa3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->