### PR TITLE
Add Cloud MCP url to URL allowlist

### DIFF
--- a/docs/partials/_url_allowlist.mdx
+++ b/docs/partials/_url_allowlist.mdx
@@ -13,6 +13,10 @@ If you are running the tests from within a restrictive VPN you will need to allo
 - `https://download.cypress.io` - **CDN download of Cypress binary**
 - `https://on.cypress.io` - **URL shortener for link redirects**
 
+**If you have enabled Cloud MCP] for your organization, you will want to enable:**
+
+- `https://mcp.cypress.io` - **Cypress Cloud MCP**
+
 **If you are using GitHub Enterprise or GitLab for Enterprise (Self-managed), you may also need to add the following to the version control IP allowlist:**
 
 - `3.211.102.119` - **Dedicated IP**

--- a/docs/partials/_url_allowlist.mdx
+++ b/docs/partials/_url_allowlist.mdx
@@ -13,7 +13,7 @@ If you are running the tests from within a restrictive VPN you will need to allo
 - `https://download.cypress.io` - **CDN download of Cypress binary**
 - `https://on.cypress.io` - **URL shortener for link redirects**
 
-**If you have enabled Cloud MCP] for your organization, you will want to enable:**
+**If you have enabled Cloud MCP for your organization, you will want to allow it:**
 
 - `https://mcp.cypress.io` - **Cypress Cloud MCP**
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change to a shared MDX partial; no runtime, auth, or infrastructure impact.
> 
> **Overview**
> Documents **`https://mcp.cypress.io`** (Cypress Cloud MCP) in the shared URL allowlist partial used for restrictive VPN/firewall setups.
> 
> The new entry is scoped to orgs that have **Cloud MCP** enabled, alongside the existing Cypress Cloud and API URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4d34629232e5c4f6000b0d4870e493c2394b3f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->