### PR TITLE
Fix Clear Cypress cache docs to use npx and correct follow-up command

### DIFF
--- a/docs/app/references/troubleshooting.mdx
+++ b/docs/app/references/troubleshooting.mdx
@@ -71,16 +71,12 @@ contents of the Cypress cache.
 This will clear out all installed versions of Cypress that may be cached on your
 machine.
 
-```shell
-npx cypress cache clear
-```
+<CypressCacheClearCommands />
 
-After running this command, you will need to run `npx cypress install` before
+After running this command, you will need to run `cypress install` before
 running Cypress again.
 
-```shell
-npx cypress install
-```
+<CypressInstallBinaryCommands />
 
 ### Allow the Cypress Chrome extension
 

--- a/docs/app/references/troubleshooting.mdx
+++ b/docs/app/references/troubleshooting.mdx
@@ -72,13 +72,15 @@ This will clear out all installed versions of Cypress that may be cached on your
 machine.
 
 ```shell
-cypress cache clear
+npx cypress cache clear
 ```
 
-After running this command, you will need to run `cypress install` before
+After running this command, you will need to run `npx cypress install` before
 running Cypress again.
 
-<CypressInstallCommands />
+```shell
+npx cypress install
+```
 
 ### Allow the Cypress Chrome extension
 

--- a/docs/partials/_cypress-cache-clear-commands.mdx
+++ b/docs/partials/_cypress-cache-clear-commands.mdx
@@ -1,0 +1,23 @@
+<Tabs>
+  <TabItem value="npm">
+
+```shell
+npx cypress cache clear
+```
+
+  </TabItem>
+  <TabItem value="yarn">
+
+```shell
+yarn cypress cache clear
+```
+
+  </TabItem>
+  <TabItem value="pnpm">
+
+```shell
+pnpm cypress cache clear
+```
+
+  </TabItem>
+</Tabs>

--- a/docs/partials/_cypress-install-binary-commands.mdx
+++ b/docs/partials/_cypress-install-binary-commands.mdx
@@ -1,0 +1,23 @@
+<Tabs>
+  <TabItem value="npm">
+
+```shell
+npx cypress install
+```
+
+  </TabItem>
+  <TabItem value="yarn">
+
+```shell
+yarn cypress install
+```
+
+  </TabItem>
+  <TabItem value="pnpm">
+
+```shell
+pnpm cypress install
+```
+
+  </TabItem>
+</Tabs>

--- a/src/theme/MDXComponents.js
+++ b/src/theme/MDXComponents.js
@@ -10,6 +10,8 @@ import ComponentOnlyBadge from "@site/src/components/component-only-badge";
 import TestReplayInfo from "@site/docs/partials/_test-replay-info.mdx";
 import CypressConfigFileTabs from "@site/src/components/cypress-config-file-tabs";
 import CypressInstallCommands from "@site/docs/partials/_cypress-install-commands.mdx";
+import CypressCacheClearCommands from "@site/docs/partials/_cypress-cache-clear-commands.mdx";
+import CypressInstallBinaryCommands from "@site/docs/partials/_cypress-install-binary-commands.mdx";
 import CypressEnvVsCypressExpose from "@site/docs/partials/_cy-env-vs-cypress-expose.mdx";
 import CypressOpenCommands from "@site/docs/partials/_cypress-open-commands.mdx";
 import CypressRunCommands from "@site/docs/partials/_cypress-run-commands.mdx";
@@ -177,6 +179,8 @@ export default {
   ComponentOnlyBadge,
   CypressConfigFileTabs,
   CypressInstallCommands,
+  CypressCacheClearCommands,
+  CypressInstallBinaryCommands,
   CypressEnvVsCypressExpose,
   CypressOpenCommands,
   CypressRunCommands,


### PR DESCRIPTION
Use `npx cypress cache clear` instead of bare `cypress cache clear` since
users likely don't have Cypress installed globally. Replace the follow-up
`<CypressInstallCommands />` (which showed `npm install cypress`) with
`npx cypress install`, which is the correct command to reinstall the binary
after clearing the cache on an already-installed project.

Fixes #4464

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and MDX partial wiring only; no runtime or test behavior changes.
> 
> **Overview**
> The **Clear Cypress cache** troubleshooting section no longer shows a bare `cypress cache clear` shell snippet or the generic install-package partial after clearing the cache.
> 
> It now embeds **`CypressCacheClearCommands`** (npm/yarn/pnpm tabbed commands like `npx cypress cache clear`) and **`CypressInstallBinaryCommands`** (`npx` / `yarn` / `pnpm cypress install`) so readers reinstall the binary correctly instead of seeing `npm install cypress`. Two new MDX partials back those components, registered in **`MDXComponents.js`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c381478fc5e9852eedf68e95e918220063008c39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->