### PR TITLE
Remove archived cypress-example-conduit-app references from code coverage docs

### DIFF
--- a/docs/app/tooling/code-coverage.mdx
+++ b/docs/app/tooling/code-coverage.mdx
@@ -561,7 +561,7 @@ you. If you do want to merge the reports yourself:
   command
 
 You can find an example of merging partial reports in our
-[cypress-io/cypress-example-conduit-app](https://github.com/cypress-io/cypress-example-conduit-app)
+[RealWorld App](https://github.com/cypress-io/cypress-realworld-app).
 
 ## E2E and unit code coverage
 
@@ -699,7 +699,7 @@ coverage, creating a single full stack report.
 :::info
 
 The full source code for this section can be found in the
-[cypress-io/cypress-example-conduit-app](https://github.com/cypress-io/cypress-example-conduit-app)
+[RealWorld App](https://github.com/cypress-io/cypress-realworld-app)
 repository.
 
 :::
@@ -780,18 +780,14 @@ application back end is running at port 3000 and we are using the default "GET
 
 From now on, the front end code coverage collected during end-to-end tests will
 be merged with the code coverage from the instrumented back end code and saved
-in a single report. Here is an example report from the
-[cypress-io/cypress-example-conduit-app](https://github.com/cypress-io/cypress-example-conduit-app)
-example:
+in a single report. Here is an example combined full stack coverage report:
 
 <DocsImage
   src="/img/app/code-coverage/full-coverage.png"
   alt="Combined code coverage report from front and back end code"
 />
 
-You can explore the above combined full stack coverage report at the
-[coveralls.io/github/cypress-io/cypress-example-conduit-app](https://coveralls.io/github/cypress-io/cypress-example-conduit-app)
-dashboard. You can also find full stack code coverage in our
+You can also find full stack code coverage in our
 [RealWorld App](https://github.com/cypress-io/cypress-realworld-app).
 
 Even if you only want to measure the back end code coverage Cypress can help.


### PR DESCRIPTION
Replace all mentions of the archived cypress-example-conduit-app repository
with the RealWorld App, per the recommendation to use it as the standard
reference for code coverage examples.

https://claude.ai/code/session_01UBELtEEYcjwhcrjauhoB4c

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link and copy updates with no runtime or test behavior changes.
> 
> **Overview**
> Updates the **code coverage** guide so examples no longer point at the archived `cypress-example-conduit-app` repo.
> 
> Links and callouts for merging partial reports, full-stack coverage source, and combined reports now use **[RealWorld App](https://github.com/cypress-io/cypress-realworld-app)** instead. Wording around the full-stack screenshot is simplified (generic “combined full stack coverage report” instead of naming the old example and Coveralls dashboard).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0342ab74401f15182ceb49cef76ce65845ff8142. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->