### PR TITLE
add types for custom commands and queries

### DIFF
--- a/docs/api/commands/env.mdx
+++ b/docs/api/commands/env.mdx
@@ -174,6 +174,9 @@ cy.env(['baseUrl']).then(({ baseUrl }) => {
 
 Create custom commands that use `cy.env()`:
 
+<Tabs>
+<TabItem value="cypress/support/commands.js">
+
 ```javascript
 // cypress/support/commands.js
 Cypress.Commands.add('apiRequest', (endpoint, options = {}) => {
@@ -192,6 +195,42 @@ Cypress.Commands.add('apiRequest', (endpoint, options = {}) => {
 // In your test
 cy.apiRequest('/users').its('status').should('eq', 200)
 ```
+
+</TabItem>
+<TabItem value="cypress/support/commands.ts">
+
+```typescript
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      apiRequest(
+        endpoint: string,
+        options?: Partial<Cypress.RequestOptions>
+      ): Chainable<Cypress.Response<any>>
+    }
+  }
+}
+
+// cypress/support/commands.js
+Cypress.Commands.add('apiRequest', (endpoint, options = {}) => {
+  cy.env(['apiUrl', 'apiKey']).then(({ apiUrl, apiKey }) => {
+    cy.request({
+      url: `${apiUrl}${endpoint}`,
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        ...options.headers,
+      },
+      ...options,
+    })
+  })
+})
+
+// In your test
+cy.apiRequest('/users').its('status').should('eq', 200)
+```
+
+</TabItem>
+</Tabs>
 
 ### Suppress command logging
 

--- a/docs/api/commands/hover.mdx
+++ b/docs/api/commands/hover.mdx
@@ -90,18 +90,60 @@ Although Cypress does not have a built-in `cy.hover()` command, you can create
 your own custom command using
 [`Cypress.Commands.add()`](/api/cypress-api/custom-commands).
 
+<Tabs>
+<TabItem value="cypress/support/commands.js">
+
 ```javascript
 Cypress.Commands.add('hover', (...args) => {})
 ```
+
+</TabItem>
+<TabItem value="cypress/support/commands.ts">
+
+```typescript
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      hover(...args: any[]): Chainable<JQuery>
+    }
+  }
+}
+
+Cypress.Commands.add('hover', (...args) => {})
+```
+
+</TabItem>
+</Tabs>
 
 Note that while `Cypress.Commands.add()` is the recommended way to define a
 custom `cy.hover()` command,
 [`Cypress.Commands.overwrite()`](/api/cypress-api/custom-commands#Overwrite-Existing-Commands)
 will still work.
 
+<Tabs>
+<TabItem value="cypress/support/commands.js">
+
 ```javascript
 Cypress.Commands.overwrite('hover', (originalFn, ...otherArgs) => {})
 ```
+
+</TabItem>
+<TabItem value="cypress/support/commands.ts">
+
+```typescript
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      hover(...args: any[]): Chainable<JQuery>
+    }
+  }
+}
+
+Cypress.Commands.overwrite('hover', (originalFn, ...otherArgs) => {})
+```
+
+</TabItem>
+</Tabs>
 
 ## See also
 

--- a/docs/api/commands/mount.mdx
+++ b/docs/api/commands/mount.mdx
@@ -41,6 +41,9 @@ to start with for your commands:
 <Tabs>
 <TabItem value='React'>
 
+<Tabs>
+<TabItem value="cypress/support/commands.js">
+
 ```js
 import { mount } from 'cypress/react'
 
@@ -52,7 +55,34 @@ Cypress.Commands.add('mount', (component, options) => {
 ```
 
 </TabItem>
+<TabItem value="cypress/support/commands.ts">
+
+```ts
+import { mount } from 'cypress/react'
+
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      mount: typeof mount
+    }
+  }
+}
+
+Cypress.Commands.add('mount', (component, options) => {
+  // Wrap any parent components needed
+  // ie: return mount(<MyProvider>{component}</MyProvider>, options)
+  return mount(component, options)
+})
+```
+
+</TabItem>
+</Tabs>
+
+</TabItem>
 <TabItem value='Vue'>
+
+<Tabs>
+<TabItem value="cypress/support/commands.js">
 
 ```js
 import { mount } from 'cypress/vue'
@@ -80,7 +110,52 @@ Cypress.Commands.add('mount', (component, options = {}) => {
 ```
 
 </TabItem>
+<TabItem value="cypress/support/commands.ts">
+
+```ts
+import { mount } from 'cypress/vue'
+
+type MountParams = Parameters<typeof mount>
+type OptionsParam = MountParams[1]
+
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      mount: typeof mount
+    }
+  }
+}
+
+Cypress.Commands.add('mount', (component, options = {}) => {
+  // Setup options object
+  options.global = options.global || {}
+  options.global.stubs = options.global.stubs || {}
+  options.global.stubs['transition'] = false
+  options.global.components = options.global.components || {}
+  options.global.plugins = options.global.plugins || []
+
+  /* Add any global plugins */
+  // options.global.plugins.push({
+  //   install(app) {
+  //     app.use(MyPlugin);
+  //   },
+  // });
+
+  /* Add any global components */
+  // options.global.components['Button'] = Button;
+
+  return mount(component, options)
+})
+```
+
+</TabItem>
+</Tabs>
+
+</TabItem>
 <TabItem value='Angular'>
+
+<Tabs>
+<TabItem value="cypress/support/commands.js">
 
 ```js
 import { mount } from 'cypress/angular'
@@ -89,6 +164,28 @@ Cypress.Commands.add('mount', (component, config) => {
   return mount(component, config)
 })
 ```
+
+</TabItem>
+<TabItem value="cypress/support/commands.ts">
+
+```ts
+import { mount } from 'cypress/angular'
+
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      mount: typeof mount
+    }
+  }
+}
+
+Cypress.Commands.add('mount', (component, config) => {
+  return mount(component, config)
+})
+```
+
+</TabItem>
+</Tabs>
 
 </TabItem>
 </Tabs>

--- a/docs/api/commands/origin.mdx
+++ b/docs/api/commands/origin.mdx
@@ -304,6 +304,9 @@ do this with `cy.origin()`.
 
 <Icon name="exclamation-triangle" color="#f0ad4e" /> **Inefficient Usage**
 
+<Tabs>
+<TabItem value="cypress/support/commands.js">
+
 ```js
 Cypress.Commands.add('login', (username, password) => {
   // Remember to pass in arguments via `args`
@@ -320,6 +323,36 @@ Cypress.Commands.add('login', (username, password) => {
 })
 ```
 
+</TabItem>
+<TabItem value="cypress/support/commands.ts">
+
+```typescript
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      login(username: string, password: string): Chainable<void>
+    }
+  }
+}
+
+Cypress.Commands.add('login', (username, password) => {
+  // Remember to pass in arguments via `args`
+  const args = { username, password }
+  cy.origin('cypress.io', { args }, ({ username, password }) => {
+    // Go to https://example.cypress.com/login
+    cy.visit('/login')
+    cy.contains('Username').find('input').type(username)
+    cy.contains('Password').find('input').type(password)
+    cy.get('button').contains('Login').click()
+  })
+  // Confirm we're back at the primary origin before continuing
+  cy.url().should('contain', '/home')
+})
+```
+
+</TabItem>
+</Tabs>
+
 Having to go through an entire login flow before every test is not very
 performant. Up until now you could get around this problem by putting login code
 in the first test of your file, then performing subsequent tests reusing the
@@ -332,6 +365,9 @@ cache session information and reuse it across tests. So now let's enhance our
 custom login command with `cy.session()` for a complete syndicated login flow
 with session caching and validation. No mocking, no workarounds, no third-party
 plugins!
+
+<Tabs>
+<TabItem value="cypress/support/commands.js">
 
 ```js
 Cypress.Commands.add('login', (username, password) => {
@@ -356,6 +392,44 @@ Cypress.Commands.add('login', (username, password) => {
   )
 })
 ```
+
+</TabItem>
+<TabItem value="cypress/support/commands.ts">
+
+```typescript
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      login(username: string, password: string): Chainable<void>
+    }
+  }
+}
+
+Cypress.Commands.add('login', (username, password) => {
+  const args = { username, password }
+  cy.session(
+    // Username & password can be used as the cache key too
+    args,
+    () => {
+      cy.origin('cypress.io', { args }, ({ username, password }) => {
+        cy.visit('/login')
+        cy.contains('Username').find('input').type(username)
+        cy.contains('Password').find('input').type(password)
+        cy.get('button').contains('Login').click()
+      })
+      cy.url().should('contain', '/home')
+    },
+    {
+      validate() {
+        cy.request('/api/user').its('status').should('eq', 200)
+      },
+    }
+  )
+})
+```
+
+</TabItem>
+</Tabs>
 
 ## Learn More
 
@@ -464,11 +538,34 @@ and setting up custom commands to run within the `cy.origin()` callback:
 
 `cypress/support/commands.js`:
 
+<Tabs>
+<TabItem value="cypress/support/commands.js">
+
 ```js
 Cypress.Commands.add('clickLink', (label) => {
   cy.get('a').contains(label).click()
 })
 ```
+
+</TabItem>
+<TabItem value="cypress/support/commands.ts">
+
+```typescript
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      clickLink(label: string): Chainable<JQuery<HTMLElement>>
+    }
+  }
+}
+
+Cypress.Commands.add('clickLink', (label) => {
+  cy.get('a').contains(label).click()
+})
+```
+
+</TabItem>
+</Tabs>
 
 `cypress/support/e2e.js`:
 

--- a/docs/api/commands/session.mdx
+++ b/docs/api/commands/session.mdx
@@ -136,6 +136,9 @@ command with a call to `cy.session()`.
 
 **Before**
 
+<Tabs>
+<TabItem value="cypress/support/commands.js">
+
 ```javascript
 Cypress.Commands.add('login', (username, password) => {
   cy.visit('/login')
@@ -146,7 +149,34 @@ Cypress.Commands.add('login', (username, password) => {
 })
 ```
 
+</TabItem>
+<TabItem value="cypress/support/commands.ts">
+
+```typescript
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      login(username: string, password: string): Chainable<void>
+    }
+  }
+}
+
+Cypress.Commands.add('login', (username, password) => {
+  cy.visit('/login')
+  cy.get('[data-test=name]').type(username)
+  cy.get('[data-test=password]').type(password)
+  cy.get('form').contains('Log In').click()
+  cy.url().should('contain', '/login-successful')
+})
+```
+
+</TabItem>
+</Tabs>
+
 **After**
+
+<Tabs>
+<TabItem value="cypress/support/commands.js">
 
 ```javascript
 Cypress.Commands.add('login', (username, password) => {
@@ -160,7 +190,36 @@ Cypress.Commands.add('login', (username, password) => {
 })
 ```
 
+</TabItem>
+<TabItem value="cypress/support/commands.ts">
+
+```typescript
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      login(username: string, password: string): Chainable<void>
+    }
+  }
+}
+
+Cypress.Commands.add('login', (username, password) => {
+  cy.session([username, password], () => {
+    cy.visit('/login')
+    cy.get('[data-test=name]').type(username)
+    cy.get('[data-test=password]').type(password)
+    cy.get('form').contains('Log In').click()
+    cy.url().should('contain', '/login-successful')
+  })
+})
+```
+
+</TabItem>
+</Tabs>
+
 **With session validation**
+
+<Tabs>
+<TabItem value="cypress/support/commands.js">
 
 ```javascript
 Cypress.Commands.add('login', (username, password) => {
@@ -181,6 +240,40 @@ Cypress.Commands.add('login', (username, password) => {
   )
 })
 ```
+
+</TabItem>
+<TabItem value="cypress/support/commands.ts">
+
+```typescript
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      login(username: string, password: string): Chainable<void>
+    }
+  }
+}
+
+Cypress.Commands.add('login', (username, password) => {
+  cy.session(
+    [username, password],
+    () => {
+      cy.visit('/login')
+      cy.get('[data-test=name]').type(username)
+      cy.get('[data-test=password]').type(password)
+      cy.get('form').contains('Log In').click()
+      cy.url().should('contain', '/login-successful')
+    },
+    {
+      validate() {
+        cy.request('/whoami').its('status').should('eq', 200)
+      },
+    }
+  )
+})
+```
+
+</TabItem>
+</Tabs>
 
 ### Updating an existing login helper function
 
@@ -504,6 +597,9 @@ to solve this by refactoring the login code to assert directly inside `setup`.
 
 **Before**
 
+<Tabs>
+<TabItem value="cypress/support/commands.js">
+
 ```javascript
 Cypress.Commands.add('loginByApi', (username, password) => {
   return cy.request('POST', `/api/login`, {
@@ -519,7 +615,42 @@ it('should return the correct value', () => {
 })
 ```
 
+</TabItem>
+<TabItem value="cypress/support/commands.ts">
+
+```typescript
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      loginByApi(
+        username: string,
+        password: string
+      ): Chainable<Cypress.Response<any>>
+    }
+  }
+}
+
+Cypress.Commands.add('loginByApi', (username, password) => {
+  return cy.request('POST', `/api/login`, {
+    username,
+    password,
+  })
+})
+
+it('should return the correct value', () => {
+  cy.loginByApi('user', 's3cr3t').then((response) => {
+    expect(response.status).to.eq(200)
+  })
+})
+```
+
+</TabItem>
+</Tabs>
+
 **After**
+
+<Tabs>
+<TabItem value="cypress/support/commands.js">
 
 ```javascript
 Cypress.Commands.add('loginByApi', (username, password) => {
@@ -537,6 +668,37 @@ it('is a redundant test', () => {
   /* which you can now delete! */
 })
 ```
+
+</TabItem>
+<TabItem value="cypress/support/commands.ts">
+
+```typescript
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      loginByApi(username: string, password: string): Chainable<void>
+    }
+  }
+}
+
+Cypress.Commands.add('loginByApi', (username, password) => {
+  cy.session(username, () => {
+    cy.request('POST', `/api/login`, {
+      username,
+      password,
+    }).then((response) => {
+      expect(response.status).to.eq(200)
+    })
+  })
+})
+
+it('is a redundant test', () => {
+  /* which you can now delete! */
+})
+```
+
+</TabItem>
+</Tabs>
 
 ### Cross-domain sessions
 

--- a/docs/api/cypress-api/custom-commands.mdx
+++ b/docs/api/cypress-api/custom-commands.mdx
@@ -122,17 +122,43 @@ Examples of parent commands:
 
 #### Click link containing text
 
+<Tabs>
+<TabItem value="cypress/support/commands.js">
+
 ```js
 Cypress.Commands.add('clickLink', (label) => {
   cy.get('a').contains(label).click()
 })
 ```
 
-```js
+</TabItem>
+<TabItem value="cypress/support/commands.ts">
+
+```typescript
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      clickLink(label: string): Chainable<JQuery<HTMLElement>>
+    }
+  }
+}
+
+Cypress.Commands.add('clickLink', (label) => {
+  cy.get('a').contains(label).click()
+})
+```
+
+</TabItem>
+</Tabs>
+
+```js title="spec.cy.js"
 cy.clickLink('Buy Now')
 ```
 
 #### Check a token
+
+<Tabs>
+<TabItem value="cypress/support/commands.js">
 
 ```js
 Cypress.Commands.add('checkToken', (token) => {
@@ -140,7 +166,27 @@ Cypress.Commands.add('checkToken', (token) => {
 })
 ```
 
-```js
+</TabItem>
+<TabItem value="cypress/support/commands.ts">
+
+```typescript
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      checkToken(token: string): Chainable<JQuery<HTMLElement>>
+    }
+  }
+}
+
+Cypress.Commands.add('checkToken', (token) => {
+  cy.window().its('localStorage.token').should('eq', token)
+})
+```
+
+</TabItem>
+</Tabs>
+
+```js title="spec.cy.js"
 cy.checkToken('abc123')
 ```
 
@@ -149,6 +195,9 @@ cy.checkToken('abc123')
 Originally used in
 [cypress-downloadfile](https://github.com/Xvier/cypress-downloadfile), this
 command calls other Cypress commands.
+
+<Tabs>
+<TabItem value="cypress/support/commands.js">
 
 ```javascript
 Cypress.Commands.add('downloadFile', (url, directory, fileName) => {
@@ -163,11 +212,45 @@ Cypress.Commands.add('downloadFile', (url, directory, fileName) => {
 })
 ```
 
-```js
+</TabItem>
+<TabItem value="cypress/support/commands.ts">
+
+```typescript
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      downloadFile(
+        url: string,
+        directory: string,
+        fileName: string
+      ): Chainable<unknown>
+    }
+  }
+}
+
+Cypress.Commands.add('downloadFile', (url, directory, fileName) => {
+  return cy.getCookies().then((cookies) => {
+    return cy.task('downloadFile', {
+      url,
+      directory,
+      cookies,
+      fileName,
+    })
+  })
+})
+```
+
+</TabItem>
+</Tabs>
+
+```js title="spec.cy.js"
 cy.downloadFile('https://path_to_file.pdf', 'mydownloads', 'demo.pdf')
 ```
 
 #### Commands to work with `sessionStorage`
+
+<Tabs>
+<TabItem value="cypress/support/commands.js">
 
 ```js
 Cypress.Commands.add('getSessionStorage', (key) => {
@@ -181,12 +264,42 @@ Cypress.Commands.add('setSessionStorage', (key, value) => {
 })
 ```
 
-```js
+</TabItem>
+<TabItem value="cypress/support/commands.ts">
+
+```typescript
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      getSessionStorage(key: string): Chainable<void>
+      setSessionStorage(key: string, value: string): Chainable<void>
+    }
+  }
+}
+
+Cypress.Commands.add('getSessionStorage', (key) => {
+  cy.window().then((window) => window.sessionStorage.getItem(key))
+})
+
+Cypress.Commands.add('setSessionStorage', (key, value) => {
+  cy.window().then((window) => {
+    window.sessionStorage.setItem(key, value)
+  })
+})
+```
+
+</TabItem>
+</Tabs>
+
+```js title="spec.cy.js"
 cy.setSessionStorage('token', 'abc123')
 cy.getSessionStorage('token').should('eq', 'abc123')
 ```
 
 #### Log in command using UI
+
+<Tabs>
+<TabItem value="cypress/support/commands.js">
 
 ```js
 Cypress.Commands.add('loginViaUi', (user) => {
@@ -208,11 +321,54 @@ Cypress.Commands.add('loginViaUi', (user) => {
 })
 ```
 
-```js
+</TabItem>
+<TabItem value="cypress/support/commands.ts">
+
+```typescript
+interface LoginUser {
+  email: string
+  password: string
+  name: string
+}
+
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      loginViaUi(user: LoginUser): Chainable<null>
+    }
+  }
+}
+
+Cypress.Commands.add('loginViaUi', (user) => {
+  cy.session(
+    user,
+    () => {
+      cy.visit('/login')
+      cy.get('input[name=email]').type(user.email)
+      cy.get('input[name=password]').type(user.password)
+      cy.get('button#login').click()
+      cy.get('h1').contains(`Welcome back ${user.name}!`)
+    },
+    {
+      validate: () => {
+        cy.getCookie('auth_key').should('exist')
+      },
+    }
+  )
+})
+```
+
+</TabItem>
+</Tabs>
+
+```js title="spec.cy.js"
 cy.loginViaUi({ email: 'fake@email.com', password: '$ecret1', name: 'johndoe' })
 ```
 
 #### Log in command using request
+
+<Tabs>
+<TabItem value="cypress/support/commands.js">
 
 ```javascript
 Cypress.Commands.add('loginViaApi', (userType, options = {}) => {
@@ -258,7 +414,60 @@ Cypress.Commands.add('loginViaApi', (userType, options = {}) => {
 })
 ```
 
-```javascript
+</TabItem>
+<TabItem value="cypress/support/commands.ts">
+
+```typescript
+type UserType = 'admin' | 'user'
+
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      loginViaApi(
+        userType: UserType,
+        options?: Partial<Cypress.Loggable>
+      ): Chainable<Cypress.Response<unknown>>
+    }
+  }
+}
+
+Cypress.Commands.add('loginViaApi', (userType, options = {}) => {
+  const types = {
+    admin: {
+      name: 'Jane Lane',
+      admin: true,
+    },
+    user: {
+      name: 'Jim Bob',
+      admin: false,
+    },
+  }
+
+  const user = types[userType]
+
+  cy.request({
+    url: '/seed/users',
+    method: 'POST',
+    body: user,
+  })
+    .its('body')
+    .then((body) => {
+      cy.request({
+        url: '/login',
+        method: 'POST',
+        body: {
+          email: body.email,
+          password: body.password,
+        },
+      })
+    })
+})
+```
+
+</TabItem>
+</Tabs>
+
+```js title="spec.cy.js"
 // can start a chain off of cy
 cy.loginViaApi('admin')
 
@@ -267,6 +476,9 @@ cy.get('button').loginViaApi('user')
 ```
 
 #### Log out command using UI
+
+<Tabs>
+<TabItem value="cypress/support/commands.js">
 
 ```js
 Cypress.Commands.add('logout', () => {
@@ -278,7 +490,34 @@ Cypress.Commands.add('logout', () => {
 })
 ```
 
+</TabItem>
+<TabItem value="cypress/support/commands.ts">
+
+```typescript
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      logout(): Chainable<JQuery<HTMLElement>>
+    }
+  }
+}
+
+Cypress.Commands.add('logout', () => {
+  cy.contains('Login').should('not.exist')
+  cy.get('.avatar').click()
+  cy.contains('Logout').click()
+  cy.get('h1').contains('Login')
+  cy.getCookie('auth_key').should('not.exist')
+})
+```
+
+</TabItem>
+</Tabs>
+
 #### Log out command using `localStorage` <E2EOnlyBadge />
+
+<Tabs>
+<TabItem value="cypress/support/commands.js">
 
 ```js
 Cypress.Commands.add('logout', () => {
@@ -288,11 +527,36 @@ Cypress.Commands.add('logout', () => {
 })
 ```
 
-```js
+</TabItem>
+<TabItem value="cypress/support/commands.ts">
+
+```typescript
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      logout(): Chainable<Cypress.AUTWindow>
+    }
+  }
+}
+
+Cypress.Commands.add('logout', () => {
+  cy.window().its('localStorage').invoke('removeItem', 'session')
+
+  cy.visit('/login')
+})
+```
+
+</TabItem>
+</Tabs>
+
+```js title="spec.cy.js"
 cy.logout()
 ```
 
 #### Create a user
+
+<Tabs>
+<TabItem value="cypress/support/commands.js">
 
 ```js
 Cypress.Commands.add('createUser', (user) => {
@@ -314,7 +578,46 @@ Cypress.Commands.add('createUser', (user) => {
 })
 ```
 
-```js
+</TabItem>
+<TabItem value="cypress/support/commands.ts">
+
+```typescript
+interface User {
+  id: number
+  name: string
+}
+
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      createUser(user: User): Chainable<Cypress.Response<unknown>>
+    }
+  }
+}
+
+Cypress.Commands.add('createUser', (user) => {
+  cy.request({
+    method: 'POST',
+    url: 'https://www.example.com/tokens',
+    body: {
+      email: 'admin_username',
+      password: 'admin_password',
+    },
+  }).then((resp) => {
+    cy.request({
+      method: 'POST',
+      url: 'https://www.example.com/users',
+      headers: { Authorization: 'Bearer ' + resp.body.token },
+      body: user,
+    })
+  })
+})
+```
+
+</TabItem>
+</Tabs>
+
+```js title="spec.cy.js"
 cy.createUser({
   id: 123,
   name: 'Jane Lane',
@@ -345,6 +648,9 @@ Examples of child commands:
 
 #### Custom `console` command
 
+<Tabs>
+<TabItem value="cypress/support/commands.js">
+
 ```javascript
 // not a super useful custom command
 // but demonstrates how subject is passed
@@ -373,7 +679,35 @@ Cypress.Commands.add(
 )
 ```
 
-```javascript
+</TabItem>
+<TabItem value="cypress/support/commands.ts">
+
+```typescript
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      console(method?: keyof Console): Chainable<JQuery<HTMLElement>>
+    }
+  }
+}
+
+Cypress.Commands.add(
+  'console',
+  {
+    prevSubject: 'element',
+  },
+  (subject, method) => {
+    method = method || 'log'
+    console[method]('The subject is', subject)
+    return subject
+  }
+)
+```
+
+</TabItem>
+</Tabs>
+
+```js title="spec.cy.js"
 cy.get('button')
   .console('info')
   .then(($button) => {
@@ -386,7 +720,7 @@ require a subject.
 
 Invoking it like this would error:
 
-```javascript
+```js title="spec.cy.js"
 cy.console() // error about how you can't call console without a subject
 ```
 
@@ -416,6 +750,9 @@ Examples of dual commands:
 
 #### Custom Dual Command
 
+<Tabs>
+<TabItem value="cypress/support/commands.js">
+
 ```javascript
 Cypress.Commands.add('dismiss', {
   prevSubject: 'optional'
@@ -435,7 +772,34 @@ Cypress.Commands.add('dismiss', {
 })
 ```
 
-```javascript
+</TabItem>
+<TabItem value="cypress/support/commands.ts">
+
+```typescript
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      dismiss(arg1?: string, arg2?: string): Chainable<JQuery<HTMLElement>>
+    }
+  }
+}
+
+Cypress.Commands.add('dismiss', {
+  prevSubject: 'optional'
+}, (subject, arg1, arg2) => {
+  if (subject) {
+    cy.wrap(subject)
+    ...
+  } else {
+    ...
+  }
+})
+```
+
+</TabItem>
+</Tabs>
+
+```js title="spec.cy.js"
 cy.dismiss() // no subject
 cy.get('#dialog').dismiss() // with subject
 ```
@@ -456,6 +820,9 @@ want to modify the behavior of a query, you'll need to use
 
 #### Overwrite `visit` command
 
+<Tabs>
+<TabItem value="cypress/support/commands.js">
+
 ```javascript
 Cypress.Commands.overwrite('visit', (originalFn, url, options) => {
   const domain = Cypress.expose('BASE_DOMAIN')
@@ -475,6 +842,39 @@ Cypress.Commands.overwrite('visit', (originalFn, url, options) => {
   return originalFn(url, options)
 })
 ```
+
+</TabItem>
+<TabItem value="cypress/support/commands.ts">
+
+```typescript
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      visit(
+        url: string,
+        options?: Partial<Cypress.VisitOptions>
+      ): Chainable<AUTWindow>
+    }
+  }
+}
+
+Cypress.Commands.overwrite('visit', (originalFn, url, options) => {
+  const domain = Cypress.expose('BASE_DOMAIN')
+
+  if (domain === '...') {
+    url = '...'
+  }
+
+  if (options?.something === 'else') {
+    url = '...'
+  }
+
+  return originalFn(url, options)
+})
+```
+
+</TabItem>
+</Tabs>
 
 :::info
 
@@ -513,6 +913,9 @@ command so that sensitive data does not display in screenshots or videos of your
 test run. This example overwrites the [.type()](/api/commands/type) command to
 allow you to mask sensitive data in the Cypress Command Log.
 
+<Tabs>
+<TabItem value="cypress/support/commands.js">
+
 ```js
 Cypress.Commands.overwrite('type', (originalFn, element, text, options) => {
   if (options && options.sensitive) {
@@ -530,7 +933,46 @@ Cypress.Commands.overwrite('type', (originalFn, element, text, options) => {
 })
 ```
 
-```js
+</TabItem>
+<TabItem value="cypress/support/commands.ts">
+
+```typescript
+interface TypeOptions extends Cypress.TypeOptions {
+  sensitive?: boolean
+}
+
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      type(
+        text: string,
+        options?: Partial<TypeOptions>
+      ): Chainable<JQuery<HTMLElement>>
+    }
+  }
+}
+
+Cypress.Commands.overwrite<'type', 'element'>(
+  'type',
+  (originalFn, element, text, options?: Partial<TypeOptions>) => {
+    if (options?.sensitive) {
+      options.log = false
+      Cypress.log({
+        $el: element,
+        name: 'type',
+        message: '*'.repeat(text.length),
+      })
+    }
+
+    return originalFn(element, text, options)
+  }
+)
+```
+
+</TabItem>
+</Tabs>
+
+```js title="spec.cy.js"
 cy.get('#username').type('username@email.com')
 cy.get('#password').type('superSecret123', { sensitive: true })
 ```
@@ -547,6 +989,9 @@ Now our sensitive password is not printed to the Cypress Command Log when
 
 This example overwrites [cy.screenshot()](/api/commands/screenshot) to always
 wait until a certain element is visible.
+
+<Tabs>
+<TabItem value="cypress/support/commands.js">
 
 ```javascript
 Cypress.Commands.overwrite(
@@ -566,10 +1011,43 @@ Cypress.Commands.overwrite(
 )
 ```
 
+</TabItem>
+<TabItem value="cypress/support/commands.ts">
+
+```typescript
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      screenshot(
+        fileName?: string,
+        options?: Partial<Cypress.ScreenshotOptions>
+      ): Chainable<Subject>
+    }
+  }
+}
+
+Cypress.Commands.overwrite(
+  'screenshot',
+  (originalFn, subject, fileName, options) => {
+    cy.get('.app')
+      .should('be.visible')
+      .then({ timeout: Cypress.config('responseTimeout') }, () => {
+        return originalFn(subject, fileName, options)
+      })
+  }
+)
+```
+
+</TabItem>
+</Tabs>
+
 #### Overwrite `click` command
 
 This example overwrites [.click()](/api/commands/click) to always have the
 `waitForAnimations` option set to `false`.
+
+<Tabs>
+<TabItem value="cypress/support/commands.js">
 
 ```js
 Cypress.Commands.overwrite(
@@ -580,6 +1058,33 @@ Cypress.Commands.overwrite(
   }
 )
 ```
+
+</TabItem>
+<TabItem value="cypress/support/commands.ts">
+
+```typescript
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      click(
+        position?: Cypress.PositionType,
+        options?: Partial<Cypress.ClickOptions>
+      ): Chainable<JQuery<HTMLElement>>
+    }
+  }
+}
+
+Cypress.Commands.overwrite<'click', 'element'>(
+  'click',
+  (originalFn, subject, positionOrX, y, options = {}) => {
+    options.waitForAnimations = false
+    return originalFn(subject, positionOrX, y, options)
+  }
+)
+```
+
+</TabItem>
+</Tabs>
 
 ## Validations
 
@@ -604,6 +1109,9 @@ subject, but not validate its type.
 
 Require subject be of type: `element`.
 
+<Tabs>
+<TabItem value="cypress/support/commands.js">
+
 ```javascript
 // this is how .click() is implemented
 Cypress.Commands.add(
@@ -617,6 +1125,36 @@ Cypress.Commands.add(
   }
 )
 ```
+
+</TabItem>
+<TabItem value="cypress/support/commands.ts">
+
+```typescript
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      click(
+        position?: Cypress.PositionType,
+        options?: Partial<Cypress.ClickOptions>
+      ): Chainable<JQuery<HTMLElement>>
+    }
+  }
+}
+
+Cypress.Commands.add(
+  'click',
+  {
+    prevSubject: 'element',
+  },
+  (subject, options) => {
+    // receives the previous subject and it's
+    // guaranteed to be an element
+  }
+)
+```
+
+</TabItem>
+</Tabs>
 
 <Icon name="check-circle" color="green" /> **Valid Usage**
 
@@ -637,6 +1175,9 @@ cy.wrap([]).click() // has subject, but not `element`, will error
 
 Require subject be one of the following types: `element`, `document` or `window`
 
+<Tabs>
+<TabItem value="cypress/support/commands.js">
+
 ```javascript
 // this is how .trigger() is implemented
 Cypress.Commands.add(
@@ -651,9 +1192,39 @@ Cypress.Commands.add(
 )
 ```
 
+</TabItem>
+<TabItem value="cypress/support/commands.ts">
+
+```typescript
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      trigger(
+        eventName: string,
+        options?: Partial<Cypress.TriggerOptions>
+      ): Chainable<JQuery<HTMLElement>>
+    }
+  }
+}
+
+Cypress.Commands.add(
+  'trigger',
+  {
+    prevSubject: ['element', 'document', 'window'],
+  },
+  (subject, eventName, options) => {
+    // receives the previous subject and it's
+    // guaranteed to be an element, document, or window
+  }
+)
+```
+
+</TabItem>
+</Tabs>
+
 <Icon name="check-circle" color="green" /> **Valid Usage**
 
-```javascript
+```javascript title="spec.cy.js"
 cy.get('button').trigger() // has subject, and is `element`
 cy.document().trigger() // has subject, and is `document`
 cy.window().trigger() // has subject, and is `window`
@@ -671,6 +1242,9 @@ Validations always work as "or" not "and".
 ### Optional with Types
 
 You can also mix optional commands **with** validations.
+
+<Tabs>
+<TabItem value="cypress/support/commands.js">
 
 ```javascript
 // this is how .scrollTo() is implemented
@@ -695,9 +1269,42 @@ Cypress.Commands.add(
 )
 ```
 
+</TabItem>
+<TabItem value="cypress/support/commands.ts">
+
+```typescript
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      scrollTo(
+        position: Cypress.PositionType | number,
+        options?: Partial<Cypress.ScrollToOptions>
+      ): Chainable<JQuery<HTMLElement>>
+    }
+  }
+}
+
+Cypress.Commands.add(
+  'scrollTo',
+  {
+    prevSubject: ['optional', 'element', 'window'],
+  },
+  (subject, ...args) => {
+    if (subject) {
+      // ...
+    } else {
+      // ...
+    }
+  }
+)
+```
+
+</TabItem>
+</Tabs>
+
 <Icon name="check-circle" color="green" /> **Valid Usage**
 
-```javascript
+```javascript title="spec.cy.js"
 cy.scrollTo() // no subject, but valid because it's optional
 cy.get('#main').scrollTo() // has subject, and is `element`
 cy.visit().scrollTo() // has subject, and since visit yields `window` it's ok
@@ -902,27 +1509,67 @@ Cypress [12.17.4](/app/references/changelog#12-17-4) includes a Webpack upgrade 
 
 If you are using TypeScript and have Webpack's `sideEffects:false` set in your package.json, custom Cypress commands will not be registered by the common pattern of writing the commands in one file and having them be run as a side effect of importing the file. For example:
 
-```typescript
-// cypress/support/commands.ts
-Cypress.Commands.add("login", (email, password) => { ... })
+<Tabs>
+<TabItem value="cypress/support/commands.js">
+
+```javascript
+Cypress.Commands.add('login', (email, password) => { ... })
 ```
 
+</TabItem>
+<TabItem value="cypress/support/commands.ts">
+
 ```typescript
-// cypress/support/e2e.ts
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      login(email: string, password: string): Chainable<void>
+    }
+  }
+}
+
+Cypress.Commands.add('login', (email, password) => { ... })
+```
+
+</TabItem>
+</Tabs>
+
+```typescript title="cypress/support/e2e.ts"
 import './commands'
 ```
 
 To support `sideEffects:false`, you can wrap the Cypress commands in a function that will be imported by the support file.
 
-```typescript
-// cypress/support/commands.ts
-export function registerCommands(){
-  Cypress.Commands.add("login", (email, password) => { ... })
+<Tabs>
+<TabItem value="cypress/support/commands.js">
+
+```javascript
+export function registerCommands() {
+  Cypress.Commands.add('login', (email, password) => { ... })
 }
 ```
 
+</TabItem>
+<TabItem value="cypress/support/commands.ts">
+
 ```typescript
-// cypress/support/e2e.ts
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      login(email: string, password: string): Chainable<void>
+    }
+  }
+}
+
+export function registerCommands() {
+  Cypress.Commands.add('login', (email, password) => { ... })
+}
+```
+
+</TabItem>
+</Tabs>
+
+```typescript title="cypress/support/e2e.ts"
 import { registerCommands } from './commands'
 
 registerCommands()
@@ -938,6 +1585,7 @@ registerCommands()
 
 - See how to add
   [TypeScript support for custom commands](/app/tooling/typescript-support#Types-for-Custom-Commands)
+  and [custom queries](/app/tooling/typescript-support#Types-for-Custom-Queries)
 - <a href="/app/plugins/plugins-list#custom-commands">
     Plugins using custom commands
   </a>

--- a/docs/api/cypress-api/custom-queries.mdx
+++ b/docs/api/cypress-api/custom-queries.mdx
@@ -59,6 +59,9 @@ Cypress.Commands.overwriteQuery(name, callbackFn)
 
 <Icon name="check-circle" color="green" /> **Correct Usage**
 
+<Tabs>
+<TabItem value="cypress/support/commands.js">
+
 ```javascript
 Cypress.Commands.addQuery('getById', function (id) {
   return (subject) => newSubject
@@ -68,6 +71,30 @@ Cypress.Commands.overwriteQuery('get', function (originalFn, ...args) {
   return originalFn.apply(this, args)
 })
 ```
+
+</TabItem>
+<TabItem value="cypress/support/commands.ts">
+
+```typescript
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      getById(id: string): Chainable<JQuery<HTMLElement>>
+    }
+  }
+}
+
+Cypress.Commands.addQuery('getById', function (id) {
+  return (subject) => newSubject
+})
+
+Cypress.Commands.overwriteQuery('get', function (originalFn, ...args) {
+  return originalFn.apply(this, args)
+})
+```
+
+</TabItem>
+</Tabs>
 
 ### Arguments
 
@@ -98,10 +125,14 @@ The callback function can be thought of as two separate parts. The _outer
 function_, which is invoked once, where you perform setup and state management,
 and the _query function_, which might be called repeatedly.
 
-Let's look at an example. This is actual Cypress code - how `.focused()` is
+Let's look at an example. This is actual Cypress code — how `.focused()` is
 implemented internally, with some small adjustments to make it work from a
-support file. The only thing omitted here for simplicity is the TypeScript
-definitions.
+support file. Use the TypeScript tab for a version that type-checks under strict
+TypeScript, or see [Types for Custom Queries](/app/tooling/typescript-support#Types-for-Custom-Queries)
+for additional guidance.
+
+<Tabs>
+<TabItem value="cypress/support/commands.js">
 
 ```javascript
 Cypress.Commands.addQuery('focused2', function focused2(options = {}) {
@@ -133,6 +164,70 @@ Cypress.Commands.addQuery('focused2', function focused2(options = {}) {
   }
 })
 ```
+
+</TabItem>
+<TabItem value="cypress/support/commands.ts">
+
+```typescript
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      /**
+       * Gets the currently focused DOM element.
+       * @example cy.focused2()
+       */
+      focused2(
+        options?: Partial<Cypress.Loggable & Cypress.Timeoutable>
+      ): Chainable<JQuery>
+    }
+
+    interface EnqueuedCommandAttributes {
+      timeout?: number
+    }
+  }
+}
+
+Cypress.Commands.addQuery(
+  'focused2',
+  function focused2(
+    options: Partial<Cypress.Loggable & Cypress.Timeoutable> = {}
+  ) {
+    const log =
+      options.log !== false &&
+      Cypress.log({
+        ...(options.timeout !== undefined && { timeout: options.timeout }),
+      })
+
+    this.set('timeout', options.timeout)
+
+    return () => {
+      let $el = cy.getFocused()
+
+      log &&
+        cy.state('current') === this &&
+        log.set({
+          $el,
+          consoleProps: () => {
+            return {
+              Yielded: $el?.length ? $el[0] : '--nothing--',
+              Elements: $el != null ? $el.length : 0,
+            }
+          },
+        })
+
+      if (!$el) {
+        $el = cy.$$(null)
+        $el.selector = 'focused'
+      }
+
+      return $el
+    }
+  }
+)
+```
+
+</TabItem>
+</Tabs>
 
 #### The outer function
 
@@ -172,7 +267,11 @@ This is a general pattern: when something goes wrong, queries just throw an
 error. Cypress will handle displaying the error in the Command Log.
 
 ```javascript
-const log = options.log !== false && Cypress.log({ timeout: options.timeout })
+const log =
+  options.log !== false &&
+  Cypress.log({
+    ...(options.timeout !== undefined && { timeout: options.timeout }),
+  })
 ```
 
 If the user has not set `{ log: false }`, we create a new `Cypress.log()`
@@ -310,6 +409,9 @@ sure to use `.call` or `.apply`.
 
 :::
 
+<Tabs>
+<TabItem value="cypress/support/commands.js">
+
 ```js
 Cypress.Commands.overwriteQuery('get', function (originalFn, ...args) {
   console.log('get called with args:', args)
@@ -324,6 +426,37 @@ Cypress.Commands.overwriteQuery('get', function (originalFn, ...args) {
 })
 ```
 
+</TabItem>
+<TabItem value="cypress/support/commands.ts">
+
+```typescript
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      get(
+        selector: string,
+        options?: Partial<Cypress.Loggable & Cypress.Timeoutable>
+      ): Chainable<JQuery<HTMLElement>>
+    }
+  }
+}
+
+Cypress.Commands.overwriteQuery('get', function (originalFn, ...args) {
+  console.log('get called with args:', args)
+
+  const innerFn = originalFn.apply(this, args)
+
+  return (subject) => {
+    console.log('get inner function called with subject:', subject)
+
+    return innerFn(subject)
+  }
+})
+```
+
+</TabItem>
+</Tabs>
+
 The `originalFn` is the function originally passed to
 `Cypress.Commands.addQuery` - it is a **function that returns a function.** This
 gives you access to both the outer arguments (before you call `originalFn`) and
@@ -334,6 +467,9 @@ of control over how the query executes.
 
 In this example, `cy.contains()` is extended to support querying for aliased
 subjects, like `cy.contains('@foo')`.
+
+<Tabs>
+<TabItem value="cypress/support/commands.js">
 
 ```js
 Cypress.Commands.overwriteQuery(
@@ -360,6 +496,45 @@ cy.wrap('asdf 1').as('content')
 
 cy.contains('@element', '@content')
 ```
+
+</TabItem>
+<TabItem value="cypress/support/commands.ts">
+
+```typescript
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      contains(
+        selector: JQuery.Selector,
+        text: string | number | RegExp,
+        options?: Partial<Cypress.Loggable & Cypress.Timeoutable>
+      ): Chainable<JQuery<HTMLElement>>
+    }
+  }
+}
+
+Cypress.Commands.overwriteQuery(
+  'contains',
+  function (originalFn, filter, text, userOptions) {
+    if (_.isString(filter) && filter[0] === '@') {
+      let alias = cy.state('aliases')[filter.slice(1)]
+      let subject = cy.getSubjectFromChain(alias?.subjectChain)
+      filter = subject
+    }
+
+    if (_.isString(text) && text[0] === '@') {
+      let alias = cy.state('aliases')[text.slice(1)]
+      let subject = cy.getSubjectFromChain(alias?.subjectChain)
+      text = subject
+    }
+
+    return originalFn.call(this, filter, text, userOptions)
+  }
+)
+```
+
+</TabItem>
+</Tabs>
 
 ## Validation
 
@@ -441,6 +616,7 @@ Try not to overcomplicate things and create too many abstractions.
 
 - See how to add
   [TypeScript support for custom commands](/app/tooling/typescript-support#Types-for-Custom-Commands)
+  and [custom queries](/app/tooling/typescript-support#Types-for-Custom-Queries)
 - <a href="/app/plugins/plugins-list#custom-commands">
     Plugins using custom commands
   </a>

--- a/docs/api/cypress-api/cypress-log.mdx
+++ b/docs/api/cypress-api/cypress-log.mdx
@@ -38,6 +38,9 @@ Pass in an options object to `Cypress.log()`.
 We want the Command Log and the console in the DevTools to log specific
 properties of our custom command.
 
+<Tabs>
+<TabItem value="cypress/support/commands.js">
+
 ```javascript
 Cypress.Commands.add('setSessionStorage', (key, value) => {
   // Turn off logging of the cy.window() to command log
@@ -62,6 +65,45 @@ Cypress.Commands.add('setSessionStorage', (key, value) => {
   })
 })
 ```
+
+</TabItem>
+<TabItem value="cypress/support/commands.ts">
+
+```typescript
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      setSessionStorage(key: string, value: string): Chainable<void>
+    }
+  }
+}
+
+Cypress.Commands.add('setSessionStorage', (key, value) => {
+  // Turn off logging of the cy.window() to command log
+  cy.window({ log: false }).then((window) => {
+    window.sessionStorage.setItem(key, value)
+  })
+
+  const log = Cypress.log({
+    name: 'setSessionStorage',
+    // shorter name for the Command Log
+    displayName: 'setSS',
+    message: `${key}, ${value}`,
+    consoleProps: () => {
+      // return an object which will
+      // print to dev tools console on click
+      return {
+        Key: key,
+        Value: value,
+        'Session Storage': window.sessionStorage,
+      }
+    },
+  })
+})
+```
+
+</TabItem>
+</Tabs>
 
 The code above displays in the Command Log as shown below, with the console
 properties shown on click of the command.

--- a/docs/api/cypress-api/ensure.mdx
+++ b/docs/api/cypress-api/ensure.mdx
@@ -50,6 +50,9 @@ error thrown, write your own `ensure` function instead.
 
 <Icon name="check-circle" color="green" /> **Correct Usage**
 
+<Tabs>
+<TabItem value="cypress/support/commands.js">
+
 ```javascript
 Cypress.Commands.addQuery('getChildById', function (id) {
   return (subject) => {
@@ -79,6 +82,51 @@ Cypress.Commands.addQuery(queryName, function (...args) {
   }
 })
 ```
+
+</TabItem>
+<TabItem value="cypress/support/commands.ts">
+
+```typescript
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      getChildById(id: string): Chainable<JQuery>
+      verifyElementActionable(...args: any[]): Chainable<JQuery>
+    }
+  }
+}
+
+Cypress.Commands.addQuery('getChildById', function (id) {
+  return (subject) => {
+    // Verify that the subject is an element, document, or window object
+    Cypress.ensure.isType(
+      subject,
+      ['element', 'document', 'window'],
+      'getChildById',
+      cy
+    )
+
+    return $$(`#${id}`, subject)
+  }
+})
+
+const queryName = 'verifyElementActionable'
+
+Cypress.Commands.addQuery(queryName, function (...args) {
+  return (subject) => {
+    // Verify that the subject fulfills a variety of conditions
+    Cypress.ensure.isElement(subject, queryName, cy)
+    Cypress.ensure.isVisible(subject, queryName, cy)
+    Cypress.ensure.isNotDisabled(subject, queryName, cy)
+    Cypress.ensure.isNotReadonly(subject, queryName, cy)
+
+    return subject
+  }
+})
+```
+
+</TabItem>
+</Tabs>
 
 ## See also
 

--- a/docs/app/component-testing/angular/examples.mdx
+++ b/docs/app/component-testing/angular/examples.mdx
@@ -418,19 +418,36 @@ Below is a sample that registers several default component declarations while
 still allowing additional ones to be passed in via the config param. The same
 pattern can also be applied to providers and module imports.
 
-```ts title=support/component.ts
-import { Type } from '@angular/core'
-import { mount, MountConfig } from 'cypress/angular'
+<Tabs>
+<TabItem value="cypress/support/component.js">
+
+```js
+import { mount } from 'cypress/angular'
 import { ButtonComponent } from 'src/app/button/button.component'
 import { CardComponent } from 'src/app/card/card.component'
 
-declare global {
-  namespace Cypress {
-    interface Chainable {
-      mount: typeof customMount
-    }
+const declarations = [ButtonComponent, CardComponent]
+
+function customMount(component, config) {
+  if (!config) {
+    config = { declarations }
+  } else {
+    config.declarations = [...(config?.declarations || []), ...declarations]
   }
+  return mount(component, config)
 }
+
+Cypress.Commands.add('mount', customMount)
+```
+
+</TabItem>
+<TabItem value="cypress/support/component.ts">
+
+```ts
+import { Type } from '@angular/core'
+import { mount, MountConfig, MountResponse } from 'cypress/angular'
+import { ButtonComponent } from 'src/app/button/button.component'
+import { CardComponent } from 'src/app/card/card.component'
 
 const declarations = [ButtonComponent, CardComponent]
 
@@ -443,8 +460,27 @@ function customMount<T>(component: string | Type<T>, config?: MountConfig<T>) {
   return mount<T>(component, config)
 }
 
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      /**
+       * Helper mount function for Angular Components
+       * @param component Angular Component or template string to mount
+       * @param config Options passed to Angular TestBed
+       */
+      mount<T>(
+        component: string | Type<T>,
+        config?: MountConfig<T>
+      ): Cypress.Chainable<MountResponse<T>>
+    }
+  }
+}
+
 Cypress.Commands.add('mount', customMount)
 ```
+
+</TabItem>
+</Tabs>
 
 This custom mount command will allow you to skip manually passing in the
 `ButtonComponent` and `CardComponent` as declarations into each `cy.mount()`
@@ -460,18 +496,46 @@ The `autoSpyOutputs` flag is deprecated and not supported in `cypress/angular-zo
 
 Here is an example of defaulting `autoSpyOutputs` for every mounted component:
 
-```ts title=support/component.ts
+<Tabs>
+<TabItem value="cypress/support/component.js">
+
+```js
+import { mount } from 'cypress/angular'
+
+Cypress.Commands.add('mount', (component, config) => {
+  return mount(component, {
+    ...config,
+    autoSpyOutputs: true,
+  })
+})
+```
+
+</TabItem>
+<TabItem value="cypress/support/component.ts">
+
+```ts
+import { Type } from '@angular/core'
+import { mount, MountConfig, MountResponse } from 'cypress/angular'
+
 declare global {
   namespace Cypress {
     interface Chainable {
-      mount: typeof mount
+      /**
+       * Helper mount function for Angular Components with autoSpyOutputs enabled
+       * @param component Angular Component or template string to mount
+       * @param config Options passed to Angular TestBed
+       */
+      mount<T>(
+        component: Type<T> | string,
+        config?: MountConfig<T>
+      ): Cypress.Chainable<MountResponse<T>>
     }
   }
 }
 
 Cypress.Commands.add(
   'mount',
-  (component: Type<unknown> | string, config: MountConfig<T>) => {
+  <T>(component: Type<T> | string, config?: MountConfig<T>) => {
     return mount(component, {
       ...config,
       autoSpyOutputs: true,
@@ -479,6 +543,9 @@ Cypress.Commands.add(
   }
 )
 ```
+
+</TabItem>
+</Tabs>
 
 :::caution
 

--- a/docs/app/component-testing/custom-frameworks.mdx
+++ b/docs/app/component-testing/custom-frameworks.mdx
@@ -241,11 +241,34 @@ When a user configures Component Testing with your Framework Definition we
 automatically configure a `cy.mount` command using your `mount` function in the
 Component Testing `supportFile`:
 
+<Tabs>
+<TabItem value="cypress/support/component.js">
+
 ```js
 import { mount } from '@lmiller1990/cypress-ct-solid-js'
 
 Cypress.Commands.add('mount', mount)
 ```
+
+</TabItem>
+<TabItem value="cypress/support/component.ts">
+
+```ts
+import { mount } from '@lmiller1990/cypress-ct-solid-js'
+
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      mount: typeof mount
+    }
+  }
+}
+
+Cypress.Commands.add('mount', mount)
+```
+
+</TabItem>
+</Tabs>
 
 ## package.json
 

--- a/docs/app/component-testing/react/examples.mdx
+++ b/docs/app/component-testing/react/examples.mdx
@@ -104,11 +104,11 @@ Cypress.Commands.add('mount', (component, options = {}) => {
 ```
 
 </TabItem>
-<TabItem value="Typings">
+<TabItem value="cypress/support/component.tsx">
 
-```ts
-import { MountOptions, MountReturn } from 'cypress/react'
-import { MemoryRouterProps } from 'react-router-dom'
+```tsx
+import { mount, MountOptions, MountReturn } from 'cypress/react'
+import { MemoryRouter, MemoryRouterProps } from 'react-router-dom'
 
 declare global {
   namespace Cypress {
@@ -125,6 +125,14 @@ declare global {
     }
   }
 }
+
+Cypress.Commands.add('mount', (component, options = {}) => {
+  const { routerProps = { initialEntries: ['/'] }, ...mountOptions } = options
+
+  const wrapped = <MemoryRouter {...routerProps}>{component}</MemoryRouter>
+
+  return mount(wrapped, mountOptions)
+})
 ```
 
 </TabItem>
@@ -181,11 +189,13 @@ Cypress.Commands.add('mount', (component, options = {}) => {
 ```
 
 </TabItem>
-<TabItem value="Typings">
+<TabItem value="cypress/support/component.tsx">
 
-```ts
-import { MountOptions, MountReturn } from 'cypress/react'
+```tsx
+import { mount, MountOptions, MountReturn } from 'cypress/react'
+import { Provider } from 'react-redux'
 import { EnhancedStore } from '@reduxjs/toolkit'
+import { getStore } from '../../src/store'
 import { RootState } from './src/StoreState'
 
 declare global {
@@ -203,6 +213,14 @@ declare global {
     }
   }
 }
+
+Cypress.Commands.add('mount', (component, options = {}) => {
+  const { reduxStore = getStore(), ...mountOptions } = options
+
+  const wrapped = <Provider store={reduxStore}>{component}</Provider>
+
+  return mount(wrapped, mountOptions)
+})
 ```
 
 </TabItem>

--- a/docs/app/component-testing/vue/examples.mdx
+++ b/docs/app/component-testing/vue/examples.mdx
@@ -217,6 +217,9 @@ If you intend to use the `wrapper` frequently and use Vue Test Util's API, we
 recommend you write a [custom mount command](/api/commands/mount) and create a
 Cypress alias to get back at the `wrapper`.
 
+<Tabs>
+<TabItem value="cypress/support/component.js">
+
 ```js
 import { mount } from 'cypress/vue'
 
@@ -225,7 +228,40 @@ Cypress.Commands.add('mount', (...args) => {
     return cy.wrap(wrapper).as('vue')
   })
 })
+```
 
+</TabItem>
+<TabItem value="cypress/support/component.ts">
+
+```ts
+import { mount } from 'cypress/vue'
+
+type MountParams = Parameters<typeof mount>
+
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      /**
+       * Mounts a Vue component and aliases the Vue Test Utils wrapper as `@vue`
+       * @param component Vue Component or JSX Element to mount
+       * @param options Options passed to Vue Test Utils
+       */
+      mount(...args: MountParams): Chainable<any>
+    }
+  }
+}
+
+Cypress.Commands.add('mount', (...args) => {
+  return mount(...args).then(({ wrapper }) => {
+    return cy.wrap(wrapper).as('vue')
+  })
+})
+```
+
+</TabItem>
+</Tabs>
+
+```js
 // the "@vue" alias will now work anywhere
 // after you've mounted your component
 cy.mount(Stepper).doStuff().get('@vue') // The subject is now the Vue Wrapper
@@ -296,11 +332,34 @@ function in your tests, we recommend using [`cy.mount()`](/api/commands/mount),
 which is a [custom command](/api/cypress-api/custom-commands) that is defined in
 the **cypress/support/component.js** file:
 
-```js title=cypress/support/component.js
+<Tabs>
+<TabItem value="cypress/support/component.js">
+
+```js
 import { mount } from 'cypress/vue'
 
 Cypress.Commands.add('mount', mount)
 ```
+
+</TabItem>
+<TabItem value="cypress/support/component.ts">
+
+```ts
+import { mount } from 'cypress/vue'
+
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      mount: typeof mount
+    }
+  }
+}
+
+Cypress.Commands.add('mount', mount)
+```
+
+</TabItem>
+</Tabs>
 
 This allows you to use `cy.mount()` in any test without having to import the
 `mount()` function in each and every spec file.
@@ -398,6 +457,60 @@ Cypress.Commands.add('mount', (component, ...args) => {
 ```
 
 </TabItem>
+<TabItem value="cypress/support/component.ts">
+
+```ts
+import { createPinia } from 'pinia' // or Vuex
+import { createI18n } from 'vue-i18n'
+import { mount } from 'cypress/vue'
+import { h } from 'vue'
+
+// We recommend that you pull this out
+// into a constants file that you share with
+// your main.js file.
+const i18nOptions = {
+  locale: 'en',
+  messages: {
+    en: {
+      hello: 'hello!',
+    },
+    ja: {
+      hello: 'こんにちは！',
+    },
+  },
+}
+
+type MountParams = Parameters<typeof mount>
+
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      /**
+       * Helper mount function for Vue Components
+       * @param component Vue Component or JSX Element to mount
+       * @param options Options passed to Vue Test Utils
+       */
+      mount(...args: MountParams): Chainable<any>
+    }
+  }
+}
+
+Cypress.Commands.add('mount', (component, ...args) => {
+  args.global = args.global || {}
+  args.global.plugins = args.global.plugins || []
+  args.global.plugins.push(createPinia())
+  args.global.plugins.push(createI18n())
+
+  return mount(
+    () => {
+      return h(VApp, {}, component)
+    },
+    ...args
+  )
+})
+```
+
+</TabItem>
 </Tabs>
 
 ### Replicating the expected Component Hierarchy
@@ -477,6 +590,49 @@ Cypress.Commands.add('mount', (component, ...args) => {
 ```
 
 </TabItem>
+<TabItem value="cypress/support/component.ts">
+
+```ts
+import Vuetify from 'vuetify/lib'
+import { VApp } from 'vuetify'
+import { mount } from 'cypress/vue'
+import { h } from 'vue'
+
+// We recommend that you pull this out
+// into a constants file that you share with
+// your main.js file.
+const vuetifyOptions = {}
+
+type MountParams = Parameters<typeof mount>
+
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      /**
+       * Helper mount function for Vue Components
+       * @param component Vue Component or JSX Element to mount
+       * @param options Options passed to Vue Test Utils
+       */
+      mount(...args: MountParams): Chainable<any>
+    }
+  }
+}
+
+Cypress.Commands.add('mount', (component, ...args) => {
+  args.global = args.global || {}
+  args.global.plugins = args.global.plugins || []
+  args.global.plugins.push(new Vuetify(vuetifyOptions))
+
+  return mount(
+    () => {
+      return h(VApp, {}, component)
+    },
+    ...args
+  )
+})
+```
+
+</TabItem>
 </Tabs>
 
 ### Vue Router
@@ -517,11 +673,12 @@ Cypress.Commands.add('mount', (component, options = {}) => {
 ```
 
 </TabItem>
-<TabItem value="Typings">
+<TabItem value="cypress/support/component.ts">
 
 ```ts
 import { mount } from 'cypress/vue'
-import { Router } from 'vue-router'
+import { createMemoryHistory, createRouter, Router } from 'vue-router'
+import { routes } from '../../src/router'
 
 type MountParams = Parameters<typeof mount>
 type OptionsParam = MountParams[1] & { router?: Router }
@@ -538,6 +695,29 @@ declare global {
     }
   }
 }
+
+Cypress.Commands.add('mount', (component, options = {}) => {
+  // Setup options object
+  options.global = options.global || {}
+  options.global.plugins = options.global.plugins || []
+
+  // create router if one is not provided
+  if (!options.router) {
+    options.router = createRouter({
+      routes: routes,
+      history: createMemoryHistory(),
+    })
+  }
+
+  // Add router plugin
+  options.global.plugins.push({
+    install(app) {
+      app.use(options.router)
+    },
+  })
+
+  return mount(component, options)
+})
 ```
 
 </TabItem>
@@ -627,10 +807,11 @@ ensure changes to the store don't affect other tests.
 :::
 
 </TabItem>
-<TabItem value="Typings">
+<TabItem value="cypress/support/component.ts">
 
 ```ts
 import { mount } from 'cypress/vue'
+import { getStore } from '../../src/plugins/store'
 import { Store } from 'vuex'
 
 type MountParams = Parameters<typeof mount>
@@ -651,6 +832,27 @@ declare global {
     }
   }
 }
+
+Cypress.Commands.add('mount', (component, options = {}) => {
+  // Setup options object
+  options.global = options.global || {}
+  options.global.stubs = options.global.stubs || {}
+  options.global.stubs['transition'] = false
+  options.global.components = options.global.components || {}
+  options.global.plugins = options.global.plugins || []
+
+  // Use store passed in from options, or initialize a new one
+  const { store = getStore(), ...mountOptions } = options
+
+  // Add Vuex plugin
+  options.global.plugins.push({
+    install(app) {
+      app.use(store)
+    },
+  })
+
+  return mount(component, mountOptions)
+})
 ```
 
 </TabItem>
@@ -686,6 +888,9 @@ If you have components that are registered globally in the main application
 file, set them up in your mount command so your component will render them
 properly:
 
+<Tabs>
+<TabItem value="cypress/support/component.js">
+
 ```js
 import { mount } from 'cypress/vue'
 import Button from '../../src/components/Button.vue'
@@ -701,3 +906,41 @@ Cypress.Commands.add('mount', (component, options = {}) => {
   return mount(component, options)
 })
 ```
+
+</TabItem>
+<TabItem value="cypress/support/component.ts">
+
+```ts
+import { mount } from 'cypress/vue'
+import Button from '../../src/components/Button.vue'
+
+type MountParams = Parameters<typeof mount>
+type OptionsParam = MountParams[1]
+
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      /**
+       * Helper mount function for Vue Components
+       * @param component Vue Component or JSX Element to mount
+       * @param options Options passed to Vue Test Utils
+       */
+      mount(component: any, options?: OptionsParam): Chainable<any>
+    }
+  }
+}
+
+Cypress.Commands.add('mount', (component, options = {}) => {
+  // Setup options object
+  options.global = options.global || {}
+  options.global.components = options.global.components || {}
+
+  // Register global components
+  options.global.components['Button'] = Button
+
+  return mount(component, options)
+})
+```
+
+</TabItem>
+</Tabs>

--- a/docs/app/core-concepts/best-practices.mdx
+++ b/docs/app/core-concepts/best-practices.mdx
@@ -317,8 +317,21 @@ custom commands for selecting elements for testing:
 - `getBySelLike` yields elements with a `data-test` attribute that **contains**
   a specified selector.
 
-```ts
-// cypress/support/commands.ts
+```typescript title="cypress/support/commands.ts"
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      getBySel(
+        selector: string,
+        ...args: any[]
+      ): Chainable<JQuery<HTMLElement>>
+      getBySelLike(
+        selector: string,
+        ...args: any[]
+      ): Chainable<JQuery<HTMLElement>>
+    }
+  }
+}
 
 Cypress.Commands.add('getBySel', (selector, ...args) => {
   return cy.get(`[data-test=${selector}]`, ...args)

--- a/docs/app/core-concepts/best-practices.mdx
+++ b/docs/app/core-concepts/best-practices.mdx
@@ -321,10 +321,7 @@ custom commands for selecting elements for testing:
 declare global {
   namespace Cypress {
     interface Chainable {
-      getBySel(
-        selector: string,
-        ...args: any[]
-      ): Chainable<JQuery<HTMLElement>>
+      getBySel(selector: string, ...args: any[]): Chainable<JQuery<HTMLElement>>
       getBySelLike(
         selector: string,
         ...args: any[]

--- a/docs/app/end-to-end-testing/testing-your-app.mdx
+++ b/docs/app/end-to-end-testing/testing-your-app.mdx
@@ -430,6 +430,9 @@ as the built-in Cypress commands. Lets make the above login example a custom
 command and add it to `cypress/support/commands.js` so it can be leveraged in
 any spec file:
 
+<Tabs>
+<TabItem value="cypress/support/commands.js">
+
 ```js
 // In cypress/support/commands.js
 
@@ -461,6 +464,40 @@ it('does something on a secured page', function () {
 })
 ```
 
+</TabItem>
+<TabItem value="cypress/support/commands.ts">
+
+```ts
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      login(username: string, password: string): Chainable<void>
+    }
+  }
+}
+
+Cypress.Commands.add('login', (username: string, password: string) => {
+  cy.visit('/login')
+
+  cy.get('input[name=username]').type(username)
+
+  // {enter} causes the form to submit
+  cy.get('input[name=password]').type(`${password}{enter}`, { log: false })
+
+  // we should be redirected to /dashboard
+  cy.url().should('include', '/dashboard')
+
+  // our auth cookie should be present
+  cy.getCookie('your-session-cookie').should('exist')
+
+  // UI should reflect this user being logged in
+  cy.get('h1').should('contain', username)
+})
+```
+
+</TabItem>
+</Tabs>
+
 #### Improving performance
 
 You're probably wondering what happened to our advice about logging in "only
@@ -473,6 +510,9 @@ powerful performance tool that lets you cache the browser context associated
 with your user and reuse it for multiple tests without going through multiple
 login flows! Let's modify the custom `cy.login()` command from our previous
 example to use `cy.session()`:
+
+<Tabs>
+<TabItem value="cypress/support/commands.js">
 
 ```js
 Cypress.Commands.add('login', (username, password) => {
@@ -493,6 +533,40 @@ Cypress.Commands.add('login', (username, password) => {
   )
 })
 ```
+
+</TabItem>
+<TabItem value="cypress/support/commands.ts">
+
+```ts
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      login(username: string, password: string): Chainable<void>
+    }
+  }
+}
+
+Cypress.Commands.add('login', (username: string, password: string) => {
+  cy.session(
+    username,
+    () => {
+      cy.visit('/login')
+      cy.get('input[name=username]').type(username)
+      cy.get('input[name=password]').type(`${password}{enter}`, { log: false })
+      cy.url().should('include', '/dashboard')
+      cy.get('h1').should('contain', username)
+    },
+    {
+      validate: () => {
+        cy.getCookie('your-session-cookie').should('exist')
+      },
+    }
+  )
+})
+```
+
+</TabItem>
+</Tabs>
 
 :::info
 

--- a/docs/app/faq.mdx
+++ b/docs/app/faq.mdx
@@ -1409,8 +1409,16 @@ While you can use the `mount` function in your tests, we recommend using
 [custom command](/api/cypress-api/custom-commands) in the
 **cypress/support/component.js** file:
 
-```ts title=cypress/support/component.js
+```typescript title="cypress/support/component.ts"
 import { mount } from 'cypress/react'
+
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      mount: typeof mount
+    }
+  }
+}
 
 Cypress.Commands.add('mount', mount)
 ```

--- a/docs/app/guides/authentication-testing/amazon-cognito-authentication.mdx
+++ b/docs/app/guides/authentication-testing/amazon-cognito-authentication.mdx
@@ -199,9 +199,12 @@ We'll write a custom command called `loginByCognito` to perform a login to
    <Icon name="github" inline="true" contentType="rwa" />
 4. Cache the results with [`cy.session()`](/api/commands/session)
 
-```jsx title="cypress/support/auth-provider-commands/cognito.ts"
+<Tabs>
+<TabItem value="cypress/support/commands.js">
+
+```js title="cypress/support/auth-provider-commands/cognito.js"
 // Amazon Cognito
-const loginToCognito = (username: string, password: string) => {
+const loginToCognito = (username, password) => {
   Cypress.log({
     displayName: 'COGNITO LOGIN',
     message: [`🔐 Authenticating | ${username}`],
@@ -243,6 +246,65 @@ Cypress.Commands.add('loginByCognito', (username, password) => {
   return loginToCognito(username, password)
 })
 ```
+
+</TabItem>
+<TabItem value="cypress/support/commands.ts">
+
+```ts
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      loginByCognito(username: string, password: string): Chainable<void>
+    }
+  }
+}
+
+// Amazon Cognito
+const loginToCognito = (username: string, password: string) => {
+  Cypress.log({
+    displayName: 'COGNITO LOGIN',
+    message: [`🔐 Authenticating | ${username}`],
+    autoEnd: false,
+  })
+
+  cy.visit('/')
+
+  cy.origin(
+    Cypress.expose('cognito_domain'),
+    {
+      args: {
+        username,
+        password,
+      },
+    },
+    ({ username, password }) => {
+      cy.contains('Sign in with your email and password')
+      // Cognito log in page has some elements of the same id but are off screen.
+      // We only want the visible elements to log in
+      cy.get('input[name="username"]:visible').type(username)
+      cy.get('input[name="password"]:visible').type(password, {
+        // use log: false to prevent your password from showing in the Command Log
+        log: false,
+      })
+      cy.get('input[name="signInSubmitButton"]:visible').click()
+    }
+  )
+
+  // give a few seconds for redirect to settle
+  cy.wait(2000)
+
+  // verify we have made it passed the login screen
+  cy.contains('Get Started').should('be.visible')
+}
+
+// right now our custom command is light. More on this later!
+Cypress.Commands.add('loginByCognito', (username: string, password: string) => {
+  return loginToCognito(username, password)
+})
+```
+
+</TabItem>
+</Tabs>
 
 Now, we can use our `loginByCognito` command in the test. Below is our test to
 login as a user via [Amazon Cognito](https://aws.amazon.com/cognito), complete
@@ -287,7 +349,10 @@ Now, we can refactor our login command to take advantage of
 [`cy.session()`](/api/commands/session) to store our logged in user so we don't
 have to reauthenticate with every test.
 
-```jsx title="cypress/support/auth-provider-commands/cognito.ts"
+<Tabs>
+<TabItem value="cypress/support/commands.js">
+
+```js title="cypress/support/auth-provider-commands/cognito.js"
 // Amazon Cognito
 Cypress.Commands.add(
   'loginByCognito, cy.origin() login',
@@ -309,6 +374,45 @@ Cypress.Commands.add(
 )
 ```
 
+</TabItem>
+<TabItem value="cypress/support/commands.ts">
+
+```ts
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      'loginByCognito, cy.origin() login'(
+        username: string,
+        password: string
+      ): Chainable<void>
+    }
+  }
+}
+
+// Amazon Cognito
+Cypress.Commands.add(
+  'loginByCognito, cy.origin() login',
+  (username: string, password: string) => {
+    cy.session(
+      `cognito-${username}`,
+      () => {
+        return loginToCognito(username, password)
+      },
+      {
+        validate() {
+          cy.visit('/')
+          // revalidate our session to make sure we are logged in
+          cy.contains('Get Started').should('be.visible')
+        },
+      }
+    )
+  }
+)
+```
+
+</TabItem>
+</Tabs>
+
 <DocsVideo
   src="https://vimeo.com/789093817"
   title="AWS Cognito Authentication with cy.session()"
@@ -329,7 +433,10 @@ user is logged into the application.
 
   <TabItem value="v5" label="Amplify v5.x.x" default>
 
-```jsx title="cypress/support/auth-provider-commands/cognito.ts"
+<Tabs>
+<TabItem value="cypress/support/commands.js">
+
+```js title="cypress/support/auth-provider-commands/cognito.js"
 import Amplify, { Auth } from 'aws-amplify'
 
 Amplify.configure(Cypress.expose('awsConfig'))
@@ -384,6 +491,78 @@ Cypress.Commands.add('loginByCognitoApi', (username, password) => {
 })
 ```
 
+</TabItem>
+<TabItem value="cypress/support/commands.ts">
+
+```ts
+import Amplify, { Auth } from 'aws-amplify'
+
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      loginByCognitoApi(username: string, password: string): Chainable<void>
+    }
+  }
+}
+
+Amplify.configure(Cypress.expose('awsConfig'))
+
+// Amazon Cognito
+Cypress.Commands.add(
+  'loginByCognitoApi',
+  (username: string, password: string) => {
+    const log = Cypress.log({
+      displayName: 'COGNITO LOGIN',
+      message: [`🔐 Authenticating | ${username}`],
+      // @ts-ignore
+      autoEnd: false,
+    })
+
+    log.snapshot('before')
+
+    const signIn = Auth.signIn({ username, password })
+
+    cy.wrap(signIn, { log: false }).then((cognitoResponse) => {
+      const keyPrefixWithUsername = `${cognitoResponse.keyPrefix}.${cognitoResponse.username}`
+
+      window.localStorage.setItem(
+        `${keyPrefixWithUsername}.idToken`,
+        cognitoResponse.signInUserSession.idToken.jwtToken
+      )
+
+      window.localStorage.setItem(
+        `${keyPrefixWithUsername}.accessToken`,
+        cognitoResponse.signInUserSession.accessToken.jwtToken
+      )
+
+      window.localStorage.setItem(
+        `${keyPrefixWithUsername}.refreshToken`,
+        cognitoResponse.signInUserSession.refreshToken.token
+      )
+
+      window.localStorage.setItem(
+        `${keyPrefixWithUsername}.clockDrift`,
+        cognitoResponse.signInUserSession.clockDrift
+      )
+
+      window.localStorage.setItem(
+        `${cognitoResponse.keyPrefix}.LastAuthUser`,
+        cognitoResponse.username
+      )
+
+      window.localStorage.setItem('amplify-authenticator-authState', 'signedIn')
+      log.snapshot('after')
+      log.end()
+    })
+
+    cy.visit('/')
+  }
+)
+```
+
+</TabItem>
+</Tabs>
+
   </TabItem>
 
   <TabItem value="v6" label="Amplify v6.x.x">
@@ -408,6 +587,14 @@ const fetchJwts = async (username: string, password: string) => {
   }
 }
 type JwtResponse = Awaited<ReturnType<typeof fetchJwts>>
+
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      loginByCognitoApi(username: string, password: string): Chainable<void>
+    }
+  }
+}
 
 // Amazon Cognito
 Cypress.Commands.add(

--- a/docs/app/guides/authentication-testing/auth0-authentication.mdx
+++ b/docs/app/guides/authentication-testing/auth0-authentication.mdx
@@ -126,7 +126,56 @@ Next, we'll write a custom command called `loginToAuth0` to perform a login to
    [Cypress Real World App](https://github.com/cypress-io/cypress-realworld-app)
 4. Cache the results with [`cy.session()`](/api/commands/session)
 
-```js title="cypress/support/auth-provider-commands/auth0.ts"
+<Tabs>
+<TabItem value="cypress/support/commands.js">
+
+```js title="cypress/support/auth-provider-commands/auth0.js"
+function loginViaAuth0Ui(username, password) {
+  // App landing page redirects to Auth0.
+  cy.visit('/')
+
+  // Login on Auth0.
+  cy.origin(
+    Cypress.expose('auth0_domain'),
+    { args: { username, password } },
+    ({ username, password }) => {
+      cy.get('input#username').type(username)
+      cy.get('input#password').type(password, { log: false })
+      cy.contains('button[value=default]', 'Continue').click()
+    }
+  )
+
+  // Ensure Auth0 has redirected us back to the RWA.
+  cy.url().should('equal', 'http://localhost:3000/')
+}
+
+Cypress.Commands.add('loginToAuth0', (username, password) => {
+  const log = Cypress.log({
+    displayName: 'AUTH0 LOGIN',
+    message: [`🔐 Authenticating | ${username}`],
+    autoEnd: false,
+  })
+  log.snapshot('before')
+
+  loginViaAuth0Ui(username, password)
+
+  log.snapshot('after')
+  log.end()
+})
+```
+
+</TabItem>
+<TabItem value="cypress/support/commands.ts">
+
+```ts
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      loginToAuth0(username: string, password: string): Chainable<void>
+    }
+  }
+}
+
 function loginViaAuth0Ui(username: string, password: string) {
   // App landing page redirects to Auth0.
   cy.visit('/')
@@ -161,6 +210,9 @@ Cypress.Commands.add('loginToAuth0', (username: string, password: string) => {
   log.end()
 })
 ```
+
+</TabItem>
+</Tabs>
 
 Now, we can use our `loginToAuth0` command in the test. Below is our test to
 login as a user via Auth0 and run a basic sanity check.
@@ -202,7 +254,50 @@ Lastly, we can refactor our login command to take advantage of
 [`cy.session()`](/api/commands/session) to store our logged in user so we don't
 have to reauthenticate before every test.
 
+<Tabs>
+<TabItem value="cypress/support/commands.js">
+
 ```js title="cypress/support/commands.js"
+Cypress.Commands.add('loginToAuth0', (username, password) => {
+  const log = Cypress.log({
+    displayName: 'AUTH0 LOGIN',
+    message: [`🔐 Authenticating | ${username}`],
+    autoEnd: false,
+  })
+  log.snapshot('before')
+
+  cy.session(
+    `auth0-${username}`,
+    () => {
+      loginViaAuth0Ui(username, password)
+    },
+    {
+      validate: () => {
+        // Validate presence of access token in localStorage.
+        cy.wrap(localStorage)
+          .invoke('getItem', 'authAccessToken')
+          .should('exist')
+      },
+    }
+  )
+
+  log.snapshot('after')
+  log.end()
+})
+```
+
+</TabItem>
+<TabItem value="cypress/support/commands.ts">
+
+```ts
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      loginToAuth0(username: string, password: string): Chainable<void>
+    }
+  }
+}
+
 Cypress.Commands.add('loginToAuth0', (username: string, password: string) => {
   const log = Cypress.log({
     displayName: 'AUTH0 LOGIN',
@@ -232,6 +327,9 @@ Cypress.Commands.add('loginToAuth0', (username: string, password: string) => {
 })
 ```
 
+</TabItem>
+</Tabs>
+
 <DocsVideo
   src="https://vimeo.com/789093910"
   title="Auth0 authentication with cy.session()"
@@ -253,29 +351,30 @@ The `loginByAuth0Api` command will execute the following steps:
 2. Finally the `auth0Cypress` `localStorage` item is set with the
    `access token`, `id_token` and user profile.
 
-```jsx title="cypress/support/commands.js"
-Cypress.Commands.add(
-  'loginByAuth0Api',
-  (username: string, password: string) => {
-    cy.log(`Logging in as ${username}`)
-    const client_id = Cypress.expose('auth0_client_id')
-    const audience = Cypress.expose('auth0_audience')
-    const scope = Cypress.expose('auth0_scope')
+<Tabs>
+<TabItem value="cypress/support/commands.js">
 
-    cy.env(['AUTH0_CLIENT_SECRET']).then(({ client_secret }) => {
-      cy.request({
-        method: 'POST',
-        url: `https://${Cypress.expose('auth0_domain')}/oauth/token`,
-        body: {
-          grant_type: 'password',
-          username,
-          password,
-          audience,
-          scope,
-          client_id,
-          client_secret,
-        },
-      }).then(({ body }) => {
+```js title="cypress/support/commands.js"
+Cypress.Commands.add('loginByAuth0Api', (username, password) => {
+  cy.log(`Logging in as ${username}`)
+  const client_id = Cypress.expose('auth0_client_id')
+  const audience = Cypress.expose('auth0_audience')
+  const scope = Cypress.expose('auth0_scope')
+
+  cy.env(['AUTH0_CLIENT_SECRET']).then(({ client_secret }) => {
+    cy.request({
+      method: 'POST',
+      url: `https://${Cypress.expose('auth0_domain')}/oauth/token`,
+      body: {
+        grant_type: 'password',
+        username,
+        password,
+        audience,
+        scope,
+        client_id,
+        client_secret,
+      },
+    }).then(({ body }) => {
       const claims = jwt.decode(body.id_token)
       const {
         nickname,
@@ -312,11 +411,89 @@ Cypress.Commands.add(
       window.localStorage.setItem('auth0Cypress', JSON.stringify(item))
 
       cy.visit('/')
+    })
+  })
+})
+```
+
+</TabItem>
+<TabItem value="cypress/support/commands.ts">
+
+```ts
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      loginByAuth0Api(username: string, password: string): Chainable<void>
+    }
+  }
+}
+
+Cypress.Commands.add(
+  'loginByAuth0Api',
+  (username: string, password: string) => {
+    cy.log(`Logging in as ${username}`)
+    const client_id = Cypress.expose('auth0_client_id')
+    const audience = Cypress.expose('auth0_audience')
+    const scope = Cypress.expose('auth0_scope')
+
+    cy.env(['AUTH0_CLIENT_SECRET']).then(({ client_secret }) => {
+      cy.request({
+        method: 'POST',
+        url: `https://${Cypress.expose('auth0_domain')}/oauth/token`,
+        body: {
+          grant_type: 'password',
+          username,
+          password,
+          audience,
+          scope,
+          client_id,
+          client_secret,
+        },
+      }).then(({ body }) => {
+        const claims = jwt.decode(body.id_token)
+        const {
+          nickname,
+          name,
+          picture,
+          updated_at,
+          email,
+          email_verified,
+          sub,
+          exp,
+        } = claims
+
+        const item = {
+          body: {
+            ...body,
+            decodedToken: {
+              claims,
+              user: {
+                nickname,
+                name,
+                picture,
+                updated_at,
+                email,
+                email_verified,
+                sub,
+              },
+              audience,
+              client_id,
+            },
+          },
+          expiresAt: exp,
+        }
+
+        window.localStorage.setItem('auth0Cypress', JSON.stringify(item))
+
+        cy.visit('/')
       })
     })
   }
 )
 ```
+
+</TabItem>
+</Tabs>
 
 With our Auth0 app setup properly in the Auth0 Developer console, necessary
 environment variables in place, and our `loginByAuth0Api` command implemented,
@@ -640,6 +817,9 @@ system's current external IP address.
 
 :::
 
+<Tabs>
+<TabItem value="cypress/support/commands.js">
+
 ```jsx title='cypress/support/commands.js'
 Cypress.Commands.add('loginByAuth0Api', (username, password) => {
   // Useful when rate limited by Auth0
@@ -662,3 +842,43 @@ Cypress.Commands.add('loginByAuth0Api', (username, password) => {
   // ... remaining loginByAuth0Api command
 })
 ```
+
+</TabItem>
+<TabItem value="cypress/support/commands.ts">
+
+```ts
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      loginByAuth0Api(username: string, password: string): Chainable<void>
+    }
+  }
+}
+
+Cypress.Commands.add(
+  'loginByAuth0Api',
+  (username: string, password: string) => {
+    // Useful when rate limited by Auth0
+    cy.exec('curl -4 icanhazip.com')
+      .its('stdout')
+      .then((ip) => {
+        cy.env(['AUTH0_MGMT_API_TOKEN']).then(({ token }) => {
+          cy.request({
+            method: 'DELETE',
+            url: `https://${Cypress.expose(
+              'auth0_domain'
+            )}/api/v2/anomaly/blocks/ips/${ip}`,
+            auth: {
+              bearer: token,
+            },
+          })
+        })
+      })
+
+    // ... remaining loginByAuth0Api command
+  }
+)
+```
+
+</TabItem>
+</Tabs>

--- a/docs/app/guides/authentication-testing/azure-active-directory-authentication.mdx
+++ b/docs/app/guides/authentication-testing/azure-active-directory-authentication.mdx
@@ -101,7 +101,81 @@ This command will use [`cy.origin()`](/api/commands/origin) to
 3. Sign in and redirect back to the demo application
 4. Cache the results with [`cy.session()`](/api/commands/session)
 
-```js title="cypress/support/commands.ts"
+<Tabs>
+<TabItem value="cypress/support/commands.js">
+
+```js title="cypress/support/commands.js"
+function loginViaAAD(username, password) {
+  cy.visit('http://localhost:3000/')
+  cy.get('button#signIn').click()
+
+  // Login to your AAD tenant.
+  cy.origin(
+    'login.microsoftonline.com',
+    {
+      args: {
+        username,
+      },
+    },
+    ({ username }) => {
+      cy.get('input[type="email"]').type(username, {
+        log: false,
+      })
+      cy.get('input[type="submit"]').click()
+    }
+  )
+
+  // depending on the user and how they are registered with Microsoft, the origin may go to live.com
+  cy.origin(
+    'login.live.com',
+    {
+      args: {
+        password,
+      },
+    },
+    ({ password }) => {
+      cy.get('input[type="password"]').type(password, {
+        log: false,
+      })
+      cy.get('input[type="submit"]').click()
+      cy.get('#idBtn_Back').click()
+    }
+  )
+
+  // Ensure Microsoft has redirected us back to the sample app with our logged in user.
+  cy.url().should('equal', 'http://localhost:3000/')
+  cy.env(['AAD_USERNAME']).then(({ username }) => {
+    cy.get('#welcome-div').should('contain', `Welcome ${username}!`)
+  })
+}
+
+Cypress.Commands.add('loginToAAD', (username, password) => {
+  const log = Cypress.log({
+    displayName: 'Azure Active Directory Login',
+    message: [`🔐 Authenticating | ${username}`],
+    autoEnd: false,
+  })
+  log.snapshot('before')
+
+  loginViaAAD(username, password)
+
+  log.snapshot('after')
+  log.end()
+})
+```
+
+</TabItem>
+<TabItem value="cypress/support/commands.ts">
+
+```ts
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      loginToAAD(username: string, password: string): Chainable<void>
+    }
+  }
+}
+
 function loginViaAAD(username: string, password: string) {
   cy.visit('http://localhost:3000/')
   cy.get('button#signIn').click()
@@ -142,10 +216,7 @@ function loginViaAAD(username: string, password: string) {
   // Ensure Microsoft has redirected us back to the sample app with our logged in user.
   cy.url().should('equal', 'http://localhost:3000/')
   cy.env(['AAD_USERNAME']).then(({ username }) => {
-    cy.get('#welcome-div').should(
-      'contain',
-      `Welcome ${username}!`
-    )
+    cy.get('#welcome-div').should('contain', `Welcome ${username}!`)
   })
 }
 
@@ -163,6 +234,9 @@ Cypress.Commands.add('loginToAAD', (username: string, password: string) => {
   log.end()
 })
 ```
+
+</TabItem>
+</Tabs>
 
 Now, we can use our `loginToAAD` command in the test. Below is our test to login
 as a user via Azure Active Directory and run a basic sanity check.
@@ -208,6 +282,14 @@ For this, we can refactor our login command to take advantage of
 and/or cookies so we don't have to reauthenticate before every test.
 
 ```ts title="cypress/support/commands.ts"
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      loginToAAD(username: string, password: string): Chainable<void>
+    }
+  }
+}
+
 Cypress.Commands.add('loginToAAD', (username: string, password: string) => {
   cy.session(
     `aad-${username}`,

--- a/docs/app/guides/authentication-testing/google-authentication.mdx
+++ b/docs/app/guides/authentication-testing/google-authentication.mdx
@@ -131,7 +131,10 @@ The `loginByGoogleApi` command will execute the following steps:
 3. Finally the `googleCypress` localStorage item is set with the `access token`
    and user profile.
 
-```jsx title="cypress/support/commands.js"
+<Tabs>
+<TabItem value="cypress/support/commands.js">
+
+```js title="cypress/support/commands.js"
 Cypress.Commands.add('loginByGoogleApi', () => {
   cy.log('Logging in to Google')
   cy.env(['googleClientId', 'googleClientSecret', 'googleRefreshToken']).then(({ clientId, clientSecret, refreshToken }) => {
@@ -170,6 +173,63 @@ Cypress.Commands.add('loginByGoogleApi', () => {
   })
 })
 ```
+
+</TabItem>
+<TabItem value="cypress/support/commands.ts">
+
+```ts
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      loginByGoogleApi(): Chainable<void>
+    }
+  }
+}
+
+Cypress.Commands.add('loginByGoogleApi', () => {
+  cy.log('Logging in to Google')
+  cy.env(['googleClientId', 'googleClientSecret', 'googleRefreshToken']).then(
+    ({ clientId, clientSecret, refreshToken }) => {
+      cy.request({
+        method: 'POST',
+        url: 'https://www.googleapis.com/oauth2/v4/token',
+        body: {
+          grant_type: 'refresh_token',
+          client_id: clientId,
+          client_secret: clientSecret,
+          refresh_token: refreshToken,
+        },
+      }).then(({ body }) => {
+        const { access_token, id_token } = body
+
+        cy.request({
+          method: 'GET',
+          url: 'https://www.googleapis.com/oauth2/v3/userinfo',
+          headers: { Authorization: `Bearer ${access_token}` },
+        }).then(({ body }) => {
+          cy.log(body)
+          const userItem = {
+            token: id_token,
+            user: {
+              googleId: body.sub,
+              email: body.email,
+              givenName: body.given_name,
+              familyName: body.family_name,
+              imageUrl: body.picture,
+            },
+          }
+
+          window.localStorage.setItem('googleCypress', JSON.stringify(userItem))
+          cy.visit('/')
+        })
+      })
+    }
+  )
+})
+```
+
+</TabItem>
+</Tabs>
 
 With our Google app setup properly, necessary environment variables in place,
 and our `loginByGoogleApi` command implemented, we'll be able to authenticate

--- a/docs/app/guides/authentication-testing/okta-authentication.mdx
+++ b/docs/app/guides/authentication-testing/okta-authentication.mdx
@@ -77,7 +77,51 @@ Okta. This command will use
    [Cypress Real World App](https://github.com/cypress-io/cypress-realworld-app)
 4. Cache the results with [`cy.session()`](/api/commands/session)
 
-```jsx title="cypress/support/auth-provider-commands/okta.ts"
+<Tabs>
+<TabItem value="cypress/support/commands.js">
+
+```js title="cypress/support/auth-provider-commands/okta.js"
+// Okta
+const loginToOkta = (username, password) => {
+  Cypress.log({
+    displayName: 'OKTA LOGIN',
+    message: [`🔐 Authenticating | ${username}`],
+    autoEnd: false,
+  })
+
+  cy.visit('/')
+  cy.origin(
+    Cypress.expose('okta_domain'),
+    { args: { username, password } },
+    ({ username, password }) => {
+      cy.get('input[name="identifier"]').type(username)
+      cy.get('input[name="credentials.passcode"]').type(password, {
+        log: false,
+      })
+      cy.get('[type="submit"]').click()
+    }
+  )
+
+  cy.get('[data-test="sidenav-username"]').should('contain', username)
+}
+// right now our custom command is light. More on this later!
+Cypress.Commands.add('loginByOkta', (username, password) => {
+  return loginToOkta(username, password)
+})
+```
+
+</TabItem>
+<TabItem value="cypress/support/commands.ts">
+
+```ts
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      loginByOkta(username: string, password: string): Chainable<void>
+    }
+  }
+}
+
 // Okta
 const loginToOkta = (username: string, password: string) => {
   Cypress.log({
@@ -106,6 +150,9 @@ Cypress.Commands.add('loginByOkta', (username: string, password: string) => {
   return loginToOkta(username, password)
 })
 ```
+
+</TabItem>
+</Tabs>
 
 Now, we can use our `loginByOkta` command in the test. Below is our test to
 login as a user via Okta and run a few basic sanity checks.
@@ -145,7 +192,38 @@ Lastly, we can refactor our login command to take advantage of
 [`cy.session()`](/api/commands/session) to store our logged in user so we don't
 have to reauthenticate with everything test.
 
-```jsx title="cypress/support/commands.js"
+<Tabs>
+<TabItem value="cypress/support/commands.js">
+
+```js title="cypress/support/commands.js"
+Cypress.Commands.add('loginByOkta', (username, password) => {
+  cy.session(
+    `okta-${username}`,
+    () => {
+      return loginToOkta(username, password)
+    },
+    {
+      validate() {
+        cy.visit('/')
+        cy.get('[data-test="sidenav-username"]').should('contain', username)
+      },
+    }
+  )
+})
+```
+
+</TabItem>
+<TabItem value="cypress/support/commands.ts">
+
+```ts
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      loginByOkta(username: string, password: string): Chainable<void>
+    }
+  }
+}
+
 Cypress.Commands.add('loginByOkta', (username: string, password: string) => {
   cy.session(
     `okta-${username}`,
@@ -161,6 +239,9 @@ Cypress.Commands.add('loginByOkta', (username: string, password: string) => {
   )
 })
 ```
+
+</TabItem>
+</Tabs>
 
 <DocsVideo
   src="https://vimeo.com/789093688"
@@ -188,7 +269,10 @@ The `loginByOktaApi` command will execute the following steps:
 3. Finally the `oktaCypress` localStorage item is set with the `access token`
    and user profile.
 
-```jsx title="cypress/support/commands.js"
+<Tabs>
+<TabItem value="cypress/support/commands.js">
+
+```js title="cypress/support/commands.js"
 import { OktaAuth } from '@okta/okta-auth-js'
 
 // Okta
@@ -233,6 +317,66 @@ Cypress.Commands.add('loginByOktaApi', (username, password) => {
   })
 })
 ```
+
+</TabItem>
+<TabItem value="cypress/support/commands.ts">
+
+```ts
+import { OktaAuth } from '@okta/okta-auth-js'
+
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      loginByOktaApi(username: string, password: string): Chainable<void>
+    }
+  }
+}
+
+// Okta
+Cypress.Commands.add('loginByOktaApi', (username: string, password: string) => {
+  cy.request({
+    method: 'POST',
+    url: `https://${Cypress.expose('okta_domain')}/api/v1/authn`,
+    body: {
+      username,
+      password,
+    },
+  }).then(({ body }) => {
+    const user = body._embedded.user
+    const config = {
+      issuer: `https://${Cypress.expose('okta_domain')}/oauth2/default`,
+      clientId: Cypress.expose('okta_client_id'),
+      redirectUri: 'http://localhost:3000/implicit/callback',
+      scopes: ['openid', 'email', 'profile'],
+    }
+
+    const authClient = new OktaAuth(config)
+
+    return authClient.token
+      .getWithoutPrompt({ sessionToken: body.sessionToken })
+      .then(({ tokens }) => {
+        const userItem = {
+          token: tokens.accessToken.value,
+          user: {
+            sub: user.id,
+            email: user.profile.login,
+            given_name: user.profile.firstName,
+            family_name: user.profile.lastName,
+            preferred_username: user.profile.login,
+          },
+        }
+
+        window.localStorage.setItem('oktaCypress', JSON.stringify(userItem))
+
+        log.snapshot('after')
+        log.end()
+      })
+  })
+})
+```
+
+</TabItem>
+</Tabs>
 
 With our Okta app setup properly in Okta Developer console, necessary
 environment variables in place, and our `loginByOktaApi` command implemented, we

--- a/docs/app/guides/authentication-testing/social-authentication.mdx
+++ b/docs/app/guides/authentication-testing/social-authentication.mdx
@@ -275,6 +275,16 @@ function logIntoMicrosoft(username: string, password: string, name: string) {
 We can wire these functions together in a single command, like so:
 
 ```ts title="cypress/support/commands.ts"
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      loginToAuth0ViaSocial(
+        SOCIAL_PROVIDER: 'microsoft' | 'google' | 'facebook'
+      ): Chainable<void>
+    }
+  }
+}
+
 Cypress.Commands.add(
   'loginToAuth0ViaSocial',
   (SOCIAL_PROVIDER: 'microsoft' | 'google' | 'facebook') => {
@@ -353,6 +363,16 @@ likelihood your account is blocked for frequent authentication attempts. Feel
 free to DRY this up a bit!
 
 ```ts title="cypress/support/commands.ts"
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      loginToAuth0ViaSocial(
+        SOCIAL_PROVIDER: 'microsoft' | 'google' | 'facebook'
+      ): Chainable<void>
+    }
+  }
+}
+
 Cypress.Commands.add(
   'loginToAuth0ViaSocial',
   (SOCIAL_PROVIDER: 'microsoft' | 'google' | 'facebook') => {

--- a/docs/app/guides/migration/playwright-to-cypress.mdx
+++ b/docs/app/guides/migration/playwright-to-cypress.mdx
@@ -1091,6 +1091,14 @@ If you interact with the same iframe across multiple tests, extract the frame
 access into a custom command to avoid repeating the boilerplate:
 
 ```ts title="cypress/support/commands.ts"
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      getIframeBody(selector: string): Chainable<JQuery<HTMLElement>>
+    }
+  }
+}
+
 Cypress.Commands.add('getIframeBody', (selector: string) => {
   return cy
     .get(selector)
@@ -1462,6 +1470,14 @@ export const test = base.extend({
 <Badge type="success">After: Cypress</Badge>
 
 ```ts title="support.cy.ts"
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      login(username: string, password: string): Chainable<void>
+    }
+  }
+}
+
 Cypress.Commands.add('login', (username: string, password: string) => {
   cy.session([username, password], () => {
     cy.visit('/login')

--- a/docs/app/guides/migration/protractor-to-cypress.mdx
+++ b/docs/app/guides/migration/protractor-to-cypress.mdx
@@ -1024,12 +1024,36 @@ it('should display the username of a logged in user', () => {
 Cypress also provides a [Custom Command](/api/cypress-api/custom-commands) API
 to enable you to add methods to the `cy` global directly:
 
+<Tabs>
+<TabItem value="cypress/support/commands.js">
+
 ```js
 Cypress.Commands.add('login', (username, password) => {
   cy.get('.username').type(username)
   cy.get('.password').type(password)
 })
 ```
+
+</TabItem>
+<TabItem value="cypress/support/commands.ts">
+
+```ts
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      login(username: string, password: string): Chainable<void>
+    }
+  }
+}
+
+Cypress.Commands.add('login', (username: string, password: string) => {
+  cy.get('.username').type(username)
+  cy.get('.password').type(password)
+})
+```
+
+</TabItem>
+</Tabs>
 
 You can use your own custom commands in any of your tests:
 

--- a/docs/app/tooling/typescript-support.mdx
+++ b/docs/app/tooling/typescript-support.mdx
@@ -13,7 +13,7 @@ sidebar_label: 'TypeScript'
 ##### <Icon name="question-circle" color="#4BBFD2" /> What you'll learn
 
 - How to set up TypeScript in Cypress
-- How to configure TypeScript for custom commands, assertions, and plugins
+- How to configure TypeScript for custom commands, custom queries, assertions, and plugins
 - How to use TypeScript with Cypress component testing
 - How to avoid clashing types with Jest
 - How to set up your development environment for TypeScript
@@ -108,8 +108,7 @@ object, you can manually add their types to avoid TypeScript errors.
 For example if you add the command `cy.dataCy` into your
 [supportFile](/app/references/configuration#Testing-Type-Specific-Options) like this:
 
-```typescript
-// cypress/support/index.ts
+```typescript title="cypress/support/index.ts"
 Cypress.Commands.add('dataCy', (value) => {
   return cy.get(`[data-cy=${value}]`)
 })
@@ -118,8 +117,7 @@ Cypress.Commands.add('dataCy', (value) => {
 Then you can add the `dataCy` command to the global Cypress Chainable interface
 (so called because commands are chained together).
 
-```typescript
-// cypress/support/index.ts
+```typescript title="cypress/support/index.ts"
 declare global {
   namespace Cypress {
     interface Chainable {
@@ -170,8 +168,7 @@ it('works', () => {
 When you add a custom command with `prevSubject`, Cypress will infer the subject
 type automatically based on the specified `prevSubject`.
 
-```typescript
-// cypress/support/index.ts
+```typescript title="cypress/support/index.ts"
 declare global {
   namespace Cypress {
     interface Chainable {
@@ -189,8 +186,7 @@ declare global {
 }
 ```
 
-```typescript
-// cypress/support/index.ts
+```typescript title="cypress/support/index.ts"
 Cypress.Commands.add(
   'typeRandomWords',
   { prevSubject: 'element' },
@@ -206,7 +202,7 @@ When overwriting either built-in or custom commands which make use of
 `prevSubject`, you must specify generic parameters to help the type-checker to
 understand the type of the `prevSubject`.
 
-```typescript
+```typescript title="cypress/support/index.ts"
 interface TypeOptions extends Cypress.TypeOptions {
   sensitive: boolean
 }
@@ -247,6 +243,95 @@ As you can see there are generic parameters `<'type', 'element'>` are used:
   [Adding Custom Commands (TS)](https://github.com/cypress-io/cypress-example-recipes#fundamentals)
   example recipe.
 
+### Types for Custom Queries
+
+When adding [custom queries](/api/cypress-api/custom-queries) with
+`Cypress.Commands.addQuery()`, you must declare the query on the `Chainable`
+interface **before** registering it. Cypress infers the query callback's
+argument types from that declaration.
+
+Unlike custom commands, query callbacks receive `this` as a `Cypress.Command`
+(not `Mocha.Context`), and the callback must return an inner function that
+performs the query synchronously.
+
+```typescript title="cypress/support/commands.ts"
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      /**
+       * Gets the currently focused DOM element.
+       * @example cy.focused2()
+       */
+      focused2(
+        options?: Partial<Cypress.Loggable & Cypress.Timeoutable>
+      ): Chainable<JQuery>
+    }
+
+    // Required so this.set('timeout', ...) type-checks in query callbacks
+    interface EnqueuedCommandAttributes {
+      timeout?: number
+    }
+  }
+}
+
+Cypress.Commands.addQuery(
+  'focused2',
+  function focused2(
+    options: Partial<Cypress.Loggable & Cypress.Timeoutable> = {}
+  ) {
+    const log =
+      options.log !== false &&
+      Cypress.log({
+        ...(options.timeout !== undefined && { timeout: options.timeout }),
+      })
+
+    this.set('timeout', options.timeout)
+
+    return () => {
+      let $el = cy.getFocused()
+      // ...
+      return $el
+    }
+  }
+)
+```
+
+:::info
+
+When passing optional `timeout` to `Cypress.log()`, avoid writing
+`{ timeout: options.timeout }` directly if `options.timeout` may be `undefined`.
+With strict TypeScript settings such as `exactOptionalPropertyTypes`, explicitly
+passing `undefined` is not assignable to an optional property. Use a conditional
+spread instead, as shown above.
+
+:::
+
+For queries that accept additional options, combine the relevant Cypress option
+interfaces with `Partial<>`, matching how built-in queries are typed. For
+example, a query with timeout and shadow DOM support might use
+`Partial<Cypress.Loggable & Cypress.Timeoutable & Cypress.Shadow>`.
+
+To overwrite an existing query, declare the query on `Chainable` as usual and
+use `Cypress.Commands.overwriteQuery()`. The first argument to your callback is
+the original query function:
+
+```typescript title="cypress/support/commands.ts"
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      get(
+        selector: string,
+        options?: Partial<Cypress.Loggable & Cypress.Timeoutable>
+      ): Chainable<JQuery<HTMLElement>>
+    }
+  }
+}
+
+Cypress.Commands.overwriteQuery('get', function (originalFn, ...args) {
+  return originalFn.apply(this, args)
+})
+```
+
 ### Types for custom assertions
 
 If you extend Cypress assertions, you can extend the assertion types to make the
@@ -260,9 +345,7 @@ You can utilize Cypress's type declarations in your
 [plugins file](/app/plugins/plugins-guide) by annotating it like the
 following:
 
-```javascript
-// cypress/plugins/index.ts
-
+```javascript title="cypress/plugins/index.ts"
 /**
  * @type {Cypress.PluginConfig}
  */

--- a/docs/ui-coverage/guides/reduce-test-duplication.mdx
+++ b/docs/ui-coverage/guides/reduce-test-duplication.mdx
@@ -41,6 +41,9 @@ In the example below, the launchpad within Cypress App shows that the **Continue
 
 Now we can focus on consolidating tests and optimizing our test suite to avoid unnecessary duplication.
 
+<Tabs>
+<TabItem value="cypress/support/commands.js">
+
 ```js
 // This example is simplified for demonstration purposes
 // In a real-world scenario, you would change the properties that are checked
@@ -62,6 +65,26 @@ it('shows projects page', () => {
   cy.contains('Projects')
 })
 ```
+
+</TabItem>
+<TabItem value="cypress/support/commands.ts">
+
+```ts
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      skipWelcome(): Chainable<void>
+    }
+  }
+}
+
+Cypress.Commands.add('skipWelcome', () => {
+  cy.setCookie('welcome', 'dismissed')
+})
+```
+
+</TabItem>
+</Tabs>
 
 After updating our tests and recording a new run, we can visit the **Tested elements** section to see the impact of our changes. The **Continue** button now appears in fewer snapshots and less interactions, indicating that we've successfully reduced duplication.
 


### PR DESCRIPTION
Close https://github.com/cypress-io/cypress-documentation/issues/5800

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, auth, or application code impact.
> 
> **Overview**
> This PR updates Cypress docs so **custom command and query examples** are shown in parallel **JavaScript** (`cypress/support/commands.js`) and **TypeScript** (`cypress/support/commands.ts`) tabs, with `declare global` / `Chainable` typings on the TS side.
> 
> Coverage spans API command pages (`env`, `hover`, `mount`, `origin`, `session`), Cypress API docs (`custom-commands`, `custom-queries`, `cypress-log`, `ensure`), component-testing guides (React/Vue/Angular/mount), auth and migration guides, and smaller recipe-style pages. Spec usage is often split into labeled `spec.cy.js` blocks where helpful.
> 
> **`typescript-support.mdx`** gains a dedicated **Types for Custom Queries** section (`addQuery`, `overwriteQuery`, `EnqueuedCommandAttributes`, strict optional handling for `Cypress.log`), and cross-links now mention custom queries alongside custom commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4c62f04a34a0153b2f8ee922b67b604553b3160. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->