### PR TITLE
fix(docs): use wait-on in Bitbucket Pipelines examples to avoid race condition

### DIFF
--- a/docs/app/continuous-integration/bitbucket-pipelines.mdx
+++ b/docs/app/continuous-integration/bitbucket-pipelines.mdx
@@ -42,6 +42,19 @@ example, this allows us to run the tests in Firefox by passing the
 
 Read about [Cypress Docker variants](/app/continuous-integration/overview#Cypress-Docker-variants) to decide which image is best for your project.
 
+:::info
+
+When starting a local server in CI, use
+[`wait-on`](https://github.com/jeffbski/wait-on) or
+[`start-server-and-test`](https://github.com/bahmutov/start-server-and-test)
+to ensure the server is ready before running Cypress tests. Running
+`npm start & cypress run` without waiting for the server can cause tests to fail
+if the server hasn't finished booting. See
+[Boot your server](/app/continuous-integration/overview#Boot-your-server) for
+more details.
+
+:::
+
 ```yaml title="bitbucket-pipelines.yml"
 image: cypress/browsers:22.15.0
 
@@ -53,6 +66,8 @@ pipelines:
           - npm ci
           # start the server in the background
           - npm run start &
+          # wait for the server to respond (replace with your server's URL)
+          - npx wait-on http://localhost:3000
           # run Cypress tests in Firefox
           - npx cypress run --browser firefox
 ```
@@ -65,7 +80,8 @@ pipelines:
 - The code is checked out from the Bitbucket repository.
 - Finally, our scripts will:
   - Install npm dependencies
-  - Start the project web server (`npm start`)
+  - Start the project web server (`npm start`) in the background
+  - Wait for the server to be available using `wait-on`
   - Run the Cypress tests within the Bitbucket repository using Firefox
 
 ## Caching Dependencies and Build Artifacts
@@ -94,6 +110,8 @@ pipelines:
           - npm ci
           # start the server in the background
           - npm run start &
+          # wait for the server to respond (replace with your server's URL)
+          - npx wait-on http://localhost:3000
           # run Cypress tests in Firefox
           - npx cypress run --browser firefox
         artifacts:
@@ -156,6 +174,7 @@ e2e: &e2e
     - cypress
   script:
     - npm run start &
+    - npx wait-on http://localhost:3000
     - npm run e2e:record -- --parallel --group UI-Chrome --ci-build-id $BITBUCKET_BUILD_NUMBER
   artifacts:
     # store any generates images and videos as artifacts
@@ -215,6 +234,7 @@ e2e: &e2e
     - cypress
   script:
     - npm run start &
+    - npx wait-on http://localhost:3000
     - npm run e2e:record -- --parallel --group UI-Chrome --ci-build-id $BITBUCKET_BUILD_NUMBER
   artifacts:
     # store any generates images and videos as artifacts


### PR DESCRIPTION
All YAML examples previously ran `npm run start &` immediately followed by
`cypress run`, which is the anti-pattern the CI Overview page explicitly warns
against — the server may not be ready when tests begin. Updated all four YAML
examples to include `npx wait-on http://localhost:3000` between server start
and cypress run, and added an info callout linking to the Boot your server
guide.

Fixes #5529

https://claude.ai/code/session_01TtAs8RAR2EJtCK69ZVEShj

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to example YAML and explanatory text; no runtime or product code affected.
> 
> **Overview**
> Updates the **Bitbucket Pipelines** guide so examples match the CI overview guidance on booting a local server before tests.
> 
> Adds an **info** callout recommending `wait-on` or `start-server-and-test`, with a link to **Boot your server**. Every YAML sample that used `npm run start &` followed immediately by Cypress now inserts `npx wait-on http://localhost:3000` in between (basic, caching, and parallel `e2e` snippets). The step-by-step bullets now describe starting the server in the background and waiting with `wait-on` before running tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79c6b62e1c5123d14a9042974447949c09bdc4b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->