### PR TITLE
docs: fast visibility now supports Shadow DOM with documented caveats

### DIFF
--- a/docs/app/core-concepts/interacting-with-elements.mdx
+++ b/docs/app/core-concepts/interacting-with-elements.mdx
@@ -90,7 +90,10 @@ Keep up-to-date with the progress of this experiment in the [Cypress repository]
 
 Experimental fast visibility is an experimental feature that is still under development. It uses different semantics from the legacy visibility algorithm, and does not yet fully support all testing scenarios.
 
-- Shadow DOM is not yet supported. Tests that interact with Shadow DOM elements may fail or behave incorrectly.
+- Shadow DOM is supported, but a few edge cases still diverge from the legacy algorithm because the fast algorithm relies on `elementFromPoint`:
+  - Subjects whose only visible region is a corner uncovered by a narrower covering element may be reported visible (the fast algorithm samples four corners and the center; the legacy algorithm only samples the center).
+  - Subjects whose `pointer-events` resolve to `none` are skipped by `elementFromPoint`, so the fast algorithm cannot find them at any sample point. Set `pointer-events: auto` on the subject if you need to assert visibility while keeping pointer-events disabled elsewhere.
+  - When a clipping ancestor (`overflow: hidden`, `clip`, `scroll`, or `auto`) sits between the subject and the subject's containing block, the fast algorithm treats the ancestor as clipping, while the legacy algorithm uses `offsetParent` rules to ignore it.
 
 #### Common Compatibility Issues
 
@@ -102,7 +105,7 @@ Elements that are simply below the fold are automatically scrolled into view per
 
 Elements positioned outside the scrollable document bounds (e.g. `position: absolute; top: -100px`) cannot be scrolled into view and are correctly identified as hidden.
 
-Subjects nested inside an ancestor with `overflow: hidden` or `overflow: clip` are not scrolled into view, since doing so would expose content the parent intentionally clipped (e.g. inputs in a transform-based carousel/slider). These subjects are reported as hidden when they fall outside the parent's clip bounds.
+Subjects positioned outside the bounds of an ancestor with `overflow: hidden`, `clip`, `scroll`, or `auto` are not scrolled into view, since doing so would expose content the parent intentionally clipped (e.g. inputs in a transform-based carousel/slider). These subjects are reported as hidden. Subjects that are in-bounds of such an ancestor — they would be visible if the ancestor itself were on-screen — are scrolled into view normally. The check walks shadow root boundaries, so subjects in Shadow DOM are treated the same as light-DOM descendants.
 
 **Covered Elements**
 

--- a/docs/app/references/experiments.mdx
+++ b/docs/app/references/experiments.mdx
@@ -197,7 +197,7 @@ Consider enabling `experimentalFastVisibility` if you:
 
 The experimental fast visibility algorithm has slightly different semantics for what it considers visible, when compared with the legacy algorithm. Tests that rely on edge-case behavior of the legacy visibility algorithm may fail or behave incorrectly.
 
-- Shadow DOM is not yet supported. Tests that interact with Shadow DOM elements may fail or behave incorrectly.
+- Shadow DOM is supported, but a few edge cases still diverge from the legacy algorithm because the fast algorithm relies on `elementFromPoint`. See [Experimental Fast Visibility limitations](/app/core-concepts/interacting-with-elements#Limitations) in the Interacting with Elements guide for details.
 
 :::
 


### PR DESCRIPTION
Pairs with [cypress-io/cypress#33737](https://github.com/cypress-io/cypress/pull/33737), which makes the `experimentalFastVisibility` algorithm shadow-DOM aware (resolves [cypress-io/cypress#33046](https://github.com/cypress-io/cypress/issues/33046)).

This PR is stacked on top of #6434 because it builds on that branch's clipping-ancestor docs.

## What changed

- Replaced the **"Shadow DOM is not yet supported"** limitation in two places (`experiments.mdx` and `interacting-with-elements.mdx`) with the new state: Shadow DOM is now supported. The remaining divergences from the legacy algorithm are documented as three concrete buckets, all rooted in fast's reliance on `elementFromPoint`:
  - **Cover narrower than the underneath element** — fast samples four corners and the center, while legacy samples only the center, so a subject with an uncovered corner can be reported visible by fast and hidden by legacy.
  - **`pointer-events: none` on the subject** — browsers skip such elements in `elementFromPoint`, so no sample point can land on them. Setting `pointer-events: auto` on the subject is the workaround.
  - **Clipping ancestor between the subject and its containing block** — legacy uses `offsetParent` rules to ignore that ancestor; fast does not.
- Refined the existing clipping-ancestor paragraph from #6434 to (1) cover all four clipping `overflow` values (`hidden`, `clip`, `scroll`, `auto`), (2) note that in-bounds subjects merely below the fold are scrolled into view normally, and (3) state that the check now walks shadow root boundaries.

## Steps to test

Render the docs locally and visit:
- `docs/app/references/experiments#Experimental-Fast-Visibility` — confirm the caution block now points at the Limitations section.
- `docs/app/core-concepts/interacting-with-elements#Experimental-Fast-Visibility` — confirm the Limitations bullets describe the three caveats and the clipping-ancestor paragraph reads correctly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only updates that clarify behavior and known edge cases of `experimentalFastVisibility`, with no runtime or API changes.
> 
> **Overview**
> **Docs update for `experimentalFastVisibility`: Shadow DOM is now documented as supported**, replacing the previous “not supported” limitation and adding concrete caveats tied to `elementFromPoint` (corner-only visibility, `pointer-events: none`, and clipping-ancestor semantics).
> 
> Clarifies scrolling/clipping behavior for `overflow: hidden|clip|scroll|auto`, including that in-bounds-but-offscreen subjects still scroll into view and that clipping checks traverse shadow roots, and updates the experiments page to link readers to the detailed limitations section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2aa82d646a02f0416d924cd0d7660acc78ef40a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->