### PR TITLE
docs(plugins): add cypress-real-dnd (real HTML5 drag-and-drop via CDP)

### DIFF
--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -506,6 +506,22 @@
           "badge": "community"
         },
         {
+          "name": "cypress-real-dnd",
+          "description": "Real HTML5 drag-and-drop via Chrome DevTools Protocol. Triggers the actual dragstart → dragover → drop pipeline, so it works with react-dnd, Sortable.js, dnd-kit's HTML5 sensor, and plain `draggable=\"true\"` elements where synthetic-event and pointer-event plugins do not.",
+          "link": "https://github.com/emidhun/cypress-real-dnd",
+          "keywords": [
+            "dragndrop",
+            "drag-and-drop",
+            "drag",
+            "drop",
+            "react-dnd",
+            "html5",
+            "cdp",
+            "commands"
+          ],
+          "badge": "community"
+        },
+        {
           "name": "cypress-fill-command",
           "description": "A Cypress command for fill inputs.",
           "link": "https://github.com/DanielFerrariR/cypress-fill-command",


### PR DESCRIPTION
## Summary

Adds `cypress-real-dnd` to the **Custom Commands** section, alongside the other drag-and-drop plugins (`cypress-drag-drop`, `cypress-dragndrop-kit`).

`cypress-real-dnd` drives a real HTML5 drag-and-drop via Chrome DevTools Protocol — capturing `Input.dragIntercepted` and replaying it at the target with `Input.dispatchDragEvent`. Unlike synthetic-event or mouse-event-only plugins, it actually triggers the browser's native `dragstart → dragover → drop` pipeline, which is what libraries like `react-dnd`, Sortable.js, and `dnd-kit`'s HTML5 sensor listen on.

- npm: https://www.npmjs.com/package/cypress-real-dnd
- repo: https://github.com/emidhun/cypress-real-dnd
- License: MIT
- Badge: `community`

## Test plan

- [x] Entry validates as JSON (`node -e "JSON.parse(require('fs').readFileSync('src/data/plugins.json'))"`)
- [x] Package is published to npm and resolves at the link above
- [x] Entry placed adjacent to existing drag-and-drop plugins in the Custom Commands section