### PR TITLE
docs: add Angular 22 component testing support for Cypress 16

### DIFF
--- a/docs/app/component-testing/angular/overview.mdx
+++ b/docs/app/component-testing/angular/overview.mdx
@@ -20,12 +20,12 @@ sidebar_label: Overview
 
 ## Framework Support
 
-Cypress Component Testing supports Angular `^21.0.0`.
+Cypress Component Testing supports Angular `^21.0.0` and `^22.0.0`.
 
 :::info
 
 Our testing harness, `cypress/angular`, requires `@angular-devkit/build-angular` to be installed in your project, even if your project is zoneless or is built with `@angular/build`.
-As of Cypress `16.0.0`, `cypress/angular` supports zoneless testing with no additional configuration. `zone.js` is no longer required.
+As of Cypress `16.0.0`, `cypress/angular` supports zoneless testing with no additional configuration. `zone.js` is no longer required. Zoneless is the default in Angular 21 and 22.
 :::
 
 ## Tutorial

--- a/docs/app/component-testing/get-started.mdx
+++ b/docs/app/component-testing/get-started.mdx
@@ -55,16 +55,16 @@ Cypress currently has official mounting libraries for
 [Svelte](/app/component-testing/svelte/overview) and support for the
 following development servers and frameworks:
 
-| Framework                                                                                                          | UI Library  | Bundler   |
-| ------------------------------------------------------------------------------------------------------------------ | ----------- | --------- |
-| [React with Vite](/app/component-testing/react/overview#React-with-Vite)                                           | React 18-19 | Vite 8    |
-| [React with Webpack](/app/component-testing/react/overview#React-with-Webpack)                                     | React 18-19 | Webpack 5 |
-| [Next.js 15-16](/app/component-testing/react/overview#Nextjs)                                                      | React 18-19 | Webpack 5 |
-| [Vue with Vite](/app/component-testing/vue/overview#Vue-with-Vite)                                                 | Vue 3       | Vite 8    |
-| [Vue with Webpack](/app/component-testing/vue/overview#Vue-with-Webpack)                                           | Vue 3       | Webpack 5 |
-| [Angular](/app/component-testing/angular/overview#Framework-Configuration)                                         | Angular 21  | Webpack 5 |
-| [Svelte with Vite](/app/component-testing/svelte/overview#Svelte-with-Vite) <Badge type="info">Alpha</Badge>       | Svelte 5    | Vite 8    |
-| [Svelte with Webpack](/app/component-testing/svelte/overview#Svelte-with-Webpack) <Badge type="info">Alpha</Badge> | Svelte 5    | Webpack 5 |
+| Framework                                                                                                          | UI Library    | Bundler   |
+| ------------------------------------------------------------------------------------------------------------------ | ------------- | --------- |
+| [React with Vite](/app/component-testing/react/overview#React-with-Vite)                                           | React 18-19   | Vite 8    |
+| [React with Webpack](/app/component-testing/react/overview#React-with-Webpack)                                     | React 18-19   | Webpack 5 |
+| [Next.js 15-16](/app/component-testing/react/overview#Nextjs)                                                      | React 18-19   | Webpack 5 |
+| [Vue with Vite](/app/component-testing/vue/overview#Vue-with-Vite)                                                 | Vue 3         | Vite 8    |
+| [Vue with Webpack](/app/component-testing/vue/overview#Vue-with-Webpack)                                           | Vue 3         | Webpack 5 |
+| [Angular](/app/component-testing/angular/overview#Framework-Configuration)                                         | Angular 21-22 | Webpack 5 |
+| [Svelte with Vite](/app/component-testing/svelte/overview#Svelte-with-Vite) <Badge type="info">Alpha</Badge>       | Svelte 5      | Vite 8    |
+| [Svelte with Webpack](/app/component-testing/svelte/overview#Svelte-with-Webpack) <Badge type="info">Alpha</Badge> | Svelte 5      | Webpack 5 |
 
 The following integrations are built and maintained by Cypress community members.
 

--- a/docs/app/references/changelog.mdx
+++ b/docs/app/references/changelog.mdx
@@ -33,6 +33,10 @@ Refer to the [16 Migration Guide](/app/references/migration-guide#Migrating-to-C
 - The default `keystrokeDelay` for [`cy.type()`](/api/commands/type) has been changed from `10` to `0` to improve performance of typing-heavy test runs. Users who relied on the implicit 10ms delay can restore it by setting `keystrokeDelay: 10` in their [Cypress configuration](/app/references/configuration#Keyboard) or via [`Cypress.Keyboard.defaults()`](/api/cypress-api/keyboard-api). Addresses [#33523](https://github.com/cypress-io/cypress/issues/33523).
 - The experimental `experimentalFastVisibility` flag has been replaced by a new [`visibilityStrategy`](/app/references/configuration#Actionability) configuration option that accepts `'legacy'` or `'modern'` and defaults to `'modern'`. The modern visibility algorithm (based on the browser's native `Element.checkVisibility()` API) is now the default for all users. `visibilityStrategy` is deprecated — set `visibilityStrategy: 'legacy'` only as a temporary migration path. See the [Visibility Strategy](/app/core-concepts/interacting-with-elements#Visibility-Strategy) guide for migration help. Addressed in [#33794](https://github.com/cypress-io/cypress/pull/33794).
 
+**Features:**
+
+- `Angular` version 22 is now supported within component testing, including Launchpad project detection and the `@cypress/schematic` Angular CLI integration. Addresses [#33753](https://github.com/cypress-io/cypress/issues/33753). Addressed in [#34043](https://github.com/cypress-io/cypress/pull/34043).
+
 ## 15.17.0
 
 _Released Jun 9, 2026_


### PR DESCRIPTION
## Summary

Documents Angular 22 (`^22.0.0`) as supported for Cypress component testing in the **Cypress 16.0.0** release line.

- **`angular/overview.mdx`** — framework support now lists `^21.0.0` and `^22.0.0`; notes that zoneless is the default in Angular 21 and 22
- **`get-started.mdx`** — supported frameworks table updated from `Angular 21` to `Angular 21-22`
- **`changelog.mdx`** — adds a **16.0.0 Features** entry for Angular 22 CT support (Launchpad detection and `@cypress/schematic`)

## Why `release/16.0.0` and not `main` / Cypress 15

Angular 22 component testing support is landing in **Cypress 16**, not Cypress 15.18.0.

The original docs PR ([#6561](https://github.com/cypress-io/cypress-documentation/pull/6561)) targeted `main` / a 15.18.0 changelog entry, but was closed alongside [cypress-io/cypress#34043](https://github.com/cypress-io/cypress/pull/34043) because Angular CLI 22 enforces a runtime Node minimum that Cypress 15 CI (Node 22.19.0) cannot satisfy. The implementation was retargeted for Cypress 16 (Node 24.15.0 on `release/16`).

This PR retargets the documentation accordingly: changelog entry under **16.0.0** (not 15.18.0), and support ranges aligned with Cypress 16's Angular 21+ minimum rather than the 15.x 18–22 range.

Related: [cypress-io/cypress#33753](https://github.com/cypress-io/cypress/issues/33753), [cypress-io/cypress#34043](https://github.com/cypress-io/cypress/pull/34043)

## Test plan

- [x] `npm run build` (no broken links)
- [ ] CI passes


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to supported version ranges and changelog; no runtime or product code changes.
> 
> **Overview**
> Documents **Angular 22** (`^22.0.0`) as supported for Cypress **16.0.0** component testing, aligned with the Cypress 16 release line rather than 15.x.
> 
> The **Angular overview** now lists `^21.0.0` and `^22.0.0`, and clarifies that **zoneless is the default in Angular 21 and 22**. The **Get Started** supported-frameworks table changes **Angular 21** to **Angular 21–22**. The **changelog** adds a **16.0.0 Features** bullet for Angular 22 CT support, including Launchpad project detection and `@cypress/schematic`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9a6ca40aabee83a3304b69b8aee644214c45508. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->