### PR TITLE
Update cloud intro

### DIFF
--- a/docs/app/get-started/why-cypress.mdx
+++ b/docs/app/get-started/why-cypress.mdx
@@ -11,21 +11,26 @@ sidebar_position: 10
 
 ##### <Icon name="question-circle" color="#0097A8" /> What you'll learn
 
-- The solutions Cypress provides for testing
+- What Cypress does, and where it fits as your team grows
+- How Cypress reduces the cost and risk of shipping software
 - The features of Cypress App, Cypress Cloud, UI Coverage, and Cypress Accessibility
 - Our mission and what we believe in
 - Key differences between Cypress and other testing tools
 
 :::
 
-## In a nutshell
+## What is Cypress?
 
-Cypress is a next generation front end testing tool built for the modern web.
-We address the key pain points teams
-face when testing modern applications and maintaining test suites.
+Cypress is a quality platform for teams shipping modern web applications. We bring together end-to-end testing, component testing, accessibility checks, and a clear view of test coverage into a connected workflow that runs locally and in CI, so you can catch problems before your users do.
 
-Our users are typically developers, QA engineers, and teams looking to build web applications
-and increase the quality of their existing applications.
+Most teams come to Cypress looking for a better way to write tests for their front end. They stay because, as the team and the application grow, **Cypress does more than a testing tool would.**
+
+The same platform helps a single developer write their first test, a QA team manage thousands of specs, an accessibility partner track regressions, and an engineering lead see whether a release is safe to ship. 
+
+**What you write in Cypress becomes part of how your team ships software.** Tests run while you build. Results flow into CI. Failures, flake patterns, accessibility issues, and untested areas of your app surface in one place the whole team can act on.
+
+**By the time a change is ready to merge, your team should already know whether it's safe to ship.** That's how Cypress reduces the cost and risk of releasing software: fewer surprises in production, fewer hours lost to test maintenance, and a release cadence you can trust.
+
 
 Cypress provides solutions for:
 
@@ -47,22 +52,53 @@ of your test suite and the quality of your application.
 - [UI Coverage](/ui-coverage/get-started/introduction), a premium solution providing a visual overview of test coverage across every page and component of your app, offering clear insights into uncovered areas that everyone can understand.
 - [Cypress Accessibility](/accessibility/get-started/introduction), a premium solution providing accessibility checks, which helps detect barriers for people with disabilities using your application.
 
-Cypress is a robust solution that can improve the quality of your application.
+## How Cypress grows with your team
 
-- **First:** Cypress helps you set up and start writing tests every day while
-  you build your application locally. _Test Driven Development at its best!_
-- **Next:** After building up a suite of tests and
-  [integrating Cypress](/app/continuous-integration/overview) with your
-  CI Provider, [Cypress Cloud](/cloud/get-started/introduction) can record your test
-  runs surfacing exactly what happened during the test in [Test Replay](/cloud/features/test-replay). Use [Cloud MCP](/cloud/integrations/cloud-mcp) to give your AI coding assistant the same run and failure context in your IDE. You'll never have to wonder: _Why did this fail?_
-- **Finally:** Add on [Cypress Accessibility](/accessibility/get-started/introduction) to get continuous feedback on accessibility issues and regressions, and [UI Coverage](/ui-coverage/get-started/introduction) to ensure you've tested
-  every part of your application.
+**Install the Cypress app and start writing tests as you build.** The app is free and open source.
+
+This is where the day-to-day cost of testing lives. Most teams spend more time debugging broken tests than writing new ones, and most of that time goes to one question: what was the state of the app when the test failed?
+
+Cypress is built around making that question fast to answer:
+
+- **[Time Travel](/app/core-concepts/open-mode#Command-Log)** snapshots let you replay every step of a test locally instead of guessing.
+- **[Automatic waiting](/app/core-concepts/introduction-to-cypress#Cypress-is-Not-Like-jQuery)** removes the timing logic that other tools require you to hand-write and maintain.
+- **[Studio AI](/app/guides/cypress-studio)** records interactions and suggests assertions, so you spend less time authoring boilerplate.
+
+Less time on test maintenance is more time shipping features.
+
+### Move to CI with Cypress Cloud
+
+**When you start running Cypress in your CI pipeline, new problems show up.** Tests pass locally and fail in CI. Someone marks a test as flaky and a week later three more are flaky. Engineers burn afternoons digging through CI logs. Your team lead asks "are we good to merge?" and nobody has a confident answer.
+
+[Cypress Cloud](/cloud/get-started/introduction) replaces guesswork with evidence:
+
+- **[Test Replay](/cloud/features/test-replay)** allows you to replay the test exactly as it executed during the run for zero-configuration debugging.
+- **[Flaky test management](/cloud/features/flaky-test-management)** surfaces flake patterns so they get fixed instead of quietly suppressed.
+- **[Branch Review](/cloud/features/branch-review)** gives every pull request a pre-merge picture of the test signal, so "are we good to merge?" has a real answer before code lands on main.
+- **[Smart Orchestration](/cloud/features/smart-orchestration/parallelization)** keeps CI fast as your suite grows by parallelizing specs, prioritizing the ones most likely to fail, and canceling builds that are clearly broken.
+
+Faster, more trustworthy CI is the difference between a team that ships every day and a team that ships when they get lucky.
+
+If your team uses AI coding assistants, [Cloud MCP](/cloud/integrations/cloud-mcp) <Icon useCypressIcon name="general-sparkle-double-large" className="inline mt-[-4px]" fillColor="white" /> gives them the same run and failure context inside your IDE. You'll never have to wonder: _Why did this fail?_
+
+### Scale quality with premium products
+
+**As your application grows, two harder questions arrive.** Have we actually tested everything that matters? Is what we're shipping accessible to everyone trying to use it?
+
+The stakes grow with the questions. Accessibility issues caught in development cost a few hours of engineering time. The same issues caught by a compliance review, a procurement gate, or a public complaint cost a great deal more. Coverage gaps that hide in plain sight turn into the production incidents that derail your roadmap.
+
+Two premium products meet this stage:
+
+- **[Cypress Accessibility](/accessibility/get-started/introduction)** surfaces accessibility issues continuously during your normal test runs, with no setup, code changes, or performance penalty. Issues get caught in development rather than after launch.
+- **[UI Coverage](/ui-coverage/get-started/introduction)** gives engineers, product, and QA a single shared view of which parts of your app your tests reach and which they don't.
 
 ## Features
 
-Below are listed some of the key features of each product.
+Below are some of the key features of each product.
 
 ### Cypress App
+
+_The day-to-day cost of testing lives in your local dev loop. The Cypress app is built to keep that loop short._
 
 - **Time Travel:** Cypress takes snapshots as your tests run. Hover over
   commands in the [Command Log](/app/core-concepts/open-mode#Command-Log)
@@ -91,6 +127,8 @@ Below are listed some of the key features of each product.
 
 ### Cypress Cloud
 
+_Cypress Cloud turns CI test results from something you hope to interpret correctly into a signal your whole team can act on._
+
 - **Test Replay:** Record to [Cypress Cloud](/cloud/get-started/introduction) and replay the test exactly as it executed during the run for zero-configuration debugging using [Test Replay](/cloud/features/test-replay).
 - **Smart Orchestration:** Once you're set up to record to Cypress Cloud, easily
   [parallelize](/cloud/features/smart-orchestration/parallelization) your test
@@ -105,9 +143,11 @@ Below are listed some of the key features of each product.
 - **Integrations:** Integrate with [GitHub](/cloud/integrations/github), [GitLab](/cloud/integrations/gitlab), or [Bitbucket](/cloud/integrations/bitbucket) to see test results directly on every push or pull request. Cypress Cloud also integrates with
   [Slack](/cloud/integrations/slack), [Jira](/cloud/integrations/jira), and [Microsoft Teams](/cloud/integrations/teams) to keep your team in the loop.
 - **Test Analytics:** Track test results over time with [Test Analytics](/cloud/features/analytics/overview) to identify trends, regressions, and improvements in your test suite. Use our [Data Extract API](/cloud/integrations/data-extract-api) to extract the data that is important to your team.
-- **Cypress Cloud MCP** <Icon useCypressIcon name="general-sparkle-double-large" className="inline mt-[-4px]" fillColor="white" />: Give AI coding assistants a direct window into your application's health and stability by connecting to [Cypress Cloud MCP](/cloud/integrations/cloud-mcp).
+- **Cypress Cloud MCP** <Icon useCypressIcon name="general-sparkle-double-large" className="inline mt-[-4px]" fillColor="white" />: Give AI coding assistants a direct window into your application's health and stability without leaving your IDE by connecting to [Cypress Cloud MCP](/cloud/integrations/cloud-mcp).
 
 ### Cypress Accessibility
+
+_Accessibility issues caught during testing are cheap to fix. The same issues caught by a compliance review, a procurement gate, or a user complaint are not._
 
 - **Accessibility Checks:** Maximize the value of your existing Cypress tests by instantly adding thousands of [accessibility checks](/accessibility/get-started/introduction) with no setup, code changes, or performance penalty.
 - **Run-level reports:** Get a detailed report of accessibility issues found in your test runs with [Run-level reports](/accessibility/core-concepts/run-level-reports).
@@ -116,20 +156,21 @@ Below are listed some of the key features of each product.
 
 ### UI Coverage
 
+_You can't act on coverage gaps you can't see. UI Coverage makes them visible to the whole team._
+
 - **Visualize Coverage:** [UI Coverage](/ui-coverage/get-started/introduction) provides a visual overview of test coverage across every page and component of your app, offering clear insights into uncovered areas that everyone can understand.
-- **Results API:** Use the UI Coverage [Results API](/ui-coverage/results-api) to programmatically access test coverage data and integrate it into your existing workflows.
+- **Results where you work:** Use the [Results API](/accessibility/guides/results-api) to integrate results into CI, and [Cloud MCP](/cloud/integrations/cloud-mcp) to surface them in your AI agent for faster diagnosis and iteration.
 - **Branch Review:** Compare runs to see newly introduced elements in your application or unexpected reductions in test coverage.
 
 ## Solutions
 
-Cypress can be used to ensure several different types of test. This can provide
-even more confidence that your application under test is working as intended and accessible to all users.
+Cypress can be used to ensure several different types of tests. Used together, they give you broader, more dependable coverage before release.
 
 ### End-to-end Testing
 
 Cypress was originally designed to run [end-to-end (E2E) tests](/app/end-to-end-testing/writing-your-first-end-to-end-test) on anything that
 runs in a browser. A typical E2E test visits the application in a browser and
-performs actions via the UI just like a real user would.
+performs actions via the UI just like a real user would. They catch the failures your users would actually see, which is what makes them so valuable in the moments before code ships.
 
 ```js
 it('adds todos', () => {
@@ -143,7 +184,7 @@ it('adds todos', () => {
 ### Component Testing
 
 Cypress [Component Testing](/app/component-testing/get-started) provides a component workbench for you to quickly
-build and test components from multiple front-end UI libraries — no matter how
+build and test components from multiple front-end UI libraries, no matter how
 simple or complex.
 
 Learn more about how to test components for
@@ -217,7 +258,7 @@ it('uses custom text for the button label', () => {
 
 You can write Cypress tests to check the accessibility of your application, and use plugins to run broad accessibility scans.
 When combined with [Cypress Accessibility](/accessibility/get-started/introduction) in Cypress Cloud, insights can be surfaced when specific
-accessibility standards are not met through your testing - with no configuration required. See our [Accessibility Testing guide](/app/guides/accessibility-testing) for more details.
+accessibility standards are not met through your testing, with no configuration required. See our [Accessibility Testing guide](/app/guides/accessibility-testing) for more details.
 
 ```js
 it('adds todos', () => {
@@ -235,7 +276,7 @@ it('adds todos', () => {
 
 ### UI Coverage
 
-You can increase release confidence by closing testing gaps in critical app flows using [UI Coverage](/ui-coverage/get-started/introduction). Leverage data-driven insights to cover untested areas, reduce incidents, and improve app quality.
+You can increase release confidence by closing testing gaps in critical app flows using [UI Coverage](/ui-coverage/get-started/introduction). Use data-driven insights to cover untested areas, reduce incidents, and improve app quality across the team.
 
 <DocsImage
   src="/img/ui-coverage/get-started/uicov-docs-1.gif"
@@ -359,6 +400,8 @@ redirect for every test you run. You can accomplish this once with
 [`cy.origin()`](/api/commands/origin).
 
 ### Flake resistant
+
+Flake is one of the largest hidden costs in any test suite. Reducing it is one of the most direct ways Cypress keeps a suite trustworthy over time.
 
 Cypress knows and understands everything that happens in your application
 synchronously. It is notified the moment the page loads and the moment the page

--- a/docs/app/get-started/why-cypress.mdx
+++ b/docs/app/get-started/why-cypress.mdx
@@ -25,12 +25,11 @@ Cypress is a quality platform for teams shipping modern web applications. We bri
 
 Most teams come to Cypress looking for a better way to write tests for their front end. They stay because, as the team and the application grow, **Cypress does more than a testing tool would.**
 
-The same platform helps a single developer write their first test, a QA team manage thousands of specs, an accessibility partner track regressions, and an engineering lead see whether a release is safe to ship. 
+The same platform helps a single developer write their first test, a QA team manage thousands of specs, an accessibility partner track regressions, and an engineering lead see whether a release is safe to ship.
 
 **What you write in Cypress becomes part of how your team ships software.** Tests run while you build. Results flow into CI. Failures, flake patterns, accessibility issues, and untested areas of your app surface in one place the whole team can act on.
 
 **By the time a change is ready to merge, your team should already know whether it's safe to ship.** That's how Cypress reduces the cost and risk of releasing software: fewer surprises in production, fewer hours lost to test maintenance, and a release cadence you can trust.
-
 
 Cypress provides solutions for:
 

--- a/docs/app/get-started/why-cypress.mdx
+++ b/docs/app/get-started/why-cypress.mdx
@@ -473,3 +473,10 @@ Cypress.
 The app is bundled with everything you need,
 [just clone the repository](https://github.com/cypress-io/cypress-realworld-app)
 and start testing.
+
+## See also
+
+- [Install Cypress](/app/get-started/install-cypress) so you can quickly see your first passing test within minutes for
+- [Migrate from Playwright](/app/guides/migration/playwright-to-cypress)
+- [Migrate from Selenium](/app/guides/migration/selenium-to-cypress)
+- [Migrate from Protractor](/app/guides/migration/protractor-to-cypress)

--- a/docs/app/get-started/why-cypress.mdx
+++ b/docs/app/get-started/why-cypress.mdx
@@ -158,7 +158,7 @@ _Accessibility issues caught during testing are cheap to fix. The same issues ca
 _You can't act on coverage gaps you can't see. UI Coverage makes them visible to the whole team._
 
 - **Visualize Coverage:** [UI Coverage](/ui-coverage/get-started/introduction) provides a visual overview of test coverage across every page and component of your app, offering clear insights into uncovered areas that everyone can understand.
-- **Results where you work:** Use the [Results API](/accessibility/guides/results-api) to integrate results into CI, and [Cloud MCP](/cloud/integrations/cloud-mcp) to surface them in your AI agent for faster diagnosis and iteration.
+- **Results where you work:** Use the [Results API](/ui-coverage/results-api) to integrate results into CI, and [Cloud MCP](/cloud/integrations/cloud-mcp) to surface them in your AI agent for faster diagnosis and iteration.
 - **Branch Review:** Compare runs to see newly introduced elements in your application or unexpected reductions in test coverage.
 
 ## Solutions

--- a/docs/cloud/get-started/introduction.mdx
+++ b/docs/cloud/get-started/introduction.mdx
@@ -8,7 +8,7 @@ sidebar_label: Introduction
 
 # Scale your testing with confidence on every release
 
-Cypress Cloud unlocks the full potential of Cypress test automation tools in your CI pipeline. Scale every facet of Cypress testing, and push your code with confidence every time.
+Cypress Cloud is the companion service to the open-source Cypress app, and the place your team manages the quality of its tests and your application. Cypress Cloud shows how reliable your tests and app are over time, and orchestrates runs so feedback stays fast as your suite grows. You keep writing tests the same way you do today. Cypress Cloud gives your team one place to debug failures, track quality trends, and decide whether a release is ready to ship.
 
 <Btn
   label="Sign up ➜"
@@ -23,7 +23,7 @@ Cypress Cloud unlocks the full potential of Cypress test automation tools in you
   href="https://www.youtube.com/watch?v=vFLShoCM8pA"
 />
 <Btn
-  label=" Explore an example project"
+  label="Explore an example project"
   icon="technology-terminal-log"
   href="https://cloud.cypress.io/projects/7s5okt"
 />
@@ -33,39 +33,45 @@ Cypress Cloud unlocks the full potential of Cypress test automation tools in you
   title="View and debug past test results"
 />
 
+## Costs and risks Cypress Cloud helps you reduce
+
+Most of the value of Cypress Cloud is the time, money, and risk it removes from running tests in CI:
+
+- Slow feedback and rising CI spend: [Smart Orchestration](/cloud/features/smart-orchestration/overview) runs specs across multiple machines and [balances the load](/cloud/features/smart-orchestration/load-balancing#Balance-strategy), [Spec Prioritization](/cloud/features/smart-orchestration/spec-prioritization) runs recently failed specs first, and [Auto Cancellation](/cloud/features/smart-orchestration/run-cancellation) stops a run once it has already failed, so each pipeline uses less time and compute.
+- Flaky tests that erode trust in the suite: [Flaky Test Management](/cloud/features/flaky-test-management) surfaces unreliable tests before your team starts ignoring real failures.
+- Slow debugging of failures you cannot reproduce locally: [Test Replay](/cloud/features/test-replay) reproduces the exact run with full debug capability, so triage does not depend on guesswork.
+- Regressions reaching your main branch: status checks from the [GitHub](/cloud/integrations/github), [GitLab](/cloud/integrations/gitlab), and [Bitbucket](/cloud/integrations/bitbucket) integrations block failing code from merging.
+- Blind spots in quality over time: [analytics](/cloud/features/analytics/overview) track test health at the project and organization level, so you can see when reliability or speed starts to slip.
+
 ## Benefits
 
-[Cypress Cloud](https://on.cypress.io/about-cypress-cloud?utm_medium=cloud-benefits&utm_source=docs.cypress.io&utm_term=&utm_content=Cypress+Cloud) is our enterprise-ready companion
-to the open-source Cypress app, allowing you to:
+[Cypress Cloud](https://on.cypress.io/about-cypress-cloud?utm_medium=cloud-benefits&utm_source=docs.cypress.io&utm_term=&utm_content=Cypress+Cloud) brings test results, analytics, orchestration, and integrations together in one platform. With it, you can:
 
 - [View and debug past test results](#View-and-debug-past-test-results) from your CI environment.
 - [Analyze and diagnose](#Analyze-and-diagnose-test-health) test health.
-- [Reduce test time and save money](#Reduce-test-time--CI-costs) by smartly
-  orchestrating future runs across multiple machines.
-- [Integrate with your favorite developer tools](#Integrate-with-your-favorite-tools)
-  to help streamline your workflows.
-- [View CI runs and test health](#Cypress-app-integration) directly from the
-  Cypress app.
-- [Configure Cypress Cloud how you want](#Flexible-enterprise-configuration-and-single-sign-on) and enable enterprise single sign on.
+- [Reduce test time and CI costs](#Reduce-test-time--CI-costs) by orchestrating future runs across multiple machines.
+- [Integrate with the developer tools you already use](#Integrate-with-your-favorite-tools) to streamline your workflows.
+- [View CI runs and test health](#Cypress-app-integration) directly from the Cypress app.
+- [Configure Cypress Cloud the way your team works](#Flexible-enterprise-configuration-and-single-sign-on) and enable enterprise single sign-on.
 - Use [AI at Cypress](/cloud/features/cypress-ai-features) for test authoring ([Studio AI](/app/guides/cypress-studio), [cy.prompt()](/api/commands/prompt)), test analysis (Test Intent and Error Summaries), and UI Coverage test generation.
-- Add premium solutions like [UI Coverage](https://on.cypress.io/ui-coverage-trial?utm_medium=cloud-benefits&utm_source=docs.cypress.io&utm_term=&utm_content=UI+Coverage) and [Cypress Accessibility](http://on.cypress.io/accessibility-trial?utm_medium=cloud-benefits&utm_source=docs.cypress.io&utm_term=&utm_content=Cypress+Accessibility) to get new insights into test and application quality with no code, setup, or impact on your test runs.
+- Add premium solutions like [UI Coverage](https://on.cypress.io/ui-coverage-trial?utm_medium=cloud-benefits&utm_source=docs.cypress.io&utm_term=&utm_content=UI+Coverage) and [Cypress Accessibility](http://on.cypress.io/accessibility-trial?utm_medium=cloud-benefits&utm_source=docs.cypress.io&utm_term=&utm_content=Cypress+Accessibility) for new insights into test and application quality, with no code, setup, or impact on your test runs.
 
 ### View and debug past test results
 
 Each test run is stored in Cypress Cloud, where you can see past results and the
 current state of your app on the [Latest Runs](/cloud/features/recorded-runs) page.
 
-Replay the test as it executed during the recorded run with full debug capability using [<Logo src="/img/cloud/features/test-replay/replay-icon.svg"  alt="Replay Icon"/> Test Replay](/cloud/features/test-replay).
+Replay the test exactly as it ran during the recorded run, with full debug capability, using [<Logo src="/img/cloud/features/test-replay/replay-icon.svg"  alt="Replay Icon"/> Test Replay](/cloud/features/test-replay).
 
-Or view each test's
+You can also view each test's
 [command logs, screenshots, video replays, stack traces, and CI logs](/cloud/features/recorded-runs#Test-detail-sidebar).
-Quickly identifying a test failure in CI is just a click away.
+Pinpointing a CI test failure takes a single click.
 
 ### Analyze and diagnose test health
 
-View each [run's overview](/cloud/features/recorded-runs#Overview-tab) to see and compare
-past runs and analyze trends over time. You can quickly analyze changes in your
-setup that might introduce problematic trends as well as identify unreliable
+View each [run's overview](/cloud/features/recorded-runs#Overview-tab) to compare
+past runs and analyze trends over time. You can spot changes in your
+setup that might introduce problematic trends, and identify unreliable
 tests with [Flaky Test Management](/cloud/features/flaky-test-management).
 
 <DocsVideo
@@ -74,9 +80,9 @@ tests with [Flaky Test Management](/cloud/features/flaky-test-management).
 />
 
 The [analytics](/cloud/features/analytics/overview) capabilities show test metrics over time,
-helping determine the overall health of your test suite. Quickly see which tests
-are problematic, getting slower, or growing over time. Monitor your test health at both
-the project and organization level. Retrieve your test data through Cypress Cloud APIs.
+helping you determine the overall health of your test suite. You can see which tests
+are problematic, getting slower, or growing over time, and monitor test health at both
+the project and organization level. You can also retrieve your test data through Cypress Cloud APIs.
 
 <DocsImage
   src="/img/cloud/features/analytics/analytics-runstatus.png"
@@ -90,56 +96,46 @@ the project and organization level. Retrieve your test data through Cypress Clou
 
 ### Reduce test time & CI costs
 
-[Smart Orchestration](/cloud/features/smart-orchestration/overview) enables you to run
-tests across multiple machines simultaneously in your CI environment while
-Cypress Cloud coordinates runners and
-[balances test loads](/cloud/features/smart-orchestration/load-balancing#Balance-strategy) -
-no setup required! You can prioritize recently failed specs with
-[Spec Prioritization](/cloud/features/smart-orchestration/spec-prioritization) to
-surface problems earlier, and cancel whole test runs on failure with
-[Auto Cancellation](/cloud/features/smart-orchestration/run-cancellation) to save
-on resource usage. You can also
+[Smart Orchestration](/cloud/features/smart-orchestration/overview) lets you run
+tests across multiple machines at the same time in your CI environment, while
+Cypress Cloud coordinates the runners and
+[balances test loads](/cloud/features/smart-orchestration/load-balancing#Balance-strategy)
+with no setup required. To surface problems earlier, you can prioritize recently failed specs with
+[Spec Prioritization](/cloud/features/smart-orchestration/spec-prioritization), so they run sooner on their next run.
+To save time and resource usage, you can cancel a whole run on failure with
+[Auto Cancellation](/cloud/features/smart-orchestration/run-cancellation), or
 [cancel in-progress runs](/cloud/features/recorded-runs#Run-cancellation) manually
-from Cypress Cloud if you need to.
+from Cypress Cloud when you need to.
 
 <DocsImage
   src="/img/cloud/get-started/introduction/orchestration-diagram.png"
   alt="Diagram comparing serial and parallel test configurations"
 />
 
-Cypress Cloud's
-[Spec Prioritization](/cloud/features/smart-orchestration/spec-prioritization)
-lets you prioritize recently failed specs so they run faster on their next run.
-The [Auto Cancellation](/cloud/features/smart-orchestration/run-cancellation)
-feature will cancel a whole test run on failure, saving time and resource usage.
-You can also [cancel in-progress runs](/cloud/features/recorded-runs#Run-cancellation)
-manually from Cypress Cloud if you need to.
-
 ### Integrate with your favorite tools
 
-#### Source Control providers
+#### Source control providers
 
 Cypress Cloud integrates with [GitHub](/cloud/integrations/github),
 [GitLab](/cloud/integrations/gitlab), and
-[Bitbucket](/cloud/integrations/bitbucket) to provide rock-solid
-reliability by keeping failing code out of your main branch. Use status checks
-to block commits from being merged until your Cypress tests are green, and
-surface test results directly in your PRs with pull request comments that
+[Bitbucket](/cloud/integrations/bitbucket) to help keep failing code out of your
+main branch. Use status checks
+to block commits from merging until your Cypress tests are green, and
+surface test results directly in your pull requests with comments that
 include test run statistics, specific failure details, and deep links to results
 in Cypress Cloud for fast debugging.
 
-[Business and Enterprise plans](https://www.cypress.io/pricing/) include secure
+[Business and Enterprise plans](https://www.cypress.io/pricing/) also include secure
 integration with self-managed
 [GitHub](https://docs.github.com/en/enterprise-server@3.5/admin/overview/about-github-enterprise-server)
-and [GitLab](https://docs.gitlab.com/ee/subscriptions/self_managed/) instances
-too.
+and [GitLab](https://docs.gitlab.com/ee/subscriptions/self_managed/) instances.
 
 <DocsImage
   src="/img/cloud/integrations/github/status-checks-per-spec.jpg"
   alt="Status checks per spec"
 />
 
-#### Team Communication
+#### Team communication
 
 Get notified on test progress directly in your team's
 [Slack](/cloud/integrations/slack) or
@@ -151,24 +147,24 @@ Get notified on test progress directly in your team's
   width={560}
 />
 
-#### Issue Management
+#### Issue management
 
-Keep the whole team up-to-date with [Jira](/cloud/integrations/jira)
+Keep the whole team up to date with [Jira](/cloud/integrations/jira)
 integration. You can
 [create bidirectionally linked Jira tickets](/cloud/integrations/jira#Create-a-Jira-issue-from-a-test)
 directly from specific test failures.
 
-#### AI Coding Assistants
+#### AI coding assistants
 
-Give your AI coding assistant and AI agents a direct window into your application’s health and stability by connecting to [Cypress Cloud MCP ](/cloud/integrations/cloud-mcp).
+Give your AI coding assistant and agents a direct window into your application's health and stability by connecting to the [Cypress Cloud Model Context Protocol (MCP) server](/cloud/integrations/cloud-mcp).
 
-Eliminating the context gap between CI and your editor to you remove the manual triage that makes testing a bottleneck. Instead of manually providing context, let AI independently query run results, analyze stack traces, and audit flaky tests to verify and diagnose issues directly within your development loop. Works with Claude, Cursor, GitHub Copilot, and more.
+This closes the context gap between CI and your editor, so you remove the manual triage that slows testing down. Instead of pasting in context by hand, your AI tools can query run results, analyze stack traces, and audit flaky tests to diagnose issues inside your development loop. It works with Claude, Cursor, GitHub Copilot, and more.
 
 ### Cypress app integration
 
 The [Cypress app](/cloud/features/recorded-runs#Cypress-App) integrates directly with
-Cypress Cloud to provide developers with the latest test results without having
-to switch tools. This provides notifications about new failing tests in CI, so you can then
+Cypress Cloud to give developers the latest test results without
+switching tools. You get notifications about new failing tests in CI, so you can
 re-run them immediately in your local environment to debug.
 
 <DocsImage
@@ -176,13 +172,13 @@ re-run them immediately in your local environment to debug.
   alt="Debug page showing test results and failure details in the Cypress App"
 />
 
-### Flexible enterprise configuration and single sign on
+### Flexible enterprise configuration and single sign-on
 
-You can use our flexible administrative functions to configure Cypress Cloud however you want, grouping
+You can use our flexible administrative functions to configure Cypress Cloud the way your team works. Group
 [projects](/cloud/account-management/projects) into multiple
 [organizations](/cloud/account-management/organizations) if you have a
-lot, checking [usage](/cloud/account-management/billing-and-usage), and
-administering
+lot, check [usage](/cloud/account-management/billing-and-usage), and
+administer
 [users and permissions](/cloud/account-management/users#User-roles).
 
 We also provide [SSO integration](/cloud/account-management/enterprise-sso)
@@ -192,9 +188,9 @@ for teams on [Business or Enterprise plans](https://www.cypress.io/pricing/).
 
 The Cypress
 [Real World App (RWA)](https://github.com/cypress-io/cypress-realworld-app)
-leverages [Cypress Cloud in CI](https://cloud.cypress.io/projects/7s5okt) to
+uses [Cypress Cloud in CI](https://cloud.cypress.io/projects/7s5okt) to
 test over 300 test cases in parallel across 25 machines, multiple browsers,
-multiple device sizes and multiple operating systems.
+multiple device sizes, and multiple operating systems.
 
 :::info
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation and marketing copy only; no application code, APIs, or runtime behavior changes.
> 
> **Overview**
> This PR **reframes two flagship docs pages** around shipping confidence, CI pain, and cost/risk rather than feature lists alone.
> 
> **`why-cypress.mdx`** renames the opening from “In a nutshell” to **“What is Cypress?”** and positions Cypress as a **quality platform** that scales from a solo dev to QA, accessibility, and release decisions. It adds a **“How Cypress grows with your team”** journey (local app → Cypress Cloud in CI → premium Accessibility/UI Coverage), short **value-framing blurbs** under each product in Features, light copy edits across Solutions/Key Differences, a flake-cost note, and a new **See also** block with install/migration links.
> 
> **`cloud/get-started/introduction.mdx`** replaces the lead with clearer **companion-service** positioning, adds **“Costs and risks Cypress Cloud helps you reduce”** (orchestration, flake, replay, SCM gates, analytics), tightens Benefits and section prose (including MCP naming), removes duplicate Smart Orchestration paragraphs, and normalizes headings (e.g. single sign-on, integration subheads).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecca20554b08c849c8e9aef74deddc1f01383696. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->