### PR TITLE
docs(clock): clarify that clock.restore() discards pre-existing timers

### DIFF
--- a/docs/api/commands/clock.mdx
+++ b/docs/api/commands/clock.mdx
@@ -73,6 +73,11 @@ Pass in an options object to change the default behavior of `cy.clock()`.
   Restore all overridden native functions. This is automatically called between
   tests, so should not generally be needed.
 
+  `clock.restore()` returns native timer APIs (`setTimeout`, `setInterval`, etc.)
+  to the `window`. New timers created _after_ `restore()` will run in real time.
+  However, any intervals or timeouts registered before or during the fake clock's
+  lifetime are discarded — they will not resume automatically.
+
 - **`clock.setSystemTime(now)`**
 
   Change the system time to the new `now`. Now can be a timestamp, date object,
@@ -207,6 +212,17 @@ cy.clock(Date.UTC(2018, 10, 30), ['Date'])
 You can restore the clock and allow your application to resume normally without
 manipulating native global functions related to time. This is automatically
 called between tests.
+
+:::caution
+
+`clock.restore()` returns native timer APIs (`setTimeout`, `setInterval`, etc.)
+to the `window`. New timers created _after_ `restore()` will run in real time.
+However, any intervals or timeouts that were registered before or during the
+fake clock's lifetime are discarded — they will not resume automatically. If
+your application code needs to keep running after `restore()`, it must
+re-register those timers itself.
+
+:::
 
 ```javascript
 cy.clock()


### PR DESCRIPTION
Addresses issue #5166. Users expected clock.restore() to resume
intervals/timeouts that were registered during the fake clock's
lifetime. Added a clear explanation in both the Yields section and
the Restore clock example section that restore() only returns native
APIs to the window — previously registered timers are discarded and
will not resume automatically.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to `clock.mdx`; no runtime or test behavior is modified.
> 
> **Overview**
> Documents that **`clock.restore()`** only puts native timer APIs back on `window`—it does **not** resume timers that were scheduled while the fake clock was active.
> 
> The same behavior is called out in the **Yields** section for `clock.restore()` and in a **:::caution** block under **Restore clock**, including that apps must **re-register** timers if they need to keep running after restore. This addresses confusion from issue #5166.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bc45ff2cd04f95a12fb83bc15929402a4b54db3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->