### PR TITLE
fix(scrollIntoView): remove unsafe chains in examples

### DIFF
--- a/docs/api/commands/scrollintoview.mdx
+++ b/docs/api/commands/scrollintoview.mdx
@@ -60,7 +60,8 @@ Pass in an options object to change the default behavior of `.scrollIntoView()`.
 ### Scrolling
 
 ```javascript
-cy.get('button#checkout').scrollIntoView().should('be.visible')
+cy.get('button#checkout').scrollIntoView()
+cy.get('button#checkout').should('be.visible')
 ```
 
 ### Options
@@ -116,7 +117,8 @@ or
 **_Assert element is visible after scrolling it into view_**
 
 ```javascript
-cy.get('#scroll-horizontal button').scrollIntoView().should('be.visible')
+cy.get('#scroll-horizontal button').scrollIntoView()
+cy.get('#scroll-horizontal button').should('be.visible')
 ```
 
 The commands above will display in the Command Log as:


### PR DESCRIPTION
The scrollIntoView doc page warned that chaining further commands after
.scrollIntoView() is unsafe, but two examples did exactly that by chaining
.should('be.visible') directly. Re-query the DOM before asserting visibility
to follow the documented safe pattern.

Fixes #5002

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to code samples; no runtime or test behavior changes.
> 
> **Overview**
> Updates the **scrollIntoView** API doc examples so they no longer chain `.should('be.visible')` directly after `.scrollIntoView()`, which the same page marks as unsafe for subject-dependent commands.
> 
> Both the main scrolling example and the Command Log example now **re-query** the element with a second `cy.get(...)` before asserting visibility, matching the documented safe pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f34dff3523acee521330539333882b41efa8cd38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->