### PR TITLE
feat: Add note on root vs keyed AQ config overrides

### DIFF
--- a/docs/partials/_attributefilters.mdx
+++ b/docs/partials/_attributefilters.mdx
@@ -13,7 +13,7 @@ By using `attributeFilters`, you can ensure Cypress selects more appropriate ide
 :::info
 **Note:** setting `attributeFilters` impacts both Cypress Accessibility and UI Coverage
 reports if set at the root of the configuration. Nesting this property under an `accessibility` or `uiCoverage` key is
-supported, if you need to split them up.
+supported, if you need to split them up. If a nested value exists it will override one defined at the root level for that product.
 :::
 
 ## Syntax

--- a/docs/partials/_elementfilters.mdx
+++ b/docs/partials/_elementfilters.mdx
@@ -10,7 +10,7 @@ The `elementFilters` property allows you to specify selectors for elements that 
 :::info
 **Note:** setting `elementFilters` impacts both Accessibility and UI Coverage
 reports if set at the root of the configuration. Nesting this property under an `accessibility` or `uiCoverage` key is
-supported, if you need to split them up.
+supported, if you need to split them up. If a nested value exists it will override one defined at the root level for that product.
 :::
 
 ```json

--- a/docs/partials/_significantattributes.mdx
+++ b/docs/partials/_significantattributes.mdx
@@ -11,7 +11,7 @@ You may have attributes already in place in your application that would help wit
 :::info
 **Note:** setting `significantAttributes` impacts both Cypress Accessibility and UI Coverage
 reports if set at the root of the configuration. Nesting this property under an `accessibility` or `uiCoverage` key is
-supported, if you need to split them up.
+supported, if you need to split them up. If a nested value exists it will override one defined at the root level for that product.
 :::
 
 ## Syntax

--- a/docs/partials/_viewfilters.mdx
+++ b/docs/partials/_viewfilters.mdx
@@ -12,7 +12,7 @@ By default, every URL visited within a test run is included in reports. However,
 :::info
 **Note:** setting `viewFilters` impacts both Accessibility and UI Coverage reports.
 Nesting this property under an `accessibility` or `uiCoverage` key is
-supported, if you need to split them up.
+supported, if you need to split them up. If a nested value exists it will override one defined at the root level for that product.
 :::
 
 ## Note on product-specific behavior


### PR DESCRIPTION
Adding language for situations where the same AQ config property ends up defined at both the root level and under a product-specific key. This surfaced in a troubleshooting session yesterday where a user had defined a profile that didn't appear to get triggered, but it ended up being that the profile applied a value at the root level when it was also defined under a product-specific key in the base config. Not a profile-specific thing (you can define a value at root and product-level in normal config and see the same behavior), but may be harder to see when profiles are in play due to the extra nesting

```json
{
  "profiles": [
    {
      "name": "aq-config",
      "config": {
        "elementFilters": [....] // This got merged in but ends up at root level and is effectively ignored
      }
    }
  ],
  "uiCoverage": {
    "elementFilters": [...]    // This one took effect because it's product-specific
  }
}
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording changes with no runtime or configuration code impact.
> 
> **Overview**
> Clarifies **App Quality (AQ) configuration precedence** in four shared doc partials (`attributeFilters`, `elementFilters`, `significantAttributes`, `viewFilters`). Each **Scope** info note now states that a value nested under `accessibility` or `uiCoverage` **overrides** the same property when it is also set at the **root** for that product.
> 
> This documents behavior that can confuse users when **profiles** merge root-level settings while the base config keeps product-specific values—root settings may appear present but have no effect for that product.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ef8d251b6676419963a332d2e7b857e3ac7fc32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->