### PR TITLE
docs: add `Cypress.expose()` test config overrides for 15.17.0

### DIFF
--- a/docs/api/cypress-api/expose.mdx
+++ b/docs/api/cypress-api/expose.mdx
@@ -136,6 +136,70 @@ Cypress.expose({
 Cypress.expose() // => {pluginConfig: 'updated-value', featureFlag: true}
 ```
 
+### Declare expose values with test configuration
+
+You can pass an `expose` object as part of suite- or test-level [test configuration](/app/references/configuration#Test-Configuration). This is useful when a plugin or preprocessor needs different public configuration values per suite or test.
+
+Override keys are applied at test start and restored after each test completes. Suite- and test-level overrides are merged, with test-level keys taking precedence. Values set at runtime with `Cypress.expose()` outside of test configuration overrides are not automatically restored between tests.
+
+```javascript
+describe('checkout', { expose: { flow: 'guest' } }, () => {
+  it('applies suite expose values', () => {
+    expect(Cypress.expose('flow')).to.eq('guest')
+  })
+
+  it(
+    'merges test-level expose values with suite values',
+    { expose: { step: 'payment' } },
+    () => {
+      expect(Cypress.expose('flow')).to.eq('guest')
+      expect(Cypress.expose('step')).to.eq('payment')
+    }
+  )
+})
+```
+
+When suite- and test-level expose define the same key, the test-level value takes precedence:
+
+```javascript
+describe('orders', { expose: { status: 'pending' } }, () => {
+  it('uses the test-level value', { expose: { status: 'complete' } }, () => {
+    expect(Cypress.expose('status')).to.eq('complete')
+  })
+})
+```
+
+Expose overrides persist through hooks for the current test. Only keys declared in test configuration overrides are restored after each test:
+
+```javascript
+describe('hook lifecycle', { expose: { source: 'suite' } }, () => {
+  beforeEach(() => {
+    Cypress.expose('source', 'beforeEach')
+  })
+
+  afterEach(() => {
+    expect(Cypress.expose('source')).to.eq('beforeEach')
+  })
+
+  it('sees hook mutations during the test body', () => {
+    expect(Cypress.expose('source')).to.eq('beforeEach')
+  })
+})
+```
+
+If you mutate an overridden value during a test, the next test without an override for that key sees the pre-override value again:
+
+```javascript
+it('applies the override', { expose: { token: 'override' } }, () => {
+  Cypress.expose('token', 'mutated')
+  expect(Cypress.expose('token')).to.eq('mutated')
+})
+
+it('restores the key after the override test completes', () => {
+  expect(Cypress.expose('token')).to.eq(undefined)
+})
+```
+
 ## Configuration sources
 
 Read the [Environment Variables & Secrets](/app/guides/environment-variables) guide for more details.
@@ -248,9 +312,10 @@ See [`cy.env()`](/api/commands/env) for more details.
 
 ## History
 
-| Version                                      | Changes                           |
-| -------------------------------------------- | --------------------------------- |
-| [15.10.0](/app/references/changelog#15-10-0) | `Cypress.expose()` API introduced |
+| Version                                      | Changes                                                           |
+| -------------------------------------------- | ----------------------------------------------------------------- |
+| [15.17.0](/app/references/changelog#15-17-0) | Added test configuration overrides for `Cypress.expose()` values. |
+| [15.10.0](/app/references/changelog#15-10-0) | `Cypress.expose()` API introduced                                 |
 
 ## See also
 
@@ -258,3 +323,4 @@ See [`cy.env()`](/api/commands/env) for more details.
 - [`Cypress.env()`](/api/cypress-api/env) - Deprecated API
 - [Migration Guide to `cy.env()`](/app/references/migration-guide#Migrating-away-from-Cypressenv) - Guide for migrating from `Cypress.env()`
 - [Configuration options](/app/references/configuration)
+- [Test Configuration](/app/references/configuration#Test-Configuration)

--- a/docs/app/core-concepts/writing-and-organizing-tests.mdx
+++ b/docs/app/core-concepts/writing-and-organizing-tests.mdx
@@ -619,6 +619,9 @@ This configuration will take effect during the suite or tests where they are set
 then return to their previous default values after the suite or tests are
 complete.
 
+You can also pass an `expose` object so plugins can declare public configuration
+per suite or test with [`Cypress.expose()`](/api/cypress-api/expose).
+
 #### Syntax
 
 ```javascript

--- a/docs/app/references/changelog.mdx
+++ b/docs/app/references/changelog.mdx
@@ -8,6 +8,14 @@ sidebar_label: Changelog
 
 # Changelog
 
+## 15.17.0
+
+_Released TBD_
+
+**Features:**
+
+- [`Cypress.expose()`](/api/cypress-api/expose) values can now be overridden per suite or test via test config overrides (for example, `describe()`, `context()`, `it()`, or `test()`) using `{ expose: { key: value } }`. Suite- and test-level overrides are merged, with test-level keys taking precedence; override keys are applied at test start and restored after each test without affecting unrelated values set in hooks. Addresses [#33356](https://github.com/cypress-io/cypress/issues/33356). Addressed in [#33925](https://github.com/cypress-io/cypress/pull/33925).
+
 ## 15.16.0
 
 _Released May 26, 2026_

--- a/docs/app/references/configuration.mdx
+++ b/docs/app/references/configuration.mdx
@@ -373,6 +373,12 @@ The configuration values passed in will only take effect during the suite or
 test where they are set. The values will then reset to the previous default
 values after the suite or test is complete.
 
+You can also pass an `expose` object so plugins can declare public configuration
+per suite or test with [`Cypress.expose()`](/api/cypress-api/expose). Expose
+overrides are merged across nested suites and tests, with test-level keys taking
+precedence. Override keys are applied at test start and restored after each test
+without affecting unrelated values set in hooks.
+
 #### Syntax
 
 ```javascript
@@ -713,6 +719,7 @@ DEBUG=cypress:cli,cypress:data-context:sources:FileDataSource,cypress:data-conte
 
 | Version                                      | Changes                                                                                                                                       |
 | -------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| [15.17.0](/app/references/changelog#15-17-0) | Added support for overriding [`Cypress.expose()`](/api/cypress-api/expose) values via test configuration.                                     |
 | [15.10.0](/app/references/changelog#15-10-0) | Updated `env` to no longer be settable via test configuration.                                                                                |
 | [15.10.0](/app/references/changelog#15-10-0) | Added `expose` option for exposing public configuration values.                                                                               |
 | [14.0.0](/app/references/changelog#14-0-0)   | Added support for re-enabling superdomain navigation with the `injectDocumentDomain` configuration option                                     |


### PR DESCRIPTION
## Summary

Documents [`Cypress.expose()`](/api/cypress-api/expose) test config overrides introduced in [cypress-io/cypress#33925](https://github.com/cypress-io/cypress/pull/33925) for the Cypress 15.17.0 release.

- **Updated** [`docs/api/cypress-api/expose.mdx`](docs/api/cypress-api/expose.mdx) — test config override syntax, merge/restore behavior, hook lifecycle, and mutation restore examples
- **Updated** [`docs/app/references/configuration.mdx`](docs/app/references/configuration.mdx) — mention `expose` test config overrides in Test Configuration
- **Updated** [`docs/app/core-concepts/writing-and-organizing-tests.mdx`](docs/app/core-concepts/writing-and-organizing-tests.mdx) — mention `expose` test config overrides
- **Updated** [`docs/app/references/changelog.mdx`](docs/app/references/changelog.mdx) — 15.17.0 feature entry

Addresses [#33356](https://github.com/cypress-io/cypress/issues/33356).

## Test plan

- [ ] Preview the docs site locally and verify `/api/cypress-api/expose` renders the new section
- [ ] Verify cross-links from configuration and writing-and-organizing-tests pages resolve
- [ ] Confirm 15.17.0 changelog entry renders correctly

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or security impact.
> 
> **Overview**
> Documents **Cypress 15.17.0** support for overriding **`Cypress.expose()`** values via suite- and test-level test configuration (`{ expose: { key: value } }`).
> 
> The **`expose`** API page gains a dedicated section with examples for merge precedence (test over suite), hook lifecycle, and per-test restore of override keys only. **Test configuration** and **writing and organizing tests** pages now mention the `expose` option, and the **changelog** adds a 15.17.0 feature entry plus history rows on related pages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63c960f6b70ca804e3b25ee7d13a5d6ba5d7966b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->