### PR TITLE
docs(client-certificates): explain automatic URL-based cert selection and multi-identity workarounds

### DIFF
--- a/docs/app/references/client-certificates.mdx
+++ b/docs/app/references/client-certificates.mdx
@@ -35,7 +35,8 @@ following properties
 | `certs`  | `Object[]` | A PEM format certificate/private key pair or PFX certificate container                                                   |
 
 Each object in the `certs` array can define either a **PEM format
-certificate/private key pair** or a **PFX certificate container**.
+certificate/private key pair** or a **PFX certificate container**. Both **RSA**
+and **ECDSA (EC)** keys are supported.
 
 **A PEM format certificate/private key pair can have the following properties:**
 
@@ -162,6 +163,7 @@ URL**, you can work around this limitation in a couple of ways:
 
 ## History
 
-| Version                                  | Changes                                         |
-| ---------------------------------------- | ----------------------------------------------- |
-| [8.0.0](/app/references/changelog#8-0-0) | Added Client Certificates configuration options |
+| Version                                      | Changes                                                              |
+| -------------------------------------------- | -------------------------------------------------------------------- |
+| [15.16.0](/app/references/changelog#15-16-0) | Added support for ECDSA (EC) keys in PEM and PFX client certificates |
+| [8.0.0](/app/references/changelog#8-0-0)     | Added Client Certificates configuration options                      |

--- a/docs/app/references/client-certificates.mdx
+++ b/docs/app/references/client-certificates.mdx
@@ -100,6 +100,66 @@ shown below:
 
 :::
 
+## How Certificates Are Applied
+
+Cypress automatically applies the correct client certificate for every outgoing
+network request — including those initiated by
+[`cy.visit()`](/api/commands/visit) and
+[`cy.request()`](/api/commands/request) — based on URL pattern matching.
+**No additional options need to be passed to these commands.**
+
+When Cypress makes a request, it compares the target URL against each `url`
+pattern in the `clientCertificates` array. If a matching entry is found, its
+certificates are attached to the request automatically.
+
+If more than one entry matches the same URL, Cypress selects the entry with the
+**most specific (longest) path** pattern.
+
+:::info
+
+The `url` field in each `clientCertificates` entry supports
+[minimatch](https://github.com/isaacs/minimatch) glob patterns (for example
+`https://a.host.com/api/**`), so a single entry can cover an entire path
+hierarchy.
+
+:::
+
+### Testing with multiple client identities
+
+Cypress does not support passing a specific certificate to `cy.visit()` or any
+other command at call time. Certificate selection is always URL-pattern-based
+and configured statically in `clientCertificates`.
+
+If your tests need to authenticate as different users against the **same base
+URL**, you can work around this limitation in a couple of ways:
+
+- **Distinct path patterns** – If your server exposes user-specific base paths,
+  configure a separate `clientCertificates` entry for each path pattern:
+
+  :::cypress-config-example
+
+  ```ts
+  {
+    clientCertificates: [
+      {
+        url: 'https://example.com/users/alice/**',
+        certs: [{ pfx: 'certs/alice.pfx', passphrase: 'certs/alice-passphrase.txt' }],
+      },
+      {
+        url: 'https://example.com/users/bob/**',
+        certs: [{ pfx: 'certs/bob.pfx', passphrase: 'certs/bob-passphrase.txt' }],
+      },
+    ],
+  }
+  ```
+
+  :::
+
+- **Separate configuration files** – Maintain separate Cypress configuration
+  files (for example `cypress.alice.config.ts` and `cypress.bob.config.ts`),
+  each specifying the appropriate `clientCertificates`, and run them as separate
+  test suites.
+
 ## History
 
 | Version                                  | Changes                                         |

--- a/docs/app/references/client-certificates.mdx
+++ b/docs/app/references/client-certificates.mdx
@@ -8,16 +8,25 @@ sidebar_label: 'Client Certificates'
 
 # Client Certificates
 
-Configure certificate authority (CA) and client certificates to use within tests
-on a per-URL basis.
+Many enterprise, government, and regulated-industry systems require clients to
+present a certificate to authenticate at the TLS layer — before your application
+code even runs. Without this, you face an unpleasant choice: disable certificate
+requirements in your test environment (meaning your tests run against a system
+that doesn't match production), or rely on slow and inconsistent manual testing.
+
+The `clientCertificates` configuration lets you supply the certificates Cypress
+needs to authenticate against these protected endpoints, so your automated E2E
+tests exercise the real security boundary. Misconfigurations, expired
+certificates, or changed server requirements get caught in CI — not in
+production, where the cost is highest.
 
 :::info
 
 <strong>Document Scope</strong>
 
-This document merely offers guidance on how to specify certificate file paths
-for given test URLs. Details around the content and purpose of such files are
-not within the scope of Cypress documentation.
+This document covers how to configure certificate file paths for use in your
+tests. The creation and management of certificate files themselves are outside
+the scope of Cypress documentation.
 
 :::
 


### PR DESCRIPTION
Closes #4864 

where a user wanted to pass
a specific certificate to cy.visit(). Documents that Cypress automatically
selects the correct certificate based on URL pattern matching — no changes
to cy.visit() or cy.request() are needed. Also explains how to handle the
case of testing with multiple client identities against the same base URL.

https://claude.ai/code/session_01XasiZsAdrVLw1RWgwT4kQE


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or configuration behavior impact.
> 
> **Overview**
> **Expands the Client Certificates reference** with clearer motivation (TLS client auth in regulated environments), tighter scope wording, and a note that **RSA and ECDSA (EC)** keys are supported.
> 
> Adds **How Certificates Are Applied**: certs attach automatically to outgoing traffic (including `cy.visit()` / `cy.request()`) via URL **minimatch** rules, with **longest matching path** when multiple entries match—no per-command cert options.
> 
> Adds **Testing with multiple client identities**: per-call cert selection is not supported; workarounds are **distinct URL path patterns** or **separate Cypress config files** per identity.
> 
> Updates the **History** table for **15.16.0** (ECDSA support).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35acbd3947e7c6ce34df7870574b3e5630f904d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->