### PR TITLE
Improve component testing introduction with clearer value proposition

### DIFF
--- a/docs/app/component-testing/get-started.mdx
+++ b/docs/app/component-testing/get-started.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Component Testing in Cypress | Cypress Documentation'
-description: 'Write Cypress component tests in React, Angular, Vue, or Svelte. Learn how to set up, write, and run your first component test.'
+description: 'Write Cypress component tests in React, Angular, Vue, or Svelte. Learn how to set up, write, and run your first component test in a real browser with full debugging capabilities.'
 sidebar_position: 20
 sidebar_label: Get Started
 ---
@@ -13,14 +13,31 @@ sidebar_label: Get Started
 
 ##### <Icon name="question-circle" color="#4BBFD2" /> What you'll learn
 
+- What makes Cypress Component Testing different from other component testing tools
 - How to set up Component Testing for React, Angular, Vue, or Svelte
 - How to write your first component test
 - How to run your component test
-  :::
+
+:::
+
+Cypress Component Testing mounts your components directly in a **real browser** — not a simulated DOM — so you test them exactly as they will behave for your users. Every component renders visually during the test run, and you can use browser DevTools to inspect, interact, and debug just as you would during development.
+
+## Why Cypress for Component Testing?
+
+Teams that adopt Cypress for component testing typically come looking for faster feedback on their UI components. They stay because Cypress brings together capabilities that would otherwise require assembling several separate tools:
+
+- **See your component in action.** Components render visually inside the Cypress App as each test runs. You can interact with them manually, inspect elements with DevTools, and use [Time Travel](/app/core-concepts/open-mode#Command-Log) to step back through exactly what happened at each point in the test — no guessing, no `console.log` archaeology.
+- **Write less test boilerplate.** [Automatic waiting](/app/core-concepts/introduction-to-cypress#Cypress-is-Not-Like-jQuery) means your assertions run only after your component has rendered and updated. There is no need for `waitFor`, `act()`, or manual timeouts. You describe what should be true; Cypress waits until it is.
+- **Use powerful testing primitives — built in.** [Spies and stubs](/app/guides/stubs-spies-and-clocks) to verify event handlers and isolate dependencies. [Network interception](/app/guides/network-requests) to test how your component handles any server response without a running backend. [Clock control](/api/commands/clock) to test time-sensitive logic instantly, without sleeping.
+- **One project, one quality signal.** Component tests live in the same Cypress project as your end-to-end tests. When connected to [Cypress Cloud](/cloud/get-started/introduction), results, flake patterns, and [coverage data](/ui-coverage/get-started/introduction) flow into a single view — so your team has clear evidence of quality at every layer before a release ships.
+
+Catching a component bug in isolation is far cheaper than catching the same bug in an end-to-end test or, worse, in production. Teams that test components with Cypress close that feedback loop earlier, reduce the cost of fixing defects, and ship with more confidence.
+
+## Configuring Component Testing
 
 Assuming you've successfully
 [installed Cypress](/app/get-started/install-cypress) and
-[opened Cypress](/app/get-started/open-the-app), now it's time to setup component testing.
+[opened Cypress](/app/get-started/open-the-app), now it's time to set up component testing.
 
 The Cypress App will guide you through configuring your project.
 
@@ -28,8 +45,6 @@ The Cypress App will guide you through configuring your project.
   src="/img/snippets/getting-started-with-ct.mp4"
   title="Getting Started With Component Testing"
 />
-
-## Configuring Component Testing
 
 ### Supported Frameworks
 

--- a/docs/app/get-started/why-cypress.mdx
+++ b/docs/app/get-started/why-cypress.mdx
@@ -182,9 +182,7 @@ it('adds todos', () => {
 
 ### Component Testing
 
-Cypress [Component Testing](/app/component-testing/get-started) provides a component workbench for you to quickly
-build and test components from multiple front-end UI libraries, no matter how
-simple or complex.
+Cypress [Component Testing](/app/component-testing/get-started) mounts your components directly in a real browser, giving you a live, visual workbench to build and test components from any front-end UI library — no matter how simple or complex. Because tests run in the same environment your users experience, you catch rendering issues, interaction bugs, and edge cases before they ever reach end-to-end testing or production.
 
 Learn more about how to test components for
 [React](/app/component-testing/react/overview),


### PR DESCRIPTION
Addresses #5180. The get-started page previously jumped straight into
setup steps without explaining what makes Cypress CT distinctive. Added:
- Opening paragraph emphasizing real-browser (not simulated DOM) testing
- "Why Cypress for Component Testing?" section covering visual debugging,
  automatic waiting, built-in spies/stubs/network/clock primitives, and
  the unified quality signal from connecting to Cypress Cloud
- Closing sentence tying faster component feedback to lower defect cost
  and more confident releases

Also updated the Component Testing blurb in why-cypress.mdx to replace
the bare "component workbench" sentence with one that explains the
browser-based nature and why it matters for catching bugs early.

https://claude.ai/code/session_01883SzXvPxsZQq84mQE7q99

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and structure changes in documentation only; no application, API, or test runtime behavior is affected.
> 
> **Overview**
> Documentation-only updates that front-load **why** Cypress component testing matters before the existing setup walkthrough.
> 
> **`get-started.mdx`** expands the page meta description, adds a “what makes CT different” bullet under *What you'll learn*, and inserts an opening paragraph plus a **Why Cypress for Component Testing?** section (real browser, visual debugging/Time Travel, automatic waiting, built-in spies/network/clock, unified signal with Cloud/UI Coverage). The **Configuring Component Testing** heading is moved up so value proposition precedes configuration; a duplicate section title is removed and “setup” is corrected to “set up.”
> 
> **`why-cypress.mdx`** replaces the brief “component workbench” wording with copy that stresses real-browser mounting and catching UI issues earlier than E2E or production.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1ce8d77720ab0ac61e9da25a59e31f3dab27dc0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->