### PR TITLE
fix(reporters): update mochawesome-merge command to use -o flag instead of stdout redirect

### DIFF
--- a/docs/app/tooling/reporters.mdx
+++ b/docs/app/tooling/reporters.mdx
@@ -333,7 +333,7 @@ Then we can combine them using the
 [mochawesome-merge](https://github.com/antontelesh/mochawesome-merge) utility.
 
 ```shell
-npx mochawesome-merge "cypress/results/*.json" > mochawesome.json
+npx mochawesome-merge cypress/results/*.json -o mochawesome.json
 ```
 
 We can now generate a combined HTML report from the `mochawesome.json` file


### PR DESCRIPTION
The stdout redirect (>) produces invalid JSON output for marge. Using
the -o/--output flag as documented in mochawesome-merge correctly writes
valid JSON. Fixes #5870.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to a reporter workflow example; no product code or runtime behavior.
> 
> **Overview**
> Updates the **Mochawesome merge** example in `docs/app/tooling/reporters.mdx` so the documented command matches `mochawesome-merge`’s supported usage.
> 
> The shell snippet no longer uses `>` to write `mochawesome.json`; it now uses **`npx mochawesome-merge cypress/results/*.json -o mochawesome.json`**, which avoids invalid JSON for the following **`marge`** step (per #5870).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de83c130421ec4fc5479f10e2725e96e27d63bb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->