### PR TITLE
docs: fix Vue and Svelte CT webpack copy

### DIFF
--- a/docs/app/component-testing/svelte/overview.mdx
+++ b/docs/app/component-testing/svelte/overview.mdx
@@ -98,11 +98,11 @@ bundler.
 
 #### Svelte Vite Sample Apps
 
-- [Svelte 5 Vite 6 with Typescript](https://github.com/cypress-io/cypress-component-testing-apps/tree/main/svelte-vite-ts)
+- [Svelte 5 Vite with Typescript](https://github.com/cypress-io/cypress-component-testing-apps/tree/main/svelte-vite-ts)
 
 ### Svelte with Webpack
 
-Cypress Component Testing works with Vue apps that use Webpack 4+ as the
+Cypress Component Testing works with Svelte apps that use Webpack 5+ as the
 bundler.
 
 #### Webpack Configuration

--- a/docs/app/component-testing/vue/overview.mdx
+++ b/docs/app/component-testing/vue/overview.mdx
@@ -93,7 +93,7 @@ Cypress Component Testing works with Vue apps that use Vite 5+ as the bundler.
 
 ### Vue with Webpack
 
-Cypress Component Testing works with Vue apps that use Webpack 4+ as the
+Cypress Component Testing works with Vue apps that use Webpack 5+ as the
 bundler.
 
 #### Webpack Configuration


### PR DESCRIPTION
## Summary

Small corrections to the **Vue** and **Svelte** component testing overviews:

- Use **Webpack 5+** instead of Webpack 4+ to match current supported bundlers.
- In the Svelte + Webpack section, describe **Svelte** apps (the text incorrectly said Vue).
- Adjust the Svelte Vite sample app link label so it is not tied to a specific Vite major.

## Motivation

Documentation accuracy for teams shipping component testing guidance.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that corrects bundler requirements and framework wording; no runtime or API behavior is affected.
> 
> **Overview**
> Updates the Vue and Svelte component testing overviews to state **Webpack 5+** (not 4+) as the supported bundler for CT.
> 
> Fixes Svelte’s Webpack section copy to reference **Svelte** (not Vue), and tweaks the Svelte Vite sample app link text to be less tied to a specific Vite major.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17d63dfe5c67cefeed24e25645a422748fc54382. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->