### PR TITLE
fix: remove unsafe action command chaining from docs examples

### DIFF
--- a/docs/api/commands/select.mdx
+++ b/docs/api/commands/select.mdx
@@ -81,7 +81,8 @@ Pass in an options object to change the default behavior of `.select()`.
 
 ```javascript
 // yields <option value="456">apples</option>
-cy.get('select').select('apples').should('have.value', '456')
+cy.get('select').select('apples')
+cy.get('select').should('have.value', '456')
 ```
 
 ### Value
@@ -98,7 +99,8 @@ cy.get('select').select('apples').should('have.value', '456')
 
 ```javascript
 // yields <option value="456">apples</option>
-cy.get('select').select('456').should('have.value', '456')
+cy.get('select').select('456')
+cy.get('select').should('have.value', '456')
 ```
 
 ### Index
@@ -115,7 +117,8 @@ cy.get('select').select('456').should('have.value', '456')
 
 ```javascript
 // yields <option value="456">apples</option>
-cy.get('select').select(0).should('have.value', '456')
+cy.get('select').select(0)
+cy.get('select').should('have.value', '456')
 ```
 
 ### Select multiple options

--- a/docs/api/commands/then.mdx
+++ b/docs/api/commands/then.mdx
@@ -234,14 +234,15 @@ cy.get('button')
 
 A common pattern is to perform several sequential actions on the same element —
 for example, focusing an input, clearing its value, typing a new value, and then
-blurring it. Because [`.focus()`](/api/commands/focus),
-[`.clear()`](/api/commands/clear), [`.type()`](/api/commands/type), and
-[`.blur()`](/api/commands/blur) each yield the same subject they were given, you
-can chain them directly without needing `.then()`:
+blurring it. Issue each action as a separate command — there is no need to wrap
+them in `.then()`:
 
 ```javascript
-// ✅ Preferred: direct chaining
-cy.get('input').focus().clear().type('new value').blur()
+// ✅ Preferred: separate commands
+cy.get('input').focus()
+cy.get('input').clear()
+cy.get('input').type('new value')
+cy.get('input').blur()
 ```
 
 You might be tempted to wrap multiple actions inside `.then()` to avoid

--- a/docs/api/commands/type.mdx
+++ b/docs/api/commands/type.mdx
@@ -499,7 +499,8 @@ $('#username').on('keydown', (e) => {
 
 // Cypress will not insert any characters if keydown, keypress, or textInput
 // are cancelled - which matches the default browser behavior
-cy.get('#username').type('bob@gmail.com').should('have.value', '') // true
+cy.get('#username').type('bob@gmail.com')
+cy.get('#username').should('have.value', '') // true
 ```
 
 #### Preventing `mousedown` does not prevent typing

--- a/docs/app/core-concepts/interacting-with-elements.mdx
+++ b/docs/app/core-concepts/interacting-with-elements.mdx
@@ -107,7 +107,8 @@ Elements positioned outside the viewport are now correctly identified as hidden.
 cy.get('.off-screen-element').should('be.visible')
 
 // After
-cy.get('.off-screen-element').scrollIntoView().should('be.visible')
+cy.get('.off-screen-element').scrollIntoView()
+cy.get('.off-screen-element').should('be.visible')
 ```
 
 **Covered Elements**


### PR DESCRIPTION
Code examples in select.mdx, type.mdx, then.mdx, and
interacting-with-elements.mdx chained commands directly after action
commands (.select(), .type(), .scrollIntoView()), which triggers the
cypress/unsafe-to-chain-command ESLint rule and contradicts the
documented guidance on those same pages. Split each chain into separate
commands to align with the retry-ability best practices.

Fixes #5216

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to code samples; no runtime, auth, or application logic affected.
> 
> **Overview**
> Documentation examples are updated so **action commands** (`.select()`, `.type()`, `.scrollIntoView()`) are no longer immediately chained to assertions or follow-up commands. Each example now uses a separate `cy.get(...)` (or equivalent) before `.should(...)`, matching retry-ability guidance and avoiding patterns flagged by `cypress/unsafe-to-chain-command`.
> 
> In **`then.mdx`**, the “multiple actions on the same element” section now recommends issuing **separate commands** (e.g. repeated `cy.get('input')` for focus, clear, type, blur) instead of a single chained `.focus().clear().type().blur()` line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b960d3a760badb51a9ab1e9fc7538b5660d6fafe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->