### PR TITLE
docs(aws-codebuild): add guidance for git commit info when source is downloaded as zip

### DIFF
--- a/docs/app/continuous-integration/aws-codebuild.mdx
+++ b/docs/app/continuous-integration/aws-codebuild.mdx
@@ -336,90 +336,24 @@ phases:
         "$CY_CONFIG"
 ```
 
-## Git Commit Information in AWS CodeBuild
-
-The `buildspec.yml` examples above use `git` CLI commands to populate the
-`COMMIT_INFO_*` environment variables that
-[Cypress Cloud uses for recording](/app/continuous-integration/overview#Git-information).
-These commands require a `.git` directory to be present.
-
-By default, AWS CodeBuild may download your source code as a **zip archive**
-rather than performing a `git clone`, which means no `.git` directory exists
-and the `git` commands will fail with a `fatal: not a git repository` error.
-
-### Option 1: Enable git clone depth in CodeBuild
-
-The simplest fix is to configure your CodeBuild project to clone the repository
-instead of downloading a zip:
-
-1. Open your project in the **AWS CodeBuild Console**
-2. Click **Edit** → **Source**
-3. Under **Additional configuration**, set **Git clone depth** to **Full clone**
-   (or a specific depth such as **1** — depth 1 is sufficient for the `git log -1`
-   commands used above)
-4. Click **Update source**
-
-After this change, the `git` commands in the `buildspec.yml` examples will work
-without any other modifications.
-
-### Option 2: Use the CodeBuild environment variable and GitHub API
-
-If you cannot enable git clone (for example, when the source is provided via an
-S3 artifact or another mechanism), you can retrieve commit information using the
-`CODEBUILD_RESOLVED_SOURCE_VERSION` environment variable, which CodeBuild always
-populates with the resolved commit SHA, combined with the GitHub API.
-
-This approach requires:
-
-- A GitHub Personal Access Token stored in AWS SSM Parameter Store or Secrets Manager
-- The `jq` command-line tool (available by default on CodeBuild Amazon Linux images)
-
-```yaml title="buildspec.yml"
-phases:
-  install:
-    commands:
-      # Retrieve the GitHub PAT from SSM / Secrets Manager
-      # - GITHUB_USER=$(aws ssm get-parameter --name PIPELINES_GITHUB_USER | jq -r .Parameter.Value)
-      # - GITHUB_TOKEN=$(aws secretsmanager get-secret-value --secret-id PIPELINES_GITHUB_TOKEN | jq -r .SecretString)
-
-      # Fetch commit metadata from the GitHub API using the resolved SHA
-      - GITHUB_COMMIT="$CODEBUILD_RESOLVED_SOURCE_VERSION"
-      - COMMIT_INFO=$(curl -s -u ${GITHUB_USER}:${GITHUB_TOKEN} -X GET
-        https://api.github.com/repos/${GITHUB_ORG}/${GITHUB_REPO}/git/commits/${GITHUB_COMMIT})
-      - export COMMIT_INFO_MESSAGE="$(echo $COMMIT_INFO | jq -r .message)"
-      - export COMMIT_INFO_EMAIL="$(echo $COMMIT_INFO | jq -r .author.email)"
-      - export COMMIT_INFO_AUTHOR="$(echo $COMMIT_INFO | jq -r .author.name)"
-      - export COMMIT_INFO_SHA="$(echo $COMMIT_INFO | jq -r .sha)"
-      - export COMMIT_INFO_REMOTE="$(echo $COMMIT_INFO | jq -r .html_url)"
-      - npm ci
-```
-
-Set the `GITHUB_ORG` and `GITHUB_REPO` environment variables in your CodeBuild
-project configuration to match your repository (e.g. `GITHUB_ORG=my-org`,
-`GITHUB_REPO=my-repo`).
-
-:::info
-
-The GitHub API approach only works for repositories hosted on **GitHub**. For
-other source providers, refer to their equivalent APIs or consider using
-Option 1 instead.
-
-:::
-
 ## Using Cypress Cloud with AWS CodeBuild
 
 :::caution
 
-Dashboard analytics are dependent on your CI environment reliably providing
-commit SHA data (typically via a system environment variable) which is not always
-present by default. This is not a problem for most users, but if you are facing
-integration issues with your CodeBuild setup, please make sure the git
-information is being sent properly by following
-[these guidelines](/app/continuous-integration/overview#Git-information),
-or just see
-[the example `buildspec.yml` file at the top of this page](#Basic-Setup) or
-[the section above](#Git-Commit-Information-in-AWS-CodeBuild) for CodeBuild-specific
-guidance. If you are still facing issues after this, please
+Dashboard analytics depend on Cypress receiving
+[git commit information](/app/continuous-integration/overview#Git-information).
+The `buildspec.yml` examples above export this via `git` CLI commands, which
+require a `.git` directory. If CodeBuild downloads your source as a zip archive
+instead of performing a `git clone`, those commands will fail with
+`fatal: not a git repository`.
+
+To fix this, configure your CodeBuild project to clone the repository using the
+[Git clone depth setting](https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-env-vars.html)
+in the AWS Console. If git clone is not an option, CodeBuild always populates
+`CODEBUILD_RESOLVED_SOURCE_VERSION` with the commit SHA, which you can use to
+retrieve commit metadata from your source provider's API instead.
+
+If you are still facing issues, please
 [contact us](mailto:hello@cypress.io).
 
 :::

--- a/docs/app/continuous-integration/aws-codebuild.mdx
+++ b/docs/app/continuous-integration/aws-codebuild.mdx
@@ -336,6 +336,76 @@ phases:
         "$CY_CONFIG"
 ```
 
+## Git Commit Information in AWS CodeBuild
+
+The `buildspec.yml` examples above use `git` CLI commands to populate the
+`COMMIT_INFO_*` environment variables that
+[Cypress Cloud uses for recording](/app/continuous-integration/overview#Git-information).
+These commands require a `.git` directory to be present.
+
+By default, AWS CodeBuild may download your source code as a **zip archive**
+rather than performing a `git clone`, which means no `.git` directory exists
+and the `git` commands will fail with a `fatal: not a git repository` error.
+
+### Option 1: Enable git clone depth in CodeBuild
+
+The simplest fix is to configure your CodeBuild project to clone the repository
+instead of downloading a zip:
+
+1. Open your project in the **AWS CodeBuild Console**
+2. Click **Edit** → **Source**
+3. Under **Additional configuration**, set **Git clone depth** to **Full clone**
+   (or a specific depth such as **1** — depth 1 is sufficient for the `git log -1`
+   commands used above)
+4. Click **Update source**
+
+After this change, the `git` commands in the `buildspec.yml` examples will work
+without any other modifications.
+
+### Option 2: Use the CodeBuild environment variable and GitHub API
+
+If you cannot enable git clone (for example, when the source is provided via an
+S3 artifact or another mechanism), you can retrieve commit information using the
+`CODEBUILD_RESOLVED_SOURCE_VERSION` environment variable, which CodeBuild always
+populates with the resolved commit SHA, combined with the GitHub API.
+
+This approach requires:
+
+- A GitHub Personal Access Token stored in AWS SSM Parameter Store or Secrets Manager
+- The `jq` command-line tool (available by default on CodeBuild Amazon Linux images)
+
+```yaml title="buildspec.yml"
+phases:
+  install:
+    commands:
+      # Retrieve the GitHub PAT from SSM / Secrets Manager
+      # - GITHUB_USER=$(aws ssm get-parameter --name PIPELINES_GITHUB_USER | jq -r .Parameter.Value)
+      # - GITHUB_TOKEN=$(aws secretsmanager get-secret-value --secret-id PIPELINES_GITHUB_TOKEN | jq -r .SecretString)
+
+      # Fetch commit metadata from the GitHub API using the resolved SHA
+      - GITHUB_COMMIT="$CODEBUILD_RESOLVED_SOURCE_VERSION"
+      - COMMIT_INFO=$(curl -s -u ${GITHUB_USER}:${GITHUB_TOKEN} -X GET
+        https://api.github.com/repos/${GITHUB_ORG}/${GITHUB_REPO}/git/commits/${GITHUB_COMMIT})
+      - export COMMIT_INFO_MESSAGE="$(echo $COMMIT_INFO | jq -r .message)"
+      - export COMMIT_INFO_EMAIL="$(echo $COMMIT_INFO | jq -r .author.email)"
+      - export COMMIT_INFO_AUTHOR="$(echo $COMMIT_INFO | jq -r .author.name)"
+      - export COMMIT_INFO_SHA="$(echo $COMMIT_INFO | jq -r .sha)"
+      - export COMMIT_INFO_REMOTE="$(echo $COMMIT_INFO | jq -r .html_url)"
+      - npm ci
+```
+
+Set the `GITHUB_ORG` and `GITHUB_REPO` environment variables in your CodeBuild
+project configuration to match your repository (e.g. `GITHUB_ORG=my-org`,
+`GITHUB_REPO=my-repo`).
+
+:::info
+
+The GitHub API approach only works for repositories hosted on **GitHub**. For
+other source providers, refer to their equivalent APIs or consider using
+Option 1 instead.
+
+:::
+
 ## Using Cypress Cloud with AWS CodeBuild
 
 :::caution
@@ -345,10 +415,11 @@ commit SHA data (typically via a system environment variable) which is not alway
 present by default. This is not a problem for most users, but if you are facing
 integration issues with your CodeBuild setup, please make sure the git
 information is being sent properly by following
-[these guidelines](//app/continuous-integration/overview#Git-information),
+[these guidelines](/app/continuous-integration/overview#Git-information),
 or just see
-[the example `codebuild.yml` file at the top of this page](#Basic-Setup). If you
-are still facing issues after this, please
+[the example `buildspec.yml` file at the top of this page](#Basic-Setup) or
+[the section above](#Git-Commit-Information-in-AWS-CodeBuild) for CodeBuild-specific
+guidance. If you are still facing issues after this, please
 [contact us](mailto:hello@cypress.io).
 
 :::


### PR DESCRIPTION
AWS CodeBuild can download source as a zip archive rather than doing a git
clone, causing the existing `git log` / `git rev-parse` commands to fail with
"fatal: not a git repository". Add a dedicated section that:

- Explains why the error occurs (no .git directory when zip download is used)
- Option 1: enable Git clone depth in CodeBuild project settings (simplest fix)
- Option 2: use CODEBUILD_RESOLVED_SOURCE_VERSION + GitHub API as an
  alternative for cases where git clone cannot be enabled

Also updates the Cypress Cloud caution block to link to the new section.

Fixes #4358

https://claude.ai/code/session_017cLCMqQ83Y5usp3pMJqRnT

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the AWS CodeBuild guide; no product or CI behavior changes.
> 
> **Overview**
> The **Cypress Cloud** caution on the AWS CodeBuild page is rewritten so it matches how the doc’s `buildspec.yml` examples actually set commit metadata.
> 
> It now states that dashboard analytics need [git commit information](/app/continuous-integration/overview#Git-information) from the `git`-based `COMMIT_INFO_*` exports, and that those fail with `fatal: not a git repository` when CodeBuild delivers source as a **zip** (no `.git`). Remediation is spelled out: enable **Git clone depth** in the project, or use **`CODEBUILD_RESOLVED_SOURCE_VERSION`** plus your provider’s API when clone isn’t possible. The old generic wording about env vars and a link to the basic setup example is removed in favor of this flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cff6c65c8a7949dd3e12775dd2431aba9b039c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->