### PR TITLE
Add deprecation notice for Microsoft Office 365 Connectors

### DIFF
--- a/docs/cloud/integrations/teams.mdx
+++ b/docs/cloud/integrations/teams.mdx
@@ -30,6 +30,16 @@ directly in your Microsoft Teams channels.
   width={800}
 />
 
+:::note
+
+**Microsoft connector deprecation notice**: Microsoft deprecated its legacy
+Office 365 Connectors (the old "Incoming Webhook" connector) in favor of the
+[Workflows app](https://support.microsoft.com/en-us/office/workflows-app-in-microsoft-teams-926dfc04-3d4f-4723-a612-a5c24e33cf7e).
+The setup instructions below use the Workflows-based webhook, which is the
+current, supported approach and will continue to work.
+
+:::
+
 ## Enable the Microsoft Teams integration
 
 :::caution


### PR DESCRIPTION
## Summary
Added a deprecation notice to the Microsoft Teams integration documentation to inform users about Microsoft's deprecation of legacy Office 365 Connectors in favor of the Workflows app.

## Key Changes
- Added a note section in the Teams integration documentation explaining that Microsoft deprecated its legacy Office 365 Connectors (Incoming Webhook connector)
- Clarified that the setup instructions use the current, supported Workflows-based webhook approach
- Included a link to Microsoft's official Workflows app documentation for reference

## Details
This change improves documentation clarity by proactively communicating the deprecation status to users and reassuring them that the documented approach (Workflows-based webhook) is the current, supported method that will continue to work.

https://claude.ai/code/session_01Px1APowFWPvQZ94qUg5tLy

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the Teams integration page; no runtime, auth, or integration code affected.
> 
> **Overview**
> Adds a **:::note** block near the top of the Microsoft Teams integration doc (`teams.mdx`) so readers know Microsoft deprecated legacy **Office 365 Connectors** (the old Incoming Webhook connector) in favor of the **Workflows** app, with a link to Microsoft’s Workflows documentation.
> 
> The note states that the existing setup steps already use the **Workflows-based webhook** as the supported path that will keep working—documentation-only; no product or integration behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d45414c77722ce7c32a81023ac4b22e7d4848cff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->