### PR TITLE
fix(docs): use parseInt with explicit radix 10 in Avoid Loops examples

### DIFF
--- a/docs/app/core-concepts/introduction-to-cypress.mdx
+++ b/docs/app/core-concepts/introduction-to-cypress.mdx
@@ -748,7 +748,7 @@ while (!found7) {
   cy.get('#result')
     .should('not.be.empty')
     .invoke('text')
-    .then(parseInt)
+    .then((text) => parseInt(text, 10))
     .then((number) => {
       if (number === 7) {
         found7 = true
@@ -776,7 +776,7 @@ const checkAndReload = () => {
   cy.get('#result')
     .should('not.be.empty')
     .invoke('text')
-    .then(parseInt)
+    .then((text) => parseInt(text, 10))
     .then((number) => {
       // if the expected number is found
       // stop adding any more commands


### PR DESCRIPTION
Fixes parseInt calls that omitted the radix argument. Without a radix,
parseInt uses heuristics based on the string prefix (e.g., '0x' triggers
hex parsing), which is a well-known footgun. Using an explicit radix 10
follows MDN best practices and avoids teaching bad habits.

Closes #4942

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to example snippets; no runtime or test code changes.
> 
> **Overview**
> Updates the **Avoid loops** examples in `introduction-to-cypress.mdx` so numeric parsing no longer passes `parseInt` directly to `.then()`.
> 
> Both the incorrect `while` example and the correct recursive `checkAndReload` example now use `.then((text) => parseInt(text, 10))` instead of `.then(parseInt)`, so the docs match MDN guidance and avoid implicit-radix behavior (e.g. strings like `0x…` parsing as hex).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7883e61cbcbf20eb688738d3dfde94d51cbfeedf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->