### PR TITLE
docs(config): add projectId to Global options table and document system/read-only config values

### DIFF
--- a/docs/app/references/configuration.mdx
+++ b/docs/app/references/configuration.mdx
@@ -76,7 +76,7 @@ default values.
 | `includeShadowDom`     | `false`                               | Whether to traverse shadow DOM boundaries and include elements within the shadow DOM in the results of query commands (e.g. [`cy.get()`](/api/commands/get)).                                                                                                                                              |
 | `numTestsKeptInMemory` | Default based on `run` or `open` mode | The number of tests for which snapshots and command data are kept in memory. `numTestsKeptInMemory` is set to `50` by default during `cypress open` and set to `0` by default during `cypress run`. Reduce this number if you are experiencing high memory consumption in your browser during a test run.  |
 | `port`                 | `null`                                | Port used to host Cypress. Normally this is a randomly generated port.                                                                                                                                                                                                                                     |
-| `projectId`            | `null`                                | The unique ID used to record test results to [Cypress Cloud](/cloud/get-started/introduction). Set automatically when you [connect your project to Cypress Cloud](/cloud/get-started/setup#Setup).                                                                                          |
+| `projectId`            | `null`                                | The unique ID used to record test results to [Cypress Cloud](/cloud/get-started/introduction). Set automatically when you [connect your project to Cypress Cloud](/cloud/get-started/setup#Setup).                                                                                                         |
 | `redirectionLimit`     | `20`                                  | The number of times that the application under test can redirect before erroring.                                                                                                                                                                                                                          |
 | `reporter`             | `spec`                                | The [reporter](/app/tooling/reporters) used during `cypress run`.                                                                                                                                                                                                                                          |
 | `reporterOptions`      | `null`                                | The [reporter options](/app/tooling/reporters#Reporter-Options) used. Supported options depend on the reporter.                                                                                                                                                                                            |
@@ -172,19 +172,18 @@ For more options regarding screenshots, view the
 For more information, see the docs on
 [actionability](/app/core-concepts/interacting-with-elements#Actionability).
 
-
 ### System
 
 These values are set by Cypress at startup and are read-only — they cannot be changed in your Cypress configuration file. They can be accessed via [`Cypress.config()`](/api/cypress-api/config). The `browsers` property is an exception: it can also be modified in [`setupNodeEvents`](#setupNodeEvents) to filter or add custom browsers.
 
-| Option                | Default           | Description                                                                                                                                                                                         |
-| --------------------- | ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `arch`                | `os.arch()`       | The underlying OS CPU architecture. Common values are `x64`, `arm`, and `arm64`.                                                                                                                    |
-| `browsers`            | `[]`              | A list of browsers found on your system. Populated by Cypress at startup. Can be filtered or extended in [`setupNodeEvents`](#setupNodeEvents).                                                     |
-| `isInteractive`       | `true`            | Whether Cypress is running in interactive mode (`cypress open`). Set to `false` during `cypress run`. See [Notes](#isInteractive) for usage.                                                        |
-| `platform`            | `os.platform()`   | The underlying OS platform name (e.g. `linux`, `darwin`, `win32`).                                                                                                                                  |
-| `resolvedNodePath`    | `null`            | The path to the Node.js binary used for [`cy.task()`](/api/commands/task) and [`cy.exec()`](/api/commands/exec) commands. Set by Cypress at startup.                                                |
-| `resolvedNodeVersion` | `null`            | The version of Node.js used by Cypress. Set by Cypress at startup.                                                                                                                                  |
+| Option                | Default         | Description                                                                                                                                          |
+| --------------------- | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `arch`                | `os.arch()`     | The underlying OS CPU architecture. Common values are `x64`, `arm`, and `arm64`.                                                                     |
+| `browsers`            | `[]`            | A list of browsers found on your system. Populated by Cypress at startup. Can be filtered or extended in [`setupNodeEvents`](#setupNodeEvents).      |
+| `isInteractive`       | `true`          | Whether Cypress is running in interactive mode (`cypress open`). Set to `false` during `cypress run`. See [Notes](#isInteractive) for usage.         |
+| `platform`            | `os.platform()` | The underlying OS platform name (e.g. `linux`, `darwin`, `win32`).                                                                                   |
+| `resolvedNodePath`    | `null`          | The path to the Node.js binary used for [`cy.task()`](/api/commands/task) and [`cy.exec()`](/api/commands/exec) commands. Set by Cypress at startup. |
+| `resolvedNodeVersion` | `null`          | The version of Node.js used by Cypress. Set by Cypress at startup.                                                                                   |
 
 ### Experiments
 

--- a/docs/app/references/configuration.mdx
+++ b/docs/app/references/configuration.mdx
@@ -76,6 +76,7 @@ default values.
 | `includeShadowDom`     | `false`                               | Whether to traverse shadow DOM boundaries and include elements within the shadow DOM in the results of query commands (e.g. [`cy.get()`](/api/commands/get)).                                                                                                                                              |
 | `numTestsKeptInMemory` | Default based on `run` or `open` mode | The number of tests for which snapshots and command data are kept in memory. `numTestsKeptInMemory` is set to `50` by default during `cypress open` and set to `0` by default during `cypress run`. Reduce this number if you are experiencing high memory consumption in your browser during a test run.  |
 | `port`                 | `null`                                | Port used to host Cypress. Normally this is a randomly generated port.                                                                                                                                                                                                                                     |
+| `projectId`            | `null`                                | The unique ID used to record test results to [Cypress Cloud](/cloud/get-started/introduction). Set automatically when you [connect your project to Cypress Cloud](/cloud/get-started/setup#Setup).                                                                                          |
 | `redirectionLimit`     | `20`                                  | The number of times that the application under test can redirect before erroring.                                                                                                                                                                                                                          |
 | `reporter`             | `spec`                                | The [reporter](/app/tooling/reporters) used during `cypress run`.                                                                                                                                                                                                                                          |
 | `reporterOptions`      | `null`                                | The [reporter options](/app/tooling/reporters#Reporter-Options) used. Supported options depend on the reporter.                                                                                                                                                                                            |
@@ -170,6 +171,20 @@ For more options regarding screenshots, view the
 
 For more information, see the docs on
 [actionability](/app/core-concepts/interacting-with-elements#Actionability).
+
+
+### System
+
+These values are set by Cypress at startup and are read-only — they cannot be changed in your Cypress configuration file. They can be accessed via [`Cypress.config()`](/api/cypress-api/config). The `browsers` property is an exception: it can also be modified in [`setupNodeEvents`](#setupNodeEvents) to filter or add custom browsers.
+
+| Option                | Default           | Description                                                                                                                                                                                         |
+| --------------------- | ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `arch`                | `os.arch()`       | The underlying OS CPU architecture. Common values are `x64`, `arm`, and `arm64`.                                                                                                                    |
+| `browsers`            | `[]`              | A list of browsers found on your system. Populated by Cypress at startup. Can be filtered or extended in [`setupNodeEvents`](#setupNodeEvents).                                                     |
+| `isInteractive`       | `true`            | Whether Cypress is running in interactive mode (`cypress open`). Set to `false` during `cypress run`. See [Notes](#isInteractive) for usage.                                                        |
+| `platform`            | `os.platform()`   | The underlying OS platform name (e.g. `linux`, `darwin`, `win32`).                                                                                                                                  |
+| `resolvedNodePath`    | `null`            | The path to the Node.js binary used for [`cy.task()`](/api/commands/task) and [`cy.exec()`](/api/commands/exec) commands. Set by Cypress at startup.                                                |
+| `resolvedNodeVersion` | `null`            | The version of Node.js used by Cypress. Set by Cypress at startup.                                                                                                                                  |
 
 ### Experiments
 


### PR DESCRIPTION
Adds projectId to the Global options table since it is a user-configurable
value (set when connecting to Cypress Cloud) that was missing from the
reference docs.

Adds a new System section documenting read-only values that Cypress sets
automatically at startup — arch, browsers, isInteractive, platform,
resolvedNodePath, resolvedNodeVersion — so users know these keys are
accessible via Cypress.config() and understand their meaning.

Fixes #4781

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to the configuration reference; no runtime or test behavior changes.
> 
> **Overview**
> The configuration reference now documents **`projectId`** in the **Global** options table (Cypress Cloud recording ID, typically set when connecting the project).
> 
> A new **System** section lists **read-only** startup values exposed via **`Cypress.config()`** — **`arch`**, **`browsers`**, **`isInteractive`**, **`platform`**, **`resolvedNodePath`**, and **`resolvedNodeVersion`** — and notes that **`browsers`** can still be adjusted in **`setupNodeEvents`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49aa508e859c250360ab856aa2189cb21ee514bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->