### PR TITLE
docs: add ECDSA client certificates support for 15.15.1

### DIFF
--- a/docs/app/references/changelog.mdx
+++ b/docs/app/references/changelog.mdx
@@ -8,6 +8,14 @@ sidebar_label: Changelog
 
 # Changelog
 
+## 15.15.1
+
+_Released TBD_
+
+**Bugfixes:**
+
+- Fixed an issue where the [`clientCertificates`](/app/references/client-certificates) config option failed to load ECDSA (EC) PEM or PKCS#12 client certificates at startup with `Cannot parse PEM cert: ... OID is not RSA.` Cert and key validation now goes through Node's built-in `crypto` and `tls` primitives, which accept both RSA and ECDSA keys. RSA certificates continue to work unchanged. Fixes [#33767](https://github.com/cypress-io/cypress/issues/33767). Fixed in [#33799](https://github.com/cypress-io/cypress/pull/33799).
+
 ## 15.15.0
 
 _Released May 12, 2026_

--- a/docs/app/references/changelog.mdx
+++ b/docs/app/references/changelog.mdx
@@ -8,14 +8,6 @@ sidebar_label: Changelog
 
 # Changelog
 
-## 15.15.1
-
-_Released TBD_
-
-**Bugfixes:**
-
-- Fixed an issue where the [`clientCertificates`](/app/references/client-certificates) config option failed to load ECDSA (EC) PEM or PKCS#12 client certificates at startup with `Cannot parse PEM cert: ... OID is not RSA.` Cert and key validation now goes through Node's built-in `crypto` and `tls` primitives, which accept both RSA and ECDSA keys. RSA certificates continue to work unchanged. Fixes [#33767](https://github.com/cypress-io/cypress/issues/33767). Fixed in [#33799](https://github.com/cypress-io/cypress/pull/33799).
-
 ## 15.15.0
 
 _Released May 12, 2026_

--- a/docs/app/references/changelog.mdx
+++ b/docs/app/references/changelog.mdx
@@ -8,6 +8,10 @@ sidebar_label: Changelog
 
 # Changelog
 
+## 15.15.1
+
+_Released TBD_
+
 ## 15.15.0
 
 _Released May 12, 2026_

--- a/docs/app/references/client-certificates.mdx
+++ b/docs/app/references/client-certificates.mdx
@@ -35,7 +35,8 @@ following properties
 | `certs`  | `Object[]` | A PEM format certificate/private key pair or PFX certificate container                                                   |
 
 Each object in the `certs` array can define either a **PEM format
-certificate/private key pair** or a **PFX certificate container**.
+certificate/private key pair** or a **PFX certificate container**. Both **RSA**
+and **ECDSA (EC)** keys are supported.
 
 **A PEM format certificate/private key pair can have the following properties:**
 
@@ -102,6 +103,7 @@ shown below:
 
 ## History
 
-| Version                                  | Changes                                         |
-| ---------------------------------------- | ----------------------------------------------- |
-| [8.0.0](/app/references/changelog#8-0-0) | Added Client Certificates configuration options |
+| Version                                      | Changes                                                                       |
+| -------------------------------------------- | ----------------------------------------------------------------------------- |
+| [15.15.1](/app/references/changelog#15-15-1) | Added support for ECDSA (EC) keys in PEM and PFX client certificates          |
+| [8.0.0](/app/references/changelog#8-0-0)     | Added Client Certificates configuration options                               |

--- a/docs/app/references/client-certificates.mdx
+++ b/docs/app/references/client-certificates.mdx
@@ -103,7 +103,7 @@ shown below:
 
 ## History
 
-| Version                                      | Changes                                                                       |
-| -------------------------------------------- | ----------------------------------------------------------------------------- |
-| [15.15.1](/app/references/changelog#15-15-1) | Added support for ECDSA (EC) keys in PEM and PFX client certificates          |
-| [8.0.0](/app/references/changelog#8-0-0)     | Added Client Certificates configuration options                               |
+| Version                                      | Changes                                                              |
+| -------------------------------------------- | -------------------------------------------------------------------- |
+| [15.15.1](/app/references/changelog#15-15-1) | Added support for ECDSA (EC) keys in PEM and PFX client certificates |
+| [8.0.0](/app/references/changelog#8-0-0)     | Added Client Certificates configuration options                      |


### PR DESCRIPTION
## Summary

Documents the [cypress-io/cypress#33799](https://github.com/cypress-io/cypress/pull/33799) fix for [cypress-io/cypress#33767](https://github.com/cypress-io/cypress/issues/33767), which allows `clientCertificates` to load **ECDSA (EC)** PEM and PKCS#12 client certificates (in addition to RSA).

### Changes

- **`docs/app/references/client-certificates.mdx`**:
  - Adds an explicit note that both **RSA** and **ECDSA (EC)** keys are supported in the `certs` section.
  - Adds a History table row for `15.15.1`.

The matching `changelog.mdx` entry will be added separately when 15.15.1 is released.

## Test plan

- [x] Build the docs locally and verify the `Client Certificates` page renders the new "Both RSA and ECDSA (EC) keys are supported" line and the new History row.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates adding release notes and clarifying supported client certificate key types; no runtime or security-sensitive code paths change.
> 
> **Overview**
> Adds a new `15.15.1` section to the app changelog with a placeholder release date.
> 
> Updates the `Client Certificates` reference to explicitly state that both **RSA** and **ECDSA (EC)** keys are supported for PEM and PFX/PKCS#12 certificates, and records the change in the page’s History table linked to `15.15.1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54f3aec66b28d4bfe81b8777b7115859c0799cd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->