### PR TITLE
docs: add Bun as a supported package manager

### DIFF
--- a/docs/accessibility/guides/local-development.mdx
+++ b/docs/accessibility/guides/local-development.mdx
@@ -33,6 +33,13 @@ pnpm cypress run --key <record_key> --record --spec "cypress/e2e/my-spec.cy.js"
 ```
 
   </TabItem>
+  <TabItem value="bun">
+
+```shell
+bunx cypress run --key <record_key> --record --spec "cypress/e2e/my-spec.cy.js"
+```
+
+  </TabItem>
 </Tabs>
 
 (You can skip the `--key` option by setting `CYPRESS_RECORD_KEY` as an environment variable. Learn more about recording in our [Recorded Runs documentation](/cloud/features/recorded-runs)).

--- a/docs/app/continuous-integration/overview.mdx
+++ b/docs/app/continuous-integration/overview.mdx
@@ -131,6 +131,13 @@ module.
     ```
 
   </TabItem>
+  <TabItem value="bun">
+
+    ```shell
+    bun add --dev start-server-and-test
+    ```
+
+  </TabItem>
 </Tabs>
 
 In your `package.json` scripts, pass the command to boot your server, the url

--- a/docs/app/get-started/install-cypress.mdx
+++ b/docs/app/get-started/install-cypress.mdx
@@ -73,7 +73,7 @@ Cypress is installed using one of the following supported package managers:
 | [Yarn 1 (Classic)](https://classic.yarnpkg.com/) | >=1.22.22 | [Install Yarn Classic](https://classic.yarnpkg.com/en/docs/install)              |
 | [Yarn (Modern aka berry)](https://yarnpkg.com/)  | >=4.x     | [Install Yarn Modern](https://yarnpkg.com/getting-started/install)               |
 | [pnpm](https://pnpm.io/)                         | >=8.x     | [Install pnpm](https://pnpm.io/installation)                                     |
-| [Bun](https://bun.sh/)                           | >=1.1.x   | [Install Bun](https://bun.sh/docs/installation)                                  |
+| [Bun](https://bun.sh/)                           | >=1.2.22  | [Install Bun](https://bun.sh/docs/installation)                                  |
 
 #### Yarn users
 
@@ -102,7 +102,9 @@ pnpm --allow-build=cypress add --save-dev cypress
 
 #### Bun configuration
 
-[Bun](https://bun.sh/) blocks lifecycle scripts (including `postinstall`) by default for packages that are not in its `trustedDependencies` allowlist. Cypress relies on its `postinstall` script to download the Cypress binary into the [binary cache](/app/references/advanced-installation#Binary-cache), so `cypress` must be added to `trustedDependencies` in your `package.json`:
+Cypress is detected automatically from a `bun.lock` (text, Bun >=1.2) or `bun.lockb` (binary) lockfile. When you install Cypress with `bun add`, Bun trusts the package and runs its `postinstall` script to download the Cypress binary into the [binary cache](/app/references/advanced-installation#Binary-cache).
+
+When restoring dependencies from an existing manifest with `bun install` (for example in CI), Bun does not run `postinstall` scripts for packages that aren't in its [trustedDependencies](https://bun.sh/docs/install/lifecycle) allowlist. Add `cypress` to `trustedDependencies` in `package.json` so the binary downloads on install:
 
 ```json title="package.json"
 {
@@ -110,7 +112,7 @@ pnpm --allow-build=cypress add --save-dev cypress
 }
 ```
 
-After updating `trustedDependencies`, re-run `bun install` so that Cypress' `postinstall` script executes and downloads the binary. Refer to the [Bun lifecycle scripts](https://bun.sh/docs/install/lifecycle) documentation for additional information.
+To override the location of the Bun package cache, use [`BUN_INSTALL_CACHE_DIR`](https://bun.sh/docs/install/cache). This is independent of [`CYPRESS_CACHE_FOLDER`](/app/references/advanced-installation#Binary-cache), which controls where the Cypress binary itself is stored.
 
 ### Browsers
 

--- a/docs/app/get-started/install-cypress.mdx
+++ b/docs/app/get-started/install-cypress.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Install using npm, Yarn, or pnpm | Cypress Documentation'
+title: 'Install using npm, Yarn, pnpm, or Bun | Cypress Documentation'
 description: 'The fastest way to get Cypress running. Check requirements, install it in your project, and start testing today.'
 sidebar_label: Install Cypress
 sidebar_position: 30
@@ -13,7 +13,7 @@ sidebar_position: 30
 
 ##### <Icon name="question-circle" color="#4BBFD2" /> What you'll learn
 
-- How to install Cypress using npm, Yarn, or pnpm
+- How to install Cypress using npm, Yarn, pnpm, or Bun
 - What you need before installing
 - Advanced installation options
 
@@ -73,6 +73,7 @@ Cypress is installed using one of the following supported package managers:
 | [Yarn 1 (Classic)](https://classic.yarnpkg.com/) | >=1.22.22 | [Install Yarn Classic](https://classic.yarnpkg.com/en/docs/install)              |
 | [Yarn (Modern aka berry)](https://yarnpkg.com/)  | >=4.x     | [Install Yarn Modern](https://yarnpkg.com/getting-started/install)               |
 | [pnpm](https://pnpm.io/)                         | >=8.x     | [Install pnpm](https://pnpm.io/installation)                                     |
+| [Bun](https://bun.sh/)                           | >=1.1.x   | [Install Bun](https://bun.sh/docs/installation)                                  |
 
 #### Yarn users
 
@@ -98,6 +99,18 @@ In [pnpm@10.4.0](https://github.com/pnpm/pnpm/releases/tag/v10.4.0) and above, t
 ```shell
 pnpm --allow-build=cypress add --save-dev cypress
 ```
+
+#### Bun configuration
+
+[Bun](https://bun.sh/) blocks lifecycle scripts (including `postinstall`) by default for packages that are not in its `trustedDependencies` allowlist. Cypress relies on its `postinstall` script to download the Cypress binary into the [binary cache](/app/references/advanced-installation#Binary-cache), so `cypress` must be added to `trustedDependencies` in your `package.json`:
+
+```json title="package.json"
+{
+  "trustedDependencies": ["cypress"]
+}
+```
+
+After updating `trustedDependencies`, re-run `bun install` so that Cypress' `postinstall` script executes and downloads the binary. Refer to the [Bun lifecycle scripts](https://bun.sh/docs/install/lifecycle) documentation for additional information.
 
 ### Browsers
 

--- a/docs/app/get-started/install-cypress.mdx
+++ b/docs/app/get-started/install-cypress.mdx
@@ -104,7 +104,16 @@ pnpm --allow-build=cypress add --save-dev cypress
 
 Cypress is detected automatically from a `bun.lock` (text, Bun >=1.2) or `bun.lockb` (binary) lockfile. When you install Cypress with `bun add`, Bun trusts the package and runs its `postinstall` script to download the Cypress binary into the [binary cache](/app/references/advanced-installation#Binary-cache).
 
-When restoring dependencies from an existing manifest with `bun install` (for example in CI), Bun does not run `postinstall` scripts for packages that aren't in its [trustedDependencies](https://bun.sh/docs/install/lifecycle) allowlist. Add `cypress` to `trustedDependencies` in `package.json` so the binary downloads on install:
+When restoring dependencies from an existing manifest with `bun install` (for example in CI), Bun does not run `postinstall` scripts for packages that aren't in its [trustedDependencies](https://bun.sh/docs/install/lifecycle) allowlist. To install the Cypress binary, use one of the following approaches:
+
+**Recommended:** Skip lifecycle scripts and install the binary explicitly. This avoids running `postinstall` scripts from dependencies and is the more secure approach:
+
+```shell
+bun install --ignore-scripts
+bunx cypress install
+```
+
+Alternatively, add `cypress` to `trustedDependencies` in `package.json` so Bun runs the `postinstall` script on install:
 
 ```json title="package.json"
 {
@@ -112,7 +121,7 @@ When restoring dependencies from an existing manifest with `bun install` (for ex
 }
 ```
 
-To override the location of the Bun package cache, use [`BUN_INSTALL_CACHE_DIR`](https://bun.sh/docs/install/cache). This is independent of [`CYPRESS_CACHE_FOLDER`](/app/references/advanced-installation#Binary-cache), which controls where the Cypress binary itself is stored.
+Refer to [Advanced Installation](/app/references/advanced-installation#Troubleshoot-installation) for additional Bun installation options.
 
 ### Browsers
 

--- a/docs/app/guides/migration/protractor-to-cypress.mdx
+++ b/docs/app/guides/migration/protractor-to-cypress.mdx
@@ -267,6 +267,20 @@ yarn add concurrently --dev
 ```
 
   </TabItem>
+  <TabItem value="pnpm">
+
+```bash
+pnpm add --save-dev concurrently
+```
+
+  </TabItem>
+  <TabItem value="bun">
+
+```bash
+bun add --dev concurrently
+```
+
+  </TabItem>
 </Tabs>
 
 Then we will update our `package.json` with the following scripts:
@@ -296,6 +310,20 @@ npm run cy:open
 
 ```bash
 yarn run cy:open
+```
+
+  </TabItem>
+  <TabItem value="pnpm">
+
+```bash
+pnpm run cy:open
+```
+
+  </TabItem>
+  <TabItem value="bun">
+
+```bash
+bun run cy:open
 ```
 
   </TabItem>

--- a/docs/app/plugins/plugins-guide.mdx
+++ b/docs/app/plugins/plugins-guide.mdx
@@ -48,6 +48,14 @@ pnpm add --save-dev <plugin name>
 ```
 
   </TabItem>
+
+  <TabItem value="bun">
+
+```shell
+bun add --dev <plugin name>
+```
+
+  </TabItem>
 </Tabs>
 
 ## Using a plugin

--- a/docs/app/references/advanced-installation.mdx
+++ b/docs/app/references/advanced-installation.mdx
@@ -91,6 +91,7 @@ The Cypress [Life Cycle script](https://docs.npmjs.com/cli/using-npm/scripts) `p
     {label: 'npm', value: 'npm'},
     {label: 'Yarn', value: 'yarn'},
     {label: 'pnpm', value: 'pnpm'},
+    {label: 'Bun', value: 'bun'},
   ]}>
   <TabItem value="npm">
 
@@ -116,6 +117,14 @@ DEBUG=cypress:cli* pnpm cypress install
 ```
 
   </TabItem>
+  <TabItem value="bun">
+
+```shell
+CYPRESS_INSTALL_BINARY=0 bun add --dev cypress
+DEBUG=cypress:cli* bunx cypress install
+```
+
+  </TabItem>
 </Tabs>
 
 To set environment variables `CYPRESS_INSTALL_BINARY` and `DEBUG` in Windows CMD or PowerShell terminals, refer to examples in [Print DEBUG Logs](./troubleshooting#Print-DEBUG-logs).
@@ -128,6 +137,7 @@ In Continuous Integration (CI) use the following commands to display debug logs 
     {label: 'npm', value: 'npm'},
     {label: 'Yarn', value: 'yarn'},
     {label: 'pnpm', value: 'pnpm'},
+    {label: 'Bun', value: 'bun'},
   ]}>
   <TabItem value="npm">
 
@@ -149,6 +159,14 @@ DEBUG=cypress:cli* yarn cypress install
 ```shell
 pnpm install --frozen-lockfile --ignore-scripts
 DEBUG=cypress:cli* pnpm cypress install
+```
+
+  </TabItem>
+  <TabItem value="bun">
+
+```shell
+bun install --frozen-lockfile --ignore-scripts
+DEBUG=cypress:cli* bunx cypress install
 ```
 
   </TabItem>
@@ -463,6 +481,7 @@ To uninstall Cypress from a project, use the same package manager you used to [i
     {label: 'npm', value: 'npm'},
     {label: 'Yarn', value: 'yarn'},
     {label: 'pnpm', value: 'pnpm'},
+    {label: 'Bun', value: 'bun'},
   ]}>
   <TabItem value="npm">
 
@@ -485,6 +504,13 @@ pnpm remove cypress
 ```
 
   </TabItem>
+  <TabItem value="bun">
+
+```shell
+bun remove cypress
+```
+
+  </TabItem>
 </Tabs>
 
 To uninstall all cached Cypress binary versions, use the [cypress cache clear](./command-line#cypress-cache-clear) command with the appropriate package manager prefix described in [How to run commands](./command-line#How-to-run-commands).
@@ -496,4 +522,4 @@ To delete cached [Cypress App Data](./troubleshooting#Clear-App-Data), manually 
 - Linux: `~/.config/Cypress`
 - Windows: `$APPDATA/Cypress` (POSIX-syntax) or `%APPDATA%\Cypress` (Windows-syntax)
 
-Refer to your package manager documentation for details of package manager `cache clean` commands to remove other packages cached by npm, Yarn or pnpm.
+Refer to your package manager documentation for details of package manager `cache clean` commands to remove other packages cached by npm, Yarn, pnpm or Bun.

--- a/docs/app/references/advanced-installation.mdx
+++ b/docs/app/references/advanced-installation.mdx
@@ -202,6 +202,8 @@ environment:
   CYPRESS_CACHE_FOLDER: '~/.cache/Cypress'
 ```
 
+If you use Bun, [`BUN_INSTALL_CACHE_DIR`](https://bun.sh/docs/install/cache) controls Bun's package cache and is independent of `CYPRESS_CACHE_FOLDER`, which stores the Cypress binary.
+
 See also
 [Continuous Integration - Caching](/app/continuous-integration/overview#Caching)
 section in the documentation.

--- a/docs/app/references/command-line.mdx
+++ b/docs/app/references/command-line.mdx
@@ -23,7 +23,7 @@ You can alternatively require and run Cypress as a node module using our
 ## How to run commands
 
 You can run Cypress from your **project root** using a command which
-depends on the package manager you are using: npm, Yarn or pnpm.
+depends on the package manager you are using: npm, Yarn, pnpm or Bun.
 For example, you would prefix the command
 [cypress run](#cypress-run) as shown:
 
@@ -39,6 +39,7 @@ and record the results with Cypress Cloud, the command should be:
     {label: 'npm', value: 'npm'},
     {label: 'Yarn', value: 'yarn'},
     {label: 'pnpm', value: 'pnpm'},
+    {label: 'Bun', value: 'bun'},
   ]}>
   <TabItem value="npm">
 
@@ -58,6 +59,13 @@ yarn cypress run --record --spec "cypress/e2e/my-spec.cy.js"
 
 ```shell
 pnpm cypress run --record --spec "cypress/e2e/my-spec.cy.js"
+```
+
+  </TabItem>
+  <TabItem value="bun">
+
+```shell
+bunx cypress run --record --spec "cypress/e2e/my-spec.cy.js"
 ```
 
   </TabItem>
@@ -97,6 +105,7 @@ Running the script `e2e:chrome` as follows will run the command you defined:
     {label: 'npm', value: 'npm'},
     {label: 'Yarn', value: 'yarn'},
     {label: 'pnpm', value: 'pnpm'},
+    {label: 'Bun', value: 'bun'},
   ]}>
   <TabItem value="npm">
 
@@ -116,6 +125,13 @@ yarn e2e:chrome
 
 ```shell
 pnpm e2e:chrome
+```
+
+  </TabItem>
+  <TabItem value="bun">
+
+```shell
+bun run e2e:chrome
 ```
 
   </TabItem>
@@ -146,6 +162,7 @@ The option [`--spec`](#cypress-run-spec-lt-spec-gt) allows you to specify which 
     {label: 'npm', value: 'npm'},
     {label: 'Yarn', value: 'yarn'},
     {label: 'pnpm', value: 'pnpm'},
+    {label: 'Bun', value: 'bun'},
   ]}>
   <TabItem value="npm">
 
@@ -168,6 +185,13 @@ pnpm e2e:chrome --spec "cypress/e2e/my-spec.cy.js"
 ```
 
   </TabItem>
+  <TabItem value="bun">
+
+```shell
+bun run e2e:chrome --spec "cypress/e2e/my-spec.cy.js"
+```
+
+  </TabItem>
 </Tabs>
 
 Refer to each package manager's documentation for full details of command and script usage:
@@ -177,6 +201,7 @@ Refer to each package manager's documentation for full details of command and sc
   [`npm-run-script`](https://docs.npmjs.com/cli/run-script.html)).
 - [Yarn CLI](https://classic.yarnpkg.com/lang/en/docs/cli/)
 - [pnpm CLI](https://pnpm.io/pnpm-cli)
+- [Bun CLI](https://bun.sh/docs/cli/run)
 
 ## Commands
 

--- a/docs/app/references/troubleshooting.mdx
+++ b/docs/app/references/troubleshooting.mdx
@@ -154,6 +154,7 @@ If you need to share debug output collected in a file, consider first compressin
     {label: 'npm', value: 'npm'},
     {label: 'Yarn', value: 'yarn'},
     {label: 'pnpm', value: 'pnpm'},
+    {label: 'Bun', value: 'bun'},
   ]}>
   <TabItem value="npm">
 
@@ -176,11 +177,18 @@ DEBUG=cypress:* pnpm cypress run
 ```
 
   </TabItem>
+  <TabItem value="bun">
+
+```shell
+DEBUG=cypress:* bunx cypress run
+```
+
+  </TabItem>
 </Tabs>
 
 You can change `run` to `open` in the above to capture debug logs when starting your tests from the [Cypress Specs](../core-concepts/open-mode#Specs) UI.
 
-For non-POSIX type shells on Windows, set the `DEBUG` environment variable as follows. (Replace `npx` with `yarn` or `pnpm` if you are using Yarn or pnpm package managers instead of npm.)
+For non-POSIX type shells on Windows, set the `DEBUG` environment variable as follows. (Replace `npx` with `yarn`, `pnpm` or `bunx` if you are using Yarn, pnpm or Bun package managers instead of npm.)
 
 **On Windows CMD:**
 

--- a/docs/app/tooling/typescript-support.mdx
+++ b/docs/app/tooling/typescript-support.mdx
@@ -48,6 +48,20 @@ yarn add typescript --dev
 ```
 
 </TabItem>
+<TabItem value='pnpm'>
+
+```shell
+pnpm add --save-dev typescript
+```
+
+</TabItem>
+<TabItem value='bun'>
+
+```shell
+bun add --dev typescript
+```
+
+</TabItem>
 </Tabs>
 
 ### Configure tsconfig.json

--- a/docs/partials/_cypress-cache-clear-commands.mdx
+++ b/docs/partials/_cypress-cache-clear-commands.mdx
@@ -20,4 +20,11 @@ pnpm cypress cache clear
 ```
 
   </TabItem>
+  <TabItem value="bun">
+
+```shell
+bunx cypress cache clear
+```
+
+  </TabItem>
 </Tabs>

--- a/docs/partials/_cypress-install-binary-commands.mdx
+++ b/docs/partials/_cypress-install-binary-commands.mdx
@@ -20,4 +20,11 @@ pnpm cypress install
 ```
 
   </TabItem>
+  <TabItem value="bun">
+
+```shell
+bunx cypress install
+```
+
+  </TabItem>
 </Tabs>

--- a/docs/partials/_cypress-install-commands.mdx
+++ b/docs/partials/_cypress-install-commands.mdx
@@ -22,4 +22,12 @@ pnpm add --save-dev cypress
 ```
 
   </TabItem>
+
+  <TabItem value="bun">
+
+```shell
+bun add --dev cypress
+```
+
+  </TabItem>
 </Tabs>

--- a/docs/partials/_cypress-open-commands.mdx
+++ b/docs/partials/_cypress-open-commands.mdx
@@ -20,4 +20,11 @@ pnpm cypress open
 ```
 
   </TabItem>
+  <TabItem value="bun">
+
+```shell
+bunx cypress open
+```
+
+  </TabItem>
 </Tabs>

--- a/docs/partials/_cypress-run-commands.mdx
+++ b/docs/partials/_cypress-run-commands.mdx
@@ -20,4 +20,11 @@ pnpm cypress run
 ```
 
   </TabItem>
+  <TabItem value="bun">
+
+```shell
+bunx cypress run
+```
+
+  </TabItem>
 </Tabs>


### PR DESCRIPTION
Added Bun as a fourth supported package manager.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or security-sensitive code paths affected.
> 
> **Overview**
> Documents **Bun** as a fourth supported package manager alongside npm, Yarn, and pnpm across install, CLI, CI, troubleshooting, and shared partials.
> 
> The **install** guide adds Bun **>=1.2.22** to the package manager table and a **Bun configuration** section: lockfile detection, `postinstall` / **trustedDependencies**, and the recommended CI pattern `bun install --ignore-scripts` plus `bunx cypress install`. **Advanced installation** adds Bun tabs for troubleshoot/CI binary install, `bun remove`, and a note that **`BUN_INSTALL_CACHE_DIR`** is separate from **`CYPRESS_CACHE_FOLDER`**.
> 
> Tabbed examples now include **`bun`**, **`bun add --dev`**, **`bun run`**, and **`bunx`** for Cypress commands (`open`, `run`, `install`, `cache clear`). Several pages also fix **pnpm** tab markup where Bun tabs were inserted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit defbf9b76f90d18f9f484b8ed93d845c3610209b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->