### PR TITLE
docs: add controlled-component onChange guidance for range inputs (issue #1570)

### DIFF
--- a/docs/api/commands/invoke.mdx
+++ b/docs/api/commands/invoke.mdx
@@ -192,6 +192,18 @@ The above example can be written simply as:
 cy.contains('The code example').should('have.attr', 'id', 'code-snippet')
 ```
 
+:::caution
+
+**`.invoke('val', value)` does not simulate user input.** It calls jQuery's
+`.val()` directly, which updates the value but does not fire `input`/`change`
+events. Following it with `.trigger('change')` will also fail to fire `onChange`
+on controlled framework components (e.g. React sliders), because setting the
+value through jQuery updates React's internal value tracker. See
+[Triggering events on controlled framework components](/api/commands/trigger#triggering-events-on-controlled-framework-components-react-vue-etc)
+and issue [#1570](https://github.com/cypress-io/cypress/issues/1570).
+
+:::
+
 ## Notes
 
 ### Third Party Plugins

--- a/docs/api/commands/invoke.mdx
+++ b/docs/api/commands/invoke.mdx
@@ -194,13 +194,10 @@ cy.contains('The code example').should('have.attr', 'id', 'code-snippet')
 
 :::caution
 
-**`.invoke('val', value)` does not simulate user input.** It calls jQuery's
-`.val()` directly, which updates the value but does not fire `input`/`change`
-events. Following it with `.trigger('change')` will also fail to fire `onChange`
-on controlled framework components (e.g. React sliders), because setting the
-value through jQuery updates React's internal value tracker. See
-[Triggering events on controlled framework components](/api/commands/trigger#triggering-events-on-controlled-framework-components-react-vue-etc)
-and issue [#1570](https://github.com/cypress-io/cypress/issues/1570).
+**`.invoke('val', value)` does not simulate user input** and may not fire
+`onChange` handlers in controlled components (e.g. React sliders). See
+[Interact with a range input in a controlled component](/api/commands/trigger#interact-with-a-range-input-in-a-controlled-component-react-vue-etc)
+for the recommended approach.
 
 :::
 

--- a/docs/api/commands/invoke.mdx
+++ b/docs/api/commands/invoke.mdx
@@ -192,15 +192,6 @@ The above example can be written simply as:
 cy.contains('The code example').should('have.attr', 'id', 'code-snippet')
 ```
 
-:::caution
-
-**`.invoke('val', value)` does not simulate user input** and may not fire
-`onChange` handlers in controlled components (e.g. React sliders). See
-[Interact with a range input in a controlled component](/api/commands/trigger#interact-with-a-range-input-in-a-controlled-component-react-vue-etc)
-for the recommended approach.
-
-:::
-
 ## Notes
 
 ### Third Party Plugins

--- a/docs/api/commands/trigger.mdx
+++ b/docs/api/commands/trigger.mdx
@@ -273,101 +273,25 @@ the browser to actually "do" anything for these events. For the most part, it
 shouldn't matter, which is why `.trigger()` is an excellent stop-gap if the
 command / event you're looking for hasn't been implemented yet.
 
-### Triggering events on controlled framework components (React, Vue, etc.)
+### Interact with a range input in a controlled component (React, Vue, etc.)
 
-Combining `.invoke('val', value)` with `.trigger('change')` (or `.trigger('input')`)
-**will not** fire the `onChange` handler of a controlled component in frameworks
-like React. This commonly affects `<input type="range">` sliders.
-
-```js
-// ⚠️ Moves the slider visually, but React's onChange does NOT fire
-cy.get('input[type=range]').invoke('val', 70).trigger('change')
-```
-
-**Why this happens**
-
-This is not a Cypress limitation — it is how React's synthetic event system works:
-
-- React installs its own setter over the input's `value` property to maintain an
-  internal value tracker. `.invoke('val', 70)` calls jQuery's `.val()`, which goes
-  **through** that setter and updates React's tracker to `70`.
-- `.trigger('change')` then dispatches a real, bubbling DOM event. A plain
-  `addEventListener('change', …)` would fire — but React only dispatches its
-  synthetic `onChange` when the element's value **differs** from its tracked value.
-  Since the tracker already reads `70`, React treats it as "no change" and skips
-  the handler.
-- React also maps `onChange` for these inputs to the native **`input`** event, so
-  even `.trigger('input')` is gated by the same tracker check.
-
-**What to do instead**
-
-Use commands that simulate real user interaction. These go through native value
-setters, leaving React's tracker stale so the change is detected:
+To set a range input to a specific value in a controlled component, use the
+native setter before dispatching the event. This ensures framework `onChange`
+handlers fire correctly.
 
 ```js
-// Use arrow keys to nudge a range/number input (fires input + change)
-cy.get('input[type=range]').type('{rightArrow}')
-cy.get('input[type=range]').type('{leftArrow}')
-```
-
-To jump a controlled input to an arbitrary value, set it through the **native**
-setter (bypassing the framework's wrapper) before dispatching the event:
-
-```js
-const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
-  window.HTMLInputElement.prototype,
-  'value',
-).set
-
 cy.get('input[type=range]').then(($range) => {
   const el = $range[0]
+  const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+    window.HTMLInputElement.prototype,
+    'value',
+  ).set
 
   nativeInputValueSetter.call(el, 70)
   el.dispatchEvent(new Event('input', { bubbles: true }))
   el.dispatchEvent(new Event('change', { bubbles: true }))
 })
 ```
-
-This pattern can be wrapped in a custom command for reuse:
-
-```js
-// cypress/support/commands.js
-Cypress.Commands.add(
-  'setSliderValue',
-  { prevSubject: 'element' },
-  (subject, value) => {
-    const el = subject[0]
-
-    const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
-      window.HTMLInputElement.prototype,
-      'value',
-    ).set
-
-    nativeInputValueSetter.call(el, value)
-    el.dispatchEvent(new Event('input', { bubbles: true }))
-    el.dispatchEvent(new Event('change', { bubbles: true }))
-
-    return subject
-  },
-)
-```
-
-```ts
-// cypress/support/index.d.ts (TypeScript)
-declare namespace Cypress {
-  interface Chainable {
-    setSliderValue(value: number | string): Chainable<JQuery<HTMLElement>>
-  }
-}
-```
-
-Usage:
-
-```js
-cy.get('input[type=range]').setSliderValue(70)
-```
-
-See issue [#1570](https://github.com/cypress-io/cypress/issues/1570) for more detail.
 
 ## Rules
 

--- a/docs/api/commands/trigger.mdx
+++ b/docs/api/commands/trigger.mdx
@@ -273,6 +273,102 @@ the browser to actually "do" anything for these events. For the most part, it
 shouldn't matter, which is why `.trigger()` is an excellent stop-gap if the
 command / event you're looking for hasn't been implemented yet.
 
+### Triggering events on controlled framework components (React, Vue, etc.)
+
+Combining `.invoke('val', value)` with `.trigger('change')` (or `.trigger('input')`)
+**will not** fire the `onChange` handler of a controlled component in frameworks
+like React. This commonly affects `<input type="range">` sliders.
+
+```js
+// ⚠️ Moves the slider visually, but React's onChange does NOT fire
+cy.get('input[type=range]').invoke('val', 70).trigger('change')
+```
+
+**Why this happens**
+
+This is not a Cypress limitation — it is how React's synthetic event system works:
+
+- React installs its own setter over the input's `value` property to maintain an
+  internal value tracker. `.invoke('val', 70)` calls jQuery's `.val()`, which goes
+  **through** that setter and updates React's tracker to `70`.
+- `.trigger('change')` then dispatches a real, bubbling DOM event. A plain
+  `addEventListener('change', …)` would fire — but React only dispatches its
+  synthetic `onChange` when the element's value **differs** from its tracked value.
+  Since the tracker already reads `70`, React treats it as "no change" and skips
+  the handler.
+- React also maps `onChange` for these inputs to the native **`input`** event, so
+  even `.trigger('input')` is gated by the same tracker check.
+
+**What to do instead**
+
+Use commands that simulate real user interaction. These go through native value
+setters, leaving React's tracker stale so the change is detected:
+
+```js
+// Use arrow keys to nudge a range/number input (fires input + change)
+cy.get('input[type=range]').type('{rightArrow}')
+cy.get('input[type=range]').type('{leftArrow}')
+```
+
+To jump a controlled input to an arbitrary value, set it through the **native**
+setter (bypassing the framework's wrapper) before dispatching the event:
+
+```js
+const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+  window.HTMLInputElement.prototype,
+  'value',
+).set
+
+cy.get('input[type=range]').then(($range) => {
+  const el = $range[0]
+
+  nativeInputValueSetter.call(el, 70)
+  el.dispatchEvent(new Event('input', { bubbles: true }))
+  el.dispatchEvent(new Event('change', { bubbles: true }))
+})
+```
+
+This pattern can be wrapped in a custom command for reuse:
+
+```js
+// cypress/support/commands.js
+Cypress.Commands.add(
+  'setSliderValue',
+  { prevSubject: 'element' },
+  (subject, value) => {
+    const el = subject[0]
+
+    const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+      window.HTMLInputElement.prototype,
+      'value',
+    ).set
+
+    nativeInputValueSetter.call(el, value)
+    el.dispatchEvent(new Event('input', { bubbles: true }))
+    el.dispatchEvent(new Event('change', { bubbles: true }))
+
+    return subject
+  },
+)
+```
+
+```ts
+// cypress/support/index.d.ts (TypeScript)
+declare namespace Cypress {
+  interface Chainable {
+    setSliderValue(value: number | string): Chainable<JQuery<HTMLElement>>
+  }
+}
+```
+
+Usage:
+
+```js
+cy.get('input[type=range]').setSliderValue(70)
+```
+
+See issue [#1570](https://github.com/cypress-io/cypress/issues/1570) for more detail.
+
 ## Rules
 
 <HeaderRequirements />

--- a/docs/api/commands/trigger.mdx
+++ b/docs/api/commands/trigger.mdx
@@ -280,17 +280,15 @@ native setter before dispatching the event. This ensures framework `onChange`
 handlers fire correctly.
 
 ```js
-cy.get('input[type=range]').then(($range) => {
-  const el = $range[0]
-  const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
-    window.HTMLInputElement.prototype,
-    'value',
-  ).set
+const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+  window.HTMLInputElement.prototype,
+  'value',
+).set
 
-  nativeInputValueSetter.call(el, 70)
-  el.dispatchEvent(new Event('input', { bubbles: true }))
-  el.dispatchEvent(new Event('change', { bubbles: true }))
-})
+cy.get('input[type=range]')
+  .then(($range) => nativeInputValueSetter.call($range[0], 70))
+  .trigger('input')
+  .trigger('change')
 ```
 
 ## Rules

--- a/docs/api/commands/trigger.mdx
+++ b/docs/api/commands/trigger.mdx
@@ -282,7 +282,7 @@ handlers fire correctly.
 ```js
 const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
   window.HTMLInputElement.prototype,
-  'value',
+  'value'
 ).set
 
 cy.get('input[type=range]')


### PR DESCRIPTION
Explains why invoke('val').trigger('change') silently skips React's onChange
handler (React synthetic-event tracker behaviour, not a Cypress bug), and
documents the native-setter workaround plus a reusable cy.setSliderValue
custom command. Adds a matching caution callout to the invoke page.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to trigger.mdx with no runtime or test code impact.
> 
> **Overview**
> Adds guidance on the **`.trigger()`** page for testing **range sliders in controlled components** (React, Vue, etc.), where `invoke('val').trigger('change')` may not run framework `onChange` handlers.
> 
> The new **Notes** subsection documents using the native `HTMLInputElement` `value` setter, then firing **`input`** and **`change`**, so synthetic event tracking picks up the update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c8e8832fe55ba2ebe0cb88781ea584e7b9398f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->