### PR TITLE
Bump lowest supported to Fedora Linux 43

### DIFF
--- a/docs/app/get-started/install-cypress.mdx
+++ b/docs/app/get-started/install-cypress.mdx
@@ -43,7 +43,7 @@ Cypress supports running under these operating systems:
 - **Linux** _(x64 or arm64)_ see also [Linux Prerequisites](#Linux-Prerequisites) down below
   - Ubuntu >=22.04
   - Debian >=11
-  - Fedora >=42
+  - Fedora >=43
 - **Windows** 10 & 11 _(x64)_
 - **Windows** 11 25H2 _(arm64, runs in [x64 emulation](https://learn.microsoft.com/en-us/windows/arm/apps-on-arm-x86-emulation) mode, minimum Cypress [14.5.0](/app/references/changelog#14-5-0) required)_ - preview status
 - **Windows Server** 2019, 2022 and 2025 _(x64)_


### PR DESCRIPTION
## Situation

The [Fedora Linux Release Life Cycle](https://docs.fedoraproject.org/en-US/releases/lifecycle/) says:

> The Fedora Project releases a new version of Fedora Linux approximately every six months and provides updated packages (maintenance) to these releases for approximately 13 months.

- [F44 announcement](https://www.redhat.com/en/blog/announcing-fedora-44), released Apr 28, 2026
- [F44 schedule with F42 EOL](https://fedorapeople.org/groups/schedule/f-44/f-44-key-tasks.html),  May 13, 2026

Reference [Fedora End of Life Releases](https://docs.fedoraproject.org/en-US/releases/eol/)

## Change

In the section [Install Cypress > Operating System](https://docs.cypress.io/app/get-started/install-cypress#Operating-System):

- Change the lowest supported version of Fedora Linux from `42` to `43`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates stated OS requirements without affecting product code or runtime behavior.
> 
> **Overview**
> Updates the *Install Cypress* system requirements documentation to reflect **Fedora Linux >=43** as the minimum supported Fedora version (previously 42).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a97e7c456c6d3eb38f575b694c151a4091039688. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->