### PR TITLE
docs: Cypress 16 CT (Vite 8), migration guide, and changelog

### DIFF
--- a/docs/app/component-testing/get-started.mdx
+++ b/docs/app/component-testing/get-started.mdx
@@ -42,13 +42,13 @@ following development servers and frameworks:
 
 | Framework                                                                                                          | UI Library  | Bundler   |
 | ------------------------------------------------------------------------------------------------------------------ | ----------- | --------- |
-| [React with Vite](/app/component-testing/react/overview#React-with-Vite)                                           | React 18-19 | Vite 5-8  |
+| [React with Vite](/app/component-testing/react/overview#React-with-Vite)                                           | React 18-19 | Vite 8    |
 | [React with Webpack](/app/component-testing/react/overview#React-with-Webpack)                                     | React 18-19 | Webpack 5 |
 | [Next.js 15-16](/app/component-testing/react/overview#Nextjs)                                                      | React 18-19 | Webpack 5 |
-| [Vue with Vite](/app/component-testing/vue/overview#Vue-with-Vite)                                                 | Vue 3       | Vite 5-8  |
+| [Vue with Vite](/app/component-testing/vue/overview#Vue-with-Vite)                                                 | Vue 3       | Vite 8    |
 | [Vue with Webpack](/app/component-testing/vue/overview#Vue-with-Webpack)                                           | Vue 3       | Webpack 5 |
 | [Angular](/app/component-testing/angular/overview#Framework-Configuration)                                         | Angular 21  | Webpack 5 |
-| [Svelte with Vite](/app/component-testing/svelte/overview#Svelte-with-Vite) <Badge type="info">Alpha</Badge>       | Svelte 5    | Vite 5-8  |
+| [Svelte with Vite](/app/component-testing/svelte/overview#Svelte-with-Vite) <Badge type="info">Alpha</Badge>       | Svelte 5    | Vite 8    |
 | [Svelte with Webpack](/app/component-testing/svelte/overview#Svelte-with-Webpack) <Badge type="info">Alpha</Badge> | Svelte 5    | Webpack 5 |
 
 The following integrations are built and maintained by Cypress community members.

--- a/docs/app/component-testing/react/overview.mdx
+++ b/docs/app/component-testing/react/overview.mdx
@@ -70,7 +70,7 @@ are for reference purposes.
 
 ### React with Vite
 
-Cypress Component Testing works with React apps that use Vite 5+ as the bundler.
+Cypress Component Testing works with React apps that use Vite `8.x` as the bundler.
 
 #### Vite Configuration
 

--- a/docs/app/component-testing/svelte/overview.mdx
+++ b/docs/app/component-testing/svelte/overview.mdx
@@ -76,7 +76,7 @@ properly. The examples below are for reference purposes.
 
 ### Svelte with Vite
 
-Cypress Component Testing works with Svelte apps that use Vite 5+ as the
+Cypress Component Testing works with Svelte apps that use Vite `8.x` as the
 bundler.
 
 #### Vite Configuration
@@ -98,7 +98,7 @@ bundler.
 
 #### Svelte Vite Sample Apps
 
-- [Svelte 5 Vite with Typescript](https://github.com/cypress-io/cypress-component-testing-apps/tree/main/svelte-vite-ts)
+- [Svelte 5 with Vite and TypeScript](https://github.com/cypress-io/cypress-component-testing-apps/tree/main/svelte-vite-ts)
 
 ### Svelte with Webpack
 

--- a/docs/app/component-testing/vue/overview.mdx
+++ b/docs/app/component-testing/vue/overview.mdx
@@ -68,7 +68,7 @@ and configure them properly. The examples below are for reference purposes.
 
 ### Vue with Vite
 
-Cypress Component Testing works with Vue apps that use Vite 5+ as the bundler.
+Cypress Component Testing works with Vue apps that use Vite `8.x` as the bundler.
 
 #### Vite Configuration
 

--- a/docs/app/references/changelog.mdx
+++ b/docs/app/references/changelog.mdx
@@ -23,11 +23,13 @@ Refer to the [16 Migration Guide](/app/references/migration-guide#Migrating-to-C
 - Removed support for Node.js 20 and Node.js 25. Addresses [#33705](https://github.com/cypress-io/cypress/issues/33705) and [#33778](https://github.com/cypress-io/cypress/issues/33778).
 - **Component Testing breaking changes:**
   - Angular
-    - Removed support for Angular 18, 19, and 20. The minimum supported version is now `21.0.0`.
-    - `cypress/angular-zoneless` has been merged upstream into `cypress/angular`. In a corresponding change, the `@cypress/angular-zoneless` npm package is deprecated and no longer supported and `cypress/angular-zoneless` is no longer shipped with the Cypress binary.
+    - Removed support for Angular 18, 19, and 20. The minimum supported version is now `21.0.0`. Addresses [#33005](https://github.com/cypress-io/cypress/issues/33005), [#33655](https://github.com/cypress-io/cypress/issues/33655), and [#33656](https://github.com/cypress-io/cypress/issues/33656).
+    - `cypress/angular-zoneless` has been merged upstream into `cypress/angular`. In a corresponding change, the `@cypress/angular-zoneless` npm package is deprecated and no longer supported and `cypress/angular-zoneless` is no longer shipped with the Cypress binary. Addresses [#33007](https://github.com/cypress-io/cypress/issues/33007).
     - The zoneless testing harness is now the default in `cypress/angular`. `zone.js` is no longer required to be installed for your Cypress project.
-    - `@angular/platform-browser-dynamic` has been replaced with `@angular/platform-browser`.
+    - `@angular/platform-browser-dynamic` has been replaced with `@angular/platform-browser`. Addresses [#33006](https://github.com/cypress-io/cypress/issues/33006).
     - `autoSpyOutputs` and `autoDetectChanges` have been removed from `cypress/angular`.
+  - Vite
+    - Removed support for Vite 5, Vite 6, and Vite 7 when using the Vite dev server for component testing. The minimum supported Vite version is now `8.0.0`. Upgrade Vite (and any `@vitejs/*` plugins that pin older major versions) before upgrading Cypress. Addresses [#33724](https://github.com/cypress-io/cypress/issues/33724), [#33725](https://github.com/cypress-io/cypress/issues/33725), and [#33726](https://github.com/cypress-io/cypress/issues/33726).
 - The default `keystrokeDelay` for [`cy.type()`](/api/commands/type) has been changed from `10` to `0` to improve performance of typing-heavy test runs. Users who relied on the implicit 10ms delay can restore it by setting `keystrokeDelay: 10` in their Cypress config or via [`Cypress.Keyboard.defaults()`](/api/cypress-api/keyboard-api). Addresses [#33523](https://github.com/cypress-io/cypress/issues/33523).
 
 ## 15.15.0

--- a/docs/app/references/migration-guide.mdx
+++ b/docs/app/references/migration-guide.mdx
@@ -18,7 +18,39 @@ version 16.0.
 
 Cypress 16 requires [Node.js](https://nodejs.org/en) **22.x**, **24.x**, or **26.x and above** to install the Cypress binary. Node.js 20 and Node.js 25 are no longer supported. See [system requirements](/app/get-started/install-cypress#Nodejs) and [Node's release schedule](https://github.com/nodejs/Release).
 
-### Angular `18`, `19`, and `20` CT no longer supported
+### Default `keystrokeDelay` changed from `10` to `0`
+
+The default delay between keystrokes in [`cy.type()`](/api/commands/type) has been changed from `10` to `0` milliseconds to improve performance of typing-heavy test runs. This also affects [`Cypress.Keyboard.defaults()`](/api/cypress-api/keyboard-api), which now defaults `keystrokeDelay` to `0`.
+
+If your tests relied on the implicit 10ms delay between keystrokes, you can restore the previous behavior using any of these approaches:
+
+#### Set `keystrokeDelay` in your Cypress configuration
+
+:::cypress-config-example
+
+```ts
+{
+  keystrokeDelay: 10,
+}
+```
+
+:::
+
+#### Set `keystrokeDelay` via `Cypress.Keyboard.defaults()`
+
+```javascript
+Cypress.Keyboard.defaults({
+  keystrokeDelay: 10,
+})
+```
+
+#### Set `delay` per command
+
+```javascript
+cy.get('input').type('slow typing', { delay: 10 })
+```
+
+### Angular `18`, `19`, and `20` are no longer supported for Component Testing
 
 Angular 18 and 19 have reached [end-of-life](https://angular.dev/reference/releases#actively-supported-versions), and Angular 20 reaches LTS end in November 2026. As a result, the minimum required Angular version for component testing is now `21.0.0`.
 
@@ -66,38 +98,6 @@ import { mount } from 'cypress/angular-zoneless'
 import { mount } from 'cypress/angular'
 ```
 
-### Default `keystrokeDelay` changed from `10` to `0`
-
-The default delay between keystrokes in [`cy.type()`](/api/commands/type) has been changed from `10` to `0` milliseconds to improve performance of typing-heavy test runs. This also affects [`Cypress.Keyboard.defaults()`](/api/cypress-api/keyboard-api), which now defaults `keystrokeDelay` to `0`.
-
-If your tests relied on the implicit 10ms delay between keystrokes, you can restore the previous behavior using any of these approaches:
-
-#### Set `keystrokeDelay` in your Cypress configuration
-
-:::cypress-config-example
-
-```ts
-{
-  keystrokeDelay: 10,
-}
-```
-
-:::
-
-#### Set `keystrokeDelay` via `Cypress.Keyboard.defaults()`
-
-```javascript
-Cypress.Keyboard.defaults({
-  keystrokeDelay: 10,
-})
-```
-
-#### Set `delay` per command
-
-```javascript
-cy.get('input').type('slow typing', { delay: 10 })
-```
-
 ### `@angular/platform-browser-dynamic` has been replaced with `@angular/platform-browser`
 
 As of Cypress `16.0.0`, the `@angular/platform-browser-dynamic` package has been replaced with the `@angular/platform-browser` package.
@@ -105,6 +105,49 @@ As of Cypress `16.0.0`, the `@angular/platform-browser-dynamic` package has been
 This is because the `@angular/platform-browser-dynamic` package is deprecated and no longer the default.
 
 To migrate, nothing additional is required as Angular 21 uses `@angular/platform-browser` by default. You can likely uninstall the `@angular/platform-browser-dynamic` package from your project dependencies.
+
+### Vite `5`, `6`, and `7` are no longer supported for Component Testing
+
+As of Cypress `16.0.0`, [`@cypress/vite-dev-server`](https://www.npmjs.com/package/@cypress/vite-dev-server) requires **Vite `8.x`** or above for component testing. Vite `5`, `6`, and `7` are no longer supported when Cypress resolves the Vite version installed in your project.
+
+If an unsupported Vite version is detected, Cypress throws `ViteVersionNotSupportedError`:
+
+```text
+ViteVersionNotSupportedError: Vite 8 is the required version to use cypress/vite-dev-server. Found Vite version v<your-version>
+```
+
+The recommended path is to upgrade your project to Vite `8`.
+
+#### To continue using Vite `5` through `7`
+
+If you are upgrading to Cypress `16` but still need Vite `5`, `6`, or `7` for component testing, install `7.x` of `@cypress/vite-dev-server` from `npm` and configure it explicitly as the dev server:
+
+```sh
+npm install --save-dev @cypress/vite-dev-server@7
+```
+
+Then configure the `devServer` in your `cypress.config.js` or `cypress.config.ts` file:
+
+```js
+import { defineConfig } from 'cypress'
+import { devServer } from '@cypress/vite-dev-server'
+
+export default defineConfig({
+  component: {
+    devServer(devServerConfig) {
+      return devServer({
+        ...devServerConfig,
+        framework: '<YOUR_FRAMEWORK>',
+        bundler: 'vite',
+      })
+    },
+  },
+})
+```
+
+Change `<YOUR_FRAMEWORK>>` to `'react'`, `'vue'`, `'svelte'`, or another [supported framework](/app/component-testing/component-framework-configuration) to match your component testing setup.
+
+Note that `@cypress/vite-dev-server@7` is deprecated and no longer supported by Cypress. It is intended as a temporary workaround until you can migrate to Vite `8`. More information on configuring a custom dev server can be found in the [Cypress Vite Dev Server documentation](https://github.com/cypress-io/cypress/blob/@cypress/vite-dev-server-v7.2.1/npm/vite-dev-server/README.md).
 
 ## Migrating away from Cypress.env()
 


### PR DESCRIPTION
## Summary

This pull request updates documentation for Cypress **16.0** on the documentation release branch.

### Component testing
- State **Vite `8.x`** as the supported Vite major line in the [get started](/app/component-testing/get-started) supported-frameworks table and in the React, Vue, and Svelte component testing overviews (replacing prior Vite 5–8 / 5+ wording).

### Migration guide
- Cypress 16 migration updates, including default `keystrokeDelay` being moved to the top (away from CT), Angular component testing  issues linked, and **Vite 5–7** no longer being supported for the Vite dev server (with optional legacy `@cypress/vite-dev-server@7` workaround documented).

### Changelog
- Add GitHub issue references to relevant **16.0** breaking-change bullets.

---

**Target branch:** `release/16.0.0`

Made with [Cursor](https://cursor.com)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are documentation-only, but they describe breaking support changes (Vite/Angular) where accuracy matters for user upgrades.
> 
> **Overview**
> Updates Component Testing docs to state **Vite `8.x` is the required/supported major** for React/Vue/Svelte CT (including the supported-frameworks table), replacing prior “Vite 5+ / 5–8” wording and fixing a Svelte sample-app link label.
> 
> Expands Cypress 16 docs to better surface migration impacts: adds a new migration section for **Vite 5–7 no longer supported** (with an optional `@cypress/vite-dev-server@7` workaround and example config), moves the `keystrokeDelay` default change earlier in the migration guide, and adds issue references to the 16.0 changelog breaking-change bullets (Angular and Vite).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fc782975321d8b241bc6673a5458650bba62c20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->