### PR TITLE
docs(component-testing): document custom devServer return type and devServerEvents usage

### DIFF
--- a/docs/app/component-testing/component-framework-configuration.mdx
+++ b/docs/app/component-testing/component-framework-configuration.mdx
@@ -316,15 +316,20 @@ If your project uses a bundler other than Vite or Webpack, or you need complete
 control over compilation, pass a custom function to `component.devServer`. This
 is how community integrations and preview-server setups work.
 
-The function's signature takes in an object with the following properties as its
-only parameter and needs to resolve an object containing the port of your dev
-server and a callback to shut it down.
+The function receives a single `DevServerOptions` argument and must return (or
+resolve to) a `ResolvedDevServerConfig` describing how Cypress should connect to
+and stop the server.
 
 ```ts
 interface DevServerOptions {
   specs: Cypress.Spec[]
   cypressConfig: Cypress.PluginConfigOptions
   devServerEvents: NodeJS.EventEmitter
+}
+
+interface ResolvedDevServerConfig {
+  port: number                         // port the dev server is listening on
+  close?: (done?: () => void) => void  // called by Cypress to shut the server down
 }
 ```
 
@@ -436,10 +441,24 @@ CypressInstance.action('app:window:before:load', window)
 For a more complete example you can check out the
 [kickstart script used in the vite-devserver.](https://github.com/cypress-io/cypress/blob/develop/npm/vite-dev-server/client/initCypressTests.js)
 
-The `devServerEvents` event emitter should be used to notify cypress about
-finished builds by emitting a `dev-server:compile:success` event and to listen
-for the `dev-server:specs:changed` event that will notify you about changed
-entry points.
+The `devServerEvents` event emitter is used to communicate compile lifecycle
+events between your server and Cypress:
+
+- Emit `dev-server:compile:success` to notify Cypress that a build finished and
+  tests can run.
+- Listen for `dev-server:specs:changed` to be notified when Cypress updates the
+  set of active spec files (e.g. when a new spec is added), so you can
+  recompile the new entry points.
+
+```ts
+// signal to Cypress that compilation is done
+devServerEvents.emit('dev-server:compile:success')
+
+// recompile when the active spec list changes
+devServerEvents.on('dev-server:specs:changed', ({ specs }) => {
+  recompile(specs)
+})
+```
 
 ## Spec Pattern for Component Tests
 

--- a/docs/app/component-testing/component-framework-configuration.mdx
+++ b/docs/app/component-testing/component-framework-configuration.mdx
@@ -328,8 +328,8 @@ interface DevServerOptions {
 }
 
 interface ResolvedDevServerConfig {
-  port: number                         // port the dev server is listening on
-  close?: (done?: () => void) => void  // called by Cypress to shut the server down
+  port: number // port the dev server is listening on
+  close?: (done?: () => void) => void // called by Cypress to shut the server down
 }
 ```
 


### PR DESCRIPTION
Closes https://github.com/cypress-io/cypress-documentation/issues/4613

- Add `ResolvedDevServerConfig` TypeScript interface showing that `port`
  is required and `close` is an optional shutdown callback
- Update the introductory sentence to name both input and return types
- Replace the vague one-liner about `devServerEvents` with a bullet list
  and a concrete code example showing how to emit `dev-server:compile:success`
  and listen for `dev-server:specs:changed`


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or configuration behavior changes.
> 
> **Overview**
> Documentation-only updates to the **Fully Custom Dev Server** section in component testing configuration.
> 
> The custom `devServer` callback is now described in terms of **`DevServerOptions`** input and **`ResolvedDevServerConfig`** return value, with an explicit interface showing required **`port`** and optional **`close`** shutdown hook.
> 
> **`devServerEvents`** guidance is expanded from a short note into bullets plus a sample: emit **`dev-server:compile:success`** when a build is ready, and handle **`dev-server:specs:changed`** to recompile when the active spec set changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8892b7f075d928a86d641deecd6692da90b5a56d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->