### PR TITLE
Chore: Update stale accessibility link

### DIFF
--- a/docs/app/guides/accessibility-testing.mdx
+++ b/docs/app/guides/accessibility-testing.mdx
@@ -79,7 +79,7 @@ It is best to proactively manage this, because unnecessary flake, failures, or t
 
 In-test accessibility checks are the only kind available in typical testing scenarios. They come with some limitations and tradeoffs that [Cypress Accessibility](/accessibility/get-started/introduction), available in Cypress Cloud, is designed to solve. By moving the checks outside of the test context and running them in Cypress Cloud as tests are recorded, Cypress Accessibility removes adoption, training, and test performance hurdles that can hinder the effective implementation of in-test checks. Cypress automatically detects all the steps within user flows, requiring no test code to be written.
 
-To learn more, you can read our [dedicated docs](/accessibility/get-started/introduction), or review a [public live example of an automatically-generated accessibility report](https://cloud.cypress.io/projects/7s5okt/runs/6520/accessibility?tab=views&columnHeading=Views&direction=ascending&rulesColumnHeading=Rules&rulesDirection=ascending&impact=critical%2Cserious%2Cmoderate%2Cminor&ruleset=wcag21a%2Cwcag21aa%2Cbest-practice&status=fail%2Cincomplete) in our Cypress Realworld App demo project.
+To learn more, you can read our [dedicated docs](/accessibility/get-started/introduction), or review a [public live example of an automatically-generated accessibility report](https://on.cypress.io/rwa-accessibility-views?utm_source=docs.cypress.io&utm_medium=app-docs-a11y-article) in our Cypress Realworld App demo project.
 
 <AccessibilityPremiumNote />
 


### PR DESCRIPTION
Closes: #6427


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change that updates a single external URL; no product code or behavior is affected.
> 
> **Overview**
> Updates the `Accessibility Testing` guide to replace a stale deep link to a Cypress Cloud accessibility report with a new `on.cypress.io` short link (with UTM tracking) for the public Realworld App accessibility report example.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b233e2ba847c066dc956c8ae443ea8ea2322ff2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->