### PR TITLE
docs(typescript): update support file names and plugins section for Cypress v10+

### DIFF
--- a/docs/app/tooling/typescript-support.mdx
+++ b/docs/app/tooling/typescript-support.mdx
@@ -108,7 +108,7 @@ object, you can manually add their types to avoid TypeScript errors.
 For example if you add the command `cy.dataCy` into your
 [supportFile](/app/references/configuration#Testing-Type-Specific-Options) like this:
 
-```typescript title="cypress/support/index.ts"
+```typescript title="cypress/support/commands.ts"
 Cypress.Commands.add('dataCy', (value) => {
   return cy.get(`[data-cy=${value}]`)
 })
@@ -117,7 +117,7 @@ Cypress.Commands.add('dataCy', (value) => {
 Then you can add the `dataCy` command to the global Cypress Chainable interface
 (so called because commands are chained together).
 
-```typescript title="cypress/support/index.ts"
+```typescript title="cypress/support/commands.ts"
 declare global {
   namespace Cypress {
     interface Chainable {
@@ -168,7 +168,7 @@ it('works', () => {
 When you add a custom command with `prevSubject`, Cypress will infer the subject
 type automatically based on the specified `prevSubject`.
 
-```typescript title="cypress/support/index.ts"
+```typescript title="cypress/support/commands.ts"
 declare global {
   namespace Cypress {
     interface Chainable {
@@ -186,7 +186,7 @@ declare global {
 }
 ```
 
-```typescript title="cypress/support/index.ts"
+```typescript title="cypress/support/commands.ts"
 Cypress.Commands.add(
   'typeRandomWords',
   { prevSubject: 'element' },
@@ -202,7 +202,7 @@ When overwriting either built-in or custom commands which make use of
 `prevSubject`, you must specify generic parameters to help the type-checker to
 understand the type of the `prevSubject`.
 
-```typescript title="cypress/support/index.ts"
+```typescript title="cypress/support/commands.ts"
 interface TypeOptions extends Cypress.TypeOptions {
   sensitive: boolean
 }
@@ -341,15 +341,32 @@ instructions.
 
 ### Types for plugins
 
-You can utilize Cypress's type declarations in your
-[plugins file](/app/plugins/plugins-guide) by annotating it like the
-following:
+When using [`defineConfig`](/app/references/configuration) in your
+`cypress.config.ts` file, TypeScript types for
+[`setupNodeEvents`](/app/references/configuration#setupNodeEvents) are inferred
+automatically — no additional annotation is needed:
 
-```javascript title="cypress/plugins/index.ts"
-/**
- * @type {Cypress.PluginConfig}
- */
-module.exports = (on, config) => {}
+```typescript title="cypress.config.ts"
+import { defineConfig } from 'cypress'
+
+export default defineConfig({
+  e2e: {
+    setupNodeEvents(on, config) {
+      // implement node event listeners here
+    },
+  },
+})
+```
+
+If you extract your plugin setup into a separate function or file, you can
+annotate it with the `Cypress.PluginConfig` type:
+
+```typescript title="cypress/plugins/index.ts"
+const setupNodeEvents: Cypress.PluginConfig = (on, config) => {
+  // implement node event listeners here
+}
+
+export default setupNodeEvents
 ```
 
 ### Using an External Typings File

--- a/docs/app/tooling/typescript-support.mdx
+++ b/docs/app/tooling/typescript-support.mdx
@@ -105,8 +105,9 @@ This allows Cypress to run your TypeScript configuration inside the Cypress runt
 When adding [custom commands](/api/cypress-api/custom-commands) to the `cy`
 object, you can manually add their types to avoid TypeScript errors.
 
-For example if you add the command `cy.dataCy` into your
-[supportFile](/app/references/configuration#Testing-Type-Specific-Options) like this:
+For example, if you add the command `cy.dataCy` to
+`cypress/support/commands.ts` (which is imported by your
+[support entry file](/app/references/configuration#Testing-Type-Specific-Options) `cypress/support/e2e.ts`) like this:
 
 ```typescript title="cypress/support/commands.ts"
 Cypress.Commands.add('dataCy', (value) => {


### PR DESCRIPTION
- Replace legacy `cypress/support/index.ts` with `cypress/support/commands.ts`
  in all custom command examples, matching the v10+ default scaffold and making
  the section consistent with the existing "Types for Custom Queries" examples.
- Rewrite the "Types for plugins" section: remove the outdated
  `cypress/plugins/index.ts` + JSDoc approach; show that `setupNodeEvents` in
  `cypress.config.ts` is typed automatically via `defineConfig`, and document
  `Cypress.PluginConfig` for the extracted-function pattern.

Closes #5262

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to example paths and plugin typing guidance; no runtime or product code affected.
> 
> **Overview**
> Updates the TypeScript docs to match **Cypress v10+** layout and configuration patterns.
> 
> Custom command examples now point at **`cypress/support/commands.ts`** (imported via **`cypress/support/e2e.ts`**) instead of the legacy **`cypress/support/index.ts`**, aligning with the default scaffold and the existing custom-queries section.
> 
> The **Types for plugins** section is rewritten: it documents automatic typing of **`setupNodeEvents`** when using **`defineConfig`** in **`cypress.config.ts`**, and **`Cypress.PluginConfig`** for extracted plugin setup, replacing the old **`cypress/plugins/index.ts`** JSDoc **`@type`** pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98819e3a0294cb877e072e40ad49f0c030890bd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->