### PR TITLE
docs: Firefox video recording support

### DIFF
--- a/docs/app/guides/screenshots-and-videos.mdx
+++ b/docs/app/guides/screenshots-and-videos.mdx
@@ -53,8 +53,6 @@ for more details.
 
 ## Videos
 
-<VideoRecordingSupportedBrowsers />
-
 Video recording is disabled by default, but can be turned on by setting
 [`video`](/app/references/configuration#Videos) to `true` from within your
 configuration.

--- a/docs/app/references/configuration.mdx
+++ b/docs/app/references/configuration.mdx
@@ -126,8 +126,6 @@ For more options regarding screenshots, view the
 
 ### Videos
 
-<VideoRecordingSupportedBrowsers />
-
 | Option                  | Default          | Description                                                                                                                                                                                                                                                                                                                                     |
 | ----------------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `trashAssetsBeforeRuns` | `true`           | Whether Cypress will trash assets within the `downloadsFolder`, `screenshotsFolder`, and `videosFolder` before tests run with `cypress run`. This clears the **entire contents** of those folders, including all files and nested subfolders—not only screenshots and videos. [Please read the notes for more details.](#trashAssetsBeforeRuns) |

--- a/docs/partials/_video-recording-supported-browsers.mdx
+++ b/docs/partials/_video-recording-supported-browsers.mdx
@@ -1,9 +1,0 @@
-:::caution
-
-<Icon name="exclamation-triangle" /> Currently, Cypress supports video recording
-for [supported Chromium-based
-browsers](/app/references/launching-browsers#Browsers) (Chrome/Electron/Edge).
-Support for Firefox can be tracked in [this
-issue](https://github.com/cypress-io/cypress/issues/18415).
-
-:::

--- a/src/theme/MDXComponents.js
+++ b/src/theme/MDXComponents.js
@@ -40,7 +40,6 @@ import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 import ThenShouldAndDifference from "@site/docs/partials/_then-should-and-difference.mdx";
 import WarningSetupNodeEvents from "@site/docs/partials/_warning-setup-node-events.mdx";
-import VideoRecordingSupportedBrowsers from "@site/docs/partials/_video-recording-supported-browsers.mdx"
 import ViewFilters from "@site/docs/partials/_viewfilters.mdx";
 import Views from "@site/docs/partials/_views.mdx";
 import LineBreak from "@site/src/components/line-break";
@@ -211,7 +210,6 @@ export default {
   TestReplayInfo,
   ThenShouldAndDifference,
   WarningSetupNodeEvents,
-  VideoRecordingSupportedBrowsers,
   ViewFilters,
   Views,
   Logo,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or security impact.
> 
> **Overview**
> Updates Cypress docs to reflect **Firefox video recording** by removing the shared caution that limited `cypress run` video to Chromium-based browsers from the screenshots/videos guide, configuration reference, and theme partials.
> 
> Also documents **Bun** alongside npm/Yarn/pnpm (install, CLI, CI, plugins, cache/uninstall) and expands **`Cypress.expose()`** with suite/test `{ expose: { ... } }` overrides, cross-links in test-configuration pages, and a **15.17.0** changelog entry for that API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e03548d17b8fc5cd25be767bc39335f4fb86160. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->