### PR TITLE
Add cypress/factory ECR link to AWS CodeBuild Docker images section

### DIFF
--- a/docs/app/continuous-integration/aws-codebuild.mdx
+++ b/docs/app/continuous-integration/aws-codebuild.mdx
@@ -128,6 +128,7 @@ Cypress locally and in CI are published to the
 - [Cypress 'base' Amazon ECR Public Gallery](https://gallery.ecr.aws/cypress-io/cypress/base)
 - [Cypress 'browsers' Amazon ECR Public Gallery](https://gallery.ecr.aws/cypress-io/cypress/browsers)
 - [Cypress 'included' Amazon ECR Public Gallery](https://gallery.ecr.aws/cypress-io/cypress/included)
+- [Cypress 'factory' Amazon ECR Public Gallery](https://gallery.ecr.aws/cypress-io/cypress/factory)
 
 Read about [Cypress docker variants](/app/continuous-integration/overview#Cypress-Docker-variants) to decide which image is best for your project.
 


### PR DESCRIPTION
Adds the missing cypress/factory Amazon ECR Public Gallery link to the
list of available Cypress Docker image variants in the AWS CodeBuild guide,
addressing issue #5832.

https://claude.ai/code/session_014rx261xqVQxqQR7ZqJmVNF

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or security impact.
> 
> **Overview**
> The AWS CodeBuild guide’s **Cypress Amazon Public ECR** list now includes the **`cypress/factory`** gallery link alongside `base`, `browsers`, and `included`, so readers can find the factory image variant when choosing a Docker image for CodeBuild.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f8821d4eff38a452816a52541dc070ad837810b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->