### PR TITLE
Remove outdated cypress-audit plugin entry

### DIFF
--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -216,13 +216,6 @@
           "badge": "community"
         },
         {
-          "name": "cypress-audit",
-          "description": "Run Lighthouse audit directly in your E2E test suites.",
-          "link": "https://github.com/mfrachet/cypress-audit",
-          "keywords": ["lighthouse"],
-          "badge": "community"
-        },
-        {
           "name": "cypress-hmr-restarter",
           "description": "Restarts tests when receiving webpack-dev-server HMR updates.",
           "link": "https://github.com/Svish/cypress-hmr-restarter",


### PR DESCRIPTION
The cypress-audit package only supports legacy Cypress and the owner
has not responded to requests for an update. Per issue #6036, the entry
is removed to avoid pointing users to an unmaintained plugin.

https://github.com/cypress-io/cypress-documentation/issues/6036

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only catalog edit with no runtime, auth, or application code changes.
> 
> **Overview**
> Removes the **cypress-audit** community plugin from the Cypress plugins catalog in `src/data/plugins.json` (Development Tools section).
> 
> The listing pointed users at Lighthouse-in-E2E tooling that only supports legacy Cypress and is unmaintained; dropping it aligns the docs with issue #6036 so readers are not directed to an outdated package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adfba0dbafdfcb44031f0489fb1ae6db9e8f54f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->