### PR TITLE
docs(ci): clarify what 'intelligent caching' means for npm/yarn

### DIFF
--- a/docs/app/continuous-integration/overview.mdx
+++ b/docs/app/continuous-integration/overview.mdx
@@ -431,9 +431,12 @@ minutes off install time by preventing a large binary download.
   [`npm ci`](https://docs.npmjs.com/cli/ci) or equivalents as demonstrated in
   the configs below.
 
-- **Do not** cache `node_modules` across builds. This bypasses more intelligent
-  caching packaged with `npm` or `yarn`, and can cause issues with Cypress not
-  downloading the Cypress binary on `npm install`.
+- **Do not** cache `node_modules` across builds. Instead, cache the package
+  manager's own cache directory (`~/.npm` for npm or `~/.cache/yarn` for yarn).
+  These tools maintain package-level caches that track installed versions,
+  validate integrity, and only re-download packages that have changed. Caching
+  `node_modules` directly bypasses these built-in mechanisms and can cause
+  issues such as Cypress not downloading the Cypress binary on `npm install`.
 
 - If you are using `npm install` in your build process, consider
   [switching to `npm ci`](https://blog.npmjs.org/post/171556855892/introducing-npm-ci-for-faster-more-reliable)


### PR DESCRIPTION
Replaces the vague phrase "intelligent caching" with a concrete
explanation: npm and yarn maintain their own package-level caches
(~/.npm and ~/.cache/yarn) that track versions, validate integrity,
and only re-download changed packages. Caching node_modules directly
bypasses these mechanisms.

Fixes #4596

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to CI caching recommendations; no runtime or product code affected.
> 
> **Overview**
> The CI caching guidance in `overview.mdx` now tells readers to cache **`~/.npm`** or **`~/.cache/yarn`** instead of **`node_modules`**, and explains *why*: npm/yarn keep version-aware, integrity-checked package caches, while a persisted `node_modules` tree skips that logic and can break installs (e.g. Cypress binary not downloaded on `npm install`).
> 
> The old vague “intelligent caching” wording is removed in favor of this concrete recommendation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9d97ac57e58ffd004a7b6848999dd4efd411f53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->