### PR TITLE
docs(scrollIntoView): clarify assertions are not retried after the command

### DIFF
--- a/docs/api/commands/scrollintoview.mdx
+++ b/docs/api/commands/scrollintoview.mdx
@@ -105,8 +105,10 @@ or
 
 <HeaderAssertions />
 
-- `.scrollIntoView()` will automatically wait for assertions you have chained to
-  pass
+- `.scrollIntoView()` itself will not be retried — it fires once. Assertions
+  chained after `.scrollIntoView()` will be retried until they pass or time out.
+  See
+  [Only queries are retried](/app/core-concepts/retry-ability#Only-queries-are-retried).
 
 <HeaderTimeouts />
 


### PR DESCRIPTION
The previous wording implied chaining assertions works seamlessly, without
explaining that scrollIntoView itself will not be retried if an assertion
fails. Updated to match the pattern used by other action commands (e.g.
click) and link to the retry-ability guide for context.

Closes #5160

https://claude.ai/code/session_01VLkcpjKf5Li7JH6tb7WRKP

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or test impact.
> 
> **Overview**
> Updates the **Assertions** section for `.scrollIntoView()` so it no longer suggests the command is retried when chained assertions fail.
> 
> The docs now state that `.scrollIntoView()` runs once (not retried), while assertions chained after it are retried until they pass or time out, with a link to [Only queries are retried](/app/core-concepts/retry-ability#Only-queries-are-retried)—matching action commands like `.click()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 882db60c14aeb6f86cdc6ace0d8666b2256b4f83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->