### PR TITLE
docs: recommend bun pm trust cypress for Bun postinstall

### DIFF
--- a/docs/app/get-started/install-cypress.mdx
+++ b/docs/app/get-started/install-cypress.mdx
@@ -113,7 +113,13 @@ bun install --ignore-scripts
 bunx cypress install
 ```
 
-Alternatively, add `cypress` to `trustedDependencies` in `package.json` so Bun runs the `postinstall` script on install:
+Alternatively, trust Cypress so Bun runs the `postinstall` script on install. You can use the CLI:
+
+```shell
+bun pm trust cypress
+```
+
+Or add `cypress` to `trustedDependencies` in `package.json` manually:
 
 ```json title="package.json"
 {


### PR DESCRIPTION
## Summary
- Documents `bun pm trust cypress` as the preferred way to allow Bun to run Cypress postinstall scripts
- Keeps the manual `trustedDependencies` option in `package.json` as an alternative

## Test plan
- [x] Verify the Bun configuration section renders correctly on the install page
- [x] Confirm `bun pm trust cypress` and manual `trustedDependencies` examples are both present


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to installation guidance; no runtime, auth, or data-handling code is affected.
> 
> **Overview**
> The **Bun configuration** section on the install page now documents **`bun pm trust cypress`** as the CLI way to allow Cypress’s `postinstall` when `bun install` skips untrusted lifecycle scripts (e.g. in CI).
> 
> The manual **`trustedDependencies`** entry in `package.json` remains, but the doc presents it as an alternative after the CLI option instead of being the only non–`--ignore-scripts` path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 657a5bd80022387dc4493b3e9265bb9ed916629b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->