### PR TITLE
docs(advanced-installation): fix and expand binary mirroring documentation

### DIFF
--- a/docs/app/references/advanced-installation.mdx
+++ b/docs/app/references/advanced-installation.mdx
@@ -289,7 +289,7 @@ https://download.cypress.io/desktop/12.17.4?platform=win32&arch=x64
 
 ## Mirroring
 
-If you choose to mirror the entire Cypress download site, you can specify
+If you choose to mirror the Cypress download site, you can specify
 `CYPRESS_DOWNLOAD_MIRROR` to set the download server URL from
 `https://download.cypress.io` to your own mirror.
 
@@ -300,7 +300,30 @@ CYPRESS_DOWNLOAD_MIRROR="https://www.example.com" cypress install
 ```
 
 Cypress will then attempt to download a binary with this format:
-`https://www.example.com/desktop/:version?platform=p`
+`https://www.example.com/desktop/:version?platform=p&arch=a`
+
+Your mirror server must handle requests to `/desktop/:version` with `platform`
+and `arch` query parameters, and serve the appropriate Cypress binary as a
+`.zip` file.
+
+**Supported platform and architecture combinations:**
+
+| `platform` | `arch`  | Notes                                                       |
+| ---------- | ------- | ----------------------------------------------------------- |
+| `linux`    | `x64`   |                                                             |
+| `darwin`   | `x64`   | macOS Intel                                                 |
+| `darwin`   | `arm64` | macOS Apple Silicon                                         |
+| `win32`    | `x64`   | Windows; also used for ARM64 Windows (no native ARM64 binary) |
+
+:::note
+On Windows ARM64 machines, Cypress automatically substitutes `arm64` with `x64`
+when building the download URL, so your mirror will only ever receive `win32`
+requests with `arch=x64`.
+:::
+
+If your mirror uses a different URL structure than `download.cypress.io`, use
+`CYPRESS_DOWNLOAD_PATH_TEMPLATE` together with `CYPRESS_DOWNLOAD_MIRROR`.
+See [Download path template](#Download-path-template) for examples.
 
 ## Download path template
 
@@ -310,13 +333,16 @@ generated based on endpoint, version, platform and architecture.
 
 **The following replacements are supported:**
 
-- `${endpoint}` is replaced with `https://download.cypress.io/desktop/:version`.
-  If `CYPRESS_DOWNLOAD_MIRROR` is set, its value is used instead of
-  `https://download.cypress.io` (note that the `/desktop` remains!)
+- `${endpoint}` is replaced with the full base URL including the version path
+  segment: `<base>/desktop/<version>` (e.g.
+  `https://download.cypress.io/desktop/10.11.0`).
+  If `CYPRESS_DOWNLOAD_MIRROR` is set, its value is used as `<base>` instead of
+  `https://download.cypress.io` (note that `/desktop/<version>` is still
+  appended).
 - `${platform}` is replaced with the platform the installation is running on
   (e.g. `win32`, `linux`, `darwin`)
 - `${arch}` is replaced with the architecture the installation is running on
-  (e.g. `x64`, `arm64`)
+  (e.g. `x64`, `arm64`). On Windows ARM64, this is always `x64`.
 - `${version}` is replaced with the version number
   that's being installed (e.g. `10.11.0`)
 

--- a/docs/app/references/advanced-installation.mdx
+++ b/docs/app/references/advanced-installation.mdx
@@ -308,11 +308,11 @@ and `arch` query parameters, and serve the appropriate Cypress binary as a
 
 **Supported platform and architecture combinations:**
 
-| `platform` | `arch`  | Notes                                                       |
-| ---------- | ------- | ----------------------------------------------------------- |
-| `linux`    | `x64`   |                                                             |
-| `darwin`   | `x64`   | macOS Intel                                                 |
-| `darwin`   | `arm64` | macOS Apple Silicon                                         |
+| `platform` | `arch`  | Notes                                                         |
+| ---------- | ------- | ------------------------------------------------------------- |
+| `linux`    | `x64`   |                                                               |
+| `darwin`   | `x64`   | macOS Intel                                                   |
+| `darwin`   | `arm64` | macOS Apple Silicon                                           |
 | `win32`    | `x64`   | Windows; also used for ARM64 Windows (no native ARM64 binary) |
 
 :::note

--- a/docs/app/references/advanced-installation.mdx
+++ b/docs/app/references/advanced-installation.mdx
@@ -335,7 +335,7 @@ generated based on endpoint, version, platform and architecture.
 
 - `${endpoint}` is replaced with the full base URL including the version path
   segment: `<base>/desktop/<version>` (e.g.
-  `https://download.cypress.io/desktop/10.11.0`).
+  `https://download.cypress.io/desktop/15.16.0`).
   If `CYPRESS_DOWNLOAD_MIRROR` is set, its value is used as `<base>` instead of
   `https://download.cypress.io` (note that `/desktop/<version>` is still
   appended).
@@ -344,7 +344,7 @@ generated based on endpoint, version, platform and architecture.
 - `${arch}` is replaced with the architecture the installation is running on
   (e.g. `x64`, `arm64`). On Windows ARM64, this is always `x64`.
 - `${version}` is replaced with the version number
-  that's being installed (e.g. `10.11.0`)
+  that's being installed (e.g. `15.16.0`)
 
 **Examples:**
 
@@ -354,14 +354,14 @@ structure of `https://cdn.cypress.io`:
 ```shell
 export CYPRESS_DOWNLOAD_MIRROR=https://cypress-download.local
 export CYPRESS_DOWNLOAD_PATH_TEMPLATE='${endpoint}/${platform}-${arch}/cypress.zip'
-# Example of a resulting URL: https://cypress-download.local/desktop/10.11.0/linux-x64/cypress.zip
+# Example of a resulting URL: https://cypress-download.local/desktop/15.16.0/linux-x64/cypress.zip
 ```
 
 To install the binary from a download server with a custom file structure:
 
 ```shell
 export CYPRESS_DOWNLOAD_PATH_TEMPLATE='https://software.local/cypress/${platform}/${arch}/${version}/cypress.zip'
-# Example of a resulting URL: https://software.local/cypress/linux/x64/10.11.0/cypress.zip
+# Example of a resulting URL: https://software.local/cypress/linux/x64/15.16.0/cypress.zip
 ```
 
 To define `CYPRESS_DOWNLOAD_PATH_TEMPLATE` in `.npmrc`, put a backslash before


### PR DESCRIPTION
Fix the CYPRESS_DOWNLOAD_MIRROR URL format (missing &arch=a query parameter),
document supported platform/arch combinations, note the Windows ARM64 → x64
substitution, and clarify that ${endpoint} includes the version path segment.
Closes #5290.

https://claude.ai/code/session_01HTK6bi1hsUxuyAou1KuuAq

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to installation/mirroring guidance with no runtime or security behavior changes.
> 
> **Overview**
> Updates **Advanced Installation** docs so binary mirroring and custom download URLs match how Cypress actually requests binaries.
> 
> The **Mirroring** section now shows the correct mirror URL pattern (`platform` and `arch` query params), what mirrors must serve, a table of supported `platform`/`arch` pairs, and that Windows ARM64 installs use `arch=x64` in the URL. It also points readers to `CYPRESS_DOWNLOAD_PATH_TEMPLATE` when their mirror layout differs from `download.cypress.io`.
> 
> The **Download path template** section clarifies that `${endpoint}` already includes `/desktop/<version>`, documents ARM64-on-Windows as always `x64` for `${arch}`, and refreshes example URLs to a current version (e.g. `15.16.0`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 412ef94033b507d072b9d93570b5c971a5865c5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->