### PR TITLE
docs: add Cypress.metadata API documentation for 15.16.0

### DIFF
--- a/docs/api/cypress-api/metadata.mdx
+++ b/docs/api/cypress-api/metadata.mdx
@@ -1,0 +1,213 @@
+---
+title: 'Cypress.metadata | Cypress Documentation'
+description: 'Store arbitrary per-test state in Cypress with Cypress.metadata. Set values at runtime or via suite and test config overrides.'
+sidebar_label: metadata
+sidebar_position: 125
+sidebar_custom_props: { 'new_label': true }
+---
+
+<ProductHeading product="app" />
+
+# Cypress.metadata
+
+Store arbitrary per-test state in your spec.
+
+`Cypress.metadata` is a spec-scoped [`Map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) intended primarily for **plugin authors** who need a convenient place to keep internal state during one test run. Because metadata persists through [hooks](/app/core-concepts/writing-and-organizing-tests#Hooks), plugins can set values in `beforeEach`, read them in the test body, and clean up in `afterEach` without routing that state through [`Cypress.config()`](/api/cypress-api/config) or [`Cypress.expose()`](/api/cypress-api/expose).
+
+:::info
+
+<strong>Primary use case</strong>
+
+Most test authors do not need `Cypress.metadata` directly. Plugins and preprocessors use it to pass per-test context between hooks and the test body within the same test.
+
+:::
+
+:::info
+
+<strong>Scope</strong>
+
+`Cypress.metadata` is scoped to the current spec file in the primary origin. Cypress runs each spec in isolation, so metadata does not carry over to other spec files (unless `experimentalSingleTabRunMode` is enabled). Values are meant to live for a single test (including its hooks), not as long-lived shared configuration.
+
+:::
+
+## Syntax
+
+`Cypress.metadata` exposes the standard `Map` API:
+
+```javascript
+Cypress.metadata.get(key)
+Cypress.metadata.set(key, value)
+Cypress.metadata.has(key)
+Cypress.metadata.delete(key)
+Cypress.metadata.clear()
+```
+
+### Arguments
+
+<Icon name="angle-right" /> **key _(String)_**
+
+The metadata key to get, set, check, or delete.
+
+<Icon name="angle-right" /> **value _(any)_**
+
+The value to store for the given key. Values can be any type, including objects and arrays.
+
+## Examples
+
+### Share state between hooks and the test body
+
+A common plugin pattern is to prepare context in a hook, use it during the test, and remove it afterward:
+
+```javascript
+const key = '@my-plugin/context'
+
+beforeEach(() => {
+  Cypress.metadata.set(key, { feature: 'checkout', step: 'login' })
+})
+
+afterEach(() => {
+  Cypress.metadata.delete(key)
+})
+
+it('completes checkout', () => {
+  const context = Cypress.metadata.get(key)
+
+  expect(context).to.deep.eq({ feature: 'checkout', step: 'login' })
+})
+```
+
+### Set and read metadata at runtime
+
+Plugins can also read or update metadata anywhere during a test:
+
+```javascript
+it('stores plugin context', () => {
+  Cypress.metadata.set('@my-plugin/feature', {
+    enabled: true,
+    name: 'checkout',
+  })
+
+  expect(Cypress.metadata.get('@my-plugin/feature')).to.deep.eq({
+    enabled: true,
+    name: 'checkout',
+  })
+})
+```
+
+### Declare metadata with test configuration
+
+Plugins and preprocessors can also pass a `metadata` object as part of suite- or test-level [test configuration](/app/references/configuration#Test-Configuration). This is useful when a plugin injects per-test context through `describe()` or `it()` config. Override keys are applied at test start and restored after the test completes.
+
+```javascript
+describe('checkout', { metadata: { flow: 'guest' } }, () => {
+  it('applies suite metadata', () => {
+    expect(Cypress.metadata.get('flow')).to.eq('guest')
+  })
+
+  it(
+    'merges test-level metadata with suite metadata',
+    { metadata: { step: 'payment' } },
+    () => {
+      expect(Cypress.metadata.get('flow')).to.eq('guest')
+      expect(Cypress.metadata.get('step')).to.eq('payment')
+    }
+  )
+})
+```
+
+When suite- and test-level metadata define the same key, the test-level value takes precedence:
+
+```javascript
+describe('orders', { metadata: { status: 'pending' } }, () => {
+  it('uses the test-level value', { metadata: { status: 'complete' } }, () => {
+    expect(Cypress.metadata.get('status')).to.eq('complete')
+  })
+})
+```
+
+### Metadata persists through hooks
+
+Values set in hooks remain available for the rest of the test, including `afterEach` and `after` hooks. Only keys declared in test configuration overrides are restored after each test.
+
+```javascript
+describe('hook lifecycle', { metadata: { source: 'suite' } }, () => {
+  beforeEach(() => {
+    Cypress.metadata.set('source', 'beforeEach')
+  })
+
+  afterEach(() => {
+    expect(Cypress.metadata.get('source')).to.eq('beforeEach')
+  })
+
+  it('sees hook mutations during the test body', () => {
+    expect(Cypress.metadata.get('source')).to.eq('beforeEach')
+  })
+})
+```
+
+### Clear metadata during a test
+
+Call `Cypress.metadata.clear()` to remove all entries from the map.
+
+:::caution
+
+<strong>Shared state</strong>
+
+`Cypress.metadata` is a single map shared by every plugin and test in the spec. Calling `clear()` removes **all** metadata, not just keys your code set. If another plugin or hook still expects its entries to exist, those values will be missing and can cause state collisions or flaky failures.
+
+Prefer deleting only the keys you own with `Cypress.metadata.delete(key)` instead of clearing the entire map.
+
+:::
+
+```javascript
+it('clears metadata', { metadata: { token: 'abc' } }, () => {
+  expect(Cypress.metadata.has('token')).to.be.true
+  Cypress.metadata.clear()
+  expect(Cypress.metadata.has('token')).to.be.false
+})
+```
+
+When multiple plugins use metadata in the same spec, namespace your keys (for example, `@my-plugin/context`) and clean up with `delete()`:
+
+```javascript
+const key = '@my-plugin/context'
+
+Cypress.metadata.set(key, { step: 'login' })
+// ... later in the same test or hook
+Cypress.metadata.delete(key)
+```
+
+## Notes
+
+### Test configuration overrides vs runtime changes
+
+Metadata declared in suite or test configuration is applied at test start. After the test finishes, only the overridden keys are restored to their previous values.
+
+Values set at runtime with `Cypress.metadata.set()` outside of test configuration overrides are not automatically restored between tests. Plugin authors should clean up their own keys with `Cypress.metadata.delete(key)`. Avoid `Cypress.metadata.clear()` unless you control all metadata usage in the spec, since it removes entries other plugins may still depend on.
+
+### Not available in `cy.origin()` by default
+
+`Cypress.metadata` is not serialized into [`cy.origin()`](/api/commands/origin) callbacks by default. Secondary origins do not automatically receive metadata from the primary origin.
+
+### When to use `Cypress.metadata`
+
+`Cypress.metadata` is for **internal plugin state** during a single test. Typical examples include:
+
+- A preprocessor storing context for the current example so hooks and step definitions can read it
+- Sharing temporary values between a plugin's `beforeEach` hook and the test body
+- Keeping plugin bookkeeping out of Cypress configuration APIs
+
+This API is not a replacement for user-facing configuration. For public values that application code may read, use [`Cypress.expose()`](/api/cypress-api/expose). For sensitive values, use [`cy.env()`](/api/commands/env).
+
+## History
+
+| Version                                      | Changes                      |
+| -------------------------------------------- | ---------------------------- |
+| [15.16.0](/app/references/changelog#15-16-0) | `Cypress.metadata` API added |
+
+## See also
+
+- [Test Configuration](/app/references/configuration#Test-Configuration)
+- [`Cypress.config()`](/api/cypress-api/config)
+- [`Cypress.expose()`](/api/cypress-api/expose)
+- [`cy.env()`](/api/commands/env)

--- a/docs/api/table-of-contents.mdx
+++ b/docs/api/table-of-contents.mdx
@@ -206,6 +206,7 @@ later time.
 | [`Cypress.ElementSelector`](/api/cypress-api/element-selector-api)             | Configure selector priority used by [Cypress Studio](/app/guides/cypress-studio) and [cy.prompt()](/api/commands/prompt).      |
 | [`Cypress.env`](/api/cypress-api/env) <Badge type="caution">deprecated</Badge> | Get environment variables from inside your tests.                                                                              |
 | [`Cypress.expose`](/api/cypress-api/expose)                                    | Expose configuration values to the browser context.                                                                            |
+| [`Cypress.metadata`](/api/cypress-api/metadata)                                | Store internal plugin state across a single test in a spec-scoped `Map`.                                                       |
 | [`Cypress.isBrowser()`](/api/cypress-api/isbrowser)                            | Checks if the current browser matches the given name or filter.                                                                |
 | [`Cypress.isCy()`](/api/cypress-api/iscy)                                      | checks if a variable is a valid instance of cy or a cy chainable.                                                              |
 | [`Cypress.Keyboard.defaults()`](/api/cypress-api/keyboard-api)                 | Set default values for how the `.type()` command is executed.                                                                  |

--- a/docs/app/core-concepts/writing-and-organizing-tests.mdx
+++ b/docs/app/core-concepts/writing-and-organizing-tests.mdx
@@ -619,6 +619,9 @@ This configuration will take effect during the suite or tests where they are set
 then return to their previous default values after the suite or tests are
 complete.
 
+You can also pass a `metadata` object so plugins can declare internal per-test
+state with [`Cypress.metadata`](/api/cypress-api/metadata).
+
 #### Syntax
 
 ```javascript

--- a/docs/app/references/changelog.mdx
+++ b/docs/app/references/changelog.mdx
@@ -8,6 +8,14 @@ sidebar_label: Changelog
 
 # Changelog
 
+## 15.16.0
+
+_Released TBD_
+
+**Features:**
+
+- Added [`Cypress.metadata`](/api/cypress-api/metadata), a spec-scoped `Map<string, any>` for storing internal plugin state across a single test in the primary origin. Set values at runtime with `Cypress.metadata.set()`, or declare them in suite- or test-level config overrides (for example, `describe()`, `context()`, `it()`, or `test()`) via `{ metadata: { key: value } }`. Suite- and test-level overrides are merged, with test-level keys taking precedence; override keys are applied at test start and restored after each test without affecting unrelated values set in hooks. `Cypress.metadata` is not serialized into [`cy.origin()`](/api/commands/origin) callbacks by default. Addresses [#33356](https://github.com/cypress-io/cypress/issues/33356). Addressed in [#33871](https://github.com/cypress-io/cypress/pull/33871).
+
 ## 15.15.0
 
 _Released May 12, 2026_

--- a/docs/app/references/configuration.mdx
+++ b/docs/app/references/configuration.mdx
@@ -373,6 +373,11 @@ The configuration values passed in will only take effect during the suite or
 test where they are set. The values will then reset to the previous default
 values after the suite or test is complete.
 
+You can also pass a `metadata` object so plugins can declare internal per-test
+state with [`Cypress.metadata`](/api/cypress-api/metadata). Metadata overrides
+are merged across nested suites and tests, with test-level keys taking
+precedence.
+
 #### Syntax
 
 ```javascript


### PR DESCRIPTION
## Summary

Documents the new `Cypress.metadata` API introduced in [cypress-io/cypress#33871](https://github.com/cypress-io/cypress/pull/33871) for the Cypress 15.16.0 release.

### What `Cypress.metadata` is

`Cypress.metadata` is a spec-scoped `Map<string, any>` that lets plugin authors store internal state during a single test run. Because values persist through hooks, plugins can set context in `beforeEach`, read it in the test body, and clean up in `afterEach` without routing that state through `Cypress.config()` or `Cypress.expose()`.

Values can also be declared via suite- or test-level config overrides (`{ metadata: { key: value } }`). Suite and test overrides are merged, with test-level keys taking precedence. Override keys are applied at test start and restored after each test.

### What it is intended to do

- Give **plugin authors and preprocessors** a convenient place to keep per-test internal state
- Share values between hooks and the test body within the same test (for example, Cucumber preprocessor context for the current example)
- Support optional per-suite or per-test metadata injection through existing test config override syntax

### What it is NOT intended to do

- Replace user-facing configuration — use [`Cypress.expose()`](https://docs.cypress.io/api/cypress-api/expose) for public values application code may read
- Store sensitive data — use [`cy.env()`](https://docs.cypress.io/api/commands/env) instead
- Act as long-lived shared state across spec files — metadata is scoped to the current spec in the primary origin
- Be available in `cy.origin()` callbacks by default — metadata is not serialized into secondary origins
- Serve as a general-purpose global store for test authors — most users do not need this API directly

The docs also caution that `Cypress.metadata.clear()` removes all entries from the shared map and can cause state collisions when multiple plugins use metadata in the same spec. Plugin authors should namespace keys and prefer `delete()` for cleanup.

### Changes in this PR

- **Added** [`docs/api/cypress-api/metadata.mdx`](docs/api/cypress-api/metadata.mdx) — API reference with syntax, hook lifecycle examples, test config overrides, and plugin-author guidance
- **Updated** [`docs/api/table-of-contents.mdx`](docs/api/table-of-contents.mdx) — link in the Cypress API table
- **Updated** [`docs/app/references/configuration.mdx`](docs/app/references/configuration.mdx) — mention `metadata` test config overrides
- **Updated** [`docs/app/core-concepts/writing-and-organizing-tests.mdx`](docs/app/core-concepts/writing-and-organizing-tests.mdx) — mention `metadata` test config overrides
- **Updated** [`docs/app/references/changelog.mdx`](docs/app/references/changelog.mdx) — 15.16.0 feature entry

## Test plan

- [x] Preview the docs site locally and verify `/api/cypress-api/metadata` renders correctly
- [x] Confirm sidebar entry appears under Cypress API with the new label
- [x] Verify cross-links from configuration and writing-and-organizing-tests pages resolve


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds a new API reference page and cross-links in existing docs; no runtime behavior or code paths are modified.
> 
> **Overview**
> Adds a new API reference page for `Cypress.metadata`, describing it as a spec-scoped `Map` for plugin authors, including runtime usage, test-config override behavior, lifecycle considerations, and cautions around `clear()`.
> 
> Updates the Cypress API table of contents, the test-configuration sections in the guides (`writing-and-organizing-tests` and `configuration`), and the `15.16.0` changelog entry to link to and announce the new API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93a1a1924c4be5056a4914b2d68a35c2cd472510. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->