### PR TITLE
docs(each): document that index argument is 0-based in .each() callback

### DIFF
--- a/docs/api/commands/each.mdx
+++ b/docs/api/commands/each.mdx
@@ -39,9 +39,9 @@ cy.clock().each(() => {...})    // Errors, 'clock' does not yield an array
 
 Pass a function that is invoked with the following arguments:
 
-- `value`
-- `index`
-- `collection`
+- `value` - the current item in the collection
+- `index` - the 0-based index of the current item in the collection
+- `collection` - the original collection being iterated over
 
 <HeaderYields />
 


### PR DESCRIPTION
Clarifies the callbackFn arguments for .each() by describing each parameter,
including that index is 0-based. Addresses #4889.

https://claude.ai/code/session_01GQvPitcZRMnb2nzygf8mCn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the `.each()` command page; no runtime or test code affected.
> 
> **Overview**
> Updates the **Arguments** section for `cy.each()`’s `callbackFn` in `docs/api/commands/each.mdx`: the bare `value`, `index`, and `collection` labels are replaced with short bullet descriptions, including that **`index` is 0-based**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e0522e677dd9f0092038955ee1a3fdaf0184445. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->