### PR TITLE
Update AI skill description for accuracy

### DIFF
--- a/docs/app/tooling/ai-skills.mdx
+++ b/docs/app/tooling/ai-skills.mdx
@@ -70,7 +70,7 @@ Beyond what a generic AI tool knows, this skill:
 
 - **Searches official sources first.** It routes queries to the correct section of docs.cypress.io — commands, guides, configuration, error messages — before your model reaches for Cypress data it already knows, which may be outdated.
 - **Uses LLM-optimized documentation.** The skill fetches structured Markdown content from `/llm/*` paths on docs.cypress.io, giving cleaner and more reliable results than scraping HTML.
-- **Refuses to guess.** If a claim cannot be verified in official docs, it says so rather than inventing an API or behavior — reducing the chance of a confident but incorrect answer.
+- **Grounded in docs, not training data.** If a claim cannot be verified in official docs, it says so rather than inventing an API or behavior — reducing the chance of a confident but incorrect answer.
 - **Version-aware.** When a Cypress version is detected in your project, it scopes answers to what is actually available in that version and calls out differences explicitly.
 
 ### [`cypress-explain`](https://github.com/cypress-io/ai-toolkit/tree/main/skills/cypress-explain)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change that rephrases a bullet point; no runtime or API behavior is affected.
> 
> **Overview**
> Updates `docs/app/tooling/ai-skills.mdx` to refine the `cypress-docs` skill description, replacing the “Refuses to guess” wording with a clearer **“Grounded in docs, not training data”** statement about only making claims that can be verified in official Cypress docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bb633dccca8b9ddc48a6de57572e37e396fab29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->