### PR TITLE
docs: replace archived nested-projects link with clear --project description

### DIFF
--- a/docs/app/references/command-line.mdx
+++ b/docs/app/references/command-line.mdx
@@ -479,8 +479,11 @@ cypress run --posix-exit-codes
 
 #### `cypress run --project <project-path>` {#cypress-run-project-lt-project-path-gt}
 
-To see this in action we've set up an
-[example repo to demonstrate this here](https://github.com/cypress-io/cypress-test-nested-projects).
+By default, Cypress expects your `cypress.config.js` (or `cypress.config.ts`) to
+be found in the current working directory. Use `--project` to point Cypress at a
+different directory. This is useful when you have multiple Cypress projects in
+one repository and want to run a specific one without changing your working
+directory.
 
 ```shell
 cypress run --project ./some/nested/folder
@@ -784,8 +787,11 @@ cypress open --port 8080
 
 #### `cypress open --project <project-path>` {#cypress-open-project-lt-project-path-gt}
 
-To see this in action we've set up an
-[example repo to demonstrate this here](https://github.com/cypress-io/cypress-test-nested-projects).
+By default, Cypress looks for your `cypress.config.js` (or `cypress.config.ts`)
+in the current working directory. Use `--project` to open Cypress for a project
+located in a different directory. This is useful when you have multiple Cypress
+projects in one repository and want to open a specific one without changing your
+working directory.
 
 ```shell
 cypress open --project ./some/nested/folder


### PR DESCRIPTION
Removes references to the archived cypress-test-nested-projects repo from the
`cypress run --project` and `cypress open --project` sections and replaces them
with a concise explanation of what the option does and when to use it.

Fixes #5322

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to command-line reference; no runtime, config, or test behavior changes.
> 
> **Overview**
> Updates the **`--project`** docs for **`cypress run`** and **`cypress open`** by dropping the archived **cypress-test-nested-projects** example link and replacing it with inline guidance.
> 
> The new text explains that Cypress looks for **`cypress.config.js`** / **`cypress.config.ts`** in the current working directory by default, and that **`--project`** targets another directory—especially when one repo has multiple Cypress projects and you want to run or open one without **`cd`**-ing first. The existing shell examples are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8f9cb63c60d8e1aae3f86cdf809bf2fa54bd304. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->