### PR TITLE
start agent docs for uic

### DIFF
--- a/docs/cloud/integrations/cloud-mcp.mdx
+++ b/docs/cloud/integrations/cloud-mcp.mdx
@@ -309,6 +309,8 @@ For a deeper exploration of working with Cloud MCP's accessibility tools, read o
 
 > "Using Cypress Cloud, pull the UI Coverage report for the latest run on this branch. Tell me the overall coverage score, list the views with the most untested elements, and show me the specific untested elements on the riskiest view."
 
+For more patterns, example prompts, and governance ideas when using UI Coverage with agents, read [Cypress UI Coverage - Work with AI agents](/ui-coverage/work-with-ai-agents).
+
 ## FAQs
 
 ### Troubleshooting
@@ -363,3 +365,4 @@ Alternatively, use [this feedback form](https://share.hsforms.com/2NWNpyi5KSZmG4
 - [Cypress AI](/cloud/features/cypress-ai-features)
 - [cy.prompt()](/api/commands/prompt)
 - [Cypress Accessibility - Work with AI agents](/accessibility/work-with-ai-agents)
+- [Cypress UI Coverage - Work with AI agents](/ui-coverage/work-with-ai-agents)

--- a/docs/ui-coverage/get-started/introduction.mdx
+++ b/docs/ui-coverage/get-started/introduction.mdx
@@ -77,6 +77,22 @@ From there, you can easily customize reports to fit your needs with flexible con
     </a>
   </li>
   <li class="card">
+    <a href="/ui-coverage/work-with-ai-agents" aria-labelledby="card-title-8">
+      <Icon
+        useCypressIcon
+        name="general-sparkle-triple"
+        size="24"
+        fillColor="teal-600"
+      />
+      <h3 id="card-title-8">Work with AI agents</h3>
+      <p>
+        Use Cypress Cloud MCP with UI Coverage to pull scores, views, and
+        untested elements from recorded runs, tune reports for clearer signal,
+        and review coverage deltas alongside passing tests.
+      </p>
+    </a>
+  </li>
+  <li class="card">
     <a
       href="/ui-coverage/guides/reduce-test-duplication"
       aria-labelledby="card-title-3"
@@ -157,6 +173,6 @@ UI Coverage provides an interactive, visual map of test coverage for your applic
 - **Flexible configuration**: Customize and fine-tune UI Coverage to suit specific needs and scenarios like ignoring views or elements or grouping similar elements together.
 - **Configurable CI Integration**: The [Results API](/ui-coverage/results-api) allows you to programmatically control your CI pipeline's behavior based on UI Coverage scores.
 - **Run-specific configuration**: Use [Profiles](/ui-coverage/configuration/profiles) to apply different configuration settings based on run tags, enabling team-specific reporting and optimized settings for different run types.
-- **AI agent integration**: Use [Cypress Cloud MCP](/cloud/integrations/cloud-mcp) to query coverage scores, identify untested views, and generate tests directly from your AI coding assistant.
+- **AI agent integration**: Use [Cypress Cloud MCP](/cloud/integrations/cloud-mcp) to query coverage scores, identify untested views, and generate tests directly from your AI coding assistant. For prompts, configuration tips, and governance patterns, see [Work with AI agents](/ui-coverage/work-with-ai-agents).
 
 Read more about how it works in the [Core Concepts](/ui-coverage/core-concepts/interactivity) section.

--- a/docs/ui-coverage/guides/address-coverage-gaps.mdx
+++ b/docs/ui-coverage/guides/address-coverage-gaps.mdx
@@ -46,7 +46,7 @@ The generated code will use your existing patterns for navigating and interactin
 This test can be copied directly into your spec file at the suggested location, and from there you can continue writing the test locally.
 
 :::tip
-If you use an AI coding assistant, [Cypress Cloud MCP](/cloud/integrations/cloud-mcp) lets your agent pull UI Coverage data directly into your editor. You can ask it to identify the untested elements on a specific view and write targeted tests for them — combining Cloud data with your local code in a single workflow.
+If you use an AI coding assistant, [Cypress Cloud MCP](/cloud/integrations/cloud-mcp) lets your agent pull UI Coverage data directly into your editor. You can ask it to identify the untested elements on a specific view and write targeted tests for them — combining Cloud data with your local code in a single workflow. For example prompts and review patterns, see [Work with AI agents](/ui-coverage/work-with-ai-agents).
 :::
 
 ### Write tests for specific elements

--- a/docs/ui-coverage/work-with-ai-agents.mdx
+++ b/docs/ui-coverage/work-with-ai-agents.mdx
@@ -27,10 +27,6 @@ Here are some example prompts to try out:
 
 > "Get UI Coverage for this run URL. For the view named `/checkout`, list untested interactive elements and suggest which existing spec file is the best place to add a test that exercises them."
 
-> "After my last push, did UI Coverage go up or down compared to the previous run on this branch? Name the largest change in untested elements or links. If the previous run did not pass or ran different tests, ask me which run is the best to compare with."
-
-> "Suggest configuration changes to group similar URLs together in views based on our page templates and component structure as defined in this codebase"
-
 > "Use this CSV of our most-used pages based on Google Analytics data and create a matrix of risk where pages with large amounts of user interactions have relatively low UI Coverage. Create an action plan around this to backfill missing coverage in small increments starting from the most urgent work and working backwards."
 
 ## Tune UI Coverage for agent-friendly signal

--- a/docs/ui-coverage/work-with-ai-agents.mdx
+++ b/docs/ui-coverage/work-with-ai-agents.mdx
@@ -1,0 +1,56 @@
+---
+sidebar_label: Work with AI agents
+title: 'Work with AI agents | Cypress UI Coverage Documentation'
+description: 'Use AI assistants with UI Coverage and Cypress Cloud MCP: pull coverage scores and untested elements from recorded runs, tune reports for clearer signal, and review coverage deltas alongside passing tests.'
+sidebar_position: 110
+---
+
+<ProductHeading product="ui-coverage" />
+
+# Work with AI agents
+
+UI Coverage maps how your Cypress tests use the interface: which [interactive elements and links](/ui-coverage/core-concepts/interactivity) were exercised in each view, how that adds up to a [coverage score](/ui-coverage/get-started/introduction), and the DOM snapshots from [Test Replay](/cloud/features/test-replay) that put each finding in context. That picture is built from what actually ran in the browser, so it is a strong signal for **test completeness** relative to the UI states your suite reaches.
+
+AI agents can use that signal to summarize gaps, draft targeted tests, or correlate a drop in coverage with specific specs—while your team keeps ownership of what “enough coverage” means for each area.
+
+## Cypress Cloud MCP
+
+[Cypress Cloud MCP](/cloud/integrations/cloud-mcp) lets compatible agents query UI Coverage for a run using structured tools.
+
+Use it to turn “something changed in coverage” into a concrete next step: which views regressed, which elements are newly untested, and where to add or restore interactions.
+
+### Example prompts
+
+Here are some example prompts to try out:
+
+> "Using Cypress Cloud, pull the UI Coverage report for the latest run on this branch. Summarize the overall coverage score, the views with the most untested elements, and list the untested elements on the top view."
+
+> "Get UI Coverage for this run URL. For the view named `/checkout`, list untested interactive elements and suggest which existing spec file is the best place to add a test that exercises them."
+
+> "After my last push, did UI Coverage go up or down compared to the previous run on this branch? Name the largest change in untested elements or links. If the previous run did not pass or ran different tests, ask me which run is the best to compare with."
+
+> "Suggest configuration changes to group similar URLs together in views based on our page templates and component structure as defined in this codebase"
+
+> "Use this CSV of our most-used pages based on Google Analytics data and create a matrix of risk where pages with large amounts of user interactions have relatively low UI Coverage. Create an action plan around this to backfill missing coverage in small increments starting from the most urgent work and working backwards."
+
+## Tune UI Coverage for agent-friendly signal
+
+Agents work best when reports emphasize the surfaces your team cares about. Use [configuration](/ui-coverage/configuration/overview) to shape what appears in Cloud and in MCP responses:
+
+- Use config [profiles](/ui-coverage/configuration/profiles) for team or owner-based customization,
+- [Reduce noise](/ui-coverage/guides/reduce-noise) with filters to ignore third-party or out-of-scope ui
+- Create clear [element identification](/ui-coverage/core-concepts/element-identification) and [grouping](/ui-coverage/core-concepts/element-grouping) so your agent can quickly make correct assumptions about an elements purpose.
+
+You can also use your agent to help you define and shape your configuration, by referencing the Cypress docs and describing intended changes.
+
+The goal is the same as for human review: high-signal lists of views and elements tied to ownership and critical flows, not an undifferentiated dump of every control on every page.
+
+## Governance: when to involve a human
+
+Treat unexpected coverage movement as a **quality gate on the tests and the UI under test**, not noise to ignore by default.
+
+- Use [Branch Review](/ui-coverage/guides/compare-reports) to see what changed between runs: new untested elements, new links, or new interactables in the application.
+- Use [monitoring and the Results API](/ui-coverage/guides/monitor-changes) to watch trends and wire checks into CI.
+- Use [policies and blocking flows](/ui-coverage/guides/block-pull-requests) when you need explicit thresholds or baselines before merge.
+
+Agents can draft tests, suggest spec placement, or narrate diffs; reviewers should still confirm intent, risk, and whether a drop in coverage is acceptable (for example, after a deliberate scope change). That split keeps velocity while avoiding silent drift in what your suite actually exercises.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds a new UI Coverage guide and links to it from existing UI Coverage and Cloud MCP docs.
> 
> **Overview**
> Adds a new `UI Coverage` documentation page, `work-with-ai-agents`, with example Cypress Cloud MCP prompts plus guidance on tuning UI Coverage configuration and governance for human review.
> 
> Updates existing docs to surface this guide: adds a new “Work with AI agents” card on the UI Coverage introduction page, and adds contextual links from the Cloud MCP UI Coverage triage section and UI Coverage guides (e.g., addressing coverage gaps) to the new page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 239b6a7014cbbeffed15fbe5bece0a6530555da6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->