### PR TITLE
Add ES module import examples for code coverage task registration

### DIFF
--- a/docs/app/tooling/code-coverage.mdx
+++ b/docs/app/tooling/code-coverage.mdx
@@ -320,7 +320,11 @@ import '@cypress/code-coverage/support'
 :::cypress-config-plugin-example
 
 ```js
-require('@cypress/code-coverage/task')(on, config)
+import registerCodeCoverageTasks from '@cypress/code-coverage/task'
+```
+
+```js
+registerCodeCoverageTasks(on, config)
 // include any other plugin code...
 
 // It's IMPORTANT to return the config object
@@ -531,12 +535,17 @@ again to do this by adding the code below to the
 :::cypress-config-plugin-example
 
 ```javascript
-require('@cypress/code-coverage/task')(on, config)
+import registerCodeCoverageTasks from '@cypress/code-coverage/task'
+import babelrcPreprocessor from '@cypress/code-coverage/use-babelrc'
+```
+
+```javascript
+registerCodeCoverageTasks(on, config)
 // tell Cypress to use .babelrc file
 // and instrument the specs files
 // only the extra application files will be instrumented
 // not the spec files themselves
-on('file:preprocessor', require('@cypress/code-coverage/use-babelrc'))
+on('file:preprocessor', babelrcPreprocessor)
 
 return config
 ```


### PR DESCRIPTION
Replaces inline require() calls with named ES module imports in both
cypress-config-plugin-example blocks, so the generated TypeScript tab
shows proper import syntax compatible with Vite and other ESM-only
environments.

Addresses: https://github.com/cypress-io/cypress-documentation/issues/6227

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to example snippets; no runtime or application code affected.
> 
> **Overview**
> Updates the **code coverage** guide so `cypress-config-plugin-example` blocks show **ES module** setup instead of inline `require()` calls.
> 
> Readers now see `import registerCodeCoverageTasks from '@cypress/code-coverage/task'` and `registerCodeCoverageTasks(on, config)`, with a separate import/registration block where the doc component splits snippets. The **babelrc** section also imports `babelrcPreprocessor` from `@cypress/code-coverage/use-babelrc` and passes it to `on('file:preprocessor', …)` instead of wrapping `require()` in the hook.
> 
> This aligns generated **TypeScript** tabs with **Vite** and other ESM-only Cypress configs (issue #6227).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09773395be00476b2da7ccfc8d7492f9eae74e5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->