### PR TITLE
Document @alias.all and @alias.N intercept alias index notation

### DIFF
--- a/docs/api/commands/get.mdx
+++ b/docs/api/commands/get.mdx
@@ -225,6 +225,54 @@ it('disables on click', () => {
 })
 ```
 
+#### Get all aliased intercepts
+
+When using [`cy.intercept()`](/api/commands/intercept) with an alias, you can
+retrieve **all** intercepted requests for that alias by appending `.all` to the
+alias name. This returns an array of
+[interception objects](/api/commands/intercept#Using-the-yielded-object).
+
+```javascript
+cy.intercept('GET', '/users').as('getUsers')
+
+// trigger two requests
+cy.visit('/users')
+cy.visit('/users')
+
+// yields an array of all matching interceptions
+cy.get('@getUsers.all').then((interceptions) => {
+  expect(interceptions).to.have.length(2)
+})
+```
+
+#### Get a specific aliased intercept by index
+
+You can retrieve a specific intercepted request by appending a 1-based numeric
+index to the alias name. Without an index, `cy.get('@alias')` returns the most
+recent intercepted request.
+
+```javascript
+cy.intercept('GET', '/users').as('getUsers')
+
+// trigger two requests
+cy.visit('/users')
+cy.visit('/users')
+
+// yields the first intercepted request
+cy.get('@getUsers.1').its('response.statusCode').should('eq', 200)
+
+// yields the second intercepted request
+cy.get('@getUsers.2').its('response.statusCode').should('eq', 200)
+```
+
+:::info
+
+The `.all` suffix and numeric index notation only apply to
+[`cy.intercept()`](/api/commands/intercept) aliases. Index `0` is not valid —
+indices start at `1`.
+
+:::
+
 ## Rules
 
 <HeaderRequirements />

--- a/docs/api/commands/get.mdx
+++ b/docs/api/commands/get.mdx
@@ -271,6 +271,9 @@ The `.all` suffix and numeric index notation only apply to
 [`cy.intercept()`](/api/commands/intercept) aliases. Index `0` is not valid —
 indices start at `1`.
 
+These suffixes are not supported by [`cy.wait()`](/api/commands/wait). Use
+`cy.get('@alias.all')` instead of `cy.wait('@alias.all')`.
+
 :::
 
 ## Rules

--- a/docs/api/commands/get.mdx
+++ b/docs/api/commands/get.mdx
@@ -232,49 +232,7 @@ retrieve **all** intercepted requests for that alias by appending `.all` to the
 alias name. This returns an array of
 [interception objects](/api/commands/intercept#Using-the-yielded-object).
 
-```javascript
-cy.intercept('GET', '/users').as('getUsers')
-
-// trigger two requests
-cy.visit('/users')
-cy.visit('/users')
-
-// yields an array of all matching interceptions
-cy.get('@getUsers.all').then((interceptions) => {
-  expect(interceptions).to.have.length(2)
-})
-```
-
-#### Get a specific aliased intercept by index
-
-You can retrieve a specific intercepted request by appending a 1-based numeric
-index to the alias name. Without an index, `cy.get('@alias')` returns the most
-recent intercepted request.
-
-```javascript
-cy.intercept('GET', '/users').as('getUsers')
-
-// trigger two requests
-cy.visit('/users')
-cy.visit('/users')
-
-// yields the first intercepted request
-cy.get('@getUsers.1').its('response.statusCode').should('eq', 200)
-
-// yields the second intercepted request
-cy.get('@getUsers.2').its('response.statusCode').should('eq', 200)
-```
-
-:::info
-
-The `.all` suffix and numeric index notation only apply to
-[`cy.intercept()`](/api/commands/intercept) aliases. Index `0` is not valid —
-indices start at `1`.
-
-These suffixes are not supported by [`cy.wait()`](/api/commands/wait). Use
-`cy.get('@alias.all')` instead of `cy.wait('@alias.all')`.
-
-:::
+<InterceptAliasIndex />
 
 ## Rules
 

--- a/docs/api/commands/intercept.mdx
+++ b/docs/api/commands/intercept.mdx
@@ -321,46 +321,7 @@ intercepted requests using the `.all` suffix with
 [`cy.get()`](/api/commands/get). This is useful when your application makes
 multiple requests to the same route and you need to assert on all of them.
 
-```js
-cy.intercept('GET', '/users').as('getUsers')
-
-// trigger multiple requests
-cy.visit('/users')
-cy.visit('/users')
-
-// yields an array of all interceptions for this alias
-cy.get('@getUsers.all').then((interceptions) => {
-  expect(interceptions).to.have.length(2)
-})
-```
-
-You can also retrieve a **specific** intercept by appending a 1-based numeric
-index. Without any suffix, `cy.get('@alias')` returns the most recent
-intercepted request.
-
-```js
-cy.intercept('GET', '/users').as('getUsers')
-
-cy.visit('/users')
-cy.visit('/users')
-
-// yields the first intercepted request
-cy.get('@getUsers.1').its('response.statusCode').should('eq', 200)
-
-// yields the second intercepted request
-cy.get('@getUsers.2').its('response.statusCode').should('eq', 200)
-```
-
-:::caution
-
-Index `0` is not valid — indices start at `1`. Use `.all` to get the complete
-array of intercepted requests.
-
-The `.all` and numeric index suffixes are **not** supported by
-[`cy.wait()`](/api/commands/wait). Use `cy.get('@alias.all')` instead of
-`cy.wait('@alias.all')`.
-
-:::
+<InterceptAliasIndex />
 
 ### Aliasing individual requests
 

--- a/docs/api/commands/intercept.mdx
+++ b/docs/api/commands/intercept.mdx
@@ -314,6 +314,50 @@ cy.intercept('GET', '/users').as('getAllUsers')
 cy.intercept('POST', '/users').as('createUser')
 ```
 
+### Accessing all intercepted requests
+
+When an intercepted route is aliased, you can retrieve **all** matching
+intercepted requests using the `.all` suffix with
+[`cy.get()`](/api/commands/get). This is useful when your application makes
+multiple requests to the same route and you need to assert on all of them.
+
+```js
+cy.intercept('GET', '/users').as('getUsers')
+
+// trigger multiple requests
+cy.visit('/users')
+cy.visit('/users')
+
+// yields an array of all interceptions for this alias
+cy.get('@getUsers.all').then((interceptions) => {
+  expect(interceptions).to.have.length(2)
+})
+```
+
+You can also retrieve a **specific** intercept by appending a 1-based numeric
+index. Without any suffix, `cy.get('@alias')` returns the most recent
+intercepted request.
+
+```js
+cy.intercept('GET', '/users').as('getUsers')
+
+cy.visit('/users')
+cy.visit('/users')
+
+// yields the first intercepted request
+cy.get('@getUsers.1').its('response.statusCode').should('eq', 200)
+
+// yields the second intercepted request
+cy.get('@getUsers.2').its('response.statusCode').should('eq', 200)
+```
+
+:::caution
+
+Index `0` is not valid — indices start at `1`. Use `.all` to get the complete
+array of intercepted requests.
+
+:::
+
 ### Aliasing individual requests
 
 Aliases can be set on a per-request basis by setting the `alias` property of the

--- a/docs/api/commands/intercept.mdx
+++ b/docs/api/commands/intercept.mdx
@@ -356,6 +356,10 @@ cy.get('@getUsers.2').its('response.statusCode').should('eq', 200)
 Index `0` is not valid — indices start at `1`. Use `.all` to get the complete
 array of intercepted requests.
 
+The `.all` and numeric index suffixes are **not** supported by
+[`cy.wait()`](/api/commands/wait). Use `cy.get('@alias.all')` instead of
+`cy.wait('@alias.all')`.
+
 :::
 
 ### Aliasing individual requests

--- a/docs/app/core-concepts/variables-and-aliases.mdx
+++ b/docs/app/core-concepts/variables-and-aliases.mdx
@@ -559,7 +559,7 @@ history Cypress was already keeping.
 This is useful in several situations:
 
 **Asserting request count.** The most common need is proving your app made
-*exactly* the expected number of requests — not just that it made at least one.
+_exactly_ the expected number of requests — not just that it made at least one.
 For example, verifying a polling interval doesn't fire again after some time:
 
 ```js
@@ -581,15 +581,15 @@ cy.get('@getUsers.2').its('request.url').should('include', 'page=2')
 ```
 
 **Why not multiple `cy.wait()` calls?** `cy.wait('@alias')` called twice will
-consume two requests in order, which is useful for *sequencing* — but it doesn't
+consume two requests in order, which is useful for _sequencing_ — but it doesn't
 catch a third unexpected request, and once consumed you can't go back to inspect
 an earlier one. `cy.get('@alias.all')` is backward-looking: it queries everything
 Cypress has already captured. The two complement each other — use `cy.wait()` to
 let requests settle, then `cy.get('@alias.all')` to assert on the full history:
 
 ```js
-cy.wait('@getUsers')            // let requests settle
-cy.get('@getUsers.all')         // then assert on everything captured
+cy.wait('@getUsers') // let requests settle
+cy.get('@getUsers.all') // then assert on everything captured
   .should('have.length', 2)
 ```
 

--- a/docs/app/core-concepts/variables-and-aliases.mdx
+++ b/docs/app/core-concepts/variables-and-aliases.mdx
@@ -585,6 +585,13 @@ cy.get('@getUsers.2').its('response.statusCode').should('eq', 200)
 Without an index, `cy.get('@alias')` returns the **most recent** intercepted
 request.
 
+:::caution
+
+These suffixes are **not** supported by [`cy.wait()`](/api/commands/wait). Use
+`cy.get('@alias.all')` instead of `cy.wait('@alias.all')`.
+
+:::
+
 ### Requests
 
 Aliases can also be used with [requests](/api/commands/request).

--- a/docs/app/core-concepts/variables-and-aliases.mdx
+++ b/docs/app/core-concepts/variables-and-aliases.mdx
@@ -548,6 +548,43 @@ cy.contains('Successfully created user: Brian')
 
 :::
 
+#### Accessing multiple intercepted requests
+
+When your application makes multiple requests matching the same alias, you can
+retrieve all of them using the `.all` suffix with
+[`cy.get()`](/api/commands/get). This yields an array of all matching
+[interception objects](/api/commands/intercept#Using-the-yielded-object).
+
+```js
+cy.intercept('GET', '/users').as('getUsers')
+
+// trigger multiple requests
+cy.visit('/users')
+cy.visit('/users')
+
+// assert on the total number of matching requests
+cy.get('@getUsers.all').then((interceptions) => {
+  expect(interceptions).to.have.length(2)
+})
+```
+
+You can also target a specific request using a 1-based numeric index:
+
+```js
+cy.intercept('GET', '/users').as('getUsers')
+
+cy.visit('/users')
+cy.visit('/users')
+
+// assert on the first request
+cy.get('@getUsers.1').its('response.statusCode').should('eq', 200)
+// assert on the second request
+cy.get('@getUsers.2').its('response.statusCode').should('eq', 200)
+```
+
+Without an index, `cy.get('@alias')` returns the **most recent** intercepted
+request.
+
 ### Requests
 
 Aliases can also be used with [requests](/api/commands/request).

--- a/docs/app/core-concepts/variables-and-aliases.mdx
+++ b/docs/app/core-concepts/variables-and-aliases.mdx
@@ -550,10 +550,48 @@ cy.contains('Successfully created user: Brian')
 
 #### Accessing multiple intercepted requests
 
-When your application makes multiple requests matching the same alias, you can
-retrieve all of them using the `.all` suffix with
-[`cy.get()`](/api/commands/get). This yields an array of all matching
-[interception objects](/api/commands/intercept#Using-the-yielded-object).
+When you alias a `cy.intercept()` route, Cypress silently tracks **every**
+request that matches it — not just the most recent one. By default,
+`cy.get('@alias')` and `cy.wait('@alias')` only surface the most recent
+matching request. The `.all` suffix and numeric index notation expose the full
+history Cypress was already keeping.
+
+This is useful in several situations:
+
+**Asserting request count.** The most common need is proving your app made
+*exactly* the expected number of requests — not just that it made at least one.
+For example, verifying a polling interval doesn't fire again after some time:
+
+```js
+cy.wait('@getList')
+cy.tick(10000)
+cy.get('@getList.all').should('have.length', 1) // still only one request
+```
+
+Without `.all` there is no clean way to assert count. You can only assert
+whether a request happened, not how many times.
+
+**Sequential requests with different data.** When your app paginates or retries,
+requests share a route but carry different parameters. The numeric index lets you
+validate each one independently:
+
+```js
+cy.get('@getUsers.1').its('request.url').should('include', 'page=1')
+cy.get('@getUsers.2').its('request.url').should('include', 'page=2')
+```
+
+**Why not multiple `cy.wait()` calls?** `cy.wait('@alias')` called twice will
+consume two requests in order, which is useful for *sequencing* — but it doesn't
+catch a third unexpected request, and once consumed you can't go back to inspect
+an earlier one. `cy.get('@alias.all')` is backward-looking: it queries everything
+Cypress has already captured. The two complement each other — use `cy.wait()` to
+let requests settle, then `cy.get('@alias.all')` to assert on the full history:
+
+```js
+cy.wait('@getUsers')            // let requests settle
+cy.get('@getUsers.all')         // then assert on everything captured
+  .should('have.length', 2)
+```
 
 <InterceptAliasIndex />
 

--- a/docs/app/core-concepts/variables-and-aliases.mdx
+++ b/docs/app/core-concepts/variables-and-aliases.mdx
@@ -555,42 +555,7 @@ retrieve all of them using the `.all` suffix with
 [`cy.get()`](/api/commands/get). This yields an array of all matching
 [interception objects](/api/commands/intercept#Using-the-yielded-object).
 
-```js
-cy.intercept('GET', '/users').as('getUsers')
-
-// trigger multiple requests
-cy.visit('/users')
-cy.visit('/users')
-
-// assert on the total number of matching requests
-cy.get('@getUsers.all').then((interceptions) => {
-  expect(interceptions).to.have.length(2)
-})
-```
-
-You can also target a specific request using a 1-based numeric index:
-
-```js
-cy.intercept('GET', '/users').as('getUsers')
-
-cy.visit('/users')
-cy.visit('/users')
-
-// assert on the first request
-cy.get('@getUsers.1').its('response.statusCode').should('eq', 200)
-// assert on the second request
-cy.get('@getUsers.2').its('response.statusCode').should('eq', 200)
-```
-
-Without an index, `cy.get('@alias')` returns the **most recent** intercepted
-request.
-
-:::caution
-
-These suffixes are **not** supported by [`cy.wait()`](/api/commands/wait). Use
-`cy.get('@alias.all')` instead of `cy.wait('@alias.all')`.
-
-:::
+<InterceptAliasIndex />
 
 ### Requests
 

--- a/docs/partials/_intercept-alias-index.mdx
+++ b/docs/partials/_intercept-alias-index.mdx
@@ -1,0 +1,36 @@
+```js
+cy.intercept('GET', '/users').as('getUsers')
+
+// trigger multiple requests
+cy.visit('/users')
+cy.visit('/users')
+
+// yields an array of all interceptions for this alias
+cy.get('@getUsers.all').then((interceptions) => {
+  expect(interceptions).to.have.length(2)
+})
+```
+
+You can also retrieve a specific intercept by its 1-based numeric index. Without
+any suffix, `cy.get('@alias')` returns the most recent intercepted request.
+
+```js
+cy.intercept('GET', '/users').as('getUsers')
+
+cy.visit('/users')
+cy.visit('/users')
+
+// yields the first intercepted request
+cy.get('@getUsers.1').its('response.statusCode').should('eq', 200)
+
+// yields the second intercepted request
+cy.get('@getUsers.2').its('response.statusCode').should('eq', 200)
+```
+
+:::caution
+
+Index `0` is not valid — indices start at `1`. These suffixes are **not**
+supported by [`cy.wait()`](/api/commands/wait). Use `cy.get('@alias.all')`
+instead of `cy.wait('@alias.all')`.
+
+:::

--- a/src/theme/MDXComponents.js
+++ b/src/theme/MDXComponents.js
@@ -24,6 +24,7 @@ import E2EOrCtTabs from "@site/src/components/e2e-or-ct-tabs";
 import ElementFilters from "@site/docs/partials/_elementfilters.mdx";
 import VueSyntaxTabs from "@site/src/components/vue-syntax-tabs";
 import HeaderAssertions from "@site/docs/partials/_header-assertions.mdx";
+import InterceptAliasIndex from "@site/docs/partials/_intercept-alias-index.mdx";
 import HeaderRequirements from "@site/docs/partials/_header-requirements.mdx";
 import HeaderTimeouts from "@site/docs/partials/_header-timeouts.mdx";
 import HeaderYields from "@site/docs/partials/_header-yields.mdx";
@@ -193,6 +194,7 @@ export default {
   ElementFilters,
   VueSyntaxTabs,
   HeaderAssertions,
+  InterceptAliasIndex,
   HeaderRequirements,
   HeaderTimeouts,
   HeaderYields,


### PR DESCRIPTION
Add documentation for the undocumented feature that allows accessing
all or a specific intercepted request for a cy.intercept() alias using
the @alias.all and @alias.N (1-based index) syntax with cy.get().

Closes #1573

https://claude.ai/code/session_01Jyuxkc77GBfs5EVnEaco4H

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or test behavior impact.
> 
> **Overview**
> This PR **documents** the existing `cy.get()` syntax for reading **all** or **indexed** `cy.intercept()` aliases: `@alias.all` (array of interceptions) and `@alias.N` (1-based index; default `@alias` is most recent).
> 
> A shared partial **`InterceptAliasIndex`** holds the canonical examples and cautions (no index `0`; **not** supported on `cy.wait()`). It is wired into **`get.mdx`**, **`intercept.mdx`**, and **`variables-and-aliases.mdx`**, with the aliases guide adding guidance on **request counts**, **pagination**, and **`cy.wait()` vs `cy.get('@alias.all')`**.
> 
> **`MDXComponents.js`** registers the partial so MDX pages can render `<InterceptAliasIndex />`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5ab66ad60d0be3d6ae3538067602f697c60e5d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->