### PR TITLE
feat(seo): add FAQPage JSON-LD to the Error Messages page

### DIFF
--- a/plugins/faq-structured-data.js
+++ b/plugins/faq-structured-data.js
@@ -2,12 +2,23 @@ const fs = require('fs')
 const path = require('path')
 
 /**
- * FAQ source files mapped to the routes they are published at.
- * `routeBasePath` is '/' for the docs, so docs/app/faq.mdx -> /app/faq.
+ * Source pages mapped to the routes they are published at. `routeBasePath` is
+ * '/' for the docs, so docs/app/faq.mdx -> /app/faq.
+ *
+ * Each entry may set:
+ *   - requireIconHeading: only treat `###` headings that begin with an <Icon>
+ *     as questions. Used by the Error Messages page, where icon-marked
+ *     headings are the actual errors and plain `###` headings are guide
+ *     subsections that should not become FAQ entries.
  */
-const FAQ_PAGES = [
+const STRUCTURED_DATA_PAGES = [
   { route: '/app/faq', file: 'docs/app/faq.mdx' },
   { route: '/cloud/faq', file: 'docs/cloud/faq.mdx' },
+  {
+    route: '/app/references/error-messages',
+    file: 'docs/app/references/error-messages.mdx',
+    requireIconHeading: true,
+  },
 ]
 
 /** Remove the leading YAML frontmatter block, if present. */
@@ -68,6 +79,8 @@ function inlinePartials(content, partialMap, seen = new Set(), depth = 0) {
  */
 function toPlainText(markdown) {
   let text = markdown
+  // Unescape Markdown backslash escapes (e.g. \< \> \* ) to their literals
+  text = text.replace(/\\([\\`*_{}\[\]()#+\-.!<>~|])/g, '$1')
   // Fenced code blocks
   text = text.replace(/```[\s\S]*?```/g, ' ')
   // HTML / MDX comments
@@ -104,8 +117,13 @@ function toPlainText(markdown) {
  * Parse the FAQ body into { question, answer } entries. Each `###` heading is
  * treated as a question; everything until the next `###`, `##` or `#` heading
  * is its answer. Headings inside fenced code blocks are ignored.
+ *
+ * Options:
+ *   - requireIconHeading: when true, only `###` headings that begin with an
+ *     <Icon> become questions; other `###` headings act as section breaks (so
+ *     guide subsections such as "The Problem" are not captured as entries).
  */
-function parseFaq(content) {
+function parseFaq(content, { requireIconHeading = false } = {}) {
   const lines = stripFrontmatter(content).split('\n')
   const entries = []
   let current = null
@@ -118,8 +136,17 @@ function parseFaq(content) {
       continue
     }
     if (!inFence && /^###\s+/.test(line)) {
+      const heading = line.replace(/^###\s+/, '')
+      // With requireIconHeading, a non-icon ### is a section break, not a question.
+      if (requireIconHeading && !/^<Icon[\s/>]/.test(heading)) {
+        if (current) {
+          entries.push(current)
+          current = null
+        }
+        continue
+      }
       if (current) entries.push(current)
-      current = { question: toPlainText(line.replace(/^###\s+/, '')), answerLines: [] }
+      current = { question: toPlainText(heading), answerLines: [] }
       continue
     }
     // An h1/h2 (category header or new section) ends the current answer.
@@ -160,10 +187,10 @@ function buildJsonLd(entries) {
 
 /**
  * Docusaurus plugin that generates FAQPage JSON-LD structured data from the
- * FAQ MDX files and exposes it as global data keyed by route. The swizzled
- * DocItem/Layout reads this and injects the JSON-LD <script> into the page
- * <head> for the matching FAQ routes, making the Q&As eligible for rich
- * results and AI citations.
+ * FAQ and Error Messages MDX files and exposes it as global data keyed by
+ * route. The swizzled DocItem/Layout reads this and injects the JSON-LD
+ * <script> into the page <head> for the matching routes, making the Q&As
+ * eligible for rich results and AI/answer-engine citations.
  */
 module.exports = async function faqStructuredDataPlugin(context) {
   return {
@@ -171,11 +198,13 @@ module.exports = async function faqStructuredDataPlugin(context) {
     async contentLoaded({ actions }) {
       const partialMap = loadPartialMap(context.siteDir)
       const byRoute = {}
-      for (const { route, file } of FAQ_PAGES) {
+      for (const { route, file, requireIconHeading } of STRUCTURED_DATA_PAGES) {
         const absolutePath = path.join(context.siteDir, file)
         if (!fs.existsSync(absolutePath)) continue
         const raw = fs.readFileSync(absolutePath, 'utf8')
-        const entries = parseFaq(inlinePartials(raw, partialMap))
+        const entries = parseFaq(inlinePartials(raw, partialMap), {
+          requireIconHeading,
+        })
         if (entries.length) byRoute[route] = buildJsonLd(entries)
       }
       actions.setGlobalData({ byRoute })

--- a/plugins/faq-structured-data.test.js
+++ b/plugins/faq-structured-data.test.js
@@ -79,6 +79,19 @@ describe('toPlainText', () => {
       'Select Custom > Add from the drawer'
     )
   })
+
+  test('unescapes markdown backslash escapes', () => {
+    expect(toPlainText('version 1\\.0 costs \\#1 priority')).toBe(
+      'version 1.0 costs #1 priority'
+    )
+  })
+
+  test('cleans an escaped angle-bracket placeholder (error title case)', () => {
+    // \< unescapes to <, then <…> is stripped as a tag-like token
+    expect(toPlainText('Queried from element: \\<…>')).toBe(
+      'Queried from element:'
+    )
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -178,6 +191,60 @@ describe('parseFaq', () => {
     expect(parseFaq(content)[0].answer).toBe(
       'First paragraph. Second paragraph.'
     )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// parseFaq with requireIconHeading (Error Messages page)
+// ---------------------------------------------------------------------------
+
+describe('parseFaq with requireIconHeading', () => {
+  test('only icon-led ### headings become entries', () => {
+    const content = [
+      '## Test File Errors',
+      '',
+      '### <Icon name="exclamation-triangle" color="red" /> No tests found',
+      '',
+      'Cypress could not find tests.',
+      '',
+      '## Guide Section',
+      '',
+      '### The Problem',
+      '',
+      'Some explanatory prose that is not an error.',
+      '',
+      '### The Solution',
+      '',
+      'More guide prose.',
+    ].join('\n')
+
+    const result = parseFaq(content, { requireIconHeading: true })
+    expect(result).toEqual([
+      { question: 'No tests found', answer: 'Cypress could not find tests.' },
+    ])
+  })
+
+  test('a non-icon ### acts as a section break for the preceding entry', () => {
+    const content = [
+      '### <Icon name="exclamation-triangle" /> Real error',
+      '',
+      'The real answer.',
+      '',
+      '### Not an error',
+      '',
+      'This guide prose must not leak into the previous answer.',
+    ].join('\n')
+
+    const result = parseFaq(content, { requireIconHeading: true })
+    expect(result).toHaveLength(1)
+    expect(result[0].answer).toBe('The real answer.')
+  })
+
+  test('default behavior (no option) still captures non-icon headings', () => {
+    const content = ['### What is Cloud AI?', '', 'An answer.'].join('\n')
+    expect(parseFaq(content)).toEqual([
+      { question: 'What is Cloud AI?', answer: 'An answer.' },
+    ])
   })
 })
 
@@ -314,47 +381,93 @@ describe('inlinePartials', () => {
 // Integration against the real FAQ source files
 // ---------------------------------------------------------------------------
 
+const siteDir = path.resolve(__dirname, '..')
+
+/** Assert a parsed entry list produces a well-formed FAQPage JSON-LD object. */
+function expectWellFormedFaqPage(entries) {
+  expect(entries.length).toBeGreaterThan(0)
+  const json = buildJsonLd(entries)
+  expect(json['@context']).toBe('https://schema.org')
+  expect(json['@type']).toBe('FAQPage')
+  expect(
+    json.mainEntity.every(
+      (q) =>
+        q['@type'] === 'Question' &&
+        typeof q.name === 'string' &&
+        q.name.length > 0 &&
+        q.acceptedAnswer['@type'] === 'Answer' &&
+        typeof q.acceptedAnswer.text === 'string' &&
+        q.acceptedAnswer.text.length > 0 &&
+        // no leftover JSX/markdown tags should remain in the text
+        !/<[a-zA-Z][^>]*>/.test(q.name) &&
+        !/<[a-zA-Z][^>]*>/.test(q.acceptedAnswer.text)
+    )
+  ).toBe(true)
+}
+
+/** Count ### headings outside of fenced code blocks, optionally icon-led only. */
+function countHeadings(raw, { iconOnly = false } = {}) {
+  let count = 0
+  let inFence = false
+  for (const line of raw.split('\n')) {
+    if (/^\s*```/.test(line)) inFence = !inFence
+    else if (!inFence && /^###\s+/.test(line)) {
+      if (!iconOnly || /^###\s+<Icon[\s/>]/.test(line)) count += 1
+    }
+  }
+  return count
+}
+
 describe('integration with repository FAQ pages', () => {
-  const siteDir = path.resolve(__dirname, '..')
-  const faqFiles = [
-    'docs/app/faq.mdx',
-    'docs/cloud/faq.mdx',
-  ].filter((file) => fs.existsSync(path.join(siteDir, file)))
+  const faqFiles = ['docs/app/faq.mdx', 'docs/cloud/faq.mdx'].filter((file) =>
+    fs.existsSync(path.join(siteDir, file))
+  )
 
   test.each(faqFiles)(
     'every ### heading in %s yields a well-formed FAQPage entry',
     (file) => {
       const partialMap = loadPartialMap(siteDir)
       const raw = fs.readFileSync(path.join(siteDir, file), 'utf8')
-      const inlined = inlinePartials(raw, partialMap)
-      const entries = parseFaq(inlined)
+      const entries = parseFaq(inlinePartials(raw, partialMap))
 
-      // Count ### headings outside of fenced code blocks in the source.
-      let headingCount = 0
-      let inFence = false
-      for (const line of raw.split('\n')) {
-        if (/^\s*```/.test(line)) inFence = !inFence
-        else if (!inFence && /^###\s+/.test(line)) headingCount += 1
-      }
+      expect(entries.length).toBe(countHeadings(raw))
+      expectWellFormedFaqPage(entries)
+    }
+  )
+})
 
-      expect(entries.length).toBe(headingCount)
-      expect(entries.length).toBeGreaterThan(0)
+describe('integration with the Error Messages page', () => {
+  const file = 'docs/app/references/error-messages.mdx'
+  const exists = fs.existsSync(path.join(siteDir, file))
 
-      const json = buildJsonLd(entries)
-      expect(json['@type']).toBe('FAQPage')
+  test.runIf(exists)(
+    'captures only icon-marked errors as well-formed FAQPage entries',
+    () => {
+      const partialMap = loadPartialMap(siteDir)
+      const raw = fs.readFileSync(path.join(siteDir, file), 'utf8')
+      const entries = parseFaq(inlinePartials(raw, partialMap), {
+        requireIconHeading: true,
+      })
+
+      // One entry per icon-marked error heading; plain ### subsections excluded.
+      expect(entries.length).toBe(countHeadings(raw, { iconOnly: true }))
+      expect(entries.length).toBeLessThan(countHeadings(raw))
+
+      // None of the React Hydration guide subsections should leak in.
+      const guideHeadings = [
+        'The Problem',
+        'The Solution',
+        'Framework-Specific Setup',
+        'How It Works',
+        'Troubleshooting',
+        'Caveats and Considerations',
+        'See Also',
+      ]
       expect(
-        json.mainEntity.every(
-          (q) =>
-            q['@type'] === 'Question' &&
-            typeof q.name === 'string' &&
-            q.name.length > 0 &&
-            q.acceptedAnswer['@type'] === 'Answer' &&
-            typeof q.acceptedAnswer.text === 'string' &&
-            q.acceptedAnswer.text.length > 0 &&
-            // no leftover JSX/markdown tags should remain in the answer
-            !/<[a-zA-Z][^>]*>/.test(q.acceptedAnswer.text)
-        )
-      ).toBe(true)
+        entries.some((e) => guideHeadings.some((h) => e.question.startsWith(h)))
+      ).toBe(false)
+
+      expectWellFormedFaqPage(entries)
     }
   )
 })


### PR DESCRIPTION
Extend the structured-data plugin to also emit schema.org FAQPage JSON-LD
for the Error Messages reference page, improving answer-engine (AEO) and
AI-citation ingestion for Cypress error troubleshooting.

- Generalize the plugin's page list and add the Error Messages page with
  a per-page `requireIconHeading` option. Only icon-marked (###) error
  headings become Q&A entries; the React Hydration guide subsections
  ("The Problem", "The Solution", etc.) are excluded as section breaks.
  Each error message becomes the question name (matching the visible,
  searchable heading) and its explanation becomes the answer.
- The FAQ pages keep their existing behavior (Cloud has a legitimate
  icon-less question), so the icon requirement is scoped to the error page.
- Unescape Markdown backslash escapes in toPlainText so titles like
  "Queried from element: \<…>" clean up correctly.
- No layout change needed: the swizzled DocItem/Layout already injects
  JSON-LD for any route present in the plugin's global data.
- Add unit and integration tests for requireIconHeading and the real
  Error Messages page (43 icon-marked errors, guide subsections excluded).

Verified via production build: /app/references/error-messages emits a
valid FAQPage with 43 well-formed entries; FAQ pages unchanged (99 + 67).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NZryoLJphVPm3gG6tFBpMv

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs build-time SEO plugin and test-only changes; no runtime auth, data, or layout behavior beyond injecting JSON-LD for an additional route already supported by the swizzled layout.
> 
> **Overview**
> Adds **FAQPage JSON-LD** for `/app/references/error-messages` by generalizing the plugin page list to `STRUCTURED_DATA_PAGES` and registering that route with **`requireIconHeading: true`**, so only `###` headings that start with `<Icon>` become Q&A pairs while guide subsections like "The Problem" close the current answer instead of becoming questions. Existing App and Cloud FAQ routes keep default parsing (all `###` headings).
> 
> **`toPlainText`** now unescapes Markdown backslash escapes before stripping tags, so error titles with sequences like `\<…>` produce cleaner question names.
> 
> Tests cover `requireIconHeading`, backslash unescaping, shared helpers for well-formed JSON-LD checks, and an integration test against the real error-messages MDX file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8358848b29c501b3f09897e208b404d1f88e03fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->