### PR TITLE
fix(docs): escape literal ? in minimatch glob patterns for query strings

### DIFF
--- a/docs/api/commands/intercept.mdx
+++ b/docs/api/commands/intercept.mdx
@@ -1516,15 +1516,25 @@ then you have a match!
 
 ```javascript
 expect(
-  Cypress.minimatch('http://localhost/users?_limit=3', '**/users\\?_limit=+(3|5)')
+  Cypress.minimatch(
+    'http://localhost/users?_limit=3',
+    '**/users\\?_limit=+(3|5)'
+  )
 ).to.be.true
 expect(
-  Cypress.minimatch('http://localhost/users?_limit=5', '/users\\?_limit=+(3|5)', {
-    matchBase: true,
-  })
+  Cypress.minimatch(
+    'http://localhost/users?_limit=5',
+    '/users\\?_limit=+(3|5)',
+    {
+      matchBase: true,
+    }
+  )
 ).to.be.true
 expect(
-  Cypress.minimatch('http://localhost/users?_limit=7', '**/users\\?_limit=+(3|5)')
+  Cypress.minimatch(
+    'http://localhost/users?_limit=7',
+    '**/users\\?_limit=+(3|5)'
+  )
 ).to.be.false
 ```
 
@@ -1535,9 +1545,13 @@ You can also pass in options (`object`) as the third argument, one of which is
 understand why your pattern isn't working as you expect:
 
 ```js
-Cypress.minimatch('http://localhost/users?_limit=3', '**/users\\?_limit=+(3|5)', {
-  debug: true,
-})
+Cypress.minimatch(
+  'http://localhost/users?_limit=3',
+  '**/users\\?_limit=+(3|5)',
+  {
+    debug: true,
+  }
+)
 // true (plus debug messages)
 ```
 

--- a/docs/api/commands/intercept.mdx
+++ b/docs/api/commands/intercept.mdx
@@ -211,7 +211,7 @@ match many URLs at once, either with globs or with regex. See
 cy.intercept('https://prod.cypress.io/users')
 
 // match any request that satisfies a glob pattern
-cy.intercept('/users?_limit=*')
+cy.intercept('/users\\?_limit=*')
 
 // match any request that satisfies a regex pattern
 cy.intercept(/\/users\?_limit=(3|5)$/)
@@ -1483,11 +1483,25 @@ cy.intercept('/users')
 //   https://staging.cypress.io/users
 //   http://localhost/users
 
-cy.intercept('/users?_limit=+(3|5)')
+cy.intercept('/users\\?_limit=+(3|5)')
 // matches all of these:
 //   https://prod.cypress.io/users?_limit=3
 //   http://localhost/users?_limit=5
 ```
+
+:::caution
+
+In minimatch glob syntax, `?` is a wildcard that matches **any single character** — it does not represent a literal `?`. To match a literal question mark (such as the `?` that begins a URL query string), escape it with a backslash: use `\\?` in your JavaScript string so that minimatch receives the pattern character `\?`.
+
+```js
+// INCORRECT – the unescaped ? is a wildcard matching any single character
+cy.intercept('/users?_limit=*')
+
+// CORRECT – \\? in the JS string sends \? to minimatch, matching a literal ?
+cy.intercept('/users\\?_limit=*')
+```
+
+:::
 
 ### Cypress.minimatch
 
@@ -1502,15 +1516,15 @@ then you have a match!
 
 ```javascript
 expect(
-  Cypress.minimatch('http://localhost/users?_limit=3', '**/users?_limit=+(3|5)')
+  Cypress.minimatch('http://localhost/users?_limit=3', '**/users\\?_limit=+(3|5)')
 ).to.be.true
 expect(
-  Cypress.minimatch('http://localhost/users?_limit=5', '/users?_limit=+(3|5)', {
+  Cypress.minimatch('http://localhost/users?_limit=5', '/users\\?_limit=+(3|5)', {
     matchBase: true,
   })
 ).to.be.true
 expect(
-  Cypress.minimatch('http://localhost/users?_limit=7', '**/users?_limit=+(3|5)')
+  Cypress.minimatch('http://localhost/users?_limit=7', '**/users\\?_limit=+(3|5)')
 ).to.be.false
 ```
 
@@ -1521,7 +1535,7 @@ You can also pass in options (`object`) as the third argument, one of which is
 understand why your pattern isn't working as you expect:
 
 ```js
-Cypress.minimatch('http://localhost/users?_limit=3', '**/users?_limit=+(3|5)', {
+Cypress.minimatch('http://localhost/users?_limit=3', '**/users\\?_limit=+(3|5)', {
   debug: true,
 })
 // true (plus debug messages)


### PR DESCRIPTION
In minimatch/glob syntax, `?` is a wildcard matching any single character,
not a literal question mark. Examples throughout the intercept docs used `?`
unescaped when they meant the URL query-string separator, which works
coincidentally but is inaccurate and misleading. Fix all pattern strings to
use `\\?` (which delivers `\?` to minimatch for a literal match) and add a
caution callout explaining the distinction.

Closes #4950

https://claude.ai/code/session_011oW3og3CUSyNqHDbpBd2ct

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to examples and explanatory text; no runtime or API behavior changes.
> 
> **Overview**
> The **`cy.intercept`** docs are corrected so glob examples that target URL **query strings** use a **literal** `?` instead of minimatch’s single-character wildcard.
> 
> All affected pattern strings now use **`\\?`** in JavaScript (so minimatch sees `\?`). Examples were updated in the early **Matching `url`** section, **Glob Pattern Matching URLs**, and **`Cypress.minimatch`** snippets (including multi-line formatting for readability).
> 
> A new **caution** callout explains that unescaped `?` matches any one character, shows incorrect vs correct `cy.intercept` patterns, and ties this to query-string matching. Regex-based examples are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d637a5569557435d11c80f1a413bba8a26695006. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->