### PR TITLE
docs(okta): clarify origin of authService in Adapting an Okta App section

### DIFF
--- a/docs/app/guides/authentication-testing/okta-authentication.mdx
+++ b/docs/app/guides/authentication-testing/okta-authentication.mdx
@@ -536,12 +536,15 @@ the `withOktaAuth` higher order component (HOC).
 
 A `useEffect` hook is added to get the access token for the authenticated user
 and send an `OKTA` event with the `user` and `token` objects to work with the
-existing authentication layer (`authMachine.ts`). We define a route for
+existing authentication layer (`authMachine.ts`). `authService` is the
+[XState](https://xstate.js.org/) interpreted service instance of `authMachine`,
+imported from the app's authentication state machine. We define a route for
 `implicit/callback` to render the `LoginCallback` component and a `SecureRoute`
 for the root path.
 
 ```jsx title="src/containers/AppOkta.tsx"
 // initial imports ...
+import { authService } from '../machines/authMachine'
 import {
   LoginCallback,
   SecureRoute,
@@ -643,6 +646,7 @@ development/production but not when under test in Cypress.
 
 ```jsx title="src/containers/AppOkta.tsx"
 // initial imports ...
+import { authService } from '../machines/authMachine'
 import { LoginCallback, SecureRoute, useOktaAuth, withOktaAuth } from "@okta/okta-react";
 
 // ...


### PR DESCRIPTION
Adds an explanation that authService is the XState interpreted service
instance of authMachine, and shows the import in both AppOkta.tsx code
snippets so readers don't have to consult the full example to understand
where the variable comes from.

Closes #5621

https://claude.ai/code/session_0196xYFFsQbuNCsL9KfCLjth

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to a single MDX guide with no runtime or test behavior changes.
> 
> **Overview**
> The Okta guide’s **Adapting the front end** section now explains that **`authService`** is the XState interpreted service for **`authMachine`**, so readers know why `authService.send('OKTA', …)` appears in the examples.
> 
> Both **`AppOkta.tsx`** snippets in that section now include **`import { authService } from '../machines/authMachine'`**, matching the prose and avoiding a trip to the full Real World App source to find the symbol.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d925b5b777e5b1f79afd6b6af7dd90a84191022. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->