### PR TITLE
fix(click): clarify retry behavior in Assertions section

### DIFF
--- a/docs/api/commands/click.mdx
+++ b/docs/api/commands/click.mdx
@@ -223,8 +223,10 @@ then the element will not receive focus as per the spec.
 
 - `.click()` will automatically wait for the element to reach an
   [actionable state](/app/core-concepts/interacting-with-elements).
-- `.click()`will automatically [retry](/app/core-concepts/retry-ability)
-  until all chained assertions have passed.
+- `.click()` itself will not be retried — it fires once when the element is
+  actionable. Assertions chained after `.click()` will be retried until they
+  pass or time out. See
+  [Only queries are retried](/app/core-concepts/retry-ability#Only-queries-are-retried).
 
 <HeaderTimeouts />
 


### PR DESCRIPTION
The previous wording implied .click() itself retries like a query
command, which contradicts the retry-ability guide. The click action
fires once when the element is actionable; only assertions chained
after it are retried. Adds a link to the 'Only queries are retried'
section for context.

Closes #5308

https://claude.ai/code/session_016Z8a7N1qN5yvseeCYK3Uq3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording change in the click command reference; no runtime or test behavior changes.
> 
> **Overview**
> Updates the **Assertions** section on the `.click()` API page so retry behavior matches the [retry-ability guide](https://docs.cypress.io/app/core-concepts/retry-ability#Only-queries-are-retried).
> 
> The old bullet suggested `.click()` retries like a query until chained assertions pass. The new text states that **`.click()` runs once** when the element is actionable, while **assertions after `.click()`** are what retry until they pass or time out, with a link to *Only queries are retried*.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce89e791fc9502b43b62bbdcdcf7c084f23fe7be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->