### PR TITLE
Improve UI Coverage noise reduction docs for non-developer QA teams

### DIFF
--- a/docs/ui-coverage/guides/ignore-elements.mdx
+++ b/docs/ui-coverage/guides/ignore-elements.mdx
@@ -13,17 +13,16 @@ Not all elements in your application are relevant to your test coverage. Cypress
 
 Common candidates for exclusion include:
 
-- **Global navigation and sidebars** — menus, breadcrumbs, and header/footer links that appear on every page
 - **Data grid and table controls** — column filter icons, sort arrows, or pagination buttons that are secondary concerns
 - **Third-party and embedded widgets** — chat launchers, cookie consent banners, analytics overlays, or auth iframes
 - **Transitional or loading elements** — spinners, skeletons, and progress indicators that don't represent a stable UI state
 
 ## Why ignore elements?
 
-Filtering known, stable elements keeps your reports focused on real coverage gaps. When your team sees an untested element, it should signal _work to do_ — not noise from a sidebar that has been present and unchanged for months.
+Filtering known, stable elements keeps your reports focused on real coverage gaps. When your team sees an untested element, it should signal _work to do_ — not noise from a widget or control that isn't part of the workflows you're testing.
 
 :::caution Preserve visibility into new elements
-Element filters remove matching elements entirely from coverage tracking. If a developer later adds a **new** button inside a section you've ignored (for example, a new action inside `#sidebar`), that new element will also be hidden. Use specific selectors rather than broad ones, and pair filters with [change monitoring](/ui-coverage/guides/monitor-changes) to stay aware of what's new.
+Element filters remove matching elements entirely from coverage tracking. If a developer later adds a **new** button inside a section you've ignored, that new element will also be hidden. Use specific selectors rather than broad ones, and pair filters with [change monitoring](/ui-coverage/guides/monitor-changes) to stay aware of what's new.
 :::
 
 ## Step 1: Identify elements to ignore
@@ -33,7 +32,7 @@ After recording your tests to Cypress Cloud, review the UI Coverage report to fi
 1. In Cypress Cloud, open your project and go to a recent test run.
 2. Select the **UI Coverage** tab.
 3. Open the **Untested elements** section.
-4. Look for elements that appear across many views without being part of the workflows you care about — for example, a sidebar navigation menu that appears on every page, or filter icons on every data grid column.
+4. Look for elements that appear across many views without being part of the workflows you care about — for example, filter icons on every data grid column, or a third-party chat widget.
 5. Click an element to open its detail panel. The detail panel shows the CSS selector Cypress uses to identify the element — copy this as your starting point for a filter rule.
 
 ## Step 2: Configure ignored elements
@@ -46,33 +45,19 @@ To add or update your configuration:
 2. Go to the **App Quality** tab.
 3. Add or edit the `elementFilters` array under your `uiCoverage` configuration.
 
-### Example: Ignoring a global sidebar
-
-If your app has a persistent sidebar that appears on every page, exclude all of its interactive children at once using a descendant selector:
-
-```json
-{
-  "elementFilters": [
-    {
-      "selector": "#sidebar *",
-      "include": false,
-      "comment": "Global sidebar — has its own dedicated nav test suite"
-    }
-  ]
-}
-```
-
 ### Example: Ignoring data grid filter icons
 
-Data grids often generate a large number of untested elements from per-column controls. Exclude the controls while keeping the cell content visible:
+Data grids often generate a large number of untested elements from per-column controls. If these controls are a secondary concern, exclude them while keeping the cell content tracked.
+
+The exact selector depends on your grid library or component. Use your browser's DevTools to find the right selector for your app — right-click the filter icon in the browser and choose **Inspect** to see its class names or attributes.
 
 ```json
 {
   "elementFilters": [
     {
-      "selector": ".ag-header-icon, .ag-filter-icon, [data-testid='column-filter-btn']",
+      "selector": "[data-testid='column-filter-btn']",
       "include": false,
-      "comment": "Column filter and sort icons — out of scope for current test suite"
+      "comment": "Column filter icons — out of scope for current test suite"
     }
   ]
 }
@@ -80,18 +65,17 @@ Data grids often generate a large number of untested elements from per-column co
 
 ### Example: Ignoring third-party widgets
 
-External integrations like live chat or cookie consent banners are not your code to test. Exclude them by their container or `iframe` title:
+External integrations like live chat or cookie consent banners are not your code to test. Exclude them by their container element or `iframe` title.
+
+The exact selector varies by provider — use DevTools to inspect the widget's outermost container and find a stable `id` or `class` to target. Most third-party widgets inject a wrapper element with a predictable `id`.
 
 ```json
 {
   "elementFilters": [
     {
-      "selector": "#intercom-container *",
-      "include": false
-    },
-    {
-      "selector": ".CookieConsent *",
-      "include": false
+      "selector": "#live-chat-widget *",
+      "include": false,
+      "comment": "Third-party chat widget — replace with your provider's actual container ID"
     },
     {
       "selector": "iframe[title='Login']",
@@ -104,14 +88,14 @@ External integrations like live chat or cookie consent banners are not your code
 
 ### Example: Ignoring elements using a custom data attribute
 
-If your team has access to the application source code, the most maintainable approach is to mark elements directly in the HTML using a `data` attribute. This keeps the exclusion intent visible in the code itself.
+If your team has access to the application source code, the most maintainable approach is to mark elements directly in the HTML using a `data` attribute. This keeps the exclusion intent visible in the code itself and doesn't depend on class names that might change.
 
 **In your application HTML:**
 
 ```html
-<aside data-uic-ignore="true">
-  <!-- sidebar content -->
-</aside>
+<div data-uic-ignore="true">
+  <!-- third-party widget or out-of-scope component -->
+</div>
 ```
 
 **In your UI Coverage configuration:**
@@ -133,7 +117,7 @@ After saving your configuration, trigger a new test run (or wait for the next sc
 
 1. Go to the **Untested elements** section.
 2. Confirm the elements you filtered no longer appear.
-3. If a filtered element still shows up, use your browser's DevTools to confirm your CSS selector actually matches that element on the page. The **Elements** panel in DevTools lets you run `document.querySelectorAll('your-selector')` in the Console to verify.
+3. If a filtered element still shows up, use your browser's DevTools to confirm your CSS selector actually matches that element on the page. Open the Console and run `document.querySelectorAll('your-selector')` to verify.
 
 ## Balancing noise reduction with new-element visibility
 
@@ -143,8 +127,8 @@ The key is to use **specific, targeted selectors** rather than broad ones:
 
 | Approach | Effect |
 |----------|--------|
-| `#sidebar *` | Excludes everything inside `#sidebar`, including future additions |
-| `#sidebar > nav > ul > li > a` | Only excludes the current top-level sidebar links |
+| `#chat-widget *` | Excludes everything inside the container, including any future additions |
+| `#chat-widget > button.launcher` | Only excludes the specific launcher button |
 | `[data-uic-ignore='true'] *` | Only excludes what developers explicitly opt out of |
 
 For teams that want broad noise reduction _without_ losing sight of new elements, consider using [profiles](/ui-coverage/configuration/profiles) — apply a stricter filter in daily CI runs and a less-filtered profile for weekly audit runs, so new elements surface on a regular cadence without cluttering day-to-day reports.

--- a/docs/ui-coverage/guides/ignore-elements.mdx
+++ b/docs/ui-coverage/guides/ignore-elements.mdx
@@ -9,52 +9,142 @@ sidebar_position: 50
 
 # Ignore elements
 
-Not all elements in your application are relevant to your test coverage. Cypress UI Coverage allows you to exclude specific elements from coverage reports, helping you focus on meaningful insights and avoid unnecessary noise. This guide explains why and how to ignore elements in your UI Coverage reports.
+Not all elements in your application are relevant to your test coverage. Cypress UI Coverage lets you exclude specific elements from coverage reports so you can focus on what matters without chasing down false gaps.
+
+Common candidates for exclusion include:
+
+- **Global navigation and sidebars** — menus, breadcrumbs, and header/footer links that appear on every page
+- **Data grid and table controls** — column filter icons, sort arrows, or pagination buttons that are secondary concerns
+- **Third-party and embedded widgets** — chat launchers, cookie consent banners, analytics overlays, or auth iframes
+- **Transitional or loading elements** — spinners, skeletons, and progress indicators that don't represent a stable UI state
 
 ## Why ignore elements?
 
-Ignoring elements can be beneficial in the following scenarios:
+Filtering known, stable elements keeps your reports focused on real coverage gaps. When your team sees an untested element, it should signal _work to do_ — not noise from a sidebar that has been present and unchanged for months.
 
-- **Transitional Elements**: Exclude elements that are still in a loading state or undergoing changes, as they may not represent the final state of the element.
-- **Third-Party Widgets**: Exclude elements controlled by external libraries or third-party integrations.
+:::caution Preserve visibility into new elements
+Element filters remove matching elements entirely from coverage tracking. If a developer later adds a **new** button inside a section you've ignored (for example, a new action inside `#sidebar`), that new element will also be hidden. Use specific selectors rather than broad ones, and pair filters with [change monitoring](/ui-coverage/guides/monitor-changes) to stay aware of what's new.
+:::
 
-By ignoring irrelevant elements, you can maintain clean and actionable coverage metrics.
+## Step 1: Identify elements to ignore
 
-## Identify Elements to Ignore
+After recording your tests to Cypress Cloud, review the UI Coverage report to find recurring untested elements that aren't part of the workflows you're focused on.
 
-After recording your tests to Cypress Cloud, review the UI Coverage reports:
+1. In Cypress Cloud, open your project and go to a recent test run.
+2. Select the **UI Coverage** tab.
+3. Open the **Untested elements** section.
+4. Look for elements that appear across many views without being part of the workflows you care about — for example, a sidebar navigation menu that appears on every page, or filter icons on every data grid column.
+5. Click an element to open its detail panel. The detail panel shows the CSS selector Cypress uses to identify the element — copy this as your starting point for a filter rule.
 
-1. Navigate to the **UI Coverage** tab in your test run.
-1. Look for elements that consistently appear but don't require testing.
-1. Note down the selectors, attributes, or patterns for these elements.
+## Step 2: Configure ignored elements
 
-## Configure Ignored Elements
+[Element Filters](/ui-coverage/configuration/elementfilters) in the **App Quality** configuration exclude elements by CSS selector.
 
-[Element Filters](/ui-coverage/configuration/elementfilters) in the **App Quality** configuration are used to exclude elements based on their selectors or attributes. To add or modify the configuration for your project, navigate to the **App Quality** tab in your project settings and add an **elementFilters** configuration.
+To add or update your configuration:
+
+1. In Cypress Cloud, open your project settings.
+2. Go to the **App Quality** tab.
+3. Add or edit the `elementFilters` array under your `uiCoverage` configuration.
+
+### Example: Ignoring a global sidebar
+
+If your app has a persistent sidebar that appears on every page, exclude all of its interactive children at once using a descendant selector:
 
 ```json
 {
   "elementFilters": [
     {
-      "selector": "[data-external*]",
+      "selector": "#sidebar *",
+      "include": false,
+      "comment": "Global sidebar — has its own dedicated nav test suite"
+    }
+  ]
+}
+```
+
+### Example: Ignoring data grid filter icons
+
+Data grids often generate a large number of untested elements from per-column controls. Exclude the controls while keeping the cell content visible:
+
+```json
+{
+  "elementFilters": [
+    {
+      "selector": ".ag-header-icon, .ag-filter-icon, [data-testid='column-filter-btn']",
+      "include": false,
+      "comment": "Column filter and sort icons — out of scope for current test suite"
+    }
+  ]
+}
+```
+
+### Example: Ignoring third-party widgets
+
+External integrations like live chat or cookie consent banners are not your code to test. Exclude them by their container or `iframe` title:
+
+```json
+{
+  "elementFilters": [
+    {
+      "selector": "#intercom-container *",
+      "include": false
+    },
+    {
+      "selector": ".CookieConsent *",
       "include": false
     },
     {
       "selector": "iframe[title='Login']",
-      "include": false
-    },
+      "include": false,
+      "comment": "Third-party auth iframe"
+    }
+  ]
+}
+```
+
+### Example: Ignoring elements using a custom data attribute
+
+If your team has access to the application source code, the most maintainable approach is to mark elements directly in the HTML using a `data` attribute. This keeps the exclusion intent visible in the code itself.
+
+**In your application HTML:**
+
+```html
+<aside data-uic-ignore="true">
+  <!-- sidebar content -->
+</aside>
+```
+
+**In your UI Coverage configuration:**
+
+```json
+{
+  "elementFilters": [
     {
-      "selector": ".rdrDateRangePicker, .rdrDateRangePicker *",
+      "selector": "[data-uic-ignore='true'], [data-uic-ignore='true'] *",
       "include": false
     }
   ]
 }
 ```
 
-To learn more about the configuration options, refer to the [Element Filters](/ui-coverage/configuration/elementfilters) documentation.
+## Step 3: Validate the result
 
-## Validate Ignored Elements
+After saving your configuration, trigger a new test run (or wait for the next scheduled run) and open the updated UI Coverage report.
 
-After updating the configuration, record your tests again and review the UI Coverage report. The ignored elements should no longer appear in the coverage reports, streamlining the data and focusing on the critical areas of your application.
+1. Go to the **Untested elements** section.
+2. Confirm the elements you filtered no longer appear.
+3. If a filtered element still shows up, use your browser's DevTools to confirm your CSS selector actually matches that element on the page. The **Elements** panel in DevTools lets you run `document.querySelectorAll('your-selector')` in the Console to verify.
 
-If new unnecessary elements appear in future reports, update your filters accordingly to keep reports clean and actionable.
+## Balancing noise reduction with new-element visibility
+
+A common concern is: _"If I ignore elements now, will I miss new UI components added by developers?"_
+
+The key is to use **specific, targeted selectors** rather than broad ones:
+
+| Approach | Effect |
+|----------|--------|
+| `#sidebar *` | Excludes everything inside `#sidebar`, including future additions |
+| `#sidebar > nav > ul > li > a` | Only excludes the current top-level sidebar links |
+| `[data-uic-ignore='true'] *` | Only excludes what developers explicitly opt out of |
+
+For teams that want broad noise reduction _without_ losing sight of new elements, consider using [profiles](/ui-coverage/configuration/profiles) — apply a stricter filter in daily CI runs and a less-filtered profile for weekly audit runs, so new elements surface on a regular cadence without cluttering day-to-day reports.

--- a/docs/ui-coverage/guides/ignore-elements.mdx
+++ b/docs/ui-coverage/guides/ignore-elements.mdx
@@ -13,7 +13,6 @@ Not all elements in your application are relevant to your test coverage. Cypress
 
 Common candidates for exclusion include:
 
-- **Data grid and table controls** — column filter icons, sort arrows, or pagination buttons that are secondary concerns
 - **Third-party and embedded widgets** — chat launchers, cookie consent banners, analytics overlays, or auth iframes
 - **Transitional or loading elements** — spinners, skeletons, and progress indicators that don't represent a stable UI state
 
@@ -32,7 +31,7 @@ After recording your tests to Cypress Cloud, review the UI Coverage report to fi
 1. In Cypress Cloud, open your project and go to a recent test run.
 2. Select the **UI Coverage** tab.
 3. Open the **Untested elements** section.
-4. Look for elements that appear across many views without being part of the workflows you care about — for example, filter icons on every data grid column, or a third-party chat widget.
+4. Look for elements that appear across many views without being part of the workflows you care about — for example, a third-party chat widget that appears on every page.
 5. Click an element to open its detail panel. The detail panel shows the CSS selector Cypress uses to identify the element — copy this as your starting point for a filter rule.
 
 ## Step 2: Configure ignored elements
@@ -44,24 +43,6 @@ To add or update your configuration:
 1. In Cypress Cloud, open your project settings.
 2. Go to the **App Quality** tab.
 3. Add or edit the `elementFilters` array under your `uiCoverage` configuration.
-
-### Example: Ignoring data grid filter icons
-
-Data grids often generate a large number of untested elements from per-column controls. If these controls are a secondary concern, exclude them while keeping the cell content tracked.
-
-The exact selector depends on your grid library or component. Use your browser's DevTools to find the right selector for your app — right-click the filter icon in the browser and choose **Inspect** to see its class names or attributes.
-
-```json
-{
-  "elementFilters": [
-    {
-      "selector": "[data-testid='column-filter-btn']",
-      "include": false,
-      "comment": "Column filter icons — out of scope for current test suite"
-    }
-  ]
-}
-```
 
 ### Example: Ignoring third-party widgets
 

--- a/docs/ui-coverage/guides/ignore-elements.mdx
+++ b/docs/ui-coverage/guides/ignore-elements.mdx
@@ -24,7 +24,7 @@ Element filters remove matching elements entirely from coverage tracking. If a d
 
 ## Step 1: Identify elements to filter
 
-**For wrapper elements:** Open [Test Replay](/guides/cloud/test-replay) for a test run and observe which elements Cypress highlights during interactions. If clicking one control causes a nearby container `div` or overlay to also appear as interacted with, that wrapper is a candidate for filtering.
+**For wrapper elements:** Open [Test Replay](/cloud/features/test-replay) for a test run and observe which elements Cypress highlights during interactions. If clicking one control causes a nearby container `div` or overlay to also appear as interacted with, that wrapper is a candidate for filtering.
 
 **For third-party widgets:** Go to the **Untested elements** section of the UI Coverage report and look for elements that are clearly outside your application — chat widgets, consent banners, or embedded iframes from external domains.
 

--- a/docs/ui-coverage/guides/ignore-elements.mdx
+++ b/docs/ui-coverage/guides/ignore-elements.mdx
@@ -9,46 +9,57 @@ sidebar_position: 50
 
 # Ignore elements
 
-Not all elements in your application are relevant to your test coverage. Cypress UI Coverage lets you exclude specific elements from coverage reports so you can focus on what matters without chasing down false gaps.
+UI Coverage tracks every interactive element it detects in your app. Most of the time that's exactly what you want — but some elements create false signals that make reports harder to read and act on.
 
-Common candidates for exclusion include:
+The two most common sources of noise are:
 
-- **Third-party and embedded widgets** — chat launchers, cookie consent banners, analytics overlays, or auth iframes
-- **Transitional or loading elements** — spinners, skeletons, and progress indicators that don't represent a stable UI state
+- **Non-interactive wrapper elements** — container `div`s, overlays, and shadow shields that capture clicks intended for a child element, causing them to appear as tested or untested when they aren't real user-facing controls
+- **Third-party and embedded widgets** — chat launchers, cookie consent banners, analytics overlays, or auth iframes that aren't your code to test
 
-## Why ignore elements?
-
-Filtering known, stable elements keeps your reports focused on real coverage gaps. When your team sees an untested element, it should signal _work to do_ — not noise from a widget or control that isn't part of the workflows you're testing.
+[Element Filters](/ui-coverage/configuration/elementfilters) let you exclude these elements so your report reflects actual coverage of your application.
 
 :::caution Preserve visibility into new elements
-Element filters remove matching elements entirely from coverage tracking. If a developer later adds a **new** button inside a section you've ignored, that new element will also be hidden. Use specific selectors rather than broad ones, and pair filters with [change monitoring](/ui-coverage/guides/monitor-changes) to stay aware of what's new.
+Element filters remove matching elements entirely from coverage tracking. If a developer later adds a **new** button inside a section you've filtered, that new element will also be hidden. Use specific selectors rather than broad ones, and pair filters with [change monitoring](/ui-coverage/guides/monitor-changes) to stay aware of what's new.
 :::
 
-## Step 1: Identify elements to ignore
+## Step 1: Identify elements to filter
 
-After recording your tests to Cypress Cloud, review the UI Coverage report to find recurring untested elements that aren't part of the workflows you're focused on.
+**For wrapper elements:** Open [Test Replay](/guides/cloud/test-replay) for a test run and observe which elements Cypress highlights during interactions. If clicking one control causes a nearby container `div` or overlay to also appear as interacted with, that wrapper is a candidate for filtering.
 
-1. In Cypress Cloud, open your project and go to a recent test run.
-2. Select the **UI Coverage** tab.
-3. Open the **Untested elements** section.
-4. Look for elements that appear across many views without being part of the workflows you care about — for example, a third-party chat widget that appears on every page.
-5. Click an element to open its detail panel. The detail panel shows the CSS selector Cypress uses to identify the element — copy this as your starting point for a filter rule.
+**For third-party widgets:** Go to the **Untested elements** section of the UI Coverage report and look for elements that are clearly outside your application — chat widgets, consent banners, or embedded iframes from external domains.
 
-## Step 2: Configure ignored elements
+In both cases, click the element in the UI Coverage detail panel to see the CSS selector Cypress assigned to it. Use that as the starting point for your filter rule.
 
-[Element Filters](/ui-coverage/configuration/elementfilters) in the **App Quality** configuration exclude elements by CSS selector.
+## Step 2: Configure element filters
 
 To add or update your configuration:
 
 1. In Cypress Cloud, open your project settings.
 2. Go to the **App Quality** tab.
-3. Add or edit the `elementFilters` array under your `uiCoverage` configuration.
+3. Add or edit the `elementFilters` array.
 
-### Example: Ignoring third-party widgets
+**Filter order matters.** Filters are evaluated top-down and the first match wins — list specific selectors before broad catch-alls, otherwise a general rule will shadow more targeted ones.
 
-External integrations like live chat or cookie consent banners are not your code to test. Exclude them by their container element or `iframe` title.
+### Example: Filtering wrapper elements
 
-The exact selector varies by provider — use DevTools to inspect the widget's outermost container and find a stable `id` or `class` to target. Most third-party widgets inject a wrapper element with a predictable `id`.
+A common case: clicking a navigation item causes both the link itself and a surrounding `div` wrapper to appear as interacted with. Filter the wrappers while leaving the actual links tracked:
+
+```json
+{
+  "elementFilters": [
+    { "selector": "div.submenu-wrapper", "include": false },
+    { "selector": "div.menu-overlay", "include": false }
+  ]
+}
+```
+
+Use Test Replay to confirm which selector Cypress is capturing — the selector shown in the element detail panel is the one to target.
+
+### Example: Filtering third-party widgets
+
+External integrations are not your code to test. Exclude them by their container element or `iframe` title.
+
+The exact selector varies by provider. Use your browser's DevTools to inspect the widget's outermost container and find a stable `id` or `class`. Most third-party widgets inject a wrapper with a predictable `id`.
 
 ```json
 {
@@ -67,19 +78,19 @@ The exact selector varies by provider — use DevTools to inspect the widget's o
 }
 ```
 
-### Example: Ignoring elements using a custom data attribute
+### Example: Filtering elements using a custom data attribute
 
-If your team has access to the application source code, the most maintainable approach is to mark elements directly in the HTML using a `data` attribute. This keeps the exclusion intent visible in the code itself and doesn't depend on class names that might change.
+If your team has access to the application source code, the most maintainable approach is to mark elements directly in the HTML. This keeps the exclusion intent explicit in the code and avoids depending on class names that might change.
 
 **In your application HTML:**
 
 ```html
 <div data-uic-ignore="true">
-  <!-- third-party widget or out-of-scope component -->
+  <!-- non-interactive wrapper or out-of-scope component -->
 </div>
 ```
 
-**In your UI Coverage configuration:**
+**In your configuration:**
 
 ```json
 {
@@ -94,22 +105,10 @@ If your team has access to the application source code, the most maintainable ap
 
 ## Step 3: Validate the result
 
-After saving your configuration, trigger a new test run (or wait for the next scheduled run) and open the updated UI Coverage report.
+After saving your configuration, record a new test run and open the updated UI Coverage report.
 
-1. Go to the **Untested elements** section.
-2. Confirm the elements you filtered no longer appear.
-3. If a filtered element still shows up, use your browser's DevTools to confirm your CSS selector actually matches that element on the page. Open the Console and run `document.querySelectorAll('your-selector')` to verify.
+1. Go to the **Untested elements** section and confirm the filtered elements no longer appear.
+2. Check the **Tested elements** section to confirm no legitimate elements were accidentally removed.
+3. If a filtered element still shows up, open your browser's Console and run `document.querySelectorAll('your-selector')` to confirm your selector matches the right element.
 
-## Balancing noise reduction with new-element visibility
-
-A common concern is: _"If I ignore elements now, will I miss new UI components added by developers?"_
-
-The key is to use **specific, targeted selectors** rather than broad ones:
-
-| Approach | Effect |
-|----------|--------|
-| `#chat-widget *` | Excludes everything inside the container, including any future additions |
-| `#chat-widget > button.launcher` | Only excludes the specific launcher button |
-| `[data-uic-ignore='true'] *` | Only excludes what developers explicitly opt out of |
-
-For teams that want broad noise reduction _without_ losing sight of new elements, consider using [profiles](/ui-coverage/configuration/profiles) — apply a stricter filter in daily CI runs and a less-filtered profile for weekly audit runs, so new elements surface on a regular cadence without cluttering day-to-day reports.
+If a previously-tracked element disappears unexpectedly, check whether a new broad filter rule is inadvertently matching it, and narrow the selector.

--- a/docs/ui-coverage/guides/reduce-noise.mdx
+++ b/docs/ui-coverage/guides/reduce-noise.mdx
@@ -23,7 +23,7 @@ Many QA teams write tests that verify elements exist and look correct using Cypr
 - **Read-only display elements** like status badges, data labels, and section headers
 - **Navigation items** that tests confirm are present, but only some of which are actually clicked
 
-By default, UI Coverage marks an element as "tested" only when a [Cypress interaction command](/ui-coverage/core-concepts/interactivity#interaction-commands) such as `click`, `type`, or `check` is used on it. **Assertions alone — `.should()`, `.contains()` — do not count as interactions.** This means elements your team routinely checks with assertions will still show as uncovered in reports, which can be a significant source of confusion.
+By default, UI Coverage marks an element as "tested" only when a [Cypress interaction command](/ui-coverage/core-concepts/interactivity#Interaction-Commands) such as `click`, `type`, or `check` is used on it. **Assertions alone — `.should()`, `.contains()` — do not count as interactions.** This means elements your team routinely checks with assertions will still show as uncovered in reports, which can be a significant source of confusion.
 
 ### How to count assertions as coverage
 

--- a/docs/ui-coverage/guides/reduce-noise.mdx
+++ b/docs/ui-coverage/guides/reduce-noise.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Reduce noise
 title: 'Reduce noise | Cypress UI Coverage Documentation'
-description: 'Learn how to exclude irrelevant elements from your UI Coverage reports to focus on meaningful insights.'
+description: 'Learn how to reduce noise in your UI Coverage reports by handling assertion-only tests, grouping elements and views, and tuning attribute handling.'
 sidebar_position: 60
 ---
 
@@ -9,42 +9,122 @@ sidebar_position: 60
 
 # Reduce noise
 
-A clean and focused UI Coverage report enables you to make informed decisions about your testing strategy. Cypress UI Coverage provides tools to reduce noise in your reports by properly grouping elements, special attribute handling, and grouping views that share common URL patterns. This guide explains how and why to create a streamlined report.
+A focused UI Coverage report helps your team make better decisions about testing priorities. Noise in a report — elements or views that appear "uncovered" for reasons unrelated to gaps in your test logic — makes it harder to act on real coverage data.
 
-## Group views by URL patterns
+This guide covers the most common sources of noise and how to address each one.
 
-Cypress attempts to groups views with similar URL patterns (like when a URL contains a user ID) to provide a more consolidated view of coverage metrics.
+## Handle assertion-only and layout verification tests
 
-Customozing views with similar URL patterns allows you to consolidate coverage metrics for pages you know are related. To add or modify the configuration for your project, navigate to the **App Quality** tab in your project settings and add an **viewGroups** configuration.
+### Why assertion-only elements appear uncovered
 
-### Example: Grouping user profiles
+Many QA teams write tests that verify elements exist and look correct using Cypress assertions like `.should('be.visible')` or `.should('contain.text', 'Submit')`. This is a valid and common pattern, especially for:
+
+- **Layout verification tests** that confirm UI elements render correctly without exercising them
+- **Read-only display elements** like status badges, data labels, and section headers
+- **Navigation items** that tests confirm are present, but only some of which are actually clicked
+
+By default, UI Coverage marks an element as "tested" only when a [Cypress interaction command](/ui-coverage/core-concepts/interactivity#interaction-commands) such as `click`, `type`, or `check` is used on it. **Assertions alone — `.should()`, `.contains()` — do not count as interactions.** This means elements your team routinely checks with assertions will still show as uncovered in reports, which can be a significant source of confusion.
+
+### How to count assertions as coverage
+
+You can configure UI Coverage to treat Cypress assertions as valid coverage for specific elements using [`allowedInteractionCommands`](/ui-coverage/configuration/allowedinteractioncommands). This lets you tell UI Coverage: _"for these elements, an assertion is enough — I don't need a click to count them as tested."_
+
+To add or modify this configuration, go to the **App Quality** tab in your project settings in Cypress Cloud and update the `uiCoverage.allowedInteractionCommands` array.
+
+#### Example: Read-only status badges
+
+Your tests assert that a status indicator shows the correct value, but never click it:
+
+```json
+{
+  "uiCoverage": {
+    "allowedInteractionCommands": [
+      {
+        "selector": "[data-cy='status-badge'], .status-chip",
+        "commands": ["assert"],
+        "comment": "Read-only status elements — verified via assertion, no interaction needed"
+      }
+    ]
+  }
+}
+```
+
+In your tests:
+
+```javascript
+// This assertion will now count as coverage for elements matching the selector
+cy.get('[data-cy="status-badge"]').should('contain.text', 'Active') // ✓ Tracked
+cy.get('.status-chip').should('be.visible') // ✓ Tracked
+```
+
+#### Example: Navigation links verified but not all clicked
+
+If tests confirm navigation items are present and visible, but only some paths are clicked during a run:
+
+```json
+{
+  "uiCoverage": {
+    "allowedInteractionCommands": [
+      {
+        "selector": "nav a, .sidebar-link",
+        "commands": ["assert", "click"],
+        "comment": "Nav links: assertion counts as coverage; clicks still tracked too"
+      }
+    ]
+  }
+}
+```
+
+:::caution allowedInteractionCommands replaces, not extends, the defaults
+When you define `commands` for a selector, those become the **only** commands that count for matching elements — the defaults (`click`, `type`, etc.) are replaced. If you want assertions to count _in addition to_ clicks, include both `"assert"` and `"click"` (or whichever other commands apply) in the same rule.
+:::
+
+### Deciding between asserting and ignoring
+
+When an element consistently appears as uncovered, choose the right strategy based on what your tests do with it:
+
+| Scenario | Recommended approach |
+|---|---|
+| Tests run `.should()` on this element | Add `"assert"` to `allowedInteractionCommands` for this selector |
+| Tests never reference this element and it's out of scope | Use `elementFilters` to [exclude it](/ui-coverage/guides/ignore-elements) entirely |
+| Tests _should_ interact with it but don't yet | Leave it uncovered — it's a real gap to address |
+
+## Group views by URL pattern
+
+Cypress automatically groups views with similar URL patterns (such as `/users/1`, `/users/2`), but you can customize this grouping to consolidate coverage metrics for pages you know are related.
+
+To add or modify view grouping, go to the **App Quality** tab in your project settings and add a `views` configuration.
+
+### Example: Grouping user profile pages
 
 ```
-https://cypress.io/users/alice
-https://cypress.io/users/alice?foo=bar
-https://cypress.io/users/bob
-https://cypress.io/users/bob#baz
+https://app.example.com/users/alice
+https://app.example.com/users/alice?tab=settings
+https://app.example.com/users/bob
+https://app.example.com/users/bob#activity
 ```
 
 ```json
 {
   "views": [
     {
-      "pattern": "https://cypress.io/users/*"
+      "pattern": "https://app.example.com/users/*"
     }
   ]
 }
 ```
 
-To learn more about the configuration options, refer to the [Views](/ui-coverage/configuration/views) documentation.
+This consolidates all user profile pages into a single coverage view instead of showing each user's URL separately. See [Views configuration](/ui-coverage/configuration/views) for full details.
 
 ## Group similar elements
 
-Grouping elements improves clarity by reducing repetitive entries for elements with the same functionality. This is especially useful for elements like buttons, links, or form fields that appear across multiple views. By grouping similar elements, you can focus on the overall coverage of a specific element type rather than individual instances.
+Repeated elements that represent the same component can create many separate entries in the report. Grouping them reduces visual clutter and surfaces coverage at the component level rather than per-instance.
 
-### Example: Grouping dynamic IDs
+This is especially useful for lists, tables, and navigation menus where the same element type appears many times with different IDs or generated attributes.
 
-In the example below, the UI Coverage report shows multiple buttons that represent the same button due to a dynamically generated ID. By grouping these buttons, you can reduce noise and see the total coverage for the buttons with similar functionality in your application.
+### Example: Grouping dynamically generated navigation buttons
+
+In the example below, three navigation buttons share the same pattern but have different generated IDs, causing them to appear as three separate uncovered elements:
 
 ```html
 <nav>
@@ -54,49 +134,47 @@ In the example below, the UI Coverage report shows multiple buttons that represe
 </nav>
 ```
 
-To add or modify the configuration for your project, navigate to the **App Quality** tab in your project settings and add an **elementGroups** configuration under **uiCoverage**.
+Add an `elementGroups` rule to collapse them into a single entry:
 
 ```json
 {
   "uiCoverage": {
     "elementGroups": [
       {
-        "selector": "nav [id^=nav-button]"
+        "selector": "nav [id^='nav-button']"
       }
     ]
   }
 }
 ```
 
-Now instead of 3 separate elements in the UI Coverage report, the report will show a single entry for all buttons with the `nav-button` ID prefix, simplifying the view and providing a clearer picture of the coverage.
+The report will now show a single grouped entry instead of three separate items:
 
 ```
 nav [id^=nav-button] (3 instances)
 ```
 
-To learn more about the configuration options, refer to the [Element Groups](/ui-coverage/configuration/elementgroups) documentation.
+See [Element Groups configuration](/ui-coverage/configuration/elementgroups) for full details.
 
 ## Configure attribute handling
 
-Attribute configuration ensures that Cypress surfaces element attributes that are most meaningful to your project.
-
 ### Define significant attributes
 
-Specify which attributes Cypress should prioritize when identifying elements. To add or modify the configuration for your project, navigate to the **App Quality** tab in your project settings and add an **significantAttributes** configuration under **uiCoverage**.
+By default, Cypress uses a standard set of attributes to identify elements. If your application uses custom `data-*` attributes as stable, reliable identifiers, you can tell Cypress to prioritize those instead. This reduces noise caused by auto-generated class names or IDs changing between test runs.
 
 ```json
 {
   "uiCoverage": {
-    "significantAttributes": ["data-custom-id"]
+    "significantAttributes": ["data-testid", "data-cy", "data-automation-id"]
   }
 }
 ```
 
-To learn more about the configuration options, refer to the [Significant Attributes](/ui-coverage/configuration/significantattributes) documentation.
+See [Significant Attributes configuration](/ui-coverage/configuration/significantattributes) for full details.
 
-### Use Attribute Filters
+### Use attribute filters
 
-Exclude auto-generated or irrelevant attributes that add unnecessary noise. To add or modify the configuration for your project, navigate to the **App Quality** tab in your project settings and add an **attributeFilters** configuration under **uiCoverage**.
+Auto-generated attributes like Angular's `ng-*` directives or jQuery Sizzle IDs can make element identifiers unstable or misleading. Exclude them so Cypress relies on more stable selectors:
 
 ```json
 {
@@ -117,4 +195,4 @@ Exclude auto-generated or irrelevant attributes that add unnecessary noise. To a
 }
 ```
 
-To learn more about the configuration options, refer to the [Attribute Filters](/ui-coverage/configuration/attributefilters) documentation.
+See [Attribute Filters configuration](/ui-coverage/configuration/attributefilters) for full details.

--- a/docs/ui-coverage/guides/reduce-noise.mdx
+++ b/docs/ui-coverage/guides/reduce-noise.mdx
@@ -83,11 +83,11 @@ When you define `commands` for a selector, those become the **only** commands th
 
 When an element consistently appears as uncovered, choose the right strategy based on what your tests do with it:
 
-| Scenario | Recommended approach |
-|---|---|
-| Tests run `.should()` on this element | Add `"assert"` to `allowedInteractionCommands` for this selector |
+| Scenario                                                 | Recommended approach                                                               |
+| -------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| Tests run `.should()` on this element                    | Add `"assert"` to `allowedInteractionCommands` for this selector                   |
 | Tests never reference this element and it's out of scope | Use `elementFilters` to [exclude it](/ui-coverage/guides/ignore-elements) entirely |
-| Tests _should_ interact with it but don't yet | Leave it uncovered — it's a real gap to address |
+| Tests _should_ interact with it but don't yet            | Leave it uncovered — it's a real gap to address                                    |
 
 ## Group views by URL pattern
 


### PR DESCRIPTION
Expands ignore-elements guide with concrete real-world examples (sidebar,
grid filter icons, third-party widgets), clearer step-by-step instructions,
and guidance on preserving visibility into new elements while filtering noise.

Rewrites reduce-noise guide to directly address the assertion-only test
coverage gap: adds a new section explaining why layout verification tests
show as uncovered, and shows how to use allowedInteractionCommands with
"assert" to count .should() assertions as valid coverage for read-only
and display elements. Adds a decision table to help teams choose between
asserting, ignoring, or leaving an element as a real coverage gap.

https://claude.ai/code/session_01Xtiy2kq1g74G7Jt9Qsugku

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to documentation MDX files with no runtime, API, or configuration behavior changes.
> 
> **Overview**
> **Documentation-only** updates to two UI Coverage guides aimed at QA teams who need clearer, actionable guidance on report noise.
> 
> **`ignore-elements.mdx`** reframes the guide around wrapper noise and third-party widgets, adds a caution on over-broad filters hiding new elements, and restructures content into **identify → configure → validate** steps with Test Replay and Untested-elements workflows. JSON examples are replaced/expanded (submenu overlays, chat widget + auth iframe, optional `data-uic-ignore` markup) plus filter ordering and post-change validation (including `document.querySelectorAll`).
> 
> **`reduce-noise.mdx`** adds a major section on **assertion-only / layout verification** tests: why `.should()` does not count as tested by default, how to use `uiCoverage.allowedInteractionCommands` with `"assert"` (with examples and a caution that rules **replace** defaults), and a decision table (assert vs filter vs real gap). Existing view/element grouping and attribute sections are tightened with clearer examples and updated copy (e.g. `views` pattern hostnames, quoted attribute selectors in `elementGroups`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31050d4a2b808ee9994ccca015a5330af26900d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->