### PR TITLE
Note Cloud MCP is GA

### DIFF
--- a/docs/cloud/features/cypress-ai-features.mdx
+++ b/docs/cloud/features/cypress-ai-features.mdx
@@ -158,6 +158,8 @@ Error Summaries are available on all Cypress Cloud plans at no additional cost.
 
 Cloud MCP is a remote server that gives AI assistants a direct window into your application's health and stability. By connecting your AI coding assistant or AI agent directly to your CI results, it transforms Cypress from a testing tool into a real-time engineering data source—removing the manual overhead that makes testing a bottleneck.
 
+Since May 20, 2026, Cloud MCP has been generally available on all Cypress Cloud plans at no additional cost.
+
 Instead of spending time investigating runs, your assistant uses the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) to independently monitor and analyze recorded run data, including errors, stack traces, Test Replay links, accessibility violations, and UI Coverage gaps. This makes it easier to reach for Cypress as your tool of choice.
 
 Read the [Cloud MCP documentation →](/cloud/integrations/cloud-mcp)

--- a/docs/cloud/integrations/cloud-mcp.mdx
+++ b/docs/cloud/integrations/cloud-mcp.mdx
@@ -14,6 +14,12 @@ Cypress Cloud's Model Context Protocol (MCP) server connects your AI coding assi
 
 By eliminating the context gap between CI and your editor, you remove the manual triage that makes testing a bottleneck. Cloud MCP gives your AI agent real-time access to your test results. It allows agents to query run statuses, identify flaky tests, and retrieve failure details—including Test Replay links—directly within your agentic workflow.
 
+:::note
+
+Cloud MCP reached general availability on May 20, 2026. It is included on every Cypress Cloud plan at no additional cost.
+
+:::
+
 ## How it Works
 
 The [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) is an open standard that enables AI models to safely access external data and tools.
@@ -465,6 +471,8 @@ If you previously configured Cloud MCP with a PAT and want to switch to OAuth:
 Cloud MCP is available for free to all Cypress Cloud plans, including the Starter plan. We believe AI-assisted debugging should be accessible to every developer building with Cypress.
 
 No minimum Cypress App version is required to get started.
+
+Cloud MCP reached generally available on May 20th, 2026.
 
 ### Usage Limits
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only wording changes with no product, auth, or runtime impact.
> 
> **Overview**
> Documents that **Cloud MCP** reached **general availability on May 20, 2026** and is included on every Cypress Cloud plan at no extra cost.
> 
> Adds this message in the Cypress AI features overview (`cypress-ai-features.mdx`) and on the dedicated Cloud MCP page (`cloud-mcp.mdx`)—including a top-of-page note and a line under **Pricing & Availability**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8822a170b21b0753264e95b76d58b7bd120f52e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->