### PR TITLE
Clarify each yields

### DIFF
--- a/docs/api/commands/each.mdx
+++ b/docs/api/commands/each.mdx
@@ -11,8 +11,13 @@ sidebar_label: each
 Iterate through an array like structure (arrays or objects with a `length`
 property).
 
-It is [unsafe](/app/core-concepts/retry-ability#Only-queries-are-retried) to
-chain further commands that rely on the subject after `.each()`.
+`.each()` yields the same subject it was given and is not a
+[query](/app/core-concepts/retry-ability#Only-queries-are-retried), so Cypress
+will not retry it or re-run the queries that produced its subject. Reading the
+yielded value in a following [`.then()`](/api/commands/then) callback is safe,
+but it is unsafe to chain commands or assertions that act on DOM elements after
+`.each()` — those elements may have re-rendered during iteration, leaving the
+references stale. Re-query the elements with a Cypress query instead.
 
 ## Syntax
 
@@ -50,8 +55,12 @@ Pass a function that is invoked with the following arguments:
 <HeaderYields />
 
 - `.each()` yields the same subject it was given.
-- It is [unsafe](/app/core-concepts/retry-ability#Only-queries-are-retried)
-  to chain further commands that rely on the subject after `.each()`.
+- Because `.each()` is not a
+  [query](/app/core-concepts/retry-ability#Only-queries-are-retried), it is
+  unsafe to chain further commands that act or assert on DOM elements after
+  `.each()`, as those elements may have re-rendered and gone stale during
+  iteration. Reading the yielded subject in a
+  [`.then()`](/api/commands/then) callback (as in the example below) is safe.
 
 ## Examples
 
@@ -87,6 +96,11 @@ cy.get('li')
     expect($lis).to.have.length(3) // true
   })
 ```
+
+Here the `.then()` callback only _reads_ the yielded array, which is safe. If
+instead you needed to act or assert on DOM elements that your application may
+have re-rendered during iteration, re-query them with a Cypress query rather
+than reusing the subject yielded by `.each()`.
 
 ### Promises
 

--- a/docs/api/commands/each.mdx
+++ b/docs/api/commands/each.mdx
@@ -11,14 +11,6 @@ sidebar_label: each
 Iterate through an array like structure (arrays or objects with a `length`
 property).
 
-`.each()` yields the same subject it was given and is not a
-[query](/app/core-concepts/retry-ability#Only-queries-are-retried), so Cypress
-will not retry it or re-run the queries that produced its subject. Reading the
-yielded value in a following [`.then()`](/api/commands/then) callback is safe,
-but it is unsafe to chain commands or assertions that act on DOM elements after
-`.each()` — those elements may have re-rendered during iteration, leaving the
-references stale. Re-query the elements with a Cypress query instead.
-
 ## Syntax
 
 ```javascript
@@ -37,7 +29,6 @@ cy.getCookies().each(() => {...}) // Iterate through each cookie
 <Icon name="exclamation-triangle" color="red" /> **Incorrect Usage**
 
 ```javascript
-
 cy.each(() => {...})            // Errors, cannot be chained off 'cy'
 cy.clock().each(() => {...})    // Errors, 'clock' does not yield an array
 ```


### PR DESCRIPTION
Closes https://github.com/cypress-io/cypress-documentation/issues/5568

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to `each.mdx` with no runtime or test impact.
> 
> **Overview**
> Updates the **`each`** command docs to explain **what is safe to chain after `.each()`**, not just that chaining is unsafe.
> 
> The intro warning is removed; guidance now lives under **Yields**, tying unsafety to `.each()` not being a **query** (stale DOM after re-renders during iteration). It explicitly allows **reading** the yielded subject in a **`.then()`** callback and points to the existing example.
> 
> A short note after the “original array is always yielded” example contrasts safe reads in `.then()` with needing to **re-query** when acting or asserting on elements that may have re-rendered.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7cb3b7a9ade1fc3f1b03d6212ee30f7847d19a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->