### PR TITLE
docs(preprocessors): document how to exclude files from being watched

### DIFF
--- a/docs/api/node-events/preprocessors-api.mdx
+++ b/docs/api/node-events/preprocessors-api.mdx
@@ -60,6 +60,70 @@ Editing the options allows you to do things like:
 - Modify options for TypeScript compilation
 - Add support for CoffeeScript `2.x.x`
 
+## Excluding files from being watched
+
+Certain tools generate files as a side effect of a build (for example,
+`*.d.ts` files emitted by `css-modules-typescript-loader`, or `*.hot-update.js`
+HMR files). If Cypress watches those generated files and they are re-emitted on
+each build, you can end up in an **infinite reload loop**: Cypress detects a
+change → rebuilds → the tool generates new files → Cypress detects another
+change → …
+
+To break this cycle, pass a `watchOptions.ignored` glob pattern (or array of
+patterns) to the webpack preprocessor. The value is forwarded directly to
+webpack's file watcher, which uses
+[`anymatch`](https://github.com/micromatch/anymatch) internally and therefore
+accepts glob strings, regular expressions, or functions.
+
+:::cypress-config-plugin-example
+
+```javascript
+const webpackPreprocessor = require('@cypress/webpack-preprocessor')
+
+on(
+  'file:preprocessor',
+  webpackPreprocessor({
+    watchOptions: {
+      // Ignore TypeScript declaration files generated during builds
+      ignored: '**/*.d.ts',
+    },
+  })
+)
+```
+
+:::
+
+You can also provide an array to ignore several patterns at once:
+
+:::cypress-config-plugin-example
+
+```javascript
+const webpackPreprocessor = require('@cypress/webpack-preprocessor')
+
+on(
+  'file:preprocessor',
+  webpackPreprocessor({
+    watchOptions: {
+      ignored: ['**/*.d.ts', '**/*.hot-update.js'],
+    },
+  })
+)
+```
+
+:::
+
+For more details on the available `watchOptions` values, see
+[webpack's watch configuration docs](https://webpack.js.org/configuration/watch/#watchoptionsignored).
+
+:::note
+
+The `excludeSpecPattern` configuration option hides files from the **list of
+specs** shown in the Cypress UI — it does not affect which files the preprocessor
+watches. Use `watchOptions.ignored` (shown above) when you need to prevent
+specific files from triggering a test rerun.
+
+:::
+
 ## Usage
 
 <WarningSetupNodeEvents />


### PR DESCRIPTION
Add an "Excluding files from being watched" section to the Preprocessors
API page explaining how to use `watchOptions.ignored` to prevent
generated files (e.g. *.d.ts, *.hot-update.js) from triggering
infinite reload loops. Also clarifies that `excludeSpecPattern` is
unrelated — it only hides specs from the UI list, not from the watcher.

Closes #1316

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or configuration behavior changes.
> 
> **Overview**
> Adds an **Excluding files from being watched** section to the Preprocessors API docs. It explains how infinite reload loops can happen when build tools emit files Cypress watches (e.g. `*.d.ts`, `*.hot-update.js`), and how to pass **`watchOptions.ignored`** to `@cypress/webpack-preprocessor` with single-pattern and array examples.
> 
> The section links to webpack’s watch docs and adds a **note** that **`excludeSpecPattern`** only affects which specs appear in the UI, not preprocessor file watching.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit effd60b12bb350e3a3e8a9465457fb85344a013a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->