### PR TITLE
Fix broken AWS Amplify Auth Library links in Cognito authentication guide

### DIFF
--- a/docs/app/guides/authentication-testing/amazon-cognito-authentication.mdx
+++ b/docs/app/guides/authentication-testing/amazon-cognito-authentication.mdx
@@ -22,11 +22,11 @@ apart of [Amazon Web Services (AWS)](https://aws.amazon.com).
 
 The documentation for [Amazon Cognito](https://aws.amazon.com/cognito)
 recommends using the
-[AWS Amplify Framework Authentication Library](https://aws-amplify.github.io/amplify-js/api/classes/authclass.html)
+[AWS Amplify Framework Authentication Library](https://docs.amplify.aws/javascript/build-a-backend/auth/)
 from the [AWS Amplify Framework](https://aws.amazon.com/amplify/framework/) to
 interact with a deployed [Amazon Cognito](https://aws.amazon.com/cognito)
 instance. Using the
-[AWS Amplify Framework Authentication Library](https://aws-amplify.github.io/amplify-js/api/classes/authclass.html),
+[AWS Amplify Framework Authentication Library](https://docs.amplify.aws/javascript/build-a-backend/auth/),
 we are able to programmatically drive the creation and authentication of users
 against a fully deployed back end.
 
@@ -107,7 +107,7 @@ The
 <Icon name="github" inline="true" contentType="rwa" /> is configured with an
 optional [Amazon Cognito](https://aws.amazon.com/cognito) instance via the [AWS
 Amplify Framework Authentication
-Library](https://aws-amplify.github.io/amplify-js/api/classes/authclass.html).
+Library](https://docs.amplify.aws/javascript/build-a-backend/auth/).
 The [AWS Amazon Amplify CLI](https://docs.amplify.aws/cli) is used to provision
 the [Amazon Web Services (AWS)](https://aws.amazon.com) infrastructure needed to
 configure your environment and cloud resources.
@@ -689,7 +689,7 @@ The
 configuration and runnable code for both the React SPA and the Express back end.
 
 The front end uses the
-[AWS Amplify Framework Authentication Library](https://aws-amplify.github.io/amplify-js/api/classes/authclass.html).
+[AWS Amplify Framework Authentication Library](https://docs.amplify.aws/javascript/build-a-backend/auth/).
 The back end uses the [express-jwt](https://github.com/auth0/express-jwt) to
 validate JWTs from [Amazon Cognito](https://aws.amazon.com/cognito).
 
@@ -774,7 +774,7 @@ if (process.env.REACT_APP_AWS_COGNITO) {
 
 We need to update our front end React app to allow for authentication with
 [Amazon Cognito](https://aws.amazon.com/cognito) using the
-[AWS Amplify Framework Authentication Library](https://aws-amplify.github.io/amplify-js/api/classes/authclass.html).
+[AWS Amplify Framework Authentication Library](https://docs.amplify.aws/javascript/build-a-backend/auth/).
 
 First, we create a `AppCognito.tsx` container, based off of the `App.tsx`
 component.

--- a/docs/app/guides/authentication-testing/amazon-cognito-authentication.mdx
+++ b/docs/app/guides/authentication-testing/amazon-cognito-authentication.mdx
@@ -107,9 +107,9 @@ The
 <Icon name="github" inline="true" contentType="rwa" /> is configured with an
 optional [Amazon Cognito](https://aws.amazon.com/cognito) instance via the [AWS
 Amplify Framework Authentication
-Library](https://docs.amplify.aws/javascript/build-a-backend/auth/).
-The [AWS Amazon Amplify CLI](https://docs.amplify.aws/cli) is used to provision
-the [Amazon Web Services (AWS)](https://aws.amazon.com) infrastructure needed to
+Library](https://docs.amplify.aws/javascript/build-a-backend/auth/). The [AWS
+Amazon Amplify CLI](https://docs.amplify.aws/cli) is used to provision the
+[Amazon Web Services (AWS)](https://aws.amazon.com) infrastructure needed to
 configure your environment and cloud resources.
 
 First, run the


### PR DESCRIPTION
Replaces 5 instances of the defunct https://aws-amplify.github.io/amplify-js/api/classes/authclass.html
with the current https://docs.amplify.aws/javascript/build-a-backend/auth/ URL.

Fixes #5763

https://claude.ai/code/session_01TFMvb8G9g7FmfHoLGpwET5

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link fixes with no application, test, or configuration changes.
> 
> **Overview**
> Updates the **Amazon Cognito authentication** guide so every link to the **AWS Amplify Framework Authentication Library** points at the current Amplify docs (`docs.amplify.aws/javascript/build-a-backend/auth/`) instead of the retired `aws-amplify.github.io/amplify-js` API reference.
> 
> Five link targets are updated across the intro, setup, and “adapting the app” sections. One paragraph’s line breaks are adjusted slightly where the new URL wraps differently; there is no change to procedures, samples, or runtime behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53d7f143d25963d47fbc9a7a5d271fc8c32d75b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->