### PR TITLE
Expand ct configuration docs

### DIFF
--- a/docs/app/component-testing/angular/overview.mdx
+++ b/docs/app/component-testing/angular/overview.mdx
@@ -70,7 +70,7 @@ configure it properly.
 
 For a full explanation of how the dev server and bundler work — including
 automatic config detection and override options — see
-[Component Testing Configuration — Dev Server and Bundler](/app/component-testing/component-framework-configuration#dev-server-and-bundler).
+[Component Testing Configuration — Dev Server and Bundler](/app/component-testing/component-framework-configuration#Dev-Server-and-Bundler).
 
 The examples below are for quick reference.
 

--- a/docs/app/component-testing/angular/overview.mdx
+++ b/docs/app/component-testing/angular/overview.mdx
@@ -66,7 +66,13 @@ For usage and examples, visit the
 
 Cypress Component Testing works out of the box with `@angular/cli` projects.
 Cypress will automatically detect your project is Angular during setup and
-configure it properly. The examples below are for reference purposes.
+configure it properly.
+
+For a full explanation of how the dev server and bundler work — including
+automatic config detection and override options — see
+[Component Testing Configuration — Dev Server and Bundler](/app/component-testing/component-framework-configuration#dev-server-and-bundler).
+
+The examples below are for quick reference.
 
 ### Angular CLI Configuration
 

--- a/docs/app/component-testing/component-framework-configuration.mdx
+++ b/docs/app/component-testing/component-framework-configuration.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Configure Component Tests | Cypress Documentation'
-description: 'Configure Cypress for component testing with custom index files, dev servers, and spec patterns.'
+description: 'Configure Cypress for component testing with dev servers, bundlers, custom index files, and spec patterns.'
 sidebar_position: 30
 sidebar_label: Configuration
 ---
@@ -13,22 +13,321 @@ sidebar_label: Configuration
 
 ##### <Icon name="question-circle" color="#4BBFD2" /> What you'll learn
 
-- How to configure Cypress for component testing
-- How to use a custom index file
-- How to use a custom dev server
-- How to set a custom spec pattern for component tests
+- How Cypress uses a dev server and bundler to run component tests
+- How to configure the recommended `devServer` object syntax
+- How Cypress detects and merges your Vite or Webpack configuration
+- How to use a custom index file or spec pattern
+- How to implement a fully custom dev server for unsupported bundlers
 
 :::
 
 When you launch Cypress for the first time in a project, the app will
-automatically guide you through setup and configuration. You don't need to do
-anything additional to get started.
+automatically guide you through setup and configuration. The Launchpad detects
+your UI framework and bundler, installs the required dependencies, and scaffolds
+a `cypress.config` file with a `component.devServer` block.
 
-Refer to the "Framework Configuration" guide in each UI framework's overview
-guide for a list of supported development servers and how they are configured.
+The sections below explain what that configuration does and how to customize it.
+For framework-specific options (such as Angular monorepos or Next.js), also see
+the overview guide for your UI library:
 
-Below are more advanced configuration options you can customize to fit your
-project.
+- [React](/app/component-testing/react/overview)
+- [Vue](/app/component-testing/vue/overview)
+- [Angular](/app/component-testing/angular/overview)
+- [Svelte](/app/component-testing/svelte/overview)
+
+## Dev Server and Bundler
+
+Component tests run inside a real browser, but unlike end-to-end tests they do
+not visit your production or staging app. Instead, Cypress starts a **dev
+server** that compiles and serves your component specs on demand.
+
+The dev server is responsible for:
+
+1. Compiling each spec file (and your support file) with the same transforms your
+   app uses in development — JSX/TSX, Vue SFCs, CSS modules, path aliases, and
+   so on.
+2. Serving those compiled files over HTTP so the Cypress iframe can load them.
+3. Shutting down cleanly when you close the Cypress App or finish a test run.
+
+Cypress ships with built-in dev server implementations for **Vite** and
+**Webpack**. You do not need to install `@cypress/vite-dev-server` or
+`@cypress/webpack-dev-server` separately — they are bundled with the Cypress
+binary.
+
+### How it works at runtime
+
+When you open or run component tests, Cypress:
+
+1. Reads `component.devServer` from your config file.
+2. Starts the matching dev server (Vite or Webpack) on an available port.
+3. Sets `baseUrl` to `http://localhost:<port>`.
+4. Loads your component index HTML (by default
+   `cypress/support/component-index.html`) at
+   `<baseUrl><devServerPublicPathRoute>/index.html`.
+5. Injects a small bootstrap script that dynamically imports your support file
+   (if configured) and the active spec, then hands control to Cypress.
+
+By default, `devServerPublicPathRoute` is `/__cypress/src`. This keeps component
+test assets separate from your app's normal public path. See
+[devServerPublicPathRoute](#devserverpublicpathroute) if you need to change it.
+
+### Recommended configuration (object syntax)
+
+The recommended way to configure component testing is the **object syntax** for
+`component.devServer`. Specify your UI framework and bundler — Cypress wires up
+the correct dev server implementation for you:
+
+:::cypress-config-example
+
+```ts
+{
+  component: {
+    devServer: {
+      framework: 'react', // your UI framework
+      bundler: 'vite',    // 'vite' or 'webpack'
+    },
+  },
+}
+```
+
+:::
+
+This is the configuration the Launchpad scaffolds during project setup. It is
+all most projects need.
+
+#### Supported `framework` and `bundler` values
+
+| `framework` | Supported `bundler` values | Notes                                                                                                                      |
+| ----------- | -------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `react`     | `vite`, `webpack`          |                                                                                                                            |
+| `vue`       | `vite`, `webpack`          |                                                                                                                            |
+| `svelte`    | `vite`, `webpack`          |                                                                                                                            |
+| `next`      | `webpack`                  | Uses Next.js-specific Webpack presets. See [React overview — Next.js](/app/component-testing/react/overview#Nextjs).       |
+| `angular`   | `webpack`                  | Supports an `options.projectConfig` override. See [Angular overview](/app/component-testing/angular/overview#Options-API). |
+
+Community framework definitions (packages named `cypress-ct-*` or
+`@org/cypress-ct-*`) can also be used as the `framework` value when paired with
+a supported bundler. See [Custom Frameworks](/app/component-testing/custom-frameworks).
+
+### Automatic bundler configuration detection
+
+When you use the object syntax, Cypress tries to reuse the same bundler
+configuration you already use to develop your app. You usually do **not** need
+to duplicate your entire Vite or Webpack config in `cypress.config`.
+
+#### Vite
+
+If you omit `viteConfig`, Cypress searches upward from your project root for
+the first matching file:
+
+- `vite.config.ts`
+- `vite.config.js`
+- `vite.config.mjs`
+- `vite.config.cjs`
+- `vite.config.mts`
+- `vite.config.cts`
+
+When a config file is found, Cypress loads it and merges in Cypress-specific
+settings (plugins, public path, spec entries, and file-system allow rules).
+
+If no Vite config is found, Cypress shows an error asking you to add a
+`vite.config` file or pass a `viteConfig` option explicitly.
+
+#### Webpack
+
+If you omit `webpackConfig`, Cypress searches upward from your project root for
+the first matching file:
+
+- `webpack.config.ts`
+- `webpack.config.js`
+- `webpack.config.mjs`
+- `webpack.config.cjs`
+
+For meta-frameworks like **Next.js** and **Angular**, Cypress applies
+framework-specific presets before merging your config. For React, Vue, and
+Svelte, Cypress merges your detected Webpack config with a Cypress-specific
+overlay.
+
+If no Webpack config can be detected and no framework preset applies, Cypress
+shows an error asking you to add a `webpack.config` file or pass a
+`webpackConfig` option explicitly.
+
+### Overriding bundler configuration
+
+Pass `viteConfig` or `webpackConfig` when you need to customize what Cypress
+uses — for example, to add plugins, tweak aliases, or point at a config file
+outside the project root.
+
+Both options accept either a config object or an async function that returns
+one.
+
+#### Vite overrides
+
+:::cypress-config-example
+
+```ts
+import customViteConfig from './vite.config.custom'
+```
+
+```ts
+{
+  component: {
+    devServer: {
+      framework: 'react',
+      bundler: 'vite',
+      // Use a specific Vite config object
+      viteConfig: customViteConfig,
+      // Or compute one at runtime
+      viteConfig: async () => {
+        const base = await import('./vite.config')
+        return {
+          ...base.default,
+          // test-only overrides
+        }
+      },
+    },
+  },
+}
+```
+
+:::
+
+#### Webpack overrides
+
+:::cypress-config-example
+
+```ts
+import webpackConfig from './webpack.config'
+```
+
+```ts
+{
+  component: {
+    devServer: {
+      framework: 'react',
+      bundler: 'webpack',
+      webpackConfig,
+      webpackConfig: async () => {
+        const base = await import('./webpack.config')
+        return {
+          ...base.default,
+          // test-only overrides
+        }
+      },
+    },
+  },
+}
+```
+
+:::
+
+:::tip
+
+When you pass `viteConfig` directly, Cypress sets `configFile: false` and uses
+your provided config as the starting point (still merged with Cypress-specific
+overrides). When you omit `viteConfig`, Cypress auto-discovers your
+`vite.config.*` file instead.
+
+For Webpack, explicitly passed `webpackConfig` is merged with any
+framework-specific preset and Cypress overrides.
+
+:::
+
+### Function syntax (advanced)
+
+If you need direct access to the dev server API — for example, to pass options
+that are not exposed on the object syntax — use the **function syntax** and
+import the dev server from the appropriate package:
+
+:::cypress-config-example
+
+```ts
+import { devServer as viteDevServer } from '@cypress/vite-dev-server'
+```
+
+```ts
+{
+  component: {
+    devServer (cypressDevServerConfig) {
+      return viteDevServer({
+        ...cypressDevServerConfig,
+        framework: 'react',
+        viteConfig: async () => {
+          const config = await import('./vite.config')
+          return config.default
+        },
+      })
+    },
+  },
+}
+```
+
+:::
+
+```ts
+import { devServer as webpackDevServer } from '@cypress/webpack-dev-server'
+
+export default defineConfig({
+  component: {
+    devServer(cypressDevServerConfig) {
+      return webpackDevServer({
+        ...cypressDevServerConfig,
+        framework: 'react',
+        webpackConfig: require('./webpack.config.js'),
+      })
+    },
+  },
+})
+```
+
+The function receives a `cypressDevServerConfig` object with:
+
+| Property          | Description                                |
+| ----------------- | ------------------------------------------ |
+| `specs`           | Spec files Cypress is about to run         |
+| `cypressConfig`   | The resolved Cypress configuration         |
+| `devServerEvents` | Event emitter for compile lifecycle events |
+
+It must return (or resolve to) an object with:
+
+| Property | Description                               |
+| -------- | ----------------------------------------- |
+| `port`   | Port the dev server is listening on       |
+| `close`  | Optional callback to shut the server down |
+
+You can store additional dev server options on `component.devServerConfig` when
+using the function syntax. This field is passed as the second argument to your
+`devServer` function.
+
+### devServerPublicPathRoute
+
+The `devServerPublicPathRoute` option controls the URL path prefix Cypress uses
+to load compiled specs and assets. It defaults to `/__cypress/src`.
+
+In most projects the default works well. You may need to change it if component
+tests reference assets from your app's public directory and those paths must
+match your Vite `base` setting. For Vite 5+, set an empty string to align with
+Vite's default public path:
+
+:::cypress-config-example
+
+```ts
+{
+  component: {
+    devServerPublicPathRoute: '',
+    devServer: {
+      framework: 'react',
+      bundler: 'vite',
+    },
+  },
+}
+```
+
+:::
+
+Use caution when overriding this value — an incorrect public path can cause specs
+or assets to fail to load. See the
+[configuration reference](/app/references/configuration#component) for details.
 
 ## Custom Index File
 
@@ -44,18 +343,20 @@ in the [component config](/app/references/configuration#component) options:
 ```js
 {
   component: {
-    devServer,
-    indexHtmlFile: '/custom/path/to/component-index.html'
-  }
+    devServer: {
+      framework: 'react',
+      bundler: 'vite',
+    },
+    indexHtmlFile: '/custom/path/to/component-index.html',
+  },
 }
 ```
 
-## Custom Dev Server
+## Fully Custom Dev Server
 
-A custom function can be passed into the `devServer` option, which allows the
-use of build systems not provided by Cypress out of the box. These can be from
-the Cypress community, preview builds not included with the app, or a custom one
-you create.
+If your project uses a bundler other than Vite or Webpack, or you need complete
+control over compilation, pass a custom function to `component.devServer`. This
+is how community integrations and preview-server setups work.
 
 The function's signature takes in an object with the following properties as its
 only parameter and needs to resolve an object containing the port of your dev
@@ -79,7 +380,7 @@ interface DevServerOptions {
 
       return {
         port,
-        close
+        close,
       }
     },
   },
@@ -194,8 +495,12 @@ subdirectories.
 ```js
 {
   component: {
-    specPattern: 'src/**/*.cy.{js,jsx,ts,tsx}'
-  }
+    devServer: {
+      framework: 'react',
+      bundler: 'vite',
+    },
+    specPattern: 'src/**/*.cy.{js,jsx,ts,tsx}',
+  },
 }
 ```
 

--- a/docs/app/component-testing/component-framework-configuration.mdx
+++ b/docs/app/component-testing/component-framework-configuration.mdx
@@ -23,7 +23,7 @@ sidebar_label: Configuration
 
 When you launch Cypress for the first time in a project, the app will
 automatically guide you through setup and configuration. The Launchpad detects
-your UI framework and bundler, installs the required dependencies, and scaffolds
+your UI framework and bundler, lists the required dependencies needed for you to install, and scaffolds
 a `cypress.config` file with a `component.devServer` block.
 
 The sections below explain what that configuration does and how to customize it.
@@ -44,38 +44,28 @@ server** that compiles and serves your component specs on demand.
 The dev server is responsible for:
 
 1. Compiling each spec file (and your support file) with the same transforms your
-   app uses in development — JSX/TSX, Vue SFCs, CSS modules, path aliases, and
-   so on.
-2. Serving those compiled files over HTTP so the Cypress iframe can load them.
+   app uses in development (JSX/TSX, Vue SFCs, CSS modules, path aliases, and
+   so on).
+2. Serving those compiled files over HTTP so Cypress App can load them.
 3. Shutting down cleanly when you close the Cypress App or finish a test run.
 
 Cypress ships with built-in dev server implementations for **Vite** and
 **Webpack**. You do not need to install `@cypress/vite-dev-server` or
-`@cypress/webpack-dev-server` separately — they are bundled with the Cypress
-binary.
+`@cypress/webpack-dev-server` separately, they are bundled with the Cypress App.
 
 ### How it works at runtime
 
 When you open or run component tests, Cypress:
 
-1. Reads `component.devServer` from your config file.
+1. Reads `component.devServer` from your Cypress config file.
 2. Starts the matching dev server (Vite or Webpack) on an available port.
 3. Sets `baseUrl` to `http://localhost:<port>`.
 4. Loads your component index HTML (by default
-   `cypress/support/component-index.html`) at
-   `<baseUrl><devServerPublicPathRoute>/index.html`.
-5. Injects a small bootstrap script that dynamically imports your support file
-   (if configured) and the active spec, then hands control to Cypress.
+   `cypress/support/component-index.html`) and dynamically imports your support file (if configured) and the active spec, then hands control to Cypress.
 
-By default, `devServerPublicPathRoute` is `/__cypress/src`. This keeps component
-test assets separate from your app's normal public path. See
-[devServerPublicPathRoute](#devserverpublicpathroute) if you need to change it.
+### Recommended configuration
 
-### Recommended configuration (object syntax)
-
-The recommended way to configure component testing is the **object syntax** for
-`component.devServer`. Specify your UI framework and bundler — Cypress wires up
-the correct dev server implementation for you:
+The recommended way to configure component testing is to use the `component.devServer` object. Specify your UI framework and bundler and Cypress will wire up the correct dev server implementation for you:
 
 :::cypress-config-example
 
@@ -92,7 +82,7 @@ the correct dev server implementation for you:
 
 :::
 
-This is the configuration the Launchpad scaffolds during project setup. It is
+This is the configuration that Cypress App scaffolds during project setup. It is
 all most projects need.
 
 #### Supported `framework` and `bundler` values
@@ -111,37 +101,22 @@ a supported bundler. See [Custom Frameworks](/app/component-testing/custom-frame
 
 ### Automatic bundler configuration detection
 
-When you use the object syntax, Cypress tries to reuse the same bundler
+When you use the `component.devServer` object, Cypress tries to reuse the same bundler
 configuration you already use to develop your app. You usually do **not** need
-to duplicate your entire Vite or Webpack config in `cypress.config`.
+to duplicate your entire Vite or Webpack config in your Cypress config file.
 
 #### Vite
 
-If you omit `viteConfig`, Cypress searches upward from your project root for
-the first matching file:
-
-- `vite.config.ts`
-- `vite.config.js`
-- `vite.config.mjs`
-- `vite.config.cjs`
-- `vite.config.mts`
-- `vite.config.cts`
+If you omit `viteConfig`, Cypress searches upward from your project root for a `vite.config.ts|js|mjs|cjs|mts|cts` file.
 
 When a config file is found, Cypress loads it and merges in Cypress-specific
 settings (plugins, public path, spec entries, and file-system allow rules).
 
-If no Vite config is found, Cypress shows an error asking you to add a
-`vite.config` file or pass a `viteConfig` option explicitly.
+If no config file is found, Cypress shows an error asking you to add a `vite.config` file or pass a `viteConfig` option explicitly.
 
 #### Webpack
 
-If you omit `webpackConfig`, Cypress searches upward from your project root for
-the first matching file:
-
-- `webpack.config.ts`
-- `webpack.config.js`
-- `webpack.config.mjs`
-- `webpack.config.cjs`
+If you omit `webpackConfig`, Cypress searches upward from your project root for a `webpack.config.ts|js|mjs|cjs|mts|cts` file.
 
 For meta-frameworks like **Next.js** and **Angular**, Cypress applies
 framework-specific presets before merging your config. For React, Vue, and
@@ -155,11 +130,10 @@ shows an error asking you to add a `webpack.config` file or pass a
 ### Overriding bundler configuration
 
 Pass `viteConfig` or `webpackConfig` when you need to customize what Cypress
-uses — for example, to add plugins, tweak aliases, or point at a config file
+uses. For example, to add plugins, tweak aliases, or point to a config file
 outside the project root.
 
-Both options accept either a config object or an async function that returns
-one.
+Both options accept either a config object or an async function that returns a config object.
 
 #### Vite overrides
 
@@ -221,34 +195,19 @@ import webpackConfig from './webpack.config'
 
 :::
 
-:::tip
-
-When you pass `viteConfig` directly, Cypress sets `configFile: false` and uses
-your provided config as the starting point (still merged with Cypress-specific
-overrides). When you omit `viteConfig`, Cypress auto-discovers your
-`vite.config.*` file instead.
-
-For Webpack, explicitly passed `webpackConfig` is merged with any
-framework-specific preset and Cypress overrides.
-
-:::
-
 ### Function syntax (advanced)
 
 If you need direct access to the dev server API — for example, to pass options
 that are not exposed on the object syntax — use the **function syntax** and
 import the dev server from the appropriate package:
 
-:::cypress-config-example
-
-```ts
+```ts title=cypress.config.ts
+import { defineConfig } from 'cypress'
 import { devServer as viteDevServer } from '@cypress/vite-dev-server'
-```
 
-```ts
-{
+export default defineConfig({
   component: {
-    devServer (cypressDevServerConfig) {
+    devServer(cypressDevServerConfig) {
       return viteDevServer({
         ...cypressDevServerConfig,
         framework: 'react',
@@ -259,12 +218,11 @@ import { devServer as viteDevServer } from '@cypress/vite-dev-server'
       })
     },
   },
-}
+})
 ```
 
-:::
-
-```ts
+```ts title=cypress.config.ts
+import { defineConfig } from 'cypress'
 import { devServer as webpackDevServer } from '@cypress/webpack-dev-server'
 
 export default defineConfig({

--- a/docs/app/component-testing/get-started.mdx
+++ b/docs/app/component-testing/get-started.mdx
@@ -101,6 +101,12 @@ click "Continue".
 Next, Cypress generates all the necessary configuration files and gives you a
 list of all the changes it made to your project. Click "Continue".
 
+The most important generated setting is `component.devServer` in
+`cypress.config`, which tells Cypress which UI framework and bundler to use.
+For most projects, the scaffolded values are all you need. See
+[Dev Server and Bundler](/app/component-testing/component-framework-configuration#dev-server-and-bundler)
+for how this works and how to customize it.
+
 <DocsImage
   src="/img/app/component-testing/scaffolded-files.jpg"
   caption="The Cypress launchpad will scaffold all of these files for you"

--- a/docs/app/component-testing/get-started.mdx
+++ b/docs/app/component-testing/get-started.mdx
@@ -104,7 +104,7 @@ list of all the changes it made to your project. Click "Continue".
 The most important generated setting is `component.devServer` in
 `cypress.config`, which tells Cypress which UI framework and bundler to use.
 For most projects, the scaffolded values are all you need. See
-[Dev Server and Bundler](/app/component-testing/component-framework-configuration#dev-server-and-bundler)
+[Dev Server and Bundler](/app/component-testing/component-framework-configuration#Dev-Server-and-Bundler)
 for how this works and how to customize it.
 
 <DocsImage

--- a/docs/app/component-testing/react/overview.mdx
+++ b/docs/app/component-testing/react/overview.mdx
@@ -65,8 +65,13 @@ For usage and examples, visit the
 
 Cypress Component Testing works out of the box with [Vite](https://vitejs.dev/), [Next.js](https://nextjs.org/), and a custom
 [Webpack](https://webpack.js.org/) config. Cypress will automatically detect one
-of these frameworks during setup and configure them properly. The examples below
-are for reference purposes.
+of these frameworks during setup and configure them properly.
+
+For a full explanation of how the dev server and bundler work — including
+automatic config detection and override options — see
+[Component Testing Configuration — Dev Server and Bundler](/app/component-testing/component-framework-configuration#dev-server-and-bundler).
+
+The examples below are for quick reference.
 
 ### React with Vite
 

--- a/docs/app/component-testing/react/overview.mdx
+++ b/docs/app/component-testing/react/overview.mdx
@@ -69,7 +69,7 @@ of these frameworks during setup and configure them properly.
 
 For a full explanation of how the dev server and bundler work — including
 automatic config detection and override options — see
-[Component Testing Configuration — Dev Server and Bundler](/app/component-testing/component-framework-configuration#dev-server-and-bundler).
+[Component Testing Configuration — Dev Server and Bundler](/app/component-testing/component-framework-configuration#Dev-Server-and-Bundler).
 
 The examples below are for quick reference.
 

--- a/docs/app/component-testing/svelte/overview.mdx
+++ b/docs/app/component-testing/svelte/overview.mdx
@@ -72,7 +72,13 @@ For usage and examples, visit the
 Cypress Component Testing works out of the box with [Vite](https://vitejs.dev/),
 and a custom [Webpack](https://webpack.js.org/) config. Cypress will
 automatically detect one of these frameworks during setup and configure them
-properly. The examples below are for reference purposes.
+properly.
+
+For a full explanation of how the dev server and bundler work — including
+automatic config detection and override options — see
+[Component Testing Configuration — Dev Server and Bundler](/app/component-testing/component-framework-configuration#dev-server-and-bundler).
+
+The examples below are for quick reference.
 
 ### Svelte with Vite
 

--- a/docs/app/component-testing/svelte/overview.mdx
+++ b/docs/app/component-testing/svelte/overview.mdx
@@ -76,7 +76,7 @@ properly.
 
 For a full explanation of how the dev server and bundler work — including
 automatic config detection and override options — see
-[Component Testing Configuration — Dev Server and Bundler](/app/component-testing/component-framework-configuration#dev-server-and-bundler).
+[Component Testing Configuration — Dev Server and Bundler](/app/component-testing/component-framework-configuration#Dev-Server-and-Bundler).
 
 The examples below are for quick reference.
 

--- a/docs/app/component-testing/vue/overview.mdx
+++ b/docs/app/component-testing/vue/overview.mdx
@@ -68,7 +68,7 @@ and configure them properly.
 
 For a full explanation of how the dev server and bundler work — including
 automatic config detection and override options — see
-[Component Testing Configuration — Dev Server and Bundler](/app/component-testing/component-framework-configuration#dev-server-and-bundler).
+[Component Testing Configuration — Dev Server and Bundler](/app/component-testing/component-framework-configuration#Dev-Server-and-Bundler).
 
 The examples below are for quick reference.
 

--- a/docs/app/component-testing/vue/overview.mdx
+++ b/docs/app/component-testing/vue/overview.mdx
@@ -64,7 +64,13 @@ For usage and examples, visit the
 Cypress Component Testing works out of the box with
 [Vite](https://vitejs.dev/), and a custom [Webpack](https://webpack.js.org/)
 config. Cypress will automatically detect one of these frameworks during setup
-and configure them properly. The examples below are for reference purposes.
+and configure them properly.
+
+For a full explanation of how the dev server and bundler work — including
+automatic config detection and override options — see
+[Component Testing Configuration — Dev Server and Bundler](/app/component-testing/component-framework-configuration#dev-server-and-bundler).
+
+The examples below are for quick reference.
 
 ### Vue with Vite
 

--- a/docs/app/references/migration-guide.mdx
+++ b/docs/app/references/migration-guide.mdx
@@ -397,7 +397,7 @@ export default defineConfig({
 })
 ```
 
-Note that this package version is deprecated and no longer supported by Cypress and is intended as a workaround until you can migrate to Webpack `5`. More information on how to configure the dev server `v4 `can be found in the [Cypress Webpack Dev Server documentation](https://github.com/cypress-io/cypress/blob/@cypress/webpack-dev-server-v4.0.2/npm/webpack-dev-server/README.md) and [Custom Dev Server documentation](/app/component-testing/component-framework-configuration#Custom-Dev-Server).
+Note that this package version is deprecated and no longer supported by Cypress and is intended as a workaround until you can migrate to Webpack `5`. More information on how to configure the dev server `v4 `can be found in the [Cypress Webpack Dev Server documentation](https://github.com/cypress-io/cypress/blob/@cypress/webpack-dev-server-v4.0.2/npm/webpack-dev-server/README.md) and [Custom Dev Server documentation](/app/component-testing/component-framework-configuration#Fully-Custom-Dev-Server).
 
 ##### End-to-End Testing
 


### PR DESCRIPTION
Closes https://github.com/cypress-io/cypress-documentation/issues/5826

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or application code impact.
> 
> **Overview**
> This PR **centralizes and expands** Cypress component testing configuration docs around **dev servers and bundlers**.
> 
> The main change is a new **Dev Server and Bundler** section in `component-framework-configuration.mdx` that explains how CT uses Vite/Webpack at runtime, the recommended `component.devServer` object, supported framework/bundler pairs, automatic Vite/Webpack config detection, overrides, advanced function syntax, and `devServerPublicPathRoute`. The former **Custom Dev Server** section is renamed **Fully Custom Dev Server**, and doc examples now show explicit `devServer: { framework, bundler }` blocks instead of a bare `devServer` placeholder.
> 
> **Angular, React, Vue, and Svelte** overviews now point readers to that guide for full detail and label local snippets as quick reference. **Get Started** calls out scaffolded `component.devServer` after config file generation. The **migration guide** link anchor is updated to match the renamed heading.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d37873d552dea092368f6cb034778d00a1b0d62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->