### PR TITLE
docs: add Angular 22 component testing support for 15.18.0

### DIFF
--- a/docs/app/component-testing/angular/api.mdx
+++ b/docs/app/component-testing/angular/api.mdx
@@ -14,7 +14,7 @@ sidebar_label: API
 ### mount
 
 ```js
-// for Angular 20 and 21 using zoneless configuration
+// for Angular 20, 21, and 22 using zoneless configuration
 import { mount } from 'cypress/angular-zoneless'
 ```
 

--- a/docs/app/component-testing/angular/overview.mdx
+++ b/docs/app/component-testing/angular/overview.mdx
@@ -20,12 +20,12 @@ sidebar_label: Overview
 
 ## Framework Support
 
-Cypress Component Testing supports Angular `^18.0.0`, `^19.0.0`, `^20.0.0`, and `^21.0.0`.
+Cypress Component Testing supports Angular `^18.0.0`, `^19.0.0`, `^20.0.0`, `^21.0.0`, and `^22.0.0`.
 
 :::info
 
 Our testing harness, `cypress/angular`, still requires `zone.js` and `@angular-devkit/build-angular` to be installed in your project, even if your project is zoneless or is built with `@angular/build`.
-If you wish to use the zoneless configuration, which is the default in Angular 21, you can use `cypress/angular-zoneless` testing harness instead as of Cypress `15.8.0`.
+If you wish to use the zoneless configuration, which is the default in Angular 21 and 22, you can use `cypress/angular-zoneless` testing harness instead as of Cypress `15.8.0`.
 :::
 
 ## Tutorial

--- a/docs/app/component-testing/get-started.mdx
+++ b/docs/app/component-testing/get-started.mdx
@@ -62,7 +62,7 @@ following development servers and frameworks:
 | [Next.js 14-16](/app/component-testing/react/overview#Nextjs)                                                      | React 18-19   | Webpack 5 |
 | [Vue with Vite](/app/component-testing/vue/overview#Vue-with-Vite)                                                 | Vue 3         | Vite 5-8  |
 | [Vue with Webpack](/app/component-testing/vue/overview#Vue-with-Webpack)                                           | Vue 3         | Webpack 5 |
-| [Angular](/app/component-testing/angular/overview#Framework-Configuration)                                         | Angular 18-21 | Webpack 5 |
+| [Angular](/app/component-testing/angular/overview#Framework-Configuration)                                         | Angular 18-22 | Webpack 5 |
 | [Svelte with Vite](/app/component-testing/svelte/overview#Svelte-with-Vite) <Badge type="info">Alpha</Badge>       | Svelte 5      | Vite 5-8  |
 | [Svelte with Webpack](/app/component-testing/svelte/overview#Svelte-with-Webpack) <Badge type="info">Alpha</Badge> | Svelte 5      | Webpack 5 |
 

--- a/docs/app/references/changelog.mdx
+++ b/docs/app/references/changelog.mdx
@@ -8,6 +8,14 @@ sidebar_label: Changelog
 
 # Changelog
 
+## 15.18.0
+
+_Released TBD_
+
+**Features:**
+
+- `Angular` version 22 is now supported within component testing, including Launchpad project detection and the `@cypress/schematic` Angular CLI integration. Addresses [#33753](https://github.com/cypress-io/cypress/issues/33753). Addressed in [#34043](https://github.com/cypress-io/cypress/pull/34043).
+
 ## 15.16.0
 
 _Released May 26, 2026_

--- a/docs/app/references/changelog.mdx
+++ b/docs/app/references/changelog.mdx
@@ -8,14 +8,6 @@ sidebar_label: Changelog
 
 # Changelog
 
-## 15.18.0
-
-_Released TBD_
-
-**Features:**
-
-- `Angular` version 22 is now supported within component testing, including Launchpad project detection and the `@cypress/schematic` Angular CLI integration. Addresses [#33753](https://github.com/cypress-io/cypress/issues/33753). Addressed in [#34043](https://github.com/cypress-io/cypress/pull/34043).
-
 ## 15.16.0
 
 _Released May 26, 2026_


### PR DESCRIPTION
# NOTE: needs to be based of `release/15.18.0`

## Summary

- Updates Angular component testing framework support to include `^22.0.0`.
- Updates the supported frameworks table in the component testing get-started guide (`Angular 18-22`).
- Notes that zoneless is the default in Angular 21 and 22 in the Angular overview.
- Adds the Cypress App `15.18.0` changelog entry for Angular 22 component testing support.

Related to cypress-io/cypress#34043 and cypress-io/cypress#33753.

## Test plan

- [x] `npm run lint:fix` on changed files
- [ ] `npm run build` (verify no broken links)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, security, or data-handling impact.
> 
> **Overview**
> Documents **Angular 22** (`^22.0.0`) as supported for Cypress component testing alongside existing 18–21 ranges.
> 
> Updates the **Angular overview** framework list, clarifies that **zoneless is the default in Angular 21 and 22**, and extends the **get-started** supported-frameworks table to **Angular 18–22**. The **Angular API** `mount` example comment now references zoneless setup for **Angular 20, 21, and 22**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3475dc1b54e18609bce22a69a783e017aa70aba5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->