### PR TITLE
docs: explain how to extend ApplicationWindow for custom window properties

### DIFF
--- a/docs/api/commands/window.mdx
+++ b/docs/api/commands/window.mdx
@@ -75,6 +75,33 @@ Our test can confirm the property was properly set.
 cy.window().its('tags.foo').should('equal', 'bar')
 ```
 
+#### TypeScript: custom window properties
+
+`cy.window()` yields an `AUTWindow` object typed as
+`Window & typeof globalThis & Cypress.ApplicationWindow`. To avoid TypeScript
+errors when accessing custom properties your application sets on `window`,
+extend the `Cypress.ApplicationWindow` interface:
+
+```typescript
+// cypress/support/e2e.ts (or a *.d.ts file included by your cypress/tsconfig.json)
+declare namespace Cypress {
+  interface ApplicationWindow {
+    // add the properties your app sets on window
+    env: {
+      DISABLE: boolean
+    }
+  }
+}
+```
+
+After augmenting the interface, TypeScript will recognize the custom property:
+
+```typescript
+cy.window().then((win) => {
+  win.env.DISABLE = true // no TypeScript error
+})
+```
+
 **Note:** Cypress commands are asynchronous, so you cannot check a property
 value before the Cypress commands ran.
 

--- a/docs/app/tooling/typescript-support.mdx
+++ b/docs/app/tooling/typescript-support.mdx
@@ -333,6 +333,34 @@ Cypress.Commands.overwriteQuery('get', function (originalFn, ...args) {
 })
 ```
 
+### Types for custom window properties
+
+[`cy.window()`](/api/commands/window) yields an `AUTWindow` object, which is
+typed as `Window & typeof globalThis & Cypress.ApplicationWindow`. The
+`Cypress.ApplicationWindow` interface is an empty extension point that you can
+augment to tell TypeScript about properties your application adds to `window`.
+
+Extend the interface in your support file or a `*.d.ts` file:
+
+```typescript title="cypress/support/e2e.ts"
+declare namespace Cypress {
+  interface ApplicationWindow {
+    // add the properties your app sets on window
+    env: {
+      DISABLE: boolean
+    }
+  }
+}
+```
+
+TypeScript will now recognize those properties inside `cy.window()` callbacks:
+
+```typescript
+cy.window().then((win) => {
+  win.env.DISABLE = true // no TypeScript error
+})
+```
+
 ### Types for custom assertions
 
 If you extend Cypress assertions, you can extend the assertion types to make the


### PR DESCRIPTION
cy.window() yields AUTWindow (Window & typeof globalThis & Cypress.ApplicationWindow).
TypeScript users need to augment Cypress.ApplicationWindow to avoid errors when
accessing custom properties their app sets on window.

Adds a TypeScript example to window.mdx and a new section to typescript-support.mdx.

Fixes #5136

https://claude.ai/code/session_011miby7qLbWce4fP9yyYc1a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or test behavior impact.
> 
> **Overview**
> Documents how TypeScript users can **augment `Cypress.ApplicationWindow`** so custom properties on `window` type-check inside `cy.window()` callbacks.
> 
> Adds a **TypeScript subsection** to the `window` command docs (`window.mdx`) and a matching **“Types for custom window properties”** section in the TypeScript tooling guide (`typescript-support.mdx`), including `declare namespace Cypress { interface ApplicationWindow { ... } }` examples. Addresses [#5136](https://github.com/cypress-io/cypress/issues/5136).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea755682521b312c3466d50733b6c951b5d52790. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->