### PR TITLE
docs(retry-ability): document mid-chain assertions as retry boundaries

### DIFF
--- a/docs/app/core-concepts/retry-ability.mdx
+++ b/docs/app/core-concepts/retry-ability.mdx
@@ -180,6 +180,62 @@ the "first item" assertion failed.
   alt="Retrying multiple assertions"
 />
 
+## Assertions as retry boundaries
+
+When a `.should()` assertion appears **in the middle** of a query chain—with
+more queries chained after it—the assertion acts as a retry boundary. Once the
+assertion passes, Cypress locks in the subject at that point and advances
+through the command queue. Queries that follow the assertion will retry from
+that locked-in subject, **not** from the beginning of the chain.
+
+This becomes a problem when the application re-renders the DOM after the
+mid-chain assertion passes. The element passed to the subsequent queries may
+already be detached from the DOM, and Cypress cannot requery from the top of
+the chain because the prior assertion already succeeded. You may see an error
+like:
+
+```
+Timed out retrying after 4000ms: cy.children() failed because the page
+updated as a result of this command, but you tried to continue the command
+chain. The subject is no longer attached to the DOM, and Cypress cannot
+requery the page after commands such as cy.children().
+```
+
+#### <Icon name="exclamation-triangle" color="red" /> Mid-chain assertion with risk of a stale subject
+
+```javascript
+cy.get('.list')
+  .find('li').eq(2)
+  .should('contain', 'Header') // once this passes, the li element is locked in
+  .children('.child').eq(3) // if the DOM re-renders, this li may be detached
+  .should('contain', 'child') // retry only reruns from .children(), not .get()
+```
+
+If the page re-renders between the two assertions, the `li` matched by
+`.should('contain', 'Header')` may be replaced in the DOM. When Cypress retries
+from `.children('.child')`, it uses the original—now-detached—`li` as the
+subject and fails.
+
+#### <Icon name="check-circle" color="green" /> Split the chain at assertion boundaries
+
+Break the chain into separate statements so each re-query starts fresh from the
+top:
+
+```javascript
+cy.get('.list').find('li').eq(2).should('contain', 'Header')
+cy.get('.list').find('li').eq(2).children('.child').eq(3).should('contain', 'child')
+```
+
+Or use a [`.should(callbackFn)`](/api/commands/should#Function) to keep all
+assertions retrying together against a freshly-queried element:
+
+```javascript
+cy.get('.list').find('li').eq(2).should(($li) => {
+  expect($li).to.contain('Header')
+  expect($li.children('.child').eq(3)).to.contain('child')
+})
+```
+
 ## Implicit Assertions
 
 Often a Cypress command has built-in assertions that will cause the command to

--- a/docs/app/core-concepts/retry-ability.mdx
+++ b/docs/app/core-concepts/retry-ability.mdx
@@ -195,10 +195,10 @@ the chain because the prior assertion already succeeded. You may see an error
 like:
 
 ```
-Timed out retrying after 4000ms: cy.children() failed because the page
-updated as a result of this command, but you tried to continue the command
-chain. The subject is no longer attached to the DOM, and Cypress cannot
-requery the page after commands such as cy.children().
+cy.children() failed because the page updated as a result of this command,
+but you tried to continue the command chain. The subject is no longer
+attached to the DOM, and Cypress cannot requery the page after commands
+such as cy.children().
 ```
 
 #### <Icon name="exclamation-triangle" color="red" /> Mid-chain assertion with risk of a stale subject

--- a/docs/app/core-concepts/retry-ability.mdx
+++ b/docs/app/core-concepts/retry-ability.mdx
@@ -205,9 +205,11 @@ such as cy.children().
 
 ```javascript
 cy.get('.list')
-  .find('li').eq(2)
+  .find('li')
+  .eq(2)
   .should('contain', 'Header') // once this passes, the li element is locked in
-  .children('.child').eq(3) // if the DOM re-renders, this li may be detached
+  .children('.child')
+  .eq(3) // if the DOM re-renders, this li may be detached
   .should('contain', 'child') // retry only reruns from .children(), not .get()
 ```
 
@@ -223,17 +225,25 @@ top:
 
 ```javascript
 cy.get('.list').find('li').eq(2).should('contain', 'Header')
-cy.get('.list').find('li').eq(2).children('.child').eq(3).should('contain', 'child')
+cy.get('.list')
+  .find('li')
+  .eq(2)
+  .children('.child')
+  .eq(3)
+  .should('contain', 'child')
 ```
 
 Or use a [`.should(callbackFn)`](/api/commands/should#Function) to keep all
 assertions retrying together against a freshly-queried element:
 
 ```javascript
-cy.get('.list').find('li').eq(2).should(($li) => {
-  expect($li).to.contain('Header')
-  expect($li.children('.child').eq(3)).to.contain('child')
-})
+cy.get('.list')
+  .find('li')
+  .eq(2)
+  .should(($li) => {
+    expect($li).to.contain('Header')
+    expect($li.children('.child').eq(3)).to.contain('child')
+  })
 ```
 
 ## Implicit Assertions


### PR DESCRIPTION
Adds a new "Assertions as retry boundaries" section explaining that a
.should() assertion in the middle of a query chain locks in the subject
once it passes. Subsequent queries retry from that locked-in element
rather than re-running the full chain from the top, which can cause
detached-element failures when the DOM re-renders after the mid-chain
assertion succeeds.

Closes #6338

https://claude.ai/code/session_01ErLpy2zGv3niPxfMr2kuVv

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the retry-ability guide; no runtime or test code affected.
> 
> **Overview**
> Adds an **Assertions as retry boundaries** section to `retry-ability.mdx` (after *Multiple assertions*), explaining that a mid-chain `.should()` locks the subject once it passes so later queries retry from that element—not from the top of the chain.
> 
> Documents the detached-DOM failure mode (including the `cy.children()` error), a risky mid-chain example, and fixes: **split chains** at assertion boundaries or use **`.should(callbackFn)`** so assertions retry together on a fresh query.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b71a00a0aef44c0c49d8c47779ae80d05a817be2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->