### PR TITLE
docs: clarify that --spec only runs specs matching specPattern

### DIFF
--- a/docs/app/references/command-line.mdx
+++ b/docs/app/references/command-line.mdx
@@ -565,6 +565,16 @@ Run tests specifying a single test file to run instead of all tests. The spec
 path should be an absolute path or can be relative to the current working
 directory.
 
+:::caution
+
+`--spec` only runs specs that **also match the configured
+[`specPattern`](/app/references/configuration#e2e)**. Specs located
+outside the configured `specPattern` will not be found. See
+[Test files not found when using `spec` parameter](/app/references/configuration#Test-files-not-found-when-using-spec-parameter)
+for details.
+
+:::
+
 ```shell
 cypress run --spec "cypress/e2e/examples/actions.cy.js"
 ```

--- a/docs/app/references/configuration.mdx
+++ b/docs/app/references/configuration.mdx
@@ -780,7 +780,10 @@ update `specPattern` in your Cypress config to include that location:
 // cypress.config.js
 module.exports = defineConfig({
   e2e: {
-    specPattern: ['cypress/e2e/**/*.cy.{js,jsx,ts,tsx}', 'tests/**/*.cy.{js,jsx,ts,tsx}'],
+    specPattern: [
+      'cypress/e2e/**/*.cy.{js,jsx,ts,tsx}',
+      'tests/**/*.cy.{js,jsx,ts,tsx}',
+    ],
   },
 })
 ```

--- a/docs/app/references/configuration.mdx
+++ b/docs/app/references/configuration.mdx
@@ -764,9 +764,30 @@ How the contents are removed depends on the operating system:
 ### Test files not found when using `spec` parameter
 
 When using the `--spec <path or mask>` argument, make it relative to the
-project's folder. If the specs are still missing, run Cypress with
-[DEBUG logs](/app/references/troubleshooting#Print-DEBUG-logs) with the
-following setting to see how Cypress is looking for spec files:
+project's folder.
+
+The `--spec` argument only runs specs that **also match the configured
+[`specPattern`](#e2e)**. Cypress computes the intersection of the
+`--spec` value and `specPattern`, so any spec file outside the configured
+`specPattern` will not be found — even if you pass its exact path.
+
+For example, the default `e2e.specPattern` is
+`cypress/e2e/**/*.cy.{js,jsx,ts,tsx}`. If your spec lives outside
+`cypress/e2e/`, passing its path via `--spec` will not run it until you also
+update `specPattern` in your Cypress config to include that location:
+
+```js
+// cypress.config.js
+module.exports = defineConfig({
+  e2e: {
+    specPattern: ['cypress/e2e/**/*.cy.{js,jsx,ts,tsx}', 'tests/**/*.cy.{js,jsx,ts,tsx}'],
+  },
+})
+```
+
+If the specs are still missing after verifying the path and `specPattern`, run
+Cypress with [DEBUG logs](/app/references/troubleshooting#Print-DEBUG-logs)
+with the following setting to see how Cypress is looking for spec files:
 
 ```shell
 DEBUG=cypress:cli,cypress:data-context:sources:FileDataSource,cypress:data-context:sources:ProjectDataSource


### PR DESCRIPTION
The --spec argument computes the intersection with the configured
specPattern, so specs outside specPattern are silently skipped even
when their exact path is passed. Added a clear explanation, a config
example showing how to extend specPattern, and a caution callout in
the command-line reference. Closes #4565.

https://claude.ai/code/session_01Jr6mvqYFfE4SWfgS4qbfEz

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, security, or data-handling impact.
> 
> **Overview**
> Documents that **`cypress run --spec`** only runs files that also match the configured **`e2e.specPattern`**—Cypress uses the **intersection**, so specs outside `specPattern` are skipped even when you pass an exact path.
> 
> Adds a **caution** callout on the command-line reference for `--spec` and expands the configuration troubleshooting section with the intersection behavior, a **`specPattern`** array example for specs outside `cypress/e2e/`, and a cross-link between the two pages. Closes confusion reported in #4565.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37f87cb2f849ecbc6d21b7e3b259e3232ea067d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->