### PR TITLE
Remove deprecated environment variable documentation

### DIFF
--- a/docs/app/references/advanced-installation.mdx
+++ b/docs/app/references/advanced-installation.mdx
@@ -32,8 +32,6 @@ sidebar_label: 'Advanced Installation'
 | `CYPRESS_RUN_BINARY`              | [Location of Cypress binary at run-time](#Run-binary)                                          |
 | `CYPRESS_VERIFY_TIMEOUT`          | Overrides the timeout duration for the `verify` command. The default value is 30000.           |
 | `CYPRESS_SKIP_VERIFY`             | Skips the [`verify` command](command-line#cypress-verify) when `true`                          |
-| ~~CYPRESS_SKIP_BINARY_INSTALL~~   | <Badge type="danger">removed</Badge> use `CYPRESS_INSTALL_BINARY=0` instead                    |
-| ~~CYPRESS_BINARY_VERSION~~        | <Badge type="danger">removed</Badge> use `CYPRESS_INSTALL_BINARY` instead                      |
 
 ## Proxy configuration
 


### PR DESCRIPTION
## Summary
Removed documentation for two deprecated environment variables that are no longer supported in the codebase.

## Changes
- Removed `CYPRESS_SKIP_BINARY_INSTALL` from the environment variables reference table with note to use `CYPRESS_INSTALL_BINARY=0` instead
- Removed `CYPRESS_BINARY_VERSION` from the environment variables reference table with note to use `CYPRESS_INSTALL_BINARY` instead

These variables were already marked as removed in the documentation and this change cleans up the reference by eliminating the deprecated entries entirely.

https://claude.ai/code/session_016a8DJK7U5FKLjy5mw5EANK

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or configuration behavior impact.
> 
> **Overview**
> Removes two **deprecated** rows from the environment variables table in `advanced-installation.mdx`: `CYPRESS_SKIP_BINARY_INSTALL` and `CYPRESS_BINARY_VERSION` (previously shown as removed with migration notes to `CYPRESS_INSTALL_BINARY=0` and `CYPRESS_INSTALL_BINARY`).
> 
> The reference now lists only supported variables; skipping install and custom binary/version behavior remain documented under **`CYPRESS_INSTALL_BINARY`** elsewhere on the same page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9513de5c0e6946d4e836b5d8a32927ddaf353138. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->