### PR TITLE
docs: update keystrokeDelay default from 10 to 0

### DIFF
--- a/docs/api/commands/type.mdx
+++ b/docs/api/commands/type.mdx
@@ -98,7 +98,7 @@ Pass in an options object to change the default behavior of `.type()`.
 | Option                       | Default                                                                     | Description                                                                                                                                     |
 | ---------------------------- | --------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
 | `animationDistanceThreshold` | [`animationDistanceThreshold`](/app/references/configuration#Actionability) | The distance in pixels an element must exceed over time to be [considered animating](/app/core-concepts/interacting-with-elements#Animations).  |
-| `delay`                      | `10`                                                                        | Delay after each keypress                                                                                                                       |
+| `delay`                      | `0`                                                                         | Delay after each keypress                                                                                                                       |
 | `force`                      | `false`                                                                     | Forces the action, disables [waiting for actionability](#Assertions)                                                                            |
 | `log`                        | `true`                                                                      | Displays the command in the [Command log](/app/core-concepts/open-mode#Command-Log)                                                             |
 | `parseSpecialCharSequences`  | `true`                                                                      | Parse special characters for strings surrounded by `{}`, such as `{esc}`. Set to `false` to type the literal characters instead                 |
@@ -133,11 +133,11 @@ cy.get('textarea').type('Hello world') // yields <textarea>
 
 #### Mimic user typing behavior
 
-Each keypress is delayed 10ms by default in order to simulate how a very fast
-user types!
+By default there is no delay between keypresses. To simulate more realistic
+typing, set the `delay` option.
 
 ```javascript
-cy.get('[contenteditable]').type('some text!')
+cy.get('[contenteditable]').type('some text!', { delay: 10 })
 ```
 
 #### 'Selecting' an option from datalist
@@ -691,6 +691,7 @@ following:
 
 | Version                                      | Changes                                                                                                                                |
 | -------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| [16.0.0](/app/references/changelog#16-0-0)   | Changed default `delay` from `10` to `0`                                                                                               |
 | [13.14.0](/app/references/changelog#13-14-0) | Added support for `.type({upArrow})` and `.type({downArrow})` to work on date, month, week, time, datetime-local and range input types |
 | [6.1.0](/app/references/changelog#6-1-0)     | Added option `scrollBehavior`                                                                                                          |
 | [5.6.0](/app/references/changelog#5-6-0)     | Support single key combination syntax                                                                                                  |

--- a/docs/api/commands/type.mdx
+++ b/docs/api/commands/type.mdx
@@ -133,7 +133,7 @@ cy.get('textarea').type('Hello world') // yields <textarea>
 
 #### Mimic user typing behavior
 
-By default there is no delay between keypresses. To simulate slower typing,
+By default, there is no delay between keypresses. To simulate slower typing,
 set the `delay` option.
 
 ```javascript

--- a/docs/api/commands/type.mdx
+++ b/docs/api/commands/type.mdx
@@ -133,8 +133,8 @@ cy.get('textarea').type('Hello world') // yields <textarea>
 
 #### Mimic user typing behavior
 
-By default there is no delay between keypresses. To simulate more realistic
-typing, set the `delay` option.
+By default there is no delay between keypresses. To simulate slower typing,
+set the `delay` option.
 
 ```javascript
 cy.get('[contenteditable]').type('some text!', { delay: 10 })

--- a/docs/api/cypress-api/keyboard-api.mdx
+++ b/docs/api/cypress-api/keyboard-api.mdx
@@ -54,8 +54,8 @@ The following keys are supported:
 
 An object containing the following:
 
-| Option           | Default | Description                                                                                                                                  |
-| ---------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| Option           | Default | Description                                                                                                                    |
+| ---------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------ |
 | `keystrokeDelay` | `0`     | The delay, in milliseconds, between keystrokes while typing with [.type()](/api/commands/type). Must be a non-negative number. |
 
 ## Examples

--- a/docs/api/cypress-api/keyboard-api.mdx
+++ b/docs/api/cypress-api/keyboard-api.mdx
@@ -54,9 +54,9 @@ The following keys are supported:
 
 An object containing the following:
 
-| Option           | Default | Description                                                                                                                                                    |
-| ---------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `keystrokeDelay` | `10`    | The delay, in milliseconds, between keystrokes while typing with [.type()](/api/commands/type). Set to `0` to remove the delay. Must be a non-negative number. |
+| Option           | Default | Description                                                                                                                                  |
+| ---------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `keystrokeDelay` | `0`     | The delay, in milliseconds, between keystrokes while typing with [.type()](/api/commands/type). Must be a non-negative number. |
 
 ## Examples
 
@@ -75,14 +75,6 @@ Cypress.Keyboard.defaults({
 })
 ```
 
-### Remove the keystroke delay
-
-```javascript
-Cypress.Keyboard.defaults({
-  keystrokeDelay: 0,
-})
-```
-
 ## Notes
 
 ### Where to put Keyboard configuration
@@ -97,24 +89,24 @@ which can be useful when setting it for a single test or a subset of tests.
 
 ```javascript
 it(
-  'removes keystroke delay for all typing in this test',
-  { keystrokeDelay: 0 },
+  'adds a keystroke delay for all typing in this test',
+  { keystrokeDelay: 10 },
   () => {
-    cy.get('input').eq(0).type('fast typing')
-    cy.get('input').eq(1).type('more fast typing')
+    cy.get('input').eq(0).type('slow typing')
+    cy.get('input').eq(1).type('more slow typing')
   }
 )
 
 describe(
-  'removes keystroke delay in all tests in this suite',
-  { keystrokeDelay: 0 },
+  'adds a keystroke delay in all tests in this suite',
+  { keystrokeDelay: 10 },
   () => {
-    it('types fast in the first input', () => {
-      cy.get('input').eq(0).type('fast typing')
+    it('types with delay in the first input', () => {
+      cy.get('input').eq(0).type('slow typing')
     })
 
-    it('types fast in the second input', () => {
-      cy.get('input').eq(1).type('more fast typing')
+    it('types with delay in the second input', () => {
+      cy.get('input').eq(1).type('more slow typing')
     })
   }
 )

--- a/docs/app/references/changelog.mdx
+++ b/docs/app/references/changelog.mdx
@@ -3886,10 +3886,9 @@ into your overall development experience. Read more about 10.0 in
 **Breaking Changes:**
 
 <Icon name="exclamation-triangle" color="red" /> Please run `cypress open` to go
-through our interactive migration which will guide you in updating your files
-and configuration options. Read our [Migration
-Guide](/app/references/migration-guide) which explains some breaking changes in
-more detail.**
+through our interactive migration which will guide you in updating your files and
+configuration options. Read our [Migration Guide](/app/references/migration-guide)
+which explains some breaking changes in more detail.**
 
 - We introduced several breaking changes to the **Cypress configuration file**
   detailed below:
@@ -3917,6 +3916,7 @@ more detail.**
   options, removing options, and only allowing some options within a specific
   testing type. Please run `cypress open` to have our automated migration update
   these options for you.
+
   - Many configuration options are now specific to either end-to-end or
     component testing. The types have also been updated to match the new
     structure. Addressed in
@@ -3991,6 +3991,7 @@ more detail.**
 
 - Cypress 10 now includes beta support for **component testing**. More features
   around component testing are detailed below:
+
   - Component testing is now integrated directly into the main app, allowing you
     to choose which testing experience you want upon launching Cypress. See our
     [current support for frameworks and bundlers](/app/component-testing/component-framework-configuration).
@@ -4017,6 +4018,7 @@ more detail.**
     - `@cypress/vue2@1.0.0`
 
 - We've enhanced how you can set and refresh **configuration** detailed below:
+
   - Support for `cypress.config.js|ts|cjs|mjs` configuration files was added.
     Addressed in [#20643](https://github.com/cypress-io/cypress/pull/20643).
   - The Cypress app will now refresh when changes are made in the configuration
@@ -4024,6 +4026,7 @@ more detail.**
     [#21160](https://github.com/cypress-io/cypress/pull/21160).
 
 - We've added several **new configuration options** detailed below:
+
   - The [`setupNodeEvents()`](/app/references/configuration#setupNodeEvents)
     option is a new testing type specific configuration option. It must be
     defined within the [`e2e`](/app/references/configuration#e2e) and/or
@@ -4049,6 +4052,7 @@ more detail.**
     [#19319](https://github.com/cypress-io/cypress/pull/19319),
     [#20565](https://github.com/cypress-io/cypress/pull/20565) and
     [#20853](https://github.com/cypress-io/cypress/pull/20853).
+
     - The [`e2e.specPattern`](/app/references/configuration#e2e) default
       value for new projects is `cypress/e2e/**.cy.{js,jsx,ts,tsx}`. For
       existing projects, please run `cypress open` to have your spec files
@@ -4086,6 +4090,7 @@ more detail.**
     [#18302](https://github.com/cypress-io/cypress/pull/18302).
 
 - We've made some updates to **Cypress API commands** detailed below:
+
   - Enhancements were made to provide visual indication of nested commands and
     logs. With this change, users are now able to click on log groups to print
     additional log details to the dev tools console.
@@ -4103,6 +4108,7 @@ more detail.**
     [#18941](https://github.com/cypress-io/cypress/issues/18941).
 
 - We've made some updates to the **Cypress CLI** detailed below:
+
   - You can now pass in testing type specific configuration options via the
     `--config` CLI flag without nesting JSON. Addressed in
     [#20127](https://github.com/cypress-io/cypress/pull/20127).
@@ -4120,6 +4126,7 @@ more detail.**
 
 - The `cypress open` experience has been updated to take you through our
   **Launchpad** with many features detailed below:
+
   - When you launch Cypress via `cypress open` you'll be asked whether you want
     to do end-to-end or component testing and taken through the configuration
     necessary to set up your project. Addressed in
@@ -5253,9 +5260,9 @@ of 1, and a screen size of 1280x720 by default.
 
 **Breaking Changes:**
 
-<Icon name="exclamation-triangle" color="red" /> Please read our [Migration
-Guide](/app/references/migration-guide) which explains the changes in more
-detail and how to change your code to migrate to Cypress 8.0.**
+<Icon name="exclamation-triangle" color="red" /> Please read our [Migration Guide](/app/references/migration-guide)
+which explains the changes in more detail and how to change your code to migrate
+to Cypress 8.0.**
 
 - When running `cypress run` previous to 8.0, some browsers would launch headed
   while others were launched headless by default. Cypress now runs all browsers
@@ -5749,9 +5756,9 @@ components using your favorite developer tools. Read our
 
 **Breaking Changes:**
 
-<Icon name="exclamation-triangle" color="red" /> Please read our [Migration
-Guide](/app/references/migration-guide) which explains the changes in more
-detail and how to change your code to migrate to Cypress 7.0.**
+<Icon name="exclamation-triangle" color="red" /> Please read our [Migration Guide](/app/references/migration-guide)
+which explains the changes in more detail and how to change your code to migrate
+to Cypress 7.0.**
 
 - We introduced several breaking changes to
   [cy.intercept()](/api/commands/intercept). See the
@@ -6496,9 +6503,9 @@ and wait on any type of HTTP request originating from your app. See our guide on
 
 **Breaking Changes:**
 
-<Icon name="exclamation-triangle" color="red" /> Please read our [Migration
-Guide](/app/references/migration-guide) which explains the changes in more
-detail and how to change your code to migrate to Cypress 6.0.**
+<Icon name="exclamation-triangle" color="red" /> Please read our [Migration Guide](/app/references/migration-guide)
+which explains the changes in more detail and how to change your code to migrate
+to Cypress 6.0.**
 
 - Cypress now always throws an error when asserting on an element that doesn't
   exist in the DOM (unless you're asserting that the element should
@@ -7079,9 +7086,9 @@ failed test prior to marking it as failed. Read our new guide on
 
 **Breaking Changes:**
 
-<Icon name="exclamation-triangle" color="red" /> Please read our [Migration
-Guide](/app/references/migration-guide) which explains the changes in more
-detail and how to change your code to migrate to Cypress 5.0.**
+<Icon name="exclamation-triangle" color="red" /> Please read our [Migration Guide](/app/references/migration-guide)
+which explains the changes in more detail and how to change your code to migrate
+to Cypress 5.0.**
 
 - The
   [`cypress-plugin-retries`](https://github.com/Bkucera/cypress-plugin-retries)
@@ -8329,9 +8336,9 @@ bring new powerful features.
 
 **Breaking Changes:**
 
-<Icon name="exclamation-triangle" color="red" /> Please read our [Migration
-Guide](/app/references/migration-guide) which explains the changes in more
-detail and how to change your code to migrate to Cypress 4.0.**
+<Icon name="exclamation-triangle" color="red" /> Please read our [Migration Guide](/app/references/migration-guide)
+which explains the changes in more detail and how to change your code to migrate
+to Cypress 4.0.**
 
 - Mocha, Chai, and Sinon.JS has been upgraded which includes a number of
   breaking changes and new features. Addresses

--- a/docs/app/references/changelog.mdx
+++ b/docs/app/references/changelog.mdx
@@ -3886,9 +3886,10 @@ into your overall development experience. Read more about 10.0 in
 **Breaking Changes:**
 
 <Icon name="exclamation-triangle" color="red" /> Please run `cypress open` to go
-through our interactive migration which will guide you in updating your files and
-configuration options. Read our [Migration Guide](/app/references/migration-guide)
-which explains some breaking changes in more detail.**
+through our interactive migration which will guide you in updating your files
+and configuration options. Read our [Migration
+Guide](/app/references/migration-guide) which explains some breaking changes in
+more detail.**
 
 - We introduced several breaking changes to the **Cypress configuration file**
   detailed below:
@@ -3916,7 +3917,6 @@ which explains some breaking changes in more detail.**
   options, removing options, and only allowing some options within a specific
   testing type. Please run `cypress open` to have our automated migration update
   these options for you.
-
   - Many configuration options are now specific to either end-to-end or
     component testing. The types have also been updated to match the new
     structure. Addressed in
@@ -3991,7 +3991,6 @@ which explains some breaking changes in more detail.**
 
 - Cypress 10 now includes beta support for **component testing**. More features
   around component testing are detailed below:
-
   - Component testing is now integrated directly into the main app, allowing you
     to choose which testing experience you want upon launching Cypress. See our
     [current support for frameworks and bundlers](/app/component-testing/component-framework-configuration).
@@ -4018,7 +4017,6 @@ which explains some breaking changes in more detail.**
     - `@cypress/vue2@1.0.0`
 
 - We've enhanced how you can set and refresh **configuration** detailed below:
-
   - Support for `cypress.config.js|ts|cjs|mjs` configuration files was added.
     Addressed in [#20643](https://github.com/cypress-io/cypress/pull/20643).
   - The Cypress app will now refresh when changes are made in the configuration
@@ -4026,7 +4024,6 @@ which explains some breaking changes in more detail.**
     [#21160](https://github.com/cypress-io/cypress/pull/21160).
 
 - We've added several **new configuration options** detailed below:
-
   - The [`setupNodeEvents()`](/app/references/configuration#setupNodeEvents)
     option is a new testing type specific configuration option. It must be
     defined within the [`e2e`](/app/references/configuration#e2e) and/or
@@ -4052,7 +4049,6 @@ which explains some breaking changes in more detail.**
     [#19319](https://github.com/cypress-io/cypress/pull/19319),
     [#20565](https://github.com/cypress-io/cypress/pull/20565) and
     [#20853](https://github.com/cypress-io/cypress/pull/20853).
-
     - The [`e2e.specPattern`](/app/references/configuration#e2e) default
       value for new projects is `cypress/e2e/**.cy.{js,jsx,ts,tsx}`. For
       existing projects, please run `cypress open` to have your spec files
@@ -4090,7 +4086,6 @@ which explains some breaking changes in more detail.**
     [#18302](https://github.com/cypress-io/cypress/pull/18302).
 
 - We've made some updates to **Cypress API commands** detailed below:
-
   - Enhancements were made to provide visual indication of nested commands and
     logs. With this change, users are now able to click on log groups to print
     additional log details to the dev tools console.
@@ -4108,7 +4103,6 @@ which explains some breaking changes in more detail.**
     [#18941](https://github.com/cypress-io/cypress/issues/18941).
 
 - We've made some updates to the **Cypress CLI** detailed below:
-
   - You can now pass in testing type specific configuration options via the
     `--config` CLI flag without nesting JSON. Addressed in
     [#20127](https://github.com/cypress-io/cypress/pull/20127).
@@ -4126,7 +4120,6 @@ which explains some breaking changes in more detail.**
 
 - The `cypress open` experience has been updated to take you through our
   **Launchpad** with many features detailed below:
-
   - When you launch Cypress via `cypress open` you'll be asked whether you want
     to do end-to-end or component testing and taken through the configuration
     necessary to set up your project. Addressed in
@@ -5260,9 +5253,9 @@ of 1, and a screen size of 1280x720 by default.
 
 **Breaking Changes:**
 
-<Icon name="exclamation-triangle" color="red" /> Please read our [Migration Guide](/app/references/migration-guide)
-which explains the changes in more detail and how to change your code to migrate
-to Cypress 8.0.**
+<Icon name="exclamation-triangle" color="red" /> Please read our [Migration
+Guide](/app/references/migration-guide) which explains the changes in more
+detail and how to change your code to migrate to Cypress 8.0.**
 
 - When running `cypress run` previous to 8.0, some browsers would launch headed
   while others were launched headless by default. Cypress now runs all browsers
@@ -5756,9 +5749,9 @@ components using your favorite developer tools. Read our
 
 **Breaking Changes:**
 
-<Icon name="exclamation-triangle" color="red" /> Please read our [Migration Guide](/app/references/migration-guide)
-which explains the changes in more detail and how to change your code to migrate
-to Cypress 7.0.**
+<Icon name="exclamation-triangle" color="red" /> Please read our [Migration
+Guide](/app/references/migration-guide) which explains the changes in more
+detail and how to change your code to migrate to Cypress 7.0.**
 
 - We introduced several breaking changes to
   [cy.intercept()](/api/commands/intercept). See the
@@ -6503,9 +6496,9 @@ and wait on any type of HTTP request originating from your app. See our guide on
 
 **Breaking Changes:**
 
-<Icon name="exclamation-triangle" color="red" /> Please read our [Migration Guide](/app/references/migration-guide)
-which explains the changes in more detail and how to change your code to migrate
-to Cypress 6.0.**
+<Icon name="exclamation-triangle" color="red" /> Please read our [Migration
+Guide](/app/references/migration-guide) which explains the changes in more
+detail and how to change your code to migrate to Cypress 6.0.**
 
 - Cypress now always throws an error when asserting on an element that doesn't
   exist in the DOM (unless you're asserting that the element should
@@ -7086,9 +7079,9 @@ failed test prior to marking it as failed. Read our new guide on
 
 **Breaking Changes:**
 
-<Icon name="exclamation-triangle" color="red" /> Please read our [Migration Guide](/app/references/migration-guide)
-which explains the changes in more detail and how to change your code to migrate
-to Cypress 5.0.**
+<Icon name="exclamation-triangle" color="red" /> Please read our [Migration
+Guide](/app/references/migration-guide) which explains the changes in more
+detail and how to change your code to migrate to Cypress 5.0.**
 
 - The
   [`cypress-plugin-retries`](https://github.com/Bkucera/cypress-plugin-retries)
@@ -8336,9 +8329,9 @@ bring new powerful features.
 
 **Breaking Changes:**
 
-<Icon name="exclamation-triangle" color="red" /> Please read our [Migration Guide](/app/references/migration-guide)
-which explains the changes in more detail and how to change your code to migrate
-to Cypress 4.0.**
+<Icon name="exclamation-triangle" color="red" /> Please read our [Migration
+Guide](/app/references/migration-guide) which explains the changes in more
+detail and how to change your code to migrate to Cypress 4.0.**
 
 - Mocha, Chai, and Sinon.JS has been upgraded which includes a number of
   breaking changes and new features. Addresses

--- a/docs/app/references/changelog.mdx
+++ b/docs/app/references/changelog.mdx
@@ -28,6 +28,7 @@ Refer to the [16 Migration Guide](/app/references/migration-guide#Migrating-to-C
     - The zoneless testing harness is now the default in `cypress/angular`. `zone.js` is no longer required to be installed for your Cypress project.
     - `@angular/platform-browser-dynamic` has been replaced with `@angular/platform-browser`.
     - `autoSpyOutputs` and `autoDetectChanges` have been removed from `cypress/angular`.
+- The default `keystrokeDelay` for [`cy.type()`](/api/commands/type) has been changed from `10` to `0` to improve performance of typing-heavy test runs. Users who relied on the implicit 10ms delay can restore it by setting `keystrokeDelay: 10` in their Cypress config or via [`Cypress.Keyboard.defaults()`](/api/cypress-api/keyboard-api). Addresses [#33523](https://github.com/cypress-io/cypress/issues/33523).
 
 ## 15.14.0
 

--- a/docs/app/references/migration-guide.mdx
+++ b/docs/app/references/migration-guide.mdx
@@ -66,6 +66,38 @@ import { mount } from 'cypress/angular-zoneless'
 import { mount } from 'cypress/angular'
 ```
 
+### Default `keystrokeDelay` changed from `10` to `0`
+
+The default delay between keystrokes in [`cy.type()`](/api/commands/type) has been changed from `10` to `0` milliseconds to improve performance of typing-heavy test runs. This also affects [`Cypress.Keyboard.defaults()`](/api/cypress-api/keyboard-api), which now defaults `keystrokeDelay` to `0`.
+
+If your tests relied on the implicit 10ms delay between keystrokes, you can restore the previous behavior using any of these approaches:
+
+#### Set `keystrokeDelay` in your Cypress configuration
+
+:::cypress-config-example
+
+```ts
+{
+  keystrokeDelay: 10,
+}
+```
+
+:::
+
+#### Set `keystrokeDelay` via `Cypress.Keyboard.defaults()`
+
+```javascript
+Cypress.Keyboard.defaults({
+  keystrokeDelay: 10,
+})
+```
+
+#### Set `delay` per command
+
+```javascript
+cy.get('input').type('slow typing', { delay: 10 })
+```
+
 ### `@angular/platform-browser-dynamic` has been replaced with `@angular/platform-browser`
 
 As of Cypress `16.0.0`, the `@angular/platform-browser-dynamic` package has been replaced with the `@angular/platform-browser` package.

--- a/docs/app/references/migration-guide.mdx
+++ b/docs/app/references/migration-guide.mdx
@@ -688,20 +688,19 @@ Cypress will warn that this option is deprecated.
 <Icon name="exclamation-triangle" /> `injectDocumentDomain` will be removed in a
 future version of Cypress.
 
-<Icon name="exclamation-triangle" /> Setting `injectDocumentDomain` to `true`
-may cause certain sites to stop working in Cypress. Please read the
-[configuration notes](/app/references/configuration#injectDocumentDomain) before
-use.
+<Icon name="exclamation-triangle" /> Setting `injectDocumentDomain` to `true` may
+cause certain sites to stop working in Cypress. Please read the [configuration notes](/app/references/configuration#injectDocumentDomain)
+before use.
 
-<Icon name="exclamation-triangle" /> If your test suites require
-`experimentalWebKitSupport`, `injectDocumentDomain` must be set to `true`.
+<Icon name="exclamation-triangle" /> If your test suites require `experimentalWebKitSupport`,
+`injectDocumentDomain` must be set to `true`.
 
-<Icon name="exclamation-triangle" /> Chrome may remove support for
-`document.domain` at any time; if this configuration option is enabled, Cypress
-may cease to work in Chrome at any time. If this occurs, Chrome will raise an
-issue in its developer tools indicating that the deprecated `document.domain` is
-in use. To resolve this issue, set the `injectDocumentDomain` option to `false`
-and issue any newly necessary `cy.origin()` commands.
+<Icon name="exclamation-triangle" /> Chrome may remove support for `document.domain`
+at any time; if this configuration option is enabled, Cypress may cease to work in
+Chrome at any time. If this occurs, Chrome will raise an issue in its developer tools
+indicating that the deprecated `document.domain` is in use. To resolve this issue,
+set the `injectDocumentDomain` option to `false` and issue any newly necessary `cy.origin()`
+commands.
 
 :::
 
@@ -1098,8 +1097,7 @@ in the fourth.
 
 Here's a simplified example of such a test strategy.
 
-<Badge type="danger">Before</Badge> Multiple small tests against different
-origins
+<Badge type="danger">Before</Badge> Multiple small tests against different origins
 
 ```js
 it('logs in', () => {

--- a/docs/app/references/migration-guide.mdx
+++ b/docs/app/references/migration-guide.mdx
@@ -688,19 +688,20 @@ Cypress will warn that this option is deprecated.
 <Icon name="exclamation-triangle" /> `injectDocumentDomain` will be removed in a
 future version of Cypress.
 
-<Icon name="exclamation-triangle" /> Setting `injectDocumentDomain` to `true` may
-cause certain sites to stop working in Cypress. Please read the [configuration notes](/app/references/configuration#injectDocumentDomain)
-before use.
+<Icon name="exclamation-triangle" /> Setting `injectDocumentDomain` to `true`
+may cause certain sites to stop working in Cypress. Please read the
+[configuration notes](/app/references/configuration#injectDocumentDomain) before
+use.
 
-<Icon name="exclamation-triangle" /> If your test suites require `experimentalWebKitSupport`,
-`injectDocumentDomain` must be set to `true`.
+<Icon name="exclamation-triangle" /> If your test suites require
+`experimentalWebKitSupport`, `injectDocumentDomain` must be set to `true`.
 
-<Icon name="exclamation-triangle" /> Chrome may remove support for `document.domain`
-at any time; if this configuration option is enabled, Cypress may cease to work in
-Chrome at any time. If this occurs, Chrome will raise an issue in its developer tools
-indicating that the deprecated `document.domain` is in use. To resolve this issue,
-set the `injectDocumentDomain` option to `false` and issue any newly necessary `cy.origin()`
-commands.
+<Icon name="exclamation-triangle" /> Chrome may remove support for
+`document.domain` at any time; if this configuration option is enabled, Cypress
+may cease to work in Chrome at any time. If this occurs, Chrome will raise an
+issue in its developer tools indicating that the deprecated `document.domain` is
+in use. To resolve this issue, set the `injectDocumentDomain` option to `false`
+and issue any newly necessary `cy.origin()` commands.
 
 :::
 
@@ -1097,7 +1098,8 @@ in the fourth.
 
 Here's a simplified example of such a test strategy.
 
-<Badge type="danger">Before</Badge> Multiple small tests against different origins
+<Badge type="danger">Before</Badge> Multiple small tests against different
+origins
 
 ```js
 it('logs in', () => {


### PR DESCRIPTION
## Summary

- Updates documentation to reflect the breaking change in [cypress-io/cypress#33784](https://github.com/cypress-io/cypress/pull/33784) where the default `keystrokeDelay` for `cy.type()` changed from `10` to `0`
- Adds changelog entry, migration guide section, and updates API reference pages

## Changes

- **`docs/api/commands/type.mdx`** — Updated `delay` option default from `10` to `0`, rewrote "Mimic user typing behavior" section, added 16.0.0 History entry
- **`docs/api/cypress-api/keyboard-api.mdx`** — Updated `keystrokeDelay` default from `10` to `0`, removed "Remove the keystroke delay" example (now the default), updated test config examples to show adding delay instead of removing it
- **`docs/app/references/changelog.mdx`** — Added breaking change entry under 16.0.0
- **`docs/app/references/migration-guide.mdx`** — Added migration section with three approaches to restore old behavior (config, `Cypress.Keyboard.defaults()`, per-command `delay` option)

## Test plan

- [x] Verify `type.mdx` options table shows `delay` default as `0`
- [x] Verify `keyboard-api.mdx` shows `keystrokeDelay` default as `0`
- [x] Verify changelog entry renders correctly under 16.0.0 breaking changes
- [x] Verify migration guide section renders with config example, Keyboard API example, and per-command example

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are documentation-only; main risk is minor confusion if wording/examples around restoring delays are incorrect.
> 
> **Overview**
> Documents the **breaking change** that typing now defaults to *no per-keystroke delay* (`delay`/`keystrokeDelay`: `0` instead of `10`).
> 
> Updates the `.type()` and `Cypress.Keyboard` API pages and examples to show adding delays explicitly, adds a `16.0.0` `.type()` history entry, and adds changelog + migration-guide guidance on restoring the old 10ms behavior via config, `Cypress.Keyboard.defaults()`, or per-command `delay`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf74f1fe68c026a3cbcc8e8d92b40c9593608766. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->