### PR TITLE
docs: clarify alias re-querying behavior in variables-and-aliases guide

### DIFF
--- a/docs/app/core-concepts/variables-and-aliases.mdx
+++ b/docs/app/core-concepts/variables-and-aliases.mdx
@@ -407,9 +407,10 @@ By using [`cy.get()`](/api/commands/get) we avoid the use of `this`.
 Keep in mind that there are use cases for both approaches because they have one
 major difference.
 
-When using `this.users`, it is stored on the context when it is first evaluated.
-But when using `cy.get('@users')`, any queries are re-evaluated every time the
-alias is accessed.
+`this.users` is stored on the Mocha context when `.as()` first runs and never
+re-evaluates — it behaves like a static snapshot. `cy.get('@users')` re-executes
+the full query chain every time it is accessed, returning fresh results. See
+[Dynamic vs. Static Aliases](#dynamic-vs-static-aliases) below for more detail.
 
 ```javascript
 const favorites = { color: 'blue' }
@@ -442,26 +443,26 @@ After you alias DOM elements, you can then later access them for reuse.
 cy.get('table').find('tr').as('rows')
 ```
 
-Internally, Cypress has made a reference to the `<tr>` collection returned as
-the alias "rows". To reference these same "rows" later, you can use the
-[`cy.get()`](/api/commands/get) command.
+Internally, Cypress stores the **query chain** that produced the `<tr>`
+collection — not the elements themselves. To access the alias later, use the
+[`cy.get()`](/api/commands/get) command with the `@` prefix.
 
 ```javascript
-// Cypress returns the reference to the <tr>'s
-// which allows us to continue to chain commands
-// finding the 1st row.
+// Cypress re-runs the query chain to get fresh <tr>'s,
+// then chains .first() and .click() on the result.
 cy.get('@rows').first().click()
 ```
 
-Because we've used the `@` character in [`cy.get()`](/api/commands/get), instead
-of querying the DOM for elements, [`cy.get()`](/api/commands/get) looks for an
-existing alias called `rows` and returns the reference (if it finds it).
+Because we've used the `@` character in [`cy.get()`](/api/commands/get), Cypress
+looks up the alias called `rows` and **re-executes its query chain** against the
+current DOM — it does not return a cached element reference.
 
 #### Stale Elements:
 
 In many single-page applications, the JavaScript re-renders parts of the DOM
-constantly. This is why we always re-run queries when you fetch an alias, so you
-never end up with stale elements.
+constantly. Because Cypress stores the **query chain** — not the resolved
+elements — every access of a default alias re-runs those queries against the
+current DOM, so you never end up with stale element references.
 
 ```html
 <ul id="todos">
@@ -510,6 +511,51 @@ always. It is recommended that you **alias elements before running commands**.
   <Icon name="exclamation-triangle" color="red" /> (bad)
 
 :::
+
+#### Dynamic vs. Static Aliases:
+
+There are two alias types that control whether Cypress re-queries on each
+access:
+
+| Type | Set via | Behavior |
+|------|---------|----------|
+| **`query`** (default) | `.as('name')` | Stores the query chain. Re-executes queries on every access — always returns fresh DOM elements. |
+| **`static`** | `.as('name', { type: 'static' })` | Stores the already-resolved value. Returns the same snapshot every time — never re-queries. |
+
+Use `type: 'static'` when you deliberately want to capture a value at a
+specific point in time and compare it against later state:
+
+```js
+// Capture the text value *before* an action
+cy.get('.username').invoke('val').as('originalName', { type: 'static' })
+
+cy.get('.username').clear().type('Jane')
+
+cy.get('@originalName').then((original) => {
+  cy.get('.username').invoke('val').should('not.eq', original)
+})
+```
+
+:::info
+
+**How `this.alias` relates to alias types**
+
+Accessing an alias as `this.alias` (via Mocha's shared context) always
+reflects the **value that was resolved when `.as()` first ran** — it never
+re-queries. This is the same behavior as `type: 'static'`. By contrast,
+`cy.get('@alias')` uses the default `query` type and re-runs the chain on
+every access.
+
+:::
+
+If an alias stores a **query** type (the default) and the re-query returns
+different elements than you expected, check that:
+
+1. The alias is defined **before** any action that mutates the DOM.
+2. The full traversal path from a stable root is included in the aliased chain.
+3. The aliased query does not contain conditions that will no longer match after
+   the DOM changes (e.g. `findByRole('button', { expanded: true })` won't match
+   after the button is collapsed).
 
 ### Intercepts
 

--- a/docs/app/core-concepts/variables-and-aliases.mdx
+++ b/docs/app/core-concepts/variables-and-aliases.mdx
@@ -511,7 +511,6 @@ always. It is recommended that you **alias elements before running commands**.
 
 :::
 
-
 ### Intercepts
 
 Aliases can also be used with [cy.intercept()](/api/commands/intercept).

--- a/docs/app/core-concepts/variables-and-aliases.mdx
+++ b/docs/app/core-concepts/variables-and-aliases.mdx
@@ -409,8 +409,7 @@ major difference.
 
 `this.users` is stored on the Mocha context when `.as()` first runs and never
 re-evaluates — it behaves like a static snapshot. `cy.get('@users')` re-executes
-the full query chain every time it is accessed, returning fresh results. See
-[Dynamic vs. Static Aliases](#dynamic-vs-static-aliases) below for more detail.
+the full query chain every time it is accessed, returning fresh results.
 
 ```javascript
 const favorites = { color: 'blue' }
@@ -512,50 +511,6 @@ always. It is recommended that you **alias elements before running commands**.
 
 :::
 
-#### Dynamic vs. Static Aliases:
-
-There are two alias types that control whether Cypress re-queries on each
-access:
-
-| Type | Set via | Behavior |
-|------|---------|----------|
-| **`query`** (default) | `.as('name')` | Stores the query chain. Re-executes queries on every access — always returns fresh DOM elements. |
-| **`static`** | `.as('name', { type: 'static' })` | Stores the already-resolved value. Returns the same snapshot every time — never re-queries. |
-
-Use `type: 'static'` when you deliberately want to capture a value at a
-specific point in time and compare it against later state:
-
-```js
-// Capture the text value *before* an action
-cy.get('.username').invoke('val').as('originalName', { type: 'static' })
-
-cy.get('.username').clear().type('Jane')
-
-cy.get('@originalName').then((original) => {
-  cy.get('.username').invoke('val').should('not.eq', original)
-})
-```
-
-:::info
-
-**How `this.alias` relates to alias types**
-
-Accessing an alias as `this.alias` (via Mocha's shared context) always
-reflects the **value that was resolved when `.as()` first ran** — it never
-re-queries. This is the same behavior as `type: 'static'`. By contrast,
-`cy.get('@alias')` uses the default `query` type and re-runs the chain on
-every access.
-
-:::
-
-If an alias stores a **query** type (the default) and the re-query returns
-different elements than you expected, check that:
-
-1. The alias is defined **before** any action that mutates the DOM.
-2. The full traversal path from a stable root is included in the aliased chain.
-3. The aliased query does not contain conditions that will no longer match after
-   the DOM changes (e.g. `findByRole('button', { expanded: true })` won't match
-   after the button is collapsed).
 
 ### Intercepts
 


### PR DESCRIPTION
Fixes confusing and contradictory language in the Variables and Aliases guide that was raised in [cypress-io/cypress#33806](https://github.com/cypress-io/cypress/discussions/33806).

## What changed

**`docs/app/core-concepts/variables-and-aliases.mdx`**

- **Elements section**: replaced "Cypress returns the reference" / "looks for an existing alias and returns the reference" with accurate language — Cypress stores the *query chain*, not the resolved elements, and re-executes that chain against the current DOM on every access.
- **Stale Elements intro**: reworded to make clear that re-querying is a consequence of storing the query chain rather than an incidental behavior.
- **`this.users` vs `cy.get('@users')` comparison**: tightened to describe `this.*` as a one-time snapshot (set when `.as()` first runs) vs `cy.get('@…')` which re-runs the full chain on each access.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to user-facing conceptual explanations; no runtime or test code changes.
> 
> **Overview**
> Updates the **Variables and Aliases** guide so it matches how Cypress aliases actually work, addressing confusion from [discussion #33806](https://github.com/cypress-io/cypress/discussions/33806).
> 
> The **`this.users` vs `cy.get('@users')`** section now states that `this.*` is a one-time snapshot when `.as()` runs, while `cy.get('@…')` re-runs the full query chain on each access.
> 
> In the **Elements** and **Stale Elements** sections, wording that implied Cypress caches and returns element references is replaced: aliases store the **query chain**, and `cy.get('@alias')` **re-executes** that chain against the current DOM so results stay fresh.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2547e2ab620587b82e22bb17a0ebb059135350c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->