### PR TITLE
clarify that --browser/--component/--e2e bypass Launchpad navigation, not the Launchpad itself

### DIFF
--- a/docs/app/core-concepts/open-mode.mdx
+++ b/docs/app/core-concepts/open-mode.mdx
@@ -31,8 +31,8 @@ The Cypress app includes an interactive workflow called open mode. In Cypress op
 
 The Launchpad helps you choose a testing type, pick a browser, and open your project. It also guides first time setup when needed so you can start running specs with the right configuration.
 
-If you prefer to skip the Launchpad, run
-[`cypress open`](/app/references/command-line#cypress-open) with `--browser` and either `--component` or `--e2e` to go directly to the Specs page.
+To bypass the Launchpad's manual selection steps, run
+[`cypress open`](/app/references/command-line#cypress-open) with `--browser` and either `--component` or `--e2e`. The Launchpad will still open briefly (it handles configuration errors and other edge cases), but you'll land directly on the Specs page without having to click through the testing type and browser prompts.
 
 ### Specs
 


### PR DESCRIPTION
The Launchpad still opens when using these flags (to handle config errors
and other edge cases), but users skip the manual click-through to testing
type and browser selection, landing directly on the Specs page.

Fixes #5811

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording change in open-mode.mdx with no runtime or API impact.
> 
> **Overview**
> Updates the **Launchpad** section in open mode docs so `cypress open` with `--browser` and `--component` or `--e2e` is described accurately: users **skip manual testing-type and browser prompts** and go straight to the Specs page, while the Launchpad may still appear briefly for config errors and similar cases.
> 
> Previously the text implied you could skip the Launchpad entirely; the new wording matches actual CLI behavior and addresses confusion in #5811.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfa19bc73c6ae30f4127c7bec02503f47e01d1a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->