### PR TITLE
Update circle.yml parallelization examples to use modern CircleCI orb syntax

### DIFF
--- a/docs/cloud/features/smart-orchestration/parallelization.mdx
+++ b/docs/cloud/features/smart-orchestration/parallelization.mdx
@@ -122,11 +122,24 @@ project. You can see the results of this run on
 
 ### Without parallelization
 
-In this example, a single machine runs a job named `1x-electron`, defined in the
-project's
-[circle.yml](https://github.com/cypress-io/cypress-example-kitchensink/blob/aabb10cc1bb9dee88e1bf28e0af5e9661427ee7a/circle.yml#L41)
-file. Cypress runs all 19 spec files one by one alphabetically in this job. It
-takes **1:51** to complete all of the tests.
+In this example, a single machine runs all spec files serially. Below is an
+example `.circleci/config.yml` using the
+[Cypress CircleCI Orb](https://github.com/cypress-io/circleci-orb):
+
+```yaml title=".circleci/config.yml"
+version: 2.1
+orbs:
+  cypress: cypress-io/cypress@6
+workflows:
+  build:
+    jobs:
+      - cypress/run:
+          start-command: 'npm run start'
+          cypress-command: 'npx cypress run --record'
+```
+
+Cypress runs all 19 spec files one by one alphabetically. It takes **1:51** to
+complete all of the tests.
 
 ```text
 1x-electron, Machine #1
@@ -167,10 +180,23 @@ When we run the same tests with parallelization, Cypress uses its
 [load balance strategy](/cloud/features/smart-orchestration/load-balancing#Balance-strategy)
 to order to specs to run based on the spec's previous run history. During the
 same CI run as above, we ran _all_ tests again, but this time with
-parallelization across 2 machines. This job was named `2x-electron` in the
-project's
-[circle.yml](https://github.com/cypress-io/cypress-example-kitchensink/blob/aabb10cc1bb9dee88e1bf28e0af5e9661427ee7a/circle.yml#L53)
-file and it finished in **59 seconds**.
+parallelization across 2 machines. By adding `parallelism: 2` and the
+`--parallel` flag to the `.circleci/config.yml`:
+
+```yaml title=".circleci/config.yml"
+version: 2.1
+orbs:
+  cypress: cypress-io/cypress@6
+workflows:
+  build:
+    jobs:
+      - cypress/run:
+          parallelism: 2
+          start-command: 'npm run start'
+          cypress-command: 'npx cypress run --record --parallel'
+```
+
+It finished in **59 seconds**.
 
 ```text
 2x-electron, Machine #1, 9 specs          2x-electron, Machine #2, 10 specs


### PR DESCRIPTION
Replaces outdated links pointing to a 6-year-old pinned commit of
`circle.yml` with up-to-date `.circleci/config.yml` YAML examples
using the Cypress CircleCI Orb (cypress-io/cypress@6), matching the
pattern used in the existing circleci.mdx CI guide.

Fixes #5988

https://claude.ai/code/session_017K2xPAFhewmnUwkjfDWMQu

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to CI example YAML; no product code, auth, or runtime behavior.
> 
> **Overview**
> The **parallelization** doc’s Kitchen Sink examples no longer point at a pinned legacy `circle.yml` commit. **Without parallelization** and **with parallelization** now show inline `.circleci/config.yml` snippets using the **Cypress CircleCI Orb** (`cypress-io/cypress@6`), aligned with `circleci.mdx`: serial `cypress/run` with `--record`, and `parallelism: 2` plus `--parallel` for the two-machine case. Narrative still references the same timing outcomes (**1:51** vs **59 seconds**); only how readers configure CircleCI is updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9b43d7edfcc885337da32ef983d9732c82733f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->