### PR TITLE
docs: align recent changelog release dates with MMM DD, YYYY

### DIFF
--- a/docs/app/references/changelog.mdx
+++ b/docs/app/references/changelog.mdx
@@ -34,7 +34,7 @@ _Released May 12, 2026_
 
 ## 15.14.2
 
-_Released April 29, 2026_
+_Released Apr 29, 2026_
 
 **Performance:**
 
@@ -55,7 +55,7 @@ _Released April 29, 2026_
 
 ## 15.14.1
 
-_Released April 21, 2026_
+_Released Apr 21, 2026_
 
 **Performance:**
 
@@ -69,7 +69,7 @@ _Released April 21, 2026_
 
 ## 15.14.0
 
-_Released April 16, 2026_
+_Released Apr 16, 2026_
 
 **Performance:**
 
@@ -90,7 +90,7 @@ _Released April 16, 2026_
 
 ## 15.13.1
 
-_Released April 07, 2026_
+_Released Apr 07, 2026_
 
 **Performance:**
 


### PR DESCRIPTION
Normalizes release date lines for Cypress **15.13.1** through **15.14.2** to use abbreviated months (`Apr` instead of `April`), matching the rest of the changelog after #6397.

Addresses the mixed date-stamp formatting called out in [#6441](https://github.com/cypress-io/cypress-documentation/issues/6441).

Reason / context: https://github.com/cypress-io/cypress-documentation/issues/6441#issuecomment-4433692183

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adjusts date strings and does not affect product behavior.
> 
> **Overview**
> Updates `docs/app/references/changelog.mdx` to normalize release-date lines for versions `15.13.1` through `15.14.2`, switching month names from `April` to the abbreviated `Apr` to match the surrounding changelog format.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1165fdd84bcdf3bcc40f7754b1f3ba2dc5f14d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->