### PR TITLE
docs(intercept): clarify Cypress.minimatch vs cy.intercept URL matching and add pathname guidance

### DIFF
--- a/docs/api/commands/intercept.mdx
+++ b/docs/api/commands/intercept.mdx
@@ -1514,6 +1514,34 @@ You can invoke the `Cypress.minimatch` with just two arguments - the URL
 (`string`) and the pattern (`string`), respectively - and if it yields `true`,
 then you have a match!
 
+:::info
+
+`cy.intercept()` matches patterns against the **full request URL** (including
+protocol and hostname). If the full URL does not match, it also tries matching
+against the **URL path** — everything after the hostname, including any query
+string — as a fallback.
+
+Because of this fallback, path-only patterns like `/api/users*` work with
+`cy.intercept()` even though they omit the hostname. However, when verifying
+such a pattern with `Cypress.minimatch()`, pass **just the path** — not the
+full URL — to replicate the fallback behavior accurately:
+
+```js
+// path-only pattern: test with the path
+Cypress.minimatch('/api/users/1', '/api/users*', { matchBase: true }) // true
+
+// full-URL pattern (** absorbs the hostname): test with the full URL
+Cypress.minimatch(
+  'http://localhost/api/users/1',
+  '**/api/users*'
+) // true
+```
+
+Passing the full URL to `Cypress.minimatch()` with a path-only pattern may
+return `false` even though `cy.intercept()` would match via its path fallback.
+
+:::
+
 ```javascript
 expect(
   Cypress.minimatch(
@@ -1537,6 +1565,35 @@ expect(
   )
 ).to.be.false
 ```
+
+:::tip
+
+When intercepting URLs that have complex or encoded query strings, using a
+URL glob for the entire URL (path + query string) can be error-prone. The
+`pathname` and `query`
+[routeMatcher](#routeMatcher-RouteMatcher) properties provide a more
+reliable alternative:
+
+```js
+// Instead of matching the full path + query string with a glob:
+cy.intercept('/api/v3/upload_status/**/process**')
+
+// Match just the path, and optionally assert the query separately:
+cy.intercept({
+  pathname: '/api/v3/upload_status/**/process',
+})
+
+// Or pin specific query parameter values:
+cy.intercept({
+  pathname: '/api/v3/upload_status/**/process',
+  query: { json: '{"count":12,"offset":0}' },
+})
+```
+
+`pathname` never includes the query string, so encoded or complex query
+parameters cannot interfere with path-segment glob matching.
+
+:::
 
 #### minimatch options
 

--- a/docs/api/commands/intercept.mdx
+++ b/docs/api/commands/intercept.mdx
@@ -1531,10 +1531,7 @@ full URL — to replicate the fallback behavior accurately:
 Cypress.minimatch('/api/users/1', '/api/users*', { matchBase: true }) // true
 
 // full-URL pattern (** absorbs the hostname): test with the full URL
-Cypress.minimatch(
-  'http://localhost/api/users/1',
-  '**/api/users*'
-) // true
+Cypress.minimatch('http://localhost/api/users/1', '**/api/users*') // true
 ```
 
 Passing the full URL to `Cypress.minimatch()` with a path-only pattern may

--- a/docs/api/utilities/minimatch.mdx
+++ b/docs/api/utilities/minimatch.mdx
@@ -77,6 +77,31 @@ Cypress.minimatch('/foo/bar/baz/123/quux?a=b&c=2', '/foo/*', {
 })
 ```
 
+## Notes
+
+:::caution
+
+In minimatch glob syntax, `?` is a wildcard that matches **any single
+character** — it does not represent a literal `?`. If your pattern needs to
+match the literal `?` that precedes a URL query string, escape it with a
+backslash. In a JavaScript string you write `\\?` so that minimatch receives
+the character sequence `\?`:
+
+```js
+// INCORRECT – unescaped ? is a wildcard, not a literal question mark
+Cypress.minimatch('/users?_limit=3', '/users?_limit=*', { matchBase: true })
+// false — the ? in the pattern matches any single character, not the
+// literal ? in the URL
+
+// CORRECT – \\? sends \? to minimatch, which matches a literal ?
+Cypress.minimatch('/users?_limit=3', '/users\\?_limit=*', {
+  matchBase: true,
+}) // true
+```
+
+:::
+
 ## See also
 
 - [Bundled Libraries](/app/references/bundled-libraries)
+- [cy.intercept() – Glob Pattern Matching URLs](/api/commands/intercept#Glob-Pattern-Matching-URLs)


### PR DESCRIPTION
Closes #4871 

users are confused about why Cypress.minimatch()
returns true for a pattern/URL pair that cy.intercept() fails to match.

- Explain that cy.intercept() matches against the full request URL first, then
  falls back to the URL path; path-only patterns should be tested in
  Cypress.minimatch() with just the path, not the full URL with hostname.
- Add tip recommending pathname + query routeMatcher properties as a reliable
  alternative when intercepting URLs with complex or encoded query strings,
  since pathname matching never includes the query string.
- Add ? wildcard caution and cross-reference to minimatch.mdx, mirroring the
  existing caution in intercept.mdx.

https://claude.ai/code/session_0195AXrcmXuSX4upQM8LNt5j

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or test impact.
> 
> **Overview**
> **Documentation-only** updates to `intercept` and `minimatch` aimed at issue #4871 (mismatches between `Cypress.minimatch()` and `cy.intercept()`).
> 
> The **intercept** glob section now explains that `cy.intercept()` tries the **full URL** first, then falls back to the **path** (hostname omitted), and shows how to call `Cypress.minimatch()` with path-only vs full-URL patterns so manual checks mirror runtime behavior. A new **tip** steers users toward `pathname` / `query` on `routeMatcher` when query strings are complex or encoded, instead of one big URL glob.
> 
> **minimatch** gains a **Notes** caution that `?` is a single-character wildcard (not a literal `?`), with correct `\\?` escaping examples, plus a cross-link back to intercept’s glob matching section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19c3e48b124e2879e90032d7218d36dbbf8c5708. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->