### PR TITLE
breaking: remove Node 20/25 support docs for Cypress 16

### DIFF
--- a/docs/accessibility/guides/results-api.mdx
+++ b/docs/accessibility/guides/results-api.mdx
@@ -388,7 +388,7 @@ jobs:
     steps:
       - task: NodeTool@0
         inputs:
-          versionSpec: '20.x'
+          versionSpec: '22.x'
           displayName: 'Install Node.js'
 
       - script: npm i

--- a/docs/app/get-started/install-cypress.mdx
+++ b/docs/app/get-started/install-cypress.mdx
@@ -50,7 +50,7 @@ Cypress supports running under these operating systems:
 
 ### Node.js
 
-- **Node.js** 20.x, 22.x, >=24.x
+- **Node.js** 22.x, >=24.x
 
 Follow the instructions on [Download Node.js](https://nodejs.org/en/download/) to download and install [Node.js](https://nodejs.org/).
 

--- a/docs/app/references/changelog.mdx
+++ b/docs/app/references/changelog.mdx
@@ -20,6 +20,7 @@ Refer to the [16 Migration Guide](/app/references/migration-guide#Migrating-to-C
 
 :::
 
+- Removed support for Node.js 20 and Node.js 25. Addresses [#33705](https://github.com/cypress-io/cypress/issues/33705) and [#33778](https://github.com/cypress-io/cypress/issues/33778).
 - **Component Testing breaking changes:**
   - Angular
     - Removed support for Angular 18, 19, and 20. The minimum supported version is now `21.0.0`.

--- a/docs/app/references/migration-guide.mdx
+++ b/docs/app/references/migration-guide.mdx
@@ -14,6 +14,10 @@ This guide details the code changes needed to migrate to Cypress
 version 16.0.
 [See the full changelog for version v16.0](/app/references/changelog#16-0-0).
 
+### Node.js 20 and 25 no longer supported
+
+Cypress 16 requires [Node.js](https://nodejs.org/en) **22.x**, **24.x**, or **26.x and above** to install the Cypress binary. Node.js 20 and Node.js 25 are no longer supported. See [system requirements](/app/get-started/install-cypress#Nodejs) and [Node's release schedule](https://github.com/nodejs/Release).
+
 ### Angular `18`, `19`, and `20` CT no longer supported
 
 Angular 18 and 19 have reached [end-of-life](https://angular.dev/reference/releases#actively-supported-versions), and Angular 20 reaches LTS end in November 2026. As a result, the minimum required Angular version for component testing is now `21.0.0`.

--- a/docs/cloud/integrations/cloud-mcp.mdx
+++ b/docs/cloud/integrations/cloud-mcp.mdx
@@ -123,7 +123,7 @@ See [Antigravity's documentation](https://antigravity.google/docs/mcp) for more 
 5. Restart Claude Desktop after saving. You should see a tools indicator in the chat input.
 
 See [Claude's documentation](https://code.claude.com/docs/en/mcp) for more details.
-Note: `mcp-remote` requires Node.js v20+ in the path to run successfully.
+Note: `mcp-remote` requires Node.js v22+ in the path to run successfully.
 
 </AccordionBlock>
 

--- a/docs/ui-coverage/results-api.mdx
+++ b/docs/ui-coverage/results-api.mdx
@@ -304,7 +304,7 @@ jobs:
     steps:
       - task: NodeTool@0
         inputs:
-          versionSpec: '20.x'
+          versionSpec: '22.x'
           displayName: 'Install Node.js'
 
       - script: npm i


### PR DESCRIPTION
## Summary

Documentation updates for Cypress 16 Node.js support:

- **Breaking:** remove Node 20 and 25 from supported versions; align install/migration messaging with Node 22+ requirements.

## Commits

- `breaking: remove node 20/25 for Cypress 16`
- `docs: align Node 22+ messaging for Cypress 16`

Targets **`release/16.0.0`**.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only update that changes stated Node.js support requirements and CI examples; low implementation risk but could mislead users if any remaining references are missed.
> 
> **Overview**
> Updates Cypress 16 documentation to **drop Node.js 20 and 25 support** and consistently require Node.js **22+** across install requirements, migration guidance, and the 16.0.0 breaking-changes changelog entry.
> 
> Adjusts CI/example snippets (Azure pipelines in Accessibility Results API and UI Coverage Results API docs) to install Node.js `22.x`, and updates Cloud MCP docs to note `mcp-remote` requires Node.js `v22+`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0110007998f3524b9a7e34245c38d52c91f877f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->