### PR TITLE
docs(fixture): document large file size limitations and workarounds

### DIFF
--- a/docs/api/commands/fixture.mdx
+++ b/docs/api/commands/fixture.mdx
@@ -276,6 +276,70 @@ describe('User page', () => {
 })
 ```
 
+### Large Files
+
+#### Memory and Transfer Constraints
+
+`cy.fixture()` reads the **entire file into memory** and transfers its contents
+from the Cypress Node.js server process to the browser test runner over an
+internal WebSocket connection. There is no explicit file size limit in Cypress
+itself, but large files — especially binary files like `.zip` archives — can
+cause Cypress to crash or become unresponsive due to:
+
+- **Memory pressure**: The complete file must fit in available RAM and is held
+  in the fixture cache for the duration of the test run.
+- **WebSocket message size**: File contents are sent as a single message over
+  the internal socket. Payloads that approach or exceed 100 MB can exceed
+  socket-level buffer limits.
+
+As a practical guideline, avoid using `cy.fixture()` with files larger than a
+few megabytes. Smaller test fixtures (representative subsets of production data)
+are preferable wherever possible.
+
+#### Uploading Large Files via a File Input
+
+If your goal is to simulate a file upload through an `<input type="file">`
+element, use [`.selectFile()`](/api/commands/selectfile) with a path string
+rather than loading the fixture first and then setting the input manually:
+
+```javascript
+// ✅ Preferred for file upload simulation
+cy.get('input[type="file"]').selectFile('cypress/fixtures/large.zip')
+```
+
+#### Keeping Large File Operations Server-Side
+
+For scenarios where you must work with large files but do not need to transfer
+their full contents to the browser (for example, verifying file metadata or
+invoking a server-side operation), use [`cy.task()`](/api/commands/task) to
+keep the operation in the Node.js context:
+
+```javascript
+// cypress.config.js
+const { defineConfig } = require('cypress')
+const fs = require('fs')
+
+module.exports = defineConfig({
+  e2e: {
+    setupNodeEvents(on, config) {
+      on('task', {
+        getFileSize(filePath) {
+          const { size } = fs.statSync(filePath)
+          return size
+        },
+      })
+    },
+  },
+})
+```
+
+```javascript
+// in your test
+cy.task('getFileSize', 'cypress/fixtures/large.zip').then((size) => {
+  expect(size).to.be.greaterThan(0)
+})
+```
+
 ### Loaded just once
 
 Please keep in mind that fixture files are assumed to be unchanged during the
@@ -355,4 +419,8 @@ practical purposes it should never happen.
 - [`.then()`](/api/commands/then)
 - [`.readFile()`](/api/commands/readfile) for a similar command without caching
   and with builtin retryability
+- [`.selectFile()`](/api/commands/selectfile) for simulating file uploads,
+  including with large files
+- [`cy.task()`](/api/commands/task) for keeping large file operations in the
+  Node.js context
 - [Recipe: Bootstrapping App Test Data](/app/references/recipes#Server-Communication)


### PR DESCRIPTION
cy.fixture() reads files entirely into memory and transfers them over an
internal WebSocket, making it unsuitable for large binary files like multi-MB
zip archives. This adds a Notes section explaining the memory and socket buffer
constraints, and provides guidance on using .selectFile() for file upload
simulation and cy.task() for server-side file operations.

Closes https://github.com/cypress-io/cypress-documentation/issues/5966

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to `fixture.mdx` with no runtime or API behavior changes.
> 
> **Overview**
> Adds a **Large Files** section under `cy.fixture()` Notes explaining that fixtures are fully loaded in Node and sent to the browser over an internal WebSocket, which can cause memory pressure and very large (~100 MB) payloads to hit socket limits. It recommends keeping fixtures to a few megabytes and points readers to **`.selectFile()`** with a path for upload simulation and **`cy.task()`** with a `getFileSize` example for server-side checks without shipping file bytes to the test.
> 
> The **See also** list now links `.selectFile()` and `cy.task()` with short descriptions tied to large-file workflows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07392377c75911f04cfc3dfcacfca8383a45c78f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->