### PR TITLE
Enhance client certificates documentation with mTLS examples and CI guidance

### DIFF
--- a/docs/app/references/client-certificates.mdx
+++ b/docs/app/references/client-certificates.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Configure Client Certificates in Cypress'
-description: 'Configure certificate authority (CA) and client certificates to use within tests on a per-URL basis.'
+description: 'Configure certificate authority (CA) and client certificates to test mTLS (mutual TLS) protected endpoints in Cypress on a per-URL basis.'
 sidebar_label: 'Client Certificates'
 ---
 
@@ -10,12 +10,16 @@ sidebar_label: 'Client Certificates'
 
 Many enterprise, government, and regulated-industry systems require clients to
 present a certificate to authenticate at the TLS layer — before your application
-code even runs. Without this, you face an unpleasant choice: disable certificate
+code even runs. This pattern is called **mutual TLS (mTLS)**: unlike standard
+HTTPS where only the server proves its identity, mTLS requires _both_ sides to
+present certificates, so the server can verify the caller is a trusted client.
+
+Without mTLS support, you face an unpleasant choice: disable certificate
 requirements in your test environment (meaning your tests run against a system
 that doesn't match production), or rely on slow and inconsistent manual testing.
 
 The `clientCertificates` configuration lets you supply the certificates Cypress
-needs to authenticate against these protected endpoints, so your automated E2E
+needs to authenticate against mTLS-protected endpoints, so your automated E2E
 tests exercise the real security boundary. Misconfigurations, expired
 certificates, or changed server requirements get caught in CI — not in
 production, where the cost is highest.
@@ -169,6 +173,139 @@ URL**, you can work around this limitation in a couple of ways:
   files (for example `cypress.alice.config.ts` and `cypress.bob.config.ts`),
   each specifying the appropriate `clientCertificates`, and run them as separate
   test suites.
+
+## Testing mTLS-Protected Endpoints
+
+Once `clientCertificates` is configured, Cypress attaches the correct
+certificate automatically. Your test code looks the same as any other E2E test —
+no special options are required on individual commands.
+
+### Visiting an mTLS endpoint
+
+```js
+// cypress/e2e/mtls.cy.js
+describe('mTLS-protected app', () => {
+  it('loads the dashboard', () => {
+    // Cypress attaches the client cert automatically based on the URL
+    cy.visit('https://secure.example.com/dashboard')
+    cy.get('h1').should('contain', 'Welcome')
+  })
+})
+```
+
+### Making API requests to an mTLS endpoint
+
+[`cy.request()`](/api/commands/request) also benefits from the configured
+certificates, making it straightforward to test REST APIs behind mTLS:
+
+```js
+describe('mTLS API', () => {
+  it('returns 200 for an authenticated request', () => {
+    cy.request('GET', 'https://api.example.com/data').then((response) => {
+      expect(response.status).to.eq(200)
+    })
+  })
+
+  it('returns the expected payload', () => {
+    cy.request('POST', 'https://api.example.com/records', { name: 'test' }).its(
+      'body.id'
+    ).should('be.a', 'string')
+  })
+})
+```
+
+:::tip
+
+A `400 Bad Request` response (or a TLS handshake error in the Cypress log) when
+hitting an endpoint is the most common sign that the client certificate was not
+presented. Double-check that the `url` pattern in `clientCertificates` matches
+the full URL of your target — including any port number if the server runs on a
+non-standard port (e.g. `https://secure.example.com:8443/**`).
+
+:::
+
+## Debugging Certificate Issues
+
+### Inspecting the Cypress log
+
+When Cypress makes a request to a URL that matches a `clientCertificates`
+entry, it logs `clientCertificates` details in the **Cypress App** network
+panel. Open the panel and look for the lock icon next to the matching request
+to confirm that a certificate was attached.
+
+### Common errors
+
+| Symptom | Likely cause |
+| ------- | ------------ |
+| `400 Bad Request` from server | Certificate not presented — URL pattern mismatch |
+| `SSL_ERROR_HANDSHAKE_FAILURE` | Wrong certificate, expired cert, or CA chain mismatch |
+| `ENOENT: no such file or directory` | Certificate file path is incorrect or relative path is wrong |
+| `bad decrypt` / `wrong final block length` | Passphrase file content is incorrect or has trailing whitespace |
+| Certificate works locally but not in CI | Certificate files not committed or not present at the expected path in CI |
+
+### Verifying your certificate files
+
+You can verify that your `.pem` certificate and key are a matching pair before
+running Cypress:
+
+```shell
+# Confirm the public key fingerprints match
+openssl x509 -noout -modulus -in certs/cert.pem | openssl md5
+openssl rsa  -noout -modulus -in certs/private.key | openssl md5
+
+# Inspect a PFX container
+openssl pkcs12 -info -in certs/cert.pfx -nokeys
+```
+
+## Using Client Certificates in CI
+
+### Storing certificates securely
+
+Never commit unencrypted private keys to your repository. Instead, store
+certificate material as **CI secrets** and write them to disk at the start of
+your pipeline.
+
+**GitHub Actions example:**
+
+```yaml
+- name: Write client certificates
+  run: |
+    mkdir -p certs
+    echo "${{ secrets.CLIENT_CERT }}"       | base64 --decode > certs/cert.pem
+    echo "${{ secrets.CLIENT_KEY }}"        | base64 --decode > certs/private.key
+    echo "${{ secrets.CLIENT_PASSPHRASE }}" > certs/pem-passphrase.txt
+```
+
+Then reference those paths in `cypress.config.ts`:
+
+```ts
+clientCertificates: [
+  {
+    url: 'https://secure.example.com/**',
+    certs: [
+      {
+        cert: 'certs/cert.pem',
+        key: 'certs/private.key',
+        passphrase: 'certs/pem-passphrase.txt',
+      },
+    ],
+  },
+]
+```
+
+### Adding the certificates directory to `.gitignore`
+
+```
+# .gitignore
+certs/
+```
+
+:::caution
+
+Make sure the `certs/` directory (or whichever path you use) is in `.gitignore`
+so that private keys are never accidentally committed.
+
+:::
 
 ## History
 

--- a/docs/app/references/client-certificates.mdx
+++ b/docs/app/references/client-certificates.mdx
@@ -207,9 +207,9 @@ describe('mTLS API', () => {
   })
 
   it('returns the expected payload', () => {
-    cy.request('POST', 'https://api.example.com/records', { name: 'test' }).its(
-      'body.id'
-    ).should('be.a', 'string')
+    cy.request('POST', 'https://api.example.com/records', { name: 'test' })
+      .its('body.id')
+      .should('be.a', 'string')
   })
 })
 ```
@@ -235,13 +235,13 @@ to confirm that a certificate was attached.
 
 ### Common errors
 
-| Symptom | Likely cause |
-| ------- | ------------ |
-| `400 Bad Request` from server | Certificate not presented — URL pattern mismatch |
-| `SSL_ERROR_HANDSHAKE_FAILURE` | Wrong certificate, expired cert, or CA chain mismatch |
-| `ENOENT: no such file or directory` | Certificate file path is incorrect or relative path is wrong |
-| `bad decrypt` / `wrong final block length` | Passphrase file content is incorrect or has trailing whitespace |
-| Certificate works locally but not in CI | Certificate files not committed or not present at the expected path in CI |
+| Symptom                                    | Likely cause                                                              |
+| ------------------------------------------ | ------------------------------------------------------------------------- |
+| `400 Bad Request` from server              | Certificate not presented — URL pattern mismatch                          |
+| `SSL_ERROR_HANDSHAKE_FAILURE`              | Wrong certificate, expired cert, or CA chain mismatch                     |
+| `ENOENT: no such file or directory`        | Certificate file path is incorrect or relative path is wrong              |
+| `bad decrypt` / `wrong final block length` | Passphrase file content is incorrect or has trailing whitespace           |
+| Certificate works locally but not in CI    | Certificate files not committed or not present at the expected path in CI |
 
 ## Using Client Certificates in CI
 

--- a/docs/app/references/client-certificates.mdx
+++ b/docs/app/references/client-certificates.mdx
@@ -243,20 +243,6 @@ to confirm that a certificate was attached.
 | `bad decrypt` / `wrong final block length` | Passphrase file content is incorrect or has trailing whitespace |
 | Certificate works locally but not in CI | Certificate files not committed or not present at the expected path in CI |
 
-### Verifying your certificate files
-
-You can verify that your `.pem` certificate and key are a matching pair before
-running Cypress:
-
-```shell
-# Confirm the public key fingerprints match
-openssl x509 -noout -modulus -in certs/cert.pem | openssl md5
-openssl rsa  -noout -modulus -in certs/private.key | openssl md5
-
-# Inspect a PFX container
-openssl pkcs12 -info -in certs/cert.pfx -nokeys
-```
-
 ## Using Client Certificates in CI
 
 ### Storing certificates securely


### PR DESCRIPTION
## Summary
This PR significantly expands the client certificates documentation to provide clearer explanations of mTLS (mutual TLS) concepts, practical testing examples, and comprehensive guidance for using certificates in CI/CD environments.

## Key Changes
- **Improved description**: Updated the meta description to explicitly mention mTLS testing
- **Enhanced introduction**: Added explanation of what mTLS is and how it differs from standard HTTPS, clarifying the mutual authentication requirement
- **New "Testing mTLS-Protected Endpoints" section**: 
  - Added practical examples for visiting mTLS endpoints with `cy.visit()`
  - Included examples for making API requests with `cy.request()` to mTLS-protected endpoints
  - Added a tip about common debugging signs (400 Bad Request, TLS handshake errors)
- **New "Debugging Certificate Issues" section**:
  - Instructions for inspecting the Cypress log and network panel
  - Comprehensive troubleshooting table mapping symptoms to likely causes
- **New "Using Client Certificates in CI" section**:
  - Best practices for securely storing certificates as CI secrets
  - GitHub Actions example showing how to decode and write certificates to disk
  - Configuration example referencing the certificate paths
  - `.gitignore` guidance to prevent accidental private key commits

## Notable Details
- All examples use realistic domain names and demonstrate both page navigation and API testing scenarios
- The debugging section covers the most common failure modes developers encounter
- CI guidance emphasizes security best practices (base64 encoding, secrets management, .gitignore)
- Added caution notice about preventing private key commits to version control

https://claude.ai/code/session_012HkBfGGwauhmPD6kdxjPpj

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or security logic modifications.
> 
> **Overview**
> Expands **`client-certificates.mdx`** so readers can frame **mTLS** clearly and run tests without guessing at setup.
> 
> The **meta description** and **intro** now name mutual TLS and contrast it with one-way HTTPS; wording shifts from generic “protected endpoints” to **mTLS-protected** targets.
> 
> New sections add **worked examples** (`cy.visit`, `cy.request`), a **tip** on URL pattern / port mismatches, **debugging** (network panel lock icon plus a symptom→cause table), and **CI** guidance (GitHub Actions secret → disk, `cypress.config.ts` paths, `.gitignore` for `certs/` with a caution on private keys).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 025b1673ba15ab7407795bf3f766ef107f847a21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->