### PR TITLE
update ai feature docs to clarify release status, security info, etc

### DIFF
--- a/docs/api/commands/prompt.mdx
+++ b/docs/api/commands/prompt.mdx
@@ -1073,8 +1073,6 @@ AI capabilities, including `cy.prompt`, are enabled by default for all users on 
 | [15.13.0](/app/references/changelog#15-13-0) | `cy.prompt` moves to beta. Removed `experimentalPromptCommand` flag. |
 | [15.4.0](/app/references/changelog#15-4-0)   | Introduced `cy.prompt` command                                       |
 
----
-
 ## See also
 
 - [Cypress Studio](/app/guides/cypress-studio)

--- a/docs/cloud/features/cypress-ai-features.mdx
+++ b/docs/cloud/features/cypress-ai-features.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Cypress AI'
-description: 'Learn about AI-powered testing tools in Cypress — including cy.prompt(), Studio AI, and Cloud AI features for test generation, self-healing, and failure analysis.'
+description: 'Learn about AI-powered testing capabilities and tools in Cypress — including cy.prompt(), Studio AI, and Cloud AI features for test generation, self-healing, and failure analysis.'
 sidebar_label: 'Cypress AI'
 sidebar_position: 45
 sidebar_custom_props: { 'ai_icon': true, 'new_label': true }
@@ -12,7 +12,7 @@ import Tag from '@cypress-design/react-tag'
 
 # <Icon useCypressIcon name="cypress-studio" size="48" fillColor="indigo-500" /> Cypress AI
 
-Cypress offers AI capabilities across the platform to help teams write tests faster, understand failures more clearly, and keep tests running as apps change. These capabilities are built into the tools you already use - the Cypress App and Cypress Cloud - and are designed to reduce the manual effort that can slow down testing.
+Cypress offers AI capabilities across the platform to help teams write tests faster, understand failures more clearly, and keep tests running as apps change. These capabilities are built into and for the tools you already use - the Cypress App and Cypress Cloud - and are designed to reduce the manual effort that can slow down testing.
 
 This page explains what's available, how each capability fits into your workflow, and how Cypress handles your data.
 
@@ -29,20 +29,36 @@ Cypress AI is designed to solve these problems without changing how you already 
 
 ## How Cypress AI Fits Into the Workflow
 
-Cypress AI are easy-to-use tools across your testing lifecycle. They are woven into the core workflow.
+Cypress AI are easy-to-use capabilities and tools across your testing lifecycle. They are woven into the core workflow.
 
-| Stage              | AI Capability               | Outcome                                                                                               |
-| ------------------ | --------------------------- | ----------------------------------------------------------------------------------------------------- |
-| Author Tests       | cy.prompt(), Studio AI      | Generate commands, assertions, and full tests from natural language or UI exploration                 |
-| Understand Tests   | Test Intent Summaries       | Quickly see what tests verify, reducing cognitive load and onboarding friction                        |
-| Debug Failures     | Error Summaries             | AI-powered explanations for what happened when a test failed                                          |
-| Analyze & Triage   | Cloud MCP                   | Gives AI coding assistants and AI agents a direct window into your application's health and stability |
-| Test maintenance   | cy.prompt()                 | Automatically adapt to UI changes that would otherwise break selectors                                |
-| Fill Coverage Gaps | UI Coverage Test Generation | Identify untested flows and automatically generate new tests                                          |
+Cypress AI includes two categories of functionality, and they have different default behaviors by design.
 
-## Get Started
+- **AI Capabilities**: features built into Cypress that operate within the platform and are enabled by default.
+- **AI Tooling:** interfaces, integrations, and packaged behaviors that enable AI agents and assistants to work with Cypress. You must opt-in to use these tools.
 
-Log into your Cloud account to start using Cloud AI. By default, all AI capabilities are enabled for your organization.
+### AI Capabilities
+
+| When To Use        | AI Capability               | Outcome                                                                               |
+| ------------------ | --------------------------- | ------------------------------------------------------------------------------------- |
+| Author Tests       | cy.prompt(), Studio AI      | Generate commands, assertions, and full tests from natural language or UI exploration |
+| Understand Tests   | Test Intent Summaries       | Quickly see what tests verify, reducing cognitive load and onboarding friction        |
+| Debug Failures     | Error Summaries             | AI-powered explanations for what happened when a test failed                          |
+| Test maintenance   | cy.prompt()                 | Automatically adapt to UI changes that would otherwise break selectors                |
+| Fill Coverage Gaps | UI Coverage Test Generation | Identify untested flows and automatically generate new tests                          |
+
+### AI Tooling
+
+| When To Use      | AI Tool                                    | Outcome                                                                                               |
+| ---------------- | ------------------------------------------ | ----------------------------------------------------------------------------------------------------- |
+| Author Tests     | `cypress-author` and `cypress-docs` Skills | Improves how AI tools create, update, and fix Cypress tests.                                          |
+| Understand Tests | `cypress-explain` Skill                    | Helps AI describe, and critique existing tests.                                                       |
+| Analyze & Triage | Cloud MCP                                  | Gives AI coding assistants and AI agents a direct window into your application's health and stability |
+
+## Getting Started
+
+AI Capabilities are enabled by default for all users in your organization on an applicable plan. Login to your Cypress Cloud account to get started.
+
+Each AI Tool must be enabled and installed individually. See each tool's documentation for instructions.
 
 ## Capabilities in detail
 
@@ -150,20 +166,6 @@ Error Summaries are available on all Cypress Cloud plans at no additional cost.
   alt="Test sidebar attempts and errors"
 />
 
-### Cloud MCP
-
-:::note
-**Best for:** teams moving toward agentic workflows who want to eliminate the context gap between their CI environment and their development tools.
-:::
-
-Cloud MCP is a remote server that gives AI assistants a direct window into your application's health and stability. By connecting your AI coding assistant or AI agent directly to your CI results, it transforms Cypress from a testing tool into a real-time engineering data source—removing the manual overhead that makes testing a bottleneck.
-
-Since May 20, 2026, Cloud MCP has been generally available on all Cypress Cloud plans at no additional cost.
-
-Instead of spending time investigating runs, your assistant uses the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) to independently monitor and analyze recorded run data, including errors, stack traces, Test Replay links, accessibility violations, and UI Coverage gaps. This makes it easier to reach for Cypress as your tool of choice.
-
-Read the [Cloud MCP documentation →](/cloud/integrations/cloud-mcp)
-
 ### UI Coverage Test Generation
 
 :::note
@@ -180,6 +182,37 @@ This capability is included with UI Coverage and is not available on standard Cl
 />
 
 [Read the UI Coverage Test Generation documentation →](/ui-coverage/guides/address-coverage-gaps#Generate-tests-from-UI-Coverage-reports)
+
+## AI Tools in detail
+
+### AI Skills
+
+:::note
+**Best for:** teams wanting to providing instructions to improve the output of AI when working with Cypress.
+:::
+
+Use skills when you want your AI tool to:
+
+- Apply Cypress best practices to generated and reviewed tests
+- Steer away from brittle patterns and weak selectors
+- Produce more Cypress-focused explanations and critiques
+- Establish consistent AI behavior across your team and workflows
+
+[Read the AI Skills documentation →](/app/tooling/ai-skills)
+
+### Cloud MCP
+
+:::note
+**Best for:** teams moving toward agentic workflows who want to eliminate the context gap between their CI environment and their development tools.
+:::
+
+Cloud MCP is a remote server that gives AI assistants a direct window into your application's health and stability. By connecting your AI coding assistant or AI agent directly to your CI results, it transforms Cypress from a testing tool into a real-time engineering data source—removing the manual overhead that makes testing a bottleneck.
+
+Since May 20, 2026, Cloud MCP has been generally available on all Cypress Cloud plans at no additional cost.
+
+Instead of spending time investigating runs, your assistant uses the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) to independently monitor and analyze recorded run data, including errors, stack traces, Test Replay links, accessibility violations, and UI Coverage gaps. This makes it easier to reach for Cypress as your tool of choice.
+
+Read the [Cloud MCP documentation →](/cloud/integrations/cloud-mcp)
 
 ## FAQs
 
@@ -204,13 +237,14 @@ Free accounts include a two-week trial of all paid features, including higher AI
 
 Usage limits vary by feature and plan. During beta periods, limits are subject to change.
 
-| Capability                  | Free plan              | Paid plan                 |
+| Capability / Tool           | Free plan              | Paid plan                 |
 | --------------------------- | ---------------------- | ------------------------- |
 | cy.prompt() prompts         | 100 per hour, per user | 600 per hour, per user    |
 | cy.prompt() steps           | 500 per hour, per user | 3,000 per hour, per user  |
 | Studio AI recommendations   | 60 per hour, per user  | 300 per hour, per user    |
 | Test Intent Summaries       | Included               | Included                  |
 | Error Summaries             | Included               | Included                  |
+| AI Skills                   | unlimited              | unlimited                 |
 | Cloud MCP requests          | 100 per hour, per user | 100 per hour, per user    |
 | UI Coverage Test Generation | Not available          | Included with UI Coverage |
 
@@ -218,9 +252,27 @@ If you need to increase your limits, contact support at support@cypress.io.
 
 ### Pricing
 
-During experimental and beta periods, AI features are provided at no additional charge. Pricing is subject to change. We will communicate any changes before they take effect.
+AI Skills are available to all Cypress users.
+
+Cloud MCP, Test Intent Summaries and Error Summaries are available for free to all Cypress Cloud plans, including the Starter plan.
+
+UI Coverage Test Generation is included with UI Coverage premium solutions subscriptions.
+
+Studio AI recommendations and `cy.prompt()`, during beta periods, are provided at no additional charge. Pricing is subject to change. We will communicate any changes before they take effect.
 
 See [Cypress Cloud plans](https://www.cypress.io/pricing) for full plan details.
+
+### Release Status
+
+| Capability / Tool           | Release Status      |
+| --------------------------- | ------------------- |
+| cy.prompt()                 | Beta                |
+| Studio AI recommendations   | Beta                |
+| Test Intent Summaries       | Generally Available |
+| Error Summaries             | Generally Available |
+| AI Skills                   | Generally Available |
+| Cloud MCP                   | Generally Available |
+| UI Coverage Test Generation | Generally Available |
 
 ### Security and data handling
 
@@ -228,17 +280,23 @@ See [Cypress Cloud plans](https://www.cypress.io/pricing) for full plan details.
 
 ### Disabling AI features
 
-**AI features are opt-out, not opt-in by default.** AI capabilities are enabled for all users of an organization on the applicable plan. Organization admins and owners can disable AI capabilities for their entire organization from Cypress Cloud organization settings.
+**AI Capabilities** are enabled by default for all users in your organization on an applicable plan. Organization admins and owners can disable them from Cypress Cloud organization settings.
 
 <DocsImage
   src="/img/faq/questions/cypress-ai-org-setting.png"
   alt="Cypress AI organization setting in Cypress Cloud"
 />
 
+**AI tools** must be installed individually and are not enabled by default. To stop using an AI Tool, remove it from your AI client's configuration.
+
+Cloud MCP can be disabled for an organization in the organization's Integrations page. Disabling the integration immediately revokes access for all users in that organization, regardless of whether they authenticated via OAuth or a personal access token.
+
 ## See also
 
 - [cy.prompt()](/api/commands/prompt)
 - [Cypress Studio AI](/app/guides/cypress-studio)
+- [Cloud MCP](/cloud/integrations/cloud-mcp)
+- [AI Skills](/app/tooling/ai-skills)
 - [UI Coverage Test Generation](/ui-coverage/guides/address-coverage-gaps#Generate-tests-from-UI-Coverage-reports)
 - [Recorded Runs](/cloud/features/recorded-runs)
 - [Cypress AI Security](https://on.cypress.io/ai-security)

--- a/docs/cloud/features/cypress-ai-features.mdx
+++ b/docs/cloud/features/cypress-ai-features.mdx
@@ -14,6 +14,11 @@ import Tag from '@cypress-design/react-tag'
 
 Cypress offers AI capabilities across the platform to help teams write tests faster, understand failures more clearly, and keep tests running as apps change. These capabilities are built into and for the tools you already use - the Cypress App and Cypress Cloud - and are designed to reduce the manual effort that can slow down testing.
 
+Cypress AI includes two categories of functionality, and they have different default behaviors by design.
+
+- **AI Capabilities**: features built into Cypress that operate within the platform and are enabled by default.
+- **AI Tooling:** interfaces, integrations, and packaged behaviors that enable AI agents and assistants to work with Cypress. You must opt-in to use these tools.
+
 This page explains what's available, how each capability fits into your workflow, and how Cypress handles your data.
 
 ## The Problem Developers Face
@@ -27,14 +32,15 @@ Writing tests, maintaining them, and debugging failures is time-consuming and re
 
 Cypress AI is designed to solve these problems without changing how you already work.
 
+## Getting Started
+
+AI Capabilities are enabled by default for all users in your organization on an applicable plan. Login to your Cypress Cloud account to get started.
+
+Each AI Tool must be enabled and installed individually. See each tool's documentation for instructions.
+
 ## How Cypress AI Fits Into the Workflow
 
 Cypress AI are easy-to-use capabilities and tools across your testing lifecycle. They are woven into the core workflow.
-
-Cypress AI includes two categories of functionality, and they have different default behaviors by design.
-
-- **AI Capabilities**: features built into Cypress that operate within the platform and are enabled by default.
-- **AI Tooling:** interfaces, integrations, and packaged behaviors that enable AI agents and assistants to work with Cypress. You must opt-in to use these tools.
 
 ### AI Capabilities
 
@@ -46,19 +52,13 @@ Cypress AI includes two categories of functionality, and they have different def
 | Test maintenance   | cy.prompt()                 | Automatically adapt to UI changes that would otherwise break selectors                |
 | Fill Coverage Gaps | UI Coverage Test Generation | Identify untested flows and automatically generate new tests                          |
 
-### AI Tooling
+### AI Tools
 
 | When To Use      | AI Tool                                    | Outcome                                                                                               |
 | ---------------- | ------------------------------------------ | ----------------------------------------------------------------------------------------------------- |
 | Author Tests     | `cypress-author` and `cypress-docs` Skills | Improves how AI tools create, update, and fix Cypress tests.                                          |
 | Understand Tests | `cypress-explain` Skill                    | Helps AI describe, and critique existing tests.                                                       |
 | Analyze & Triage | Cloud MCP                                  | Gives AI coding assistants and AI agents a direct window into your application's health and stability |
-
-## Getting Started
-
-AI Capabilities are enabled by default for all users in your organization on an applicable plan. Login to your Cypress Cloud account to get started.
-
-Each AI Tool must be enabled and installed individually. See each tool's documentation for instructions.
 
 ## Capabilities in detail
 

--- a/docs/cloud/integrations/cloud-mcp.mdx
+++ b/docs/cloud/integrations/cloud-mcp.mdx
@@ -484,9 +484,21 @@ If you need to increase your limits, contact support at support@cypress.io.
 
 ### Security & Privacy
 
-- **Read-Only Access:** The Cloud MCP server is designed for data retrieval and debugging. It cannot modify your test code or delete runs.
-- **User-Scoped:** The AI only sees the projects and data that your specific Cypress Cloud user has permission to access. Whether you're part of a specific team or just have access to certain projects, your AI assistant stays within those same boundaries.
-- **Local Control:** You control exactly when the server is active by managing the configuration in your local AI client.
+Cloud MCP is an API for AI agents. When your AI assistant needs information about your Cypress test runs, it calls Cloud MCP the same way any application calls an API — it sends a request, and Cypress returns data.
+
+**What Cypress can and cannot see:**
+
+- **Cypress cannot see your AI conversation:** Cypress has no access to your AI assistant's context window, chat history, or anything it generates. The only thing Cypress receives are the inputs to a tool call — for example, `getRuns(projectId: 100, runNumber: 45, limit: 10)`.
+- **Cypress does not train on your data:** Test results, stack traces, and replay links returned through Cloud MCP are used only to fulfill the request. Your data is never used to train or improve any LLM.
+- **You control the connection:** Cloud MCP is opt-in. Enabling it means your AI assistant can request Cypress data and enabling the integration does not give Cypress any visibility into your AI's context, conversation, or outputs.
+
+**How access is controlled:**
+
+- **Read-only:** Cloud MCP is designed for data retrieval and debugging. It cannot modify your test code or delete runs.
+- **User-scoped:** Your AI assistant can only access the projects and data your Cypress Cloud user has permission to see. It operates within the same access boundaries as you do.
+- **Locally managed:** You control when the server is active by managing the configuration in your local AI client.
+
+Cloud MCP implements the standard MCP authorization specification with OAuth 2.0 and uses streamable HTTP transport. It falls under our [AI security practices →](https://on.cypress.io/ai-security)
 
 ### Remove the integration
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or auth logic modifications.
> 
> **Overview**
> This PR **reorganizes the Cypress AI overview** to separate **AI Capabilities** (enabled by default in Cloud) from **AI Tooling** (opt-in: AI Skills, Cloud MCP). Workflow tables, getting started, pricing, usage limits, and disable instructions are updated to match that split; **Cloud MCP** and **AI Skills** get dedicated sections and cross-links.
> 
> It adds a **Release Status** table (e.g. `cy.prompt` and Studio AI as Beta; summaries, Skills, Cloud MCP, UI Coverage generation as GA) and clarifies **org vs per-client** controls for turning features off, including org-level Cloud MCP disable on Integrations.
> 
> **Cloud MCP** security docs are expanded to explain tool-call-only visibility, no LLM training on returned data, read-only user-scoped access, and OAuth/streamable HTTP under AI security practices. **`prompt.mdx`** has a trivial History table whitespace fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2a8c826f67040c17d3f478568818aefb6562acc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->