### PR TITLE
Fix link to Chrome command line switches

### DIFF
--- a/docs/app/references/launching-browsers.mdx
+++ b/docs/app/references/launching-browsers.mdx
@@ -471,7 +471,7 @@ browser that tend to get in the way of automated testing.
 - Disables user gesture requirements for autoplaying videos.
 
 You can see all of the default chrome command line switches we send
-[here](https://github.com/cypress-io/cypress/blob/develop/packages/server/lib/browsers/chrome.ts#L36).
+[here](https://github.com/cypress-io/cypress/blob/develop/packages/server/lib/util/chromium_flags.ts#L36).
 
 ## Browser Icon
 


### PR DESCRIPTION
Updated link to default Chrome cli flags.