### PR TITLE
docs(code-coverage): add Component Testing code coverage section

### DIFF
--- a/docs/app/component-testing/angular/overview.mdx
+++ b/docs/app/component-testing/angular/overview.mdx
@@ -138,3 +138,7 @@ export default {
 
 - [Angular 20 Standalone](https://github.com/cypress-io/cypress-component-testing-apps/tree/main/angular-standalone)
 - [Angular 21 Zoneless](https://github.com/cypress-io/cypress-component-testing-apps/tree/main/angular-zoneless)
+
+## See also
+
+- [Component Testing code coverage](/app/tooling/code-coverage#component-testing-code-coverage)

--- a/docs/app/component-testing/get-started.mdx
+++ b/docs/app/component-testing/get-started.mdx
@@ -673,6 +673,9 @@ with Cypress!
 To learn more about testing with Cypress, check out the
 [Introduction to Cypress](/app/core-concepts/introduction-to-cypress) guide.
 
+To track which parts of your components are exercised by your tests, set up
+[code coverage for component tests](/app/tooling/code-coverage#component-testing-code-coverage).
+
 :::tip
 
 Writing component tests with an AI coding tool? The `/cypress-author` skill applies Cypress best practices automatically. See [Cypress AI Skills](/app/tooling/ai-skills).

--- a/docs/app/component-testing/react/overview.mdx
+++ b/docs/app/component-testing/react/overview.mdx
@@ -201,3 +201,7 @@ Next.js pages and Component Testing for individual components in a Next.js app.
 
 - [Cypress Component Test Driven Design](https://muratkerem.gitbook.io/cctdd/)
 - [Cypress React Component Test Examples](https://github.com/muratkeremozcan/cypress-react-component-test-examples)
+
+## See also
+
+- [Component Testing code coverage](/app/tooling/code-coverage#component-testing-code-coverage)

--- a/docs/app/component-testing/svelte/overview.mdx
+++ b/docs/app/component-testing/svelte/overview.mdx
@@ -141,3 +141,7 @@ in manually via the `webpackConfig` option.
 #### Svelte Webpack Sample Apps
 
 - [Svelte 5 Webpack 5 with Typescript](https://github.com/cypress-io/cypress-component-testing-apps/tree/main/svelte-webpack-ts)
+
+## See also
+
+- [Component Testing code coverage](/app/tooling/code-coverage#component-testing-code-coverage)

--- a/docs/app/component-testing/vue/overview.mdx
+++ b/docs/app/component-testing/vue/overview.mdx
@@ -137,3 +137,7 @@ in manually via the `webpackConfig` option.
 #### Vue Webpack Sample Apps
 
 - [Vue 3 Webpack 5 with TypeScript](https://github.com/cypress-io/cypress-component-testing-apps/tree/main/vue3-webpack-ts)
+
+## See also
+
+- [Component Testing code coverage](/app/tooling/code-coverage#component-testing-code-coverage)

--- a/docs/app/tooling/code-coverage.mdx
+++ b/docs/app/tooling/code-coverage.mdx
@@ -12,6 +12,8 @@ sidebar_label: 'Code Coverage'
 
 ##### <Icon name="question-circle" color="#4BBFD2" /> What you'll learn
 
+- Why code coverage helps you ship higher quality software with less risk
+- How code coverage compares to other quality tools
 - The difference between Code Coverage and Cypress's UI Coverage
 - How to instrument your application code for code coverage
 - How to collect code coverage from Cypress tests
@@ -30,6 +32,52 @@ Cypress offers a couple of solutions to help answer these questions:
 
 - **[Code coverage](#Code-Coverage)** - find out which lines of the application's source code were executed
 - **[UI coverage](#UI-Coverage)** - find out which parts of the UI were tested
+
+### Why code coverage matters
+
+Every application ships with code that nobody has explicitly tested. Some of it
+is dead code that should be deleted. Some of it is critical logic — conditional
+branches, error handlers, edge cases — that simply never had a test written for
+it. The difference matters, because untested logic that reaches production is a
+primary source of expensive, hard-to-diagnose bugs.
+
+Code coverage makes the gap visible. It tells you precisely which lines,
+branches, and functions were executed during your test run. It turns "do we have
+enough tests?" from a matter of opinion into a measurable, trackable signal —
+one you can enforce as a quality gate on every pull request and trend over time.
+
+**Bugs are cheapest to fix when they're caught earliest.** A branch left
+uncovered in a test suite can be found and fixed in minutes by the developer who
+wrote it. The same defect found in QA takes hours to reproduce and report. The
+same defect found in production may cost orders of magnitude more — in engineer
+time, incident response, and lost user trust. Code coverage closes that loop
+earlier: when a pull request introduces a new code path with no corresponding
+test, you know *before merge*, not after.
+
+### How code coverage compares to alternatives
+
+Different quality tools answer different questions. Understanding the tradeoffs
+helps you choose the right combination for your project:
+
+| Approach | What it tells you | Key limitation |
+|---|---|---|
+| **Code coverage** | Which lines, branches, and functions were executed by tests | Requires instrumentation; a line being executed doesn't guarantee the assertion is meaningful |
+| **[UI Coverage](/ui-coverage/get-started/introduction)** | Which interactive elements across your UI were exercised by tests | No instrumentation needed; shows UI-level gaps rather than code-level logic gaps |
+| **Static analysis / linters** | Type errors, style violations, and common code smells | Cannot find runtime logic gaps or missing test scenarios |
+| **Manual QA** | Visible UX defects and end-user workflows | Doesn't scale; expensive per release; misses regressions and edge cases |
+| **Mutation testing** | Whether your tests actually detect code changes | Slow to run; typically too expensive for CI on every commit |
+
+Code coverage occupies a practical middle ground. The instrumentation adds only
+lightweight counters to your code, so it runs fast and integrates directly into
+CI. Unlike manual QA, the analysis scales infinitely — the same check runs on
+every commit at no additional cost. Unlike static analysis, it reflects actual
+runtime behavior. And unlike mutation testing, it is cheap enough to run on
+every pull request.
+
+Code coverage and UI Coverage are complementary rather than competing. Code
+coverage answers "which source code lines did the tests execute?", while UI
+Coverage answers "which parts of the UI did the tests touch?" — using both
+together gives you a more complete picture of test quality.
 
 ### Code Coverage
 

--- a/docs/app/tooling/code-coverage.mdx
+++ b/docs/app/tooling/code-coverage.mdx
@@ -51,13 +51,13 @@ one you can enforce as a quality gate on every pull request and trend over time.
 Different quality tools answer different questions. Understanding the tradeoffs
 helps you choose the right combination for your project:
 
-| Approach | What it tells you | Key limitation |
-|---|---|---|
-| **Code coverage** | Which lines, branches, and functions were executed by tests | Requires instrumentation; a line being executed doesn't guarantee the assertion is meaningful |
-| **[UI Coverage](/ui-coverage/get-started/introduction)** | Which interactive elements across your UI were exercised by tests | No instrumentation needed; shows UI-level gaps rather than code-level logic gaps |
-| **Static analysis / linters** | Type errors, style violations, and common code smells | Cannot find runtime logic gaps or missing test scenarios |
-| **Manual QA** | Visible UX defects and end-user workflows | Doesn't scale; expensive per release; misses regressions and edge cases |
-| **Mutation testing** | Whether your tests actually detect code changes | Slow to run; typically too expensive for CI on every commit |
+| Approach                                                 | What it tells you                                                 | Key limitation                                                                                |
+| -------------------------------------------------------- | ----------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| **Code coverage**                                        | Which lines, branches, and functions were executed by tests       | Requires instrumentation; a line being executed doesn't guarantee the assertion is meaningful |
+| **[UI Coverage](/ui-coverage/get-started/introduction)** | Which interactive elements across your UI were exercised by tests | No instrumentation needed; shows UI-level gaps rather than code-level logic gaps              |
+| **Static analysis / linters**                            | Type errors, style violations, and common code smells             | Cannot find runtime logic gaps or missing test scenarios                                      |
+| **Manual QA**                                            | Visible UX defects and end-user workflows                         | Doesn't scale; expensive per release; misses regressions and edge cases                       |
+| **Mutation testing**                                     | Whether your tests actually detect code changes                   | Slow to run; typically too expensive for CI on every commit                                   |
 
 Code coverage and UI Coverage are complementary rather than competing. Code
 coverage answers "which source code lines did the tests execute?", while UI

--- a/docs/app/tooling/code-coverage.mdx
+++ b/docs/app/tooling/code-coverage.mdx
@@ -471,6 +471,60 @@ the browser.
   alt="coverage HTML report on CircleCI"
 />
 
+## Component Testing code coverage
+
+Setting up code coverage for component tests uses the same
+[`@cypress/code-coverage`](https://github.com/cypress-io/code-coverage) plugin
+as [E2E code coverage](#e2e-code-coverage). The configuration is almost
+identical, with one critical difference: you must add the support import to
+your **component testing support file**.
+
+### Configure the support file
+
+Add the import to your component testing support file:
+
+```js
+// cypress/support/component.js (or component.ts for TypeScript projects)
+import '@cypress/code-coverage/support'
+```
+
+:::caution
+
+Adding the import only to `cypress/support/e2e.js` will **not** collect
+coverage during component tests. The import must be present in the component
+support file.
+
+:::
+
+The task registration in `setupNodeEvents` is the same as for E2E tests:
+
+:::cypress-config-plugin-example
+
+```js
+import registerCodeCoverageTasks from '@cypress/code-coverage/task'
+```
+
+```js
+registerCodeCoverageTasks(on, config)
+// It's IMPORTANT to return the config object
+// with any changed environment variables
+return config
+```
+
+:::
+
+### Instrumentation for component tests
+
+**Vite**: The [`vite-plugin-istanbul`](#using-vite) plugin configured in your
+`vite.config.ts` is automatically used by the Cypress component testing dev
+server. No additional configuration is needed beyond
+[the standard Vite setup described above](#using-vite).
+
+**Webpack**: Add
+[`babel-plugin-istanbul`](#using-code-transpilation-pipeline) to the Babel
+configuration or Webpack rules used by the component testing dev server so
+that source files are instrumented before the browser loads them.
+
 ## Code coverage as a guide
 
 Even a single test can cover a lot of the application code. For example, let's

--- a/docs/app/tooling/code-coverage.mdx
+++ b/docs/app/tooling/code-coverage.mdx
@@ -272,7 +272,7 @@ statements were each executed once and the last statement was never executed (it
 probably was inside an `if` statement). By using the application, we can both
 increment the counters and flip some of the zero counters into positive numbers.
 
-### Using code transpilation pipeline
+### Using code transpilation pipeline {#using-code-transpilation-pipeline}
 
 Instead of using the `npx instrument` command, we can use
 [`babel-plugin-istanbul`](https://github.com/istanbuljs/babel-plugin-istanbul)
@@ -357,7 +357,7 @@ not 3rd party dependencies from `node_modules`.
 
 :::
 
-### Using Vite
+### Using Vite {#using-vite}
 
 If your project uses [Vite](https://vitejs.dev/) (for example, a Vue 3 or React
 app scaffolded with `npm create vite`), use
@@ -409,7 +409,7 @@ for community example projects covering Vite, Vue, Angular, and other setups.
 
 :::
 
-## E2E code coverage
+## E2E code coverage {#e2e-code-coverage}
 
 To handle code coverage collected during each test, there is a
 [`@cypress/code-coverage`](https://github.com/cypress-io/code-coverage) Cypress
@@ -504,7 +504,7 @@ the browser.
   alt="coverage HTML report on CircleCI"
 />
 
-## Component Testing code coverage
+## Component Testing code coverage {#component-testing-code-coverage}
 
 Setting up code coverage for component tests uses the same
 [`@cypress/code-coverage`](https://github.com/cypress-io/code-coverage) plugin

--- a/docs/app/tooling/code-coverage.mdx
+++ b/docs/app/tooling/code-coverage.mdx
@@ -46,14 +46,6 @@ branches, and functions were executed during your test run. It turns "do we have
 enough tests?" from a matter of opinion into a measurable, trackable signal —
 one you can enforce as a quality gate on every pull request and trend over time.
 
-**Bugs are cheapest to fix when they're caught earliest.** A branch left
-uncovered in a test suite can be found and fixed in minutes by the developer who
-wrote it. The same defect found in QA takes hours to reproduce and report. The
-same defect found in production may cost orders of magnitude more — in engineer
-time, incident response, and lost user trust. Code coverage closes that loop
-earlier: when a pull request introduces a new code path with no corresponding
-test, you know *before merge*, not after.
-
 ### How code coverage compares to alternatives
 
 Different quality tools answer different questions. Understanding the tradeoffs

--- a/docs/app/tooling/code-coverage.mdx
+++ b/docs/app/tooling/code-coverage.mdx
@@ -67,13 +67,6 @@ helps you choose the right combination for your project:
 | **Manual QA** | Visible UX defects and end-user workflows | Doesn't scale; expensive per release; misses regressions and edge cases |
 | **Mutation testing** | Whether your tests actually detect code changes | Slow to run; typically too expensive for CI on every commit |
 
-Code coverage occupies a practical middle ground. The instrumentation adds only
-lightweight counters to your code, so it runs fast and integrates directly into
-CI. Unlike manual QA, the analysis scales infinitely — the same check runs on
-every commit at no additional cost. Unlike static analysis, it reflects actual
-runtime behavior. And unlike mutation testing, it is cheap enough to run on
-every pull request.
-
 Code coverage and UI Coverage are complementary rather than competing. Code
 coverage answers "which source code lines did the tests execute?", while UI
 Coverage answers "which parts of the UI did the tests touch?" — using both


### PR DESCRIPTION
Documents the key difference for CT coverage: the @cypress/code-coverage
support import must be added to cypress/support/component.js (not just
e2e.js). Also explains that vite-plugin-istanbul works automatically for
Vite-based CT dev servers and references the babel-plugin-istanbul approach
for Webpack projects.

Closes #5519.

https://claude.ai/code/session_01K61ypb7RCmzoEeuSBQhbim

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, auth, or application code impact.
> 
> **Overview**
> Expands the **code coverage** guide with motivation (why coverage matters), a comparison table vs UI Coverage, linters, manual QA, and mutation testing, plus stable **anchor IDs** on existing E2E/instrumentation sections for deep linking.
> 
> Adds a dedicated **Component Testing code coverage** section: same `@cypress/code-coverage` plugin as E2E, but the support import must live in `cypress/support/component.js` (not only `e2e.js`); documents Vite (`vite-plugin-istanbul` via the CT dev server) and Webpack (`babel-plugin-istanbul`) instrumentation paths.
> 
> **Cross-links** from Component Testing get-started and Angular/React/Vue/Svelte overview pages to the new section so CT users can find setup steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 062c1bdd7cb6107016727561ba1b95c067d248f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->