### PR TITLE
fix(code-coverage): replace deprecated transform-class-properties with @babel/plugin-proposal-class-properties

### DIFF
--- a/docs/app/tooling/code-coverage.mdx
+++ b/docs/app/tooling/code-coverage.mdx
@@ -249,7 +249,7 @@ to instrument the code as part of its transpilation. Add this plugin to the
 ```json title='.babelrc'"
 {
   "presets": ["@babel/preset-react"],
-  "plugins": ["transform-class-properties", "istanbul"]
+  "plugins": ["@babel/plugin-proposal-class-properties", "istanbul"]
 }
 ```
 
@@ -611,7 +611,7 @@ code is transpiled.
 ```json
 {
   "presets": ["@babel/preset-react"],
-  "plugins": ["transform-class-properties", "istanbul"]
+  "plugins": ["@babel/plugin-proposal-class-properties", "istanbul"]
 }
 ```
 


### PR DESCRIPTION
The `transform-class-properties` plugin is from Babel 6 and does not work
with Babel 7+. Updated both .babelrc examples in the code coverage docs to
use the correct `@babel/plugin-proposal-class-properties` plugin, which is
consistent with the already-present `@babel/preset-react` Babel 7 preset.

Fixes #5142

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to example Babel config; no runtime or application code affected.
> 
> **Overview**
> Updates both **`.babelrc`** snippets in the code coverage guide so the `plugins` array uses **`@babel/plugin-proposal-class-properties`** instead of the Babel 6-only **`transform-class-properties`**, matching the existing **`@babel/preset-react`** Babel 7 setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0b6d7d70196e878509f729ebde67e3ae292e8eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->