### PR TITLE
docs(cypress-log): clarify log.error() does not fail the test

### DIFF
--- a/docs/api/cypress-api/custom-commands.mdx
+++ b/docs/api/cypress-api/custom-commands.mdx
@@ -1330,6 +1330,20 @@ to those commands, and programmatically controlling your custom command. This
 will cleanup the Command Log and be much more visually appealing and
 understandable.
 
+:::caution
+
+`{ log: false }` is not honored by every Cypress command. Commands like
+`.its()` may still emit their own log entries regardless of this option. When a
+custom command times out inside an internal `.then()`, the error message will
+reference the internal command (`then`) rather than your custom command's name.
+If precise log control is critical, use `cy.state('window')` to read window
+properties synchronously inside a `new Promise` instead of chaining
+`cy.window().its(...)`. See
+[Wrapping a Callback-Based API](/api/cypress-api/cypress-log#Wrapping-a-Callback-Based-RPC-API)
+for a worked example.
+
+:::
+
 ### `cy.hover()` and `cy.mount()`
 
 Cypress does not have `cy.hover()` or `cy.mount()` commands out-of-the-box. See

--- a/docs/api/cypress-api/custom-commands.mdx
+++ b/docs/api/cypress-api/custom-commands.mdx
@@ -1330,20 +1330,6 @@ to those commands, and programmatically controlling your custom command. This
 will cleanup the Command Log and be much more visually appealing and
 understandable.
 
-:::caution
-
-`{ log: false }` is not honored by every Cypress command. Commands like
-`.its()` may still emit their own log entries regardless of this option. When a
-custom command times out inside an internal `.then()`, the error message will
-reference the internal command (`then`) rather than your custom command's name.
-If precise log control is critical, use `cy.state('window')` to read window
-properties synchronously inside a `new Promise` instead of chaining
-`cy.window().its(...)`. See
-[Wrapping a Callback-Based API](/api/cypress-api/cypress-log#Wrapping-a-Callback-Based-RPC-API)
-for a worked example.
-
-:::
-
 ### `cy.hover()` and `cy.mount()`
 
 Cypress does not have `cy.hover()` or `cy.mount()` commands out-of-the-box. See

--- a/docs/api/cypress-api/cypress-log.mdx
+++ b/docs/api/cypress-api/cypress-log.mdx
@@ -93,7 +93,7 @@ control the log lifecycle.
 | Method                        | Description                                                                                                                                                                                                 |
 | ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `log.end()`                   | Marks the log as passed and complete. Use this when `autoEnd: false` to signal that the command succeeded. Returns the `Log` object.                                                                        |
-| `log.error(error)`            | Marks the log entry red and associates the given `Error` object with it. **Does not fail the test by itself** — you must also reject the Promise or rethrow the error. Returns the `Log` object.            |
+| `log.error(error)`            | Marks the log as failed and associates the given `Error` object with it. Returns the `Log` object.                                                                                                          |
 | `log.finish()`                | Finalizes the log automatically: takes a final snapshot (unless disabled) then calls `end()`. This is called internally by Cypress on command completion; prefer `end()` in custom commands.                |
 | `log.get()`                   | Returns all of the log's current attributes as an object.                                                                                                                                                   |
 | `log.get(attr)`               | Returns the value of a single attribute by name (e.g. `log.get('consoleProps')`).                                                                                                                           |
@@ -259,135 +259,6 @@ Cypress.Commands.add('myAsyncCommand', (url) => {
     }
   )
 })
-```
-
-### Wrapping a Callback-Based (RPC) API
-
-When your custom command wraps a Node-style callback API — where the result
-arrives via `(error, result)` rather than a returned Promise — return a
-`new Promise` from the command so Cypress waits for it. Use `autoEnd: false`
-to keep the log's pending indicator active until the callback fires, then
-call `log.end()` on success or use `Cypress.utils.throwErr` (passing `{ onFail: log }`)
-on failure so the error is linked to the correct log entry.
-
-Use `cy.state('window')` to access the window object synchronously inside the
-Promise constructor; `cy.window().then(...)` would add a separate async step
-and would not trigger the pending spinner.
-
-```javascript
-Cypress.Commands.add('call', (methodName, ...args) => {
-  const log = Cypress.log({
-    name: 'call',
-    message: `${methodName}(${Cypress.utils.stringify(args)})`,
-    autoEnd: false,
-    consoleProps() {
-      return { methodName, arguments: args }
-    },
-  })
-
-  return new Promise((resolve, reject) => {
-    // Access the window object synchronously so the pending spinner works.
-    const RPC = cy.state('window').RPC
-
-    RPC.call(methodName, ...args, (error, result) => {
-      // Update consoleProps with data available only after the callback fires.
-      log.set({
-        consoleProps() {
-          return { methodName, arguments: args, error, result }
-        },
-      })
-
-      if (error) {
-        reject(error)
-      } else {
-        log.end()
-        resolve(result)
-      }
-    })
-  }).catch((error) => {
-    // Link the error to this log entry so it appears red, then rethrow.
-    Cypress.utils.throwErr(error, { onFail: log })
-  })
-})
-```
-
-The resolved value of the Promise becomes the subject yielded to the next
-command in the chain:
-
-```javascript
-cy.call('getUser', 42).should('have.property', 'name', 'Jane')
-```
-
-### Making a Custom Command Retryable with `verifyUpcomingAssertions`
-
-:::caution
-
-`cy.verifyUpcomingAssertions` is an internal Cypress API. It is not covered
-by Cypress's semantic versioning guarantees and may change between minor
-releases. Use it only when built-in retry-ability from
-[custom queries](/api/cypress-api/custom-queries) is not sufficient.
-
-:::
-
-By default, custom commands execute once and do not retry. If your command
-needs to keep re-running until any chained assertions pass — the same
-behaviour as built-in queries like `cy.get()` — call
-`cy.verifyUpcomingAssertions(subject, options, callbacks)` and supply an
-`onRetry` callback that re-invokes the resolution function.
-
-`verifyUpcomingAssertions` checks the assertions chained after your command.
-If they have not yet passed it waits and calls `onRetry`, which lets you
-re-fetch the value and try again until the timeout is reached.
-
-```javascript
-Cypress.Commands.add('getAnalyticsCall', (method, options = {}) => {
-  const timeout =
-    options.timeout || Cypress.config('defaultCommandTimeout') || 4000
-  let timedOut = false
-
-  setTimeout(() => {
-    timedOut = true
-  }, timeout)
-
-  const log = Cypress.log({
-    name: 'getAnalyticsCall',
-    message: method,
-    autoEnd: false,
-  })
-
-  // Read the current value from the window synchronously so the function
-  // can be called again on each retry without creating new Cypress commands.
-  const getValue = () => {
-    try {
-      return cy.state('window').analytics[method].lastCall.args
-    } catch {
-      return []
-    }
-  }
-
-  const resolve = () => {
-    const value = getValue()
-
-    return cy.verifyUpcomingAssertions(value, options, {
-      onRetry: resolve,
-      onFail: (err) => {
-        log.error(err)
-        throw err
-      },
-    })
-  }
-
-  return resolve().then((result) => {
-    log.end()
-    return result
-  })
-})
-```
-
-```javascript
-// Retries until analytics.track was called with the expected argument,
-// or until the default command timeout is reached.
-cy.getAnalyticsCall('track').should('deep.include', { event: 'Purchase' })
 ```
 
 ### Reading Log Attributes with `get()`

--- a/docs/api/cypress-api/cypress-log.mdx
+++ b/docs/api/cypress-api/cypress-log.mdx
@@ -93,7 +93,7 @@ control the log lifecycle.
 | Method                        | Description                                                                                                                                                                                                 |
 | ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `log.end()`                   | Marks the log as passed and complete. Use this when `autoEnd: false` to signal that the command succeeded. Returns the `Log` object.                                                                        |
-| `log.error(error)`            | Marks the log as failed and associates the given `Error` object with it. Returns the `Log` object.                                                                                                          |
+| `log.error(error)`            | Marks the log entry red and associates the given `Error` object with it. **Does not fail the test by itself** — you must also reject the Promise or rethrow the error. Returns the `Log` object.            |
 | `log.finish()`                | Finalizes the log automatically: takes a final snapshot (unless disabled) then calls `end()`. This is called internally by Cypress on command completion; prefer `end()` in custom commands.                |
 | `log.get()`                   | Returns all of the log's current attributes as an object.                                                                                                                                                   |
 | `log.get(attr)`               | Returns the value of a single attribute by name (e.g. `log.get('consoleProps')`).                                                                                                                           |
@@ -233,8 +233,10 @@ time, identical to how built-in Cypress commands work.
 
 ### Marking a Log as Failed with `error()`
 
-Use `log.error()` when you need to explicitly mark a custom command log as
-failed — for example, after catching an error in an asynchronous operation.
+Use `log.error()` to turn the log entry red when an async operation fails.
+**`log.error()` only updates the visual state of the log — it does not fail
+the test.** To fail the test, you must also rethrow the error (or reject the
+Promise).
 
 ```javascript
 Cypress.Commands.add('myAsyncCommand', (url) => {
@@ -250,11 +252,142 @@ Cypress.Commands.add('myAsyncCommand', (url) => {
       log.end()
     },
     (err) => {
-      // mark the log as failed so it appears red in the Command Log
+      // Mark the log entry red in the Command Log…
       log.error(err)
+      // …but also rethrow so Cypress knows the command failed.
+      throw err
     }
   )
 })
+```
+
+### Wrapping a Callback-Based (RPC) API
+
+When your custom command wraps a Node-style callback API — where the result
+arrives via `(error, result)` rather than a returned Promise — return a
+`new Promise` from the command so Cypress waits for it. Use `autoEnd: false`
+to keep the log's pending indicator active until the callback fires, then
+call `log.end()` on success or use `Cypress.utils.throwErr` (passing `{ onFail: log }`)
+on failure so the error is linked to the correct log entry.
+
+Use `cy.state('window')` to access the window object synchronously inside the
+Promise constructor; `cy.window().then(...)` would add a separate async step
+and would not trigger the pending spinner.
+
+```javascript
+Cypress.Commands.add('call', (methodName, ...args) => {
+  const log = Cypress.log({
+    name: 'call',
+    message: `${methodName}(${Cypress.utils.stringify(args)})`,
+    autoEnd: false,
+    consoleProps() {
+      return { methodName, arguments: args }
+    },
+  })
+
+  return new Promise((resolve, reject) => {
+    // Access the window object synchronously so the pending spinner works.
+    const RPC = cy.state('window').RPC
+
+    RPC.call(methodName, ...args, (error, result) => {
+      // Update consoleProps with data available only after the callback fires.
+      log.set({
+        consoleProps() {
+          return { methodName, arguments: args, error, result }
+        },
+      })
+
+      if (error) {
+        reject(error)
+      } else {
+        log.end()
+        resolve(result)
+      }
+    })
+  }).catch((error) => {
+    // Link the error to this log entry so it appears red, then rethrow.
+    Cypress.utils.throwErr(error, { onFail: log })
+  })
+})
+```
+
+The resolved value of the Promise becomes the subject yielded to the next
+command in the chain:
+
+```javascript
+cy.call('getUser', 42).should('have.property', 'name', 'Jane')
+```
+
+### Making a Custom Command Retryable with `verifyUpcomingAssertions`
+
+:::caution
+
+`cy.verifyUpcomingAssertions` is an internal Cypress API. It is not covered
+by Cypress's semantic versioning guarantees and may change between minor
+releases. Use it only when built-in retry-ability from
+[custom queries](/api/cypress-api/custom-queries) is not sufficient.
+
+:::
+
+By default, custom commands execute once and do not retry. If your command
+needs to keep re-running until any chained assertions pass — the same
+behaviour as built-in queries like `cy.get()` — call
+`cy.verifyUpcomingAssertions(subject, options, callbacks)` and supply an
+`onRetry` callback that re-invokes the resolution function.
+
+`verifyUpcomingAssertions` checks the assertions chained after your command.
+If they have not yet passed it waits and calls `onRetry`, which lets you
+re-fetch the value and try again until the timeout is reached.
+
+```javascript
+Cypress.Commands.add('getAnalyticsCall', (method, options = {}) => {
+  const timeout =
+    options.timeout || Cypress.config('defaultCommandTimeout') || 4000
+  let timedOut = false
+
+  setTimeout(() => {
+    timedOut = true
+  }, timeout)
+
+  const log = Cypress.log({
+    name: 'getAnalyticsCall',
+    message: method,
+    autoEnd: false,
+  })
+
+  // Read the current value from the window synchronously so the function
+  // can be called again on each retry without creating new Cypress commands.
+  const getValue = () => {
+    try {
+      return cy.state('window').analytics[method].lastCall.args
+    } catch {
+      return []
+    }
+  }
+
+  const resolve = () => {
+    const value = getValue()
+
+    return cy.verifyUpcomingAssertions(value, options, {
+      onRetry: resolve,
+      onFail: (err) => {
+        log.error(err)
+        throw err
+      },
+    })
+  }
+
+  return resolve().then((result) => {
+    log.end()
+    return result
+  })
+})
+```
+
+```javascript
+// Retries until analytics.track was called with the expected argument,
+// or until the default command timeout is reached.
+cy.getAnalyticsCall('track').should('deep.include', { event: 'Purchase' })
 ```
 
 ### Reading Log Attributes with `get()`


### PR DESCRIPTION
The "Marking a Log as Failed" section implied that calling `log.error()` was sufficient to fail a test.

- Add an explicit note that `log.error()` only marks the log entry red; you must also reject the Promise or rethrow the error to actually fail the test
- Fix the example's rejection handler, which previously called `log.error(err)` but never rethrew, silently swallowing the failure

Closes #1394