### PR TITLE
Replace vague "DOM based commands" with "DOM queries" linked to retry-ability

### DIFF
--- a/docs/app/core-concepts/introduction-to-cypress.mdx
+++ b/docs/app/core-concepts/introduction-to-cypress.mdx
@@ -1107,9 +1107,10 @@ that may cause it to fail without needing an explicit assertion you've added.
 Certain commands may have a specific requirement that causes them to immediately
 fail without retrying, such as [`cy.request()`](/api/commands/request).
 
-Others, such as DOM queries automatically
-[retry](/app/core-concepts/retry-ability) and wait for their corresponding
-elements to exist before failing.
+Others, such as DOM
+[queries](/app/core-concepts/retry-ability#Commands-Queries-and-Assertions),
+automatically [retry](/app/core-concepts/retry-ability) and wait for their
+corresponding elements to exist before failing.
 
 Action commands automatically wait for their element to reach an
 [actionable state](/app/core-concepts/interacting-with-elements) before
@@ -1119,10 +1120,11 @@ failing.
 
 <strong>Core Concept</strong>
 
-All DOM commands automatically wait for their elements to exist in the DOM.
+All DOM [queries](/app/core-concepts/retry-ability#Commands-Queries-and-Assertions)
+automatically wait for their elements to exist in the DOM.
 
-You **never** need to write [`.should('exist')`](/api/commands/should) after
-querying the DOM.
+You **never** need to write [`.should('exist')`](/api/commands/should) after a
+DOM query.
 
 :::
 

--- a/docs/app/faq.mdx
+++ b/docs/app/faq.mdx
@@ -416,9 +416,9 @@ explains this in detail.
 
 <strong>Remember</strong>
 
-DOM based commands will automatically
-[retry](/app/core-concepts/retry-ability) and wait for their corresponding
-elements to exist before failing.
+DOM [queries](/app/core-concepts/retry-ability#Commands-Queries-and-Assertions)
+will automatically [retry](/app/core-concepts/retry-ability) and wait for their
+corresponding elements to exist before failing.
 
 :::
 


### PR DESCRIPTION
The term "DOM based commands" was undefined and confusing for new users.
Cypress now distinguishes between "queries" (which retry) and "non-queries"
(which execute once) — link the term to the retry-ability guide section that
explains this distinction clearly.

Fixes #4549

https://claude.ai/code/session_01ViAjftDSoV6AZWnyoftwe9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Text-only MDX edits with no runtime, API, or test behavior changes.
> 
> **Overview**
> Documentation-only wording update in **Introduction to Cypress** and the **FAQ**: vague phrases like "DOM based commands" / "DOM commands" are replaced with **DOM queries**, each linked to the retry-ability section on [Commands, Queries, and Assertions](/app/core-concepts/retry-ability#Commands-Queries-and-Assertions).
> 
> Copy is tightened in the implicit-assertions tip (e.g. "after a DOM query" instead of "after querying the DOM") so readers are pointed at the query vs non-query distinction instead of an undefined "DOM based" label.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9d8bb5e13e38b8419181efd071805ea128adfbc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->