### PR TITLE
docs(code-coverage): warn about babel-plugin-istanbul duplicate plugin conflict with Jest

### DIFF
--- a/docs/app/tooling/code-coverage.mdx
+++ b/docs/app/tooling/code-coverage.mdx
@@ -258,6 +258,46 @@ intermediate folder, but the result is the same instrumented code loaded by the
 browser, with the same `window.__coverage__` object keeping track of the
 original statements.
 
+:::caution
+
+**Using Jest alongside Cypress?** Adding `babel-plugin-istanbul` directly to
+the top-level `plugins` array in `.babelrc` will cause a **"Duplicate
+plugin/preset detected"** error when Jest runs. Jest automatically instruments
+code with Istanbul (via `babel-jest`) and sets `BABEL_ENV=test`, so loading the
+plugin a second time through `.babelrc` triggers the conflict.
+
+To avoid this, scope the plugin to a separate Babel environment that is only
+active during Cypress runs:
+
+```json title='.babelrc'
+{
+  "presets": ["@babel/preset-react"],
+  "plugins": ["@babel/plugin-proposal-class-properties"],
+  "env": {
+    "cypress": {
+      "plugins": ["istanbul"]
+    }
+  }
+}
+```
+
+Then activate this environment when launching Cypress by setting `BABEL_ENV`
+in your npm script:
+
+```json title='package.json'
+{
+  "scripts": {
+    "test:e2e": "BABEL_ENV=cypress cypress run",
+    "test:ct": "BABEL_ENV=cypress cypress run --component"
+  }
+}
+```
+
+Because Jest never sets `BABEL_ENV=cypress`, the istanbul plugin will only be
+loaded during Cypress runs, and there will be no duplicate-plugin conflict.
+
+:::
+
 :::info
 
 Check out

--- a/docs/app/tooling/code-coverage.mdx
+++ b/docs/app/tooling/code-coverage.mdx
@@ -258,13 +258,13 @@ intermediate folder, but the result is the same instrumented code loaded by the
 browser, with the same `window.__coverage__` object keeping track of the
 original statements.
 
-:::caution
+#### Avoiding conflicts with Jest
 
-**Using Jest alongside Cypress?** Adding `babel-plugin-istanbul` directly to
-the top-level `plugins` array in `.babelrc` will cause a **"Duplicate
-plugin/preset detected"** error when Jest runs. Jest automatically instruments
-code with Istanbul (via `babel-jest`) and sets `BABEL_ENV=test`, so loading the
-plugin a second time through `.babelrc` triggers the conflict.
+Adding `babel-plugin-istanbul` directly to the top-level `plugins` array in
+`.babelrc` will cause a **"Duplicate plugin/preset detected"** error when Jest
+runs. Jest automatically instruments code with Istanbul (via `babel-jest`) and
+sets `BABEL_ENV=test`, so loading the plugin a second time through `.babelrc`
+triggers the conflict.
 
 To avoid this, scope the plugin to a separate Babel environment that is only
 active during Cypress runs:
@@ -295,8 +295,6 @@ in your npm script:
 
 Because Jest never sets `BABEL_ENV=cypress`, the istanbul plugin will only be
 loaded during Cypress runs, and there will be no duplicate-plugin conflict.
-
-:::
 
 :::info
 


### PR DESCRIPTION
When users run both Jest (with --coverage) and Cypress, Jest automatically
loads babel-plugin-istanbul internally and sets BABEL_ENV=test. Adding the
istanbul plugin unconditionally to .babelrc plugins triggers Babel's
"Duplicate plugin/preset detected" error.

Documents the fix: scope babel-plugin-istanbul under a Cypress-specific
Babel env block (e.g. "cypress") and activate it via BABEL_ENV=cypress in
npm scripts, keeping Jest's automatic instrumentation isolated.

Closes #4847

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or security impact.
> 
> **Overview**
> Adds a **Avoiding conflicts with Jest** subsection under the Babel transpilation guidance in the code coverage docs.
> 
> It explains that putting `babel-plugin-istanbul` in the top-level `.babelrc` `plugins` array can trigger Babel’s duplicate-plugin error when Jest runs (Jest already instruments via `babel-jest` with `BABEL_ENV=test`). The doc recommends scoping `istanbul` under a `cypress` Babel `env` block and setting `BABEL_ENV=cypress` on Cypress npm scripts so Istanbul loads only for Cypress runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e4feaddb69db59e39d8eead7b4e37cd890473c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->