### PR TITLE
docs: remove cypress-watch-preprocessor support

### DIFF
--- a/docs/api/node-events/preprocessors-api.mdx
+++ b/docs/api/node-events/preprocessors-api.mdx
@@ -21,14 +21,13 @@ them again, and then notifies Cypress to re-run the tests.
 
 ## Examples
 
-We've created three preprocessors as examples for you to look at. These are
+We've created some example preprocessors as reference for you to look at. These are
 fully functioning preprocessors.
 
 The code contains comments that explain how it utilizes the preprocessor API.
 
 - [webpack preprocessor](https://github.com/cypress-io/cypress/tree/develop/npm/webpack-preprocessor)
 - [Browserify preprocessor](https://github.com/cypress-io/cypress-browserify-preprocessor)
-- [Watch preprocessor](https://github.com/cypress-io/cypress-watch-preprocessor)
 
 ## Defaults
 

--- a/docs/app/core-concepts/writing-and-organizing-tests.mdx
+++ b/docs/app/core-concepts/writing-and-organizing-tests.mdx
@@ -970,5 +970,4 @@ a change.
 Cypress also ships other [file-watching preprocessors](/app/plugins/plugins-list) -
 you'll have to configure these explicitly if you want to use them.
 
-- [Cypress Watch Preprocessor](https://github.com/cypress-io/cypress-watch-preprocessor)
 - [Cypress webpack Preprocessor](https://github.com/cypress-io/cypress/tree/develop/npm/webpack-preprocessor)

--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -12,13 +12,6 @@
           "badge": "official"
         },
         {
-          "name": "Watch",
-          "description": "Watches your spec files and serves them as-is. Useful as an example reference or if you don't need transpiling/bundling.",
-          "link": "https://github.com/cypress-io/cypress-watch-preprocessor",
-          "keywords": ["file-watcher"],
-          "badge": "official"
-        },
-        {
           "name": "Cucumber",
           "description": "Run cucumber/gherkin-syntaxed specs with cypress.io.",
           "link": "https://github.com/badeball/cypress-cucumber-preprocessor",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation/data-only change that removes references to an official preprocessor; main risk is broken links or missing guidance for users relying on that plugin.
> 
> **Overview**
> Removes `cypress-watch-preprocessor` from the docs and plugin listings, so it’s no longer presented as an official/available file-watching preprocessor.
> 
> Updates the Preprocessors API “Examples” section and the file-watching guidance in “Writing and Organizing Tests” to drop the watch-preprocessor link and slightly reword the examples text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f59bcc71b5e71f3e10f8b6bd41a7dee0af728117. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->