### PR TITLE
Document Jira project sync mechanisms and live issue status

### DIFF
--- a/docs/cloud/integrations/jira.mdx
+++ b/docs/cloud/integrations/jira.mdx
@@ -102,6 +102,14 @@ per organization.
      alt="Jira integration completed view in Cypress Cloud showing connected projects"
    />
 
+## How project data stays in sync
+
+Cypress keeps the list of available Jira projects current through three mechanisms:
+
+- **On install:** When the Cypress app is first connected to a Jira site, it automatically pulls in all accessible projects in the background.
+- **Real-time updates:** Jira pushes changes to Cypress whenever projects are created, renamed, archived, or deleted, so the list stays current without any user action.
+- **Manual sync:** The **Sync** button in the integration settings lets you trigger an on-demand refresh if something looks out of date.
+
 ## Create a Jira issue from a test
 
 You can file a Jira issue from any test result. Here is how to do it for a failing test:
@@ -163,7 +171,7 @@ After an issue is created or linked for a test, you can review it from the test'
 
 1. Find the **Jira issue** section and expand it.
 
-Inside the expanded section, click the issue to open it directly in Jira. The section also lists **assignee**, **status**, and **date created** for that ticket so you can triage from the test result without copying keys into Jira manually.
+Inside the expanded section, click the issue to open it directly in Jira. The section also lists **assignee**, **status**, and **date created** for that ticket so you can triage from the test result without copying keys into Jira manually. The issue status is fetched live from Jira each time you view the test result, so it always reflects the current state of the ticket rather than a cached snapshot.
 
 <DocsImage
   src="/img/cloud/integrations/jira/dashboard-jira-integration-inline-issue.png"


### PR DESCRIPTION
## Summary
This PR enhances the Jira integration documentation by explaining how project data synchronization works and clarifying that issue status information is fetched live from Jira.

## Key Changes
- **Added new section "How project data stays in sync"** that documents three synchronization mechanisms:
  - Automatic project pull on initial app installation
  - Real-time updates via Jira webhooks when projects change
  - Manual sync option via the integration settings button

- **Clarified issue status behavior** in the "Review a Jira issue" section to explicitly state that issue status is fetched live from Jira each time a test result is viewed, rather than being cached

## Notable Details
These documentation updates help users understand:
1. How Cypress keeps Jira project lists current without manual intervention
2. That they can manually trigger a sync if needed
3. That issue status information displayed in test results is always up-to-date and reflects the current state in Jira

https://claude.ai/code/session_01YbD1faqAbKJtdp63DemPRR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to the Jira integration guide with no application or security impact.
> 
> **Overview**
> Adds a **How project data stays in sync** section to the Jira integration docs, describing install-time project import, webhook-driven updates when Jira projects change, and the **Sync** button for manual refresh.
> 
> In **View a linked Jira issue from a test**, clarifies that **status** (with assignee and date created) is loaded from Jira on each view, not from a cached value. Also fixes list formatting for the expanded **Jira issue** instructions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6a76a175d70279f61fd4a1255691b705afa4b4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->