### PR TITLE
Add husky pre-commit hook to auto-run lint:fix on staged files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,6 @@ cypress/videos
 .vercel
 
 .nuxt
-.husky
 themes
 .eslintcache
 db.json

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npx lint-staged

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
     "typecheck": "tsc",
-    "prepare": "husky install"
+    "prepare": "husky"
   },
   "dependencies": {
     "@cypress-design/css": "^1.0.0",


### PR DESCRIPTION
Initializes husky and wires up lint-staged as a pre-commit hook so
prettier runs automatically on any staged .md/.mdx files before each
commit. Also removes .husky from .gitignore so the hook is shared
across the team.

https://claude.ai/code/session_01HeMkUkm3ZKpyvugwTYkyhH

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Developer workflow only—no runtime, auth, or production behavior changes.
> 
> **Overview**
> Adds a **shared Husky pre-commit hook** that runs **lint-staged** so **Prettier** formats staged `*.md` / `*.mdx` before commits land.
> 
> The hook is committed by **dropping `.husky` from `.gitignore`**, and **`prepare`** is updated from `husky install` to **`husky`** (Husky v9). Staged markdown rules come from the existing **`lint-staged`** config in `package.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7af631b052d768824d395ba5e8a34ef56a4deec2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->