### PR TITLE
fix(then): fix syntax error and document async/sync mixing error

### DIFF
--- a/docs/api/commands/then.mdx
+++ b/docs/api/commands/then.mdx
@@ -71,6 +71,11 @@ flow into the next command (with the exception of `undefined` or `null`).
 - If the callback returns `undefined` or `null` (or there is no return value)
   and the callback does not call any Cypress commands, the subject will not be
   modified, and the previous subject will carry over to the next command.
+- If the callback calls Cypress commands **and** returns a non-`undefined`,
+  non-`null` synchronous value, Cypress will throw an error: _"cy.then() failed
+  because you are mixing up async and sync code."_ To return a new synchronous
+  value while also using Cypress commands, wrap the return value in a nested
+  `.then()` that contains no Cypress commands (see example below).
 
 The callback function of `.then()` is not retried. It is
 [unsafe](/app/core-concepts/retry-ability#Only-queries-are-retried) to return
@@ -130,7 +135,7 @@ cy.get('button')
 
 ```javascript
 cy.wrap(1).then((num) => {
-  cy.wrap(num)).should('equal', 1) // true
+  cy.wrap(num).should('equal', 1) // true
   cy.wrap(2)
 }).should('equal', 2) // true
 ```

--- a/docs/api/commands/then.mdx
+++ b/docs/api/commands/then.mdx
@@ -134,10 +134,12 @@ cy.get('button')
 #### The number subject is changed with another command
 
 ```javascript
-cy.wrap(1).then((num) => {
-  cy.wrap(num).should('equal', 1) // true
-  cy.wrap(2)
-}).should('equal', 2) // true
+cy.wrap(1)
+  .then((num) => {
+    cy.wrap(num).should('equal', 1) // true
+    cy.wrap(2)
+  })
+  .should('equal', 2) // true
 ```
 
 #### The number subject is changed by returning


### PR DESCRIPTION
Fix extra closing parenthesis in the "change subject with another command"
code example. Also add a bullet to the Yields section explaining that
returning a non-undefined synchronous value while also calling Cypress
commands throws the "mixing up async and sync code" error, and point users
to the nested .then() pattern as the correct workaround.

Fixes #4617

https://claude.ai/code/session_01NYtraaWdtRifwak9rfd2XS

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to the `then` command page with no runtime or API behavior changes.
> 
> **Overview**
> Updates **`cy.then()`** docs in `then.mdx` so the **Yields** section documents the runtime error when a callback both runs Cypress commands and returns a synchronous non-null value, and points readers to a nested `.then()` with no commands as the workaround.
> 
> The **“number subject is changed with another command”** example is corrected (removed an extra `)`) and reformatted for readability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2709ff414cd8128417d929aed6bb6bf0edeae4fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->