### PR TITLE
Add cypress-conditional-tags community plugin

### DIFF
--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -381,6 +381,13 @@
             "sharding"
           ],
           "badge": "community"
+        },
+        {
+          "name": "cypress-conditional-tags",
+          "description": "Access runtime tags (CLI) and test tags (config) inside Cypress test logic to build context-aware conditional behavior.",
+          "link": "https://github.com/JaydipManiya/cypress-conditional-tags",
+          "keywords": ["tags", "cli"],
+          "badge": "community"
         }
       ]
     },


### PR DESCRIPTION
Adds cypress-conditional-tags to the Cypress community plugins list.

Plugin purpose:
Access runtime tags (CLI) and test tags (config) inside Cypress test logic to enable context-aware conditional behavior.

Repository:
https://github.com/JaydipManiya/cypress-conditional-tags

NPM:
https://www.npmjs.com/package/cypress-conditional-tags