### PR TITLE
docs(google-auth): add OAuth consent screen note and fix deprecated token endpoint

### DIFF
--- a/docs/app/guides/authentication-testing/google-authentication.mdx
+++ b/docs/app/guides/authentication-testing/google-authentication.mdx
@@ -50,6 +50,15 @@ Once saved, note the **client ID** and **client secret**. You can find these und
 [Google API Credentials](https://console.developers.google.com/apis/credentials)
 page.
 
+:::info
+
+You must also configure an **OAuth Consent Screen** and add your test account(s)
+as test users before the credentials will work. Refer to
+[Google's OAuth setup documentation](https://developers.google.com/identity/protocols/oauth2)
+for instructions.
+
+:::
+
 ## Using the Google OAuth 2.0 Playground to Create Testing Credentials
 
 :::info
@@ -140,7 +149,7 @@ Cypress.Commands.add('loginByGoogleApi', () => {
   cy.env(['googleClientId', 'googleClientSecret', 'googleRefreshToken']).then(({ clientId, clientSecret, refreshToken }) => {
     cy.request({
       method: 'POST',
-      url: 'https://www.googleapis.com/oauth2/v4/token',
+      url: 'https://oauth2.googleapis.com/token',
       body: {
         grant_type: 'refresh_token',
         client_id: clientId,
@@ -192,7 +201,7 @@ Cypress.Commands.add('loginByGoogleApi', () => {
     ({ clientId, clientSecret, refreshToken }) => {
       cy.request({
         method: 'POST',
-        url: 'https://www.googleapis.com/oauth2/v4/token',
+        url: 'https://oauth2.googleapis.com/token',
         body: {
           grant_type: 'refresh_token',
           client_id: clientId,
@@ -431,3 +440,4 @@ ReactDOM.render(
   document.getElementById('root')
 )
 ```
+

--- a/docs/app/guides/authentication-testing/google-authentication.mdx
+++ b/docs/app/guides/authentication-testing/google-authentication.mdx
@@ -440,4 +440,3 @@ ReactDOM.render(
   document.getElementById('root')
 )
 ```
-


### PR DESCRIPTION
- Add a brief info callout pointing to Google's OAuth docs for consent screen
  and test user setup, which are required before credentials will work
- Update deprecated token endpoint from googleapis.com/oauth2/v4/token to
  oauth2.googleapis.com/token in both JS and TS command examples

Addresses https://github.com/cypress-io/cypress-documentation/issues/5586

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to setup guidance and example API URLs; no runtime or security-sensitive code paths.
> 
> **Overview**
> Updates the **Google authentication** testing guide so readers know they must configure the **OAuth Consent Screen** and add **test users** before client credentials work, with a link to Google's OAuth docs.
> 
> Both the **JavaScript** and **TypeScript** `loginByGoogleApi` examples now POST refresh-token grants to `https://oauth2.googleapis.com/token` instead of the deprecated `oauth2/v4` endpoint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ceb04b4d1b0cd97a46d3412dbdcc08ca571906d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->