### PR TITLE
docs: clarify best practices for multiple actions on the same element

### DIFF
--- a/docs/api/commands/then.mdx
+++ b/docs/api/commands/then.mdx
@@ -230,6 +230,61 @@ cy.get('button')
 
 <ThenShouldAndDifference />
 
+### Multiple actions on the same element
+
+A common pattern is to perform several sequential actions on the same element —
+for example, focusing an input, clearing its value, typing a new value, and then
+blurring it. Because [`.focus()`](/api/commands/focus),
+[`.clear()`](/api/commands/clear), [`.type()`](/api/commands/type), and
+[`.blur()`](/api/commands/blur) each yield the same subject they were given, you
+can chain them directly without needing `.then()`:
+
+```javascript
+// ✅ Preferred: direct chaining
+cy.get('input').focus().clear().type('new value').blur()
+```
+
+You might be tempted to wrap multiple actions inside `.then()` to avoid
+re-querying the element:
+
+```javascript
+// ⚠️ Unnecessary: .then() is not retried and does not improve retry-ability
+cy.get('input').then(($input) => {
+  cy.wrap($input).focus()
+  cy.wrap($input).clear()
+  cy.wrap($input).type('new value')
+  cy.wrap($input).blur()
+})
+```
+
+This pattern is unnecessary and can be misleading. The `.then()` callback is
+**not** retried — so it does not protect against detached DOM errors any better
+than direct chaining. In addition, `$input` inside the callback is a snapshot of
+the element at the time `.then()` ran; if the DOM updates and the element is
+replaced, the wrapped reference becomes stale.
+
+For sequential actions that need to be split across separate chains (for
+example, when each action might trigger a re-render), use separate `cy.get()`
+calls or an [alias](/app/core-concepts/variables-and-aliases):
+
+```javascript
+// ✅ Separate queries re-run before each action, protecting against re-renders
+cy.get('input').focus()
+cy.get('input').clear()
+cy.get('input').type('new value')
+cy.get('input').blur()
+
+// ✅ Equivalent with an alias
+cy.get('input').as('field')
+cy.get('@field').focus()
+cy.get('@field').clear()
+cy.get('@field').type('new value')
+cy.get('@field').blur()
+```
+
+See the [Retry-ability guide](/app/core-concepts/retry-ability) for a deeper
+explanation of how Cypress retries queries before each action.
+
 ## Rules
 
 <HeaderRequirements />
@@ -266,3 +321,5 @@ cy.get('button')
 - [`.spread()`](/api/commands/spread)
 - [Guide: Using Closures to compare values](/app/core-concepts/variables-and-aliases#Closures)
 - [Guide: Chains of Commands](/app/core-concepts/introduction-to-cypress#Chains-of-Commands)
+- [Guide: Retry-ability](/app/core-concepts/retry-ability)
+- [Guide: Only queries are retried](/app/core-concepts/retry-ability#Only-queries-are-retried)

--- a/docs/app/core-concepts/retry-ability.mdx
+++ b/docs/app/core-concepts/retry-ability.mdx
@@ -317,6 +317,48 @@ cy.get('@new').type('todo B{enter}')
 cy.get('@new').should('have.class', 'active')
 ```
 
+### Multiple sequential actions on the same element
+
+When performing several actions on a single element — such as focusing an input,
+clearing it, typing a value, and blurring — you have two good options.
+
+**Option 1: Direct chaining.** Action commands like
+[`.focus()`](/api/commands/focus), [`.clear()`](/api/commands/clear),
+[`.type()`](/api/commands/type), and [`.blur()`](/api/commands/blur) each yield
+the same element they received, so you can chain them in a single expression:
+
+```javascript
+// ✅ Recommended for stable elements
+cy.get('#payment-input').focus().clear().type('new value').blur()
+```
+
+**Option 2: Separate `cy.get()` calls.** If your application re-renders between
+actions and might replace the DOM node, use a separate query for each action.
+Cypress re-runs all queries leading up to each action, so a fresh element
+reference is used every time:
+
+```javascript
+// ✅ Recommended when the element may re-render between actions
+cy.get('#payment-input').focus()
+cy.get('#payment-input').clear()
+cy.get('#payment-input').type('new value')
+cy.get('#payment-input').blur()
+```
+
+Avoid wrapping multiple actions in a `.then()` callback with `cy.wrap()`. The
+`.then()` callback is **not** retried and does not add retry-ability protection.
+The element reference captured by `.then()` can become stale if the DOM updates:
+
+```javascript
+// ❌ Avoid: .then() is not retried; $el can become stale
+cy.get('#payment-input').then(($el) => {
+  cy.wrap($el).focus()
+  cy.wrap($el).clear()
+  cy.wrap($el).type('new value')
+  cy.wrap($el).blur()
+})
+```
+
 :::caution
 
 Very rarely you may want to retry a command like `.click()`. We describe one


### PR DESCRIPTION
Closes #6189, which asked whether using `.then()` with `cy.wrap()`
is the recommended approach for performing several sequential actions
(focus, clear, type, blur) on a single element.

Adds a "Multiple actions on the same element" section to both
`then.mdx` and `retry-ability.mdx` explaining:
- Direct chaining is preferred because action commands yield the same element
- Separate `cy.get()` calls are safer when re-renders may occur
- The `.then()` + `cy.wrap()` pattern is an anti-pattern: the callback
  is not retried and a captured element reference can become stale

https://claude.ai/code/session_01P4FfE6qBSbEYpPdrLWSxiH

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 2eac955132b1191a40633f96c06beca0b759ef87. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->