### PR TITLE
docs: clarify Cypress CSP handling

### DIFF
--- a/docs/app/faq.mdx
+++ b/docs/app/faq.mdx
@@ -1113,6 +1113,67 @@ the Cypress's control. If the application is using `window.location.replace`
 method to set a _relative_ URL, try using the `experimentalSourceRewriting`
 option described in our [Experiments](/app/references/experiments) page.
 
+### <Icon name="angle-right" /> Why isn't my application's Content Security Policy (CSP) being enforced during tests? <E2EOnlyBadge />
+
+This is expected. By default Cypress strips both the `Content-Security-Policy`
+and `Content-Security-Policy-Report-Only` headers from responses before they
+reach the browser, so the policy is never enforced during a test run. This
+prevents a strict CSP from blocking the scripts Cypress injects to drive your
+application.
+
+If you need the policy enforced — for example to test the CSP itself — see
+[How do I test my application's Content Security Policy?](#How-do-I-test-my-applications-Content-Security-Policy)
+below. For the full picture, read the
+[Content Security Policy reference](/app/references/content-security-policy).
+
+### <Icon name="angle-right" /> How do I test my application's Content Security Policy (CSP)? <E2EOnlyBadge /> {#How-do-I-test-my-applications-Content-Security-Policy}
+
+Set the
+[`experimentalCspAllowList`](/app/references/experiments#Experimental-CSP-Allow-List)
+configuration option so Cypress keeps the CSP header instead of stripping it. It
+accepts three values:
+
+- `false` _(default)_ — strip the entire CSP header.
+- `true` — keep the header, removing only the directives that interfere with
+  Cypress.
+- an array of directive names — keep the header and only the named directives.
+
+:::cypress-config-example
+
+```js
+{
+  // keep the header, stripping only Cypress-interfering directives
+  experimentalCspAllowList: true
+}
+```
+
+:::
+
+This option only affects CSP delivered via HTTP headers, requires a Cypress
+server restart to change, and cannot be overridden per test. See the
+[Content Security Policy reference](/app/references/content-security-policy) for
+details, including the directives Cypress modifies or always removes.
+
+### <Icon name="angle-right" /> My scripts are still blocked by CSP even though Cypress strips the header. Why? <E2EOnlyBadge />
+
+The most common cause is that the policy is delivered with a
+[`<meta>` tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#http-equiv)
+rather than an HTTP header. `experimentalCspAllowList` only operates on headers,
+so it cannot allow or strip a meta-tag policy. Look for `Refused to load…` /
+`Refused to execute…` CSP violation messages in the browser console to confirm.
+See the [Content Security Policy reference](/app/references/content-security-policy)
+for how Cypress handles each delivery method.
+
+### <Icon name="angle-right" /> Can I test CSP directives like `frame-ancestors` or `sandbox`? <E2EOnlyBadge />
+
+No. Cypress always removes `frame-ancestors`, `navigate-to`,
+`require-trusted-types-for`, `sandbox`, and `trusted-types` from allowed CSP
+headers — even with `experimentalCspAllowList` enabled — because leaving them in
+place would prevent Cypress from functioning. The behavior of these five
+directives cannot be tested through Cypress and must be verified outside of it.
+See [Always-stripped directives](/app/references/content-security-policy#always-stripped-directives)
+for the full list and the reason each is removed.
+
 ## Continuous Integration (CI/CD)
 
 ### <Icon name="angle-right" /> Why do my Cypress tests pass locally but not in CI?

--- a/docs/app/faq.mdx
+++ b/docs/app/faq.mdx
@@ -1121,7 +1121,7 @@ reach the browser, so the policy is never enforced during a test run. This
 prevents a strict CSP from blocking the scripts Cypress injects to drive your
 application.
 
-If you need the policy enforced — for example to test the CSP itself — see
+If you need the policy enforced (for example to test the CSP itself), see
 [How do I test my application's Content Security Policy?](#How-do-I-test-my-applications-Content-Security-Policy)
 below. For the full picture, read the
 [Content Security Policy reference](/app/references/content-security-policy).
@@ -1133,10 +1133,10 @@ Set the
 configuration option so Cypress keeps the CSP header instead of stripping it. It
 accepts three values:
 
-- `false` _(default)_ — strip the entire CSP header.
-- `true` — keep the header, removing only the directives that interfere with
+- `false` _(default)_: strip the entire CSP header.
+- `true`: keep the header, removing only the directives that interfere with
   Cypress.
-- an array of directive names — keep the header and only the named directives.
+- an array of directive names: keep the header and only the named directives.
 
 :::cypress-config-example
 
@@ -1168,7 +1168,7 @@ for how Cypress handles each delivery method.
 
 No. Cypress always removes `frame-ancestors`, `navigate-to`,
 `require-trusted-types-for`, `sandbox`, and `trusted-types` from allowed CSP
-headers — even with `experimentalCspAllowList` enabled — because leaving them in
+headers, even with `experimentalCspAllowList` enabled, because leaving them in
 place would prevent Cypress from functioning. The behavior of these five
 directives cannot be tested through Cypress and must be verified outside of it.
 See [Always-stripped directives](/app/references/content-security-policy#always-stripped-directives)

--- a/docs/app/references/content-security-policy.mdx
+++ b/docs/app/references/content-security-policy.mdx
@@ -62,15 +62,31 @@ setting the
 [`experimentalCspAllowList`](/app/references/experiments#Experimental-CSP-Allow-List)
 configuration option.
 
+## Nonce injection
+
+To allow its injected `<script>` tags to execute under your policy, Cypress
+generates a random [`nonce`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/nonce)
+for each response and appends a `'nonce-<value>'` source to the following
+directives of **every allowed CSP header**:
+
+- `script-src-elem`
+- `script-src`
+- `default-src`
+
+A directive is only modified if it is present in the policy and allowed through
+your [`experimentalCspAllowList`](/app/references/experiments#Experimental-CSP-Allow-List)
+configuration. The same `nonce` is also added to the `<script>` tags Cypress
+injects, so the browser permits them to run.
+
 :::caution
 
-Even with `experimentalCspAllowList` enabled, the CSP that reaches the browser
-is **not** byte-identical to your application's original policy. So that its
-injected scripts can execute, Cypress appends an auto-generated `nonce` value to
-the `default-src`, `script-src`, and `script-src-elem` directives whenever they
-are present and allowed. If you are verifying your application's CSP
+Because of this, the CSP that reaches the browser is **not** byte-identical to
+your application's original policy. If you are verifying your application's CSP
 implementation, be aware that these three directives are modified by Cypress and
 the delivered header will differ from the one your server originally sent.
+
+Nonce injection applies only to CSP delivered via HTTP headers — it is never
+applied to a `<meta>` tag policy.
 
 :::
 

--- a/docs/app/references/content-security-policy.mdx
+++ b/docs/app/references/content-security-policy.mdx
@@ -68,6 +68,26 @@ mutates three directives, as described in [Nonce injection](#nonce-injection)
 below. If your test asserts on the exact header value, account for this
 modification.
 
+## Always-stripped directives
+
+Regardless of your `experimentalCspAllowList` configuration, Cypress always
+removes the following five directives from allowed CSP headers, because leaving
+them in place would prevent Cypress from functioning. They cannot be allowed
+through the allow list:
+
+| Stripped directive          | Reason                                                            |
+| --------------------------- | ---------------------------------------------------------------- |
+| `frame-ancestors`           | Prevents Cypress from loading a test application into an iframe. |
+| `navigate-to`               | Affects Cypress' ability to navigate to different URLs.          |
+| `require-trusted-types-for` | Might prevent Cypress from rewriting the DOM.                    |
+| `sandbox`                   | Can restrict access to script and iframe functionality.          |
+| `trusted-types`             | Could cause Cypress injections to be marked as untrusted.        |
+
+If your application relies on any of these directives, be aware they will not be
+present in the policy delivered to the browser during a Cypress test run. See
+[Strip Minimum CSP Directives](/app/references/experiments#Experimental-CSP-Allow-List)
+for the full breakdown.
+
 ## Nonce injection
 
 To allow its injected `<script>` tags to execute under your policy, Cypress

--- a/docs/app/references/content-security-policy.mdx
+++ b/docs/app/references/content-security-policy.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Content Security Policy (CSP) in Cypress'
-description: 'How Cypress handles Content Security Policy (CSP) and how to configure it to work with your application.'
+description: 'Why Cypress manages Content Security Policy (CSP), how to tell when you need to configure it, and how to allow your policy through for testing.'
 sidebar_label: 'Content Security Policy'
 e2eSpecific: true
 ---
@@ -13,62 +13,114 @@ e2eSpecific: true
 
 ##### <Icon name="question-circle" color="#4BBFD2" /> What you'll learn
 
-- How Cypress handles Content Security Policy (CSP)
-- How to configure Cypress to work with your application's CSP
+- Why Cypress needs to manage your application's Content Security Policy (CSP)
+- How to recognize the signs that you need to configure CSP handling
+- What configuring CSP handling gives you, and what it cannot do
+- How to allow your CSP through with `experimentalCspAllowList`
 
 :::
 
-Content Security Policy (CSP) is a browser security feature that allows you to
-restrict the resources that can be loaded into your application. This can be
-problematic for Cypress, because it needs to inject JavaScript into your
-application in order to run tests and interact with the DOM. This page describes
-how Cypress handles CSP and how to configure it to work with your application.
+[Content Security Policy (CSP)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP)
+is a browser security feature that restricts the resources — scripts, styles,
+frames, and more — that are allowed to load into a page. It is one of the most
+effective defenses against cross-site scripting (XSS), but it works by blocking
+anything the page author did not explicitly permit. That is exactly what makes
+it interesting for Cypress.
 
-There are two ways to implement CSP:
+## Why Cypress needs to manage CSP
 
-- [Meta tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#http-equiv)
-- [HTTP header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy)
+To drive your application, Cypress injects its own `<script>` tags into the page
+and loads your app inside an iframe. A strict CSP is designed to stop precisely
+this kind of injection: an unmodified policy can block Cypress' scripts from
+executing, forbid the app from being framed, or restrict the DOM rewriting
+Cypress relies on. If Cypress did nothing, a security-conscious application could
+become untestable the moment it shipped a CSP.
+
+To avoid this, **Cypress removes CSP by default.** When a policy is delivered
+over HTTP headers, Cypress strips both the
+`Content-Security-Policy` and `Content-Security-Policy-Report-Only` headers from
+the response before it reaches the browser, so the browser never enforces the
+policy during a test run. For most tests — where you are exercising application
+behavior, not the policy itself — this is invisible and requires no
+configuration.
+
+## Signs you need to configure CSP handling
+
+Because Cypress strips CSP by default, two different symptoms point in opposite
+directions:
+
+- **Your app or its scripts are blocked even though Cypress strips headers.**
+  This usually means the policy is delivered with a
+  [`<meta>` tag](#how-csp-is-delivered) rather than an HTTP header, or that a
+  directive Cypress does not strip is interfering. Look for
+  `Refused to load…` / `Refused to execute…` CSP violation messages in the
+  browser console.
+- **You actually want the policy enforced.** If your goal is to _verify your own
+  CSP_ — for example asserting that a violation is reported, or that a forbidden
+  resource is blocked — the default behavior works against you, because the
+  policy you are trying to test has been removed. You will see your CSP simply
+  not taking effect during the test.
+
+If either of these describes you, you need to opt in to Cypress sending the CSP
+header through to the browser.
+
+## What configuring CSP handling gives you
+
+Opting in lets you **run your tests against a real, enforced policy** instead of
+no policy at all. This is valuable when:
+
+- You are testing the CSP implementation itself (reporting, blocking, allowed
+  sources).
+- Your application's behavior legitimately depends on CSP being present.
+- You want your test environment to mirror production as closely as possible.
+
+The trade-off is that Cypress still has to keep itself working, so the enforced
+policy is a *modified* version of yours rather than a byte-for-byte copy — see
+[Always-stripped directives](#always-stripped-directives) and
+[Nonce injection](#nonce-injection) for exactly what changes.
+
+## How CSP is delivered
+
+There are two ways to deliver a CSP, and Cypress treats them very differently:
+
+- [HTTP header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy) —
+  configurable, and the only form Cypress can allow through for testing.
+- [Meta tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#http-equiv) —
+  supported automatically, but **not** configurable.
 
 Cypress functions with the `<meta>` tag implementation without any configuration
-required. This works because Cypress loads the necessary `<script>` tags into
-your application before any `<meta>` tag is parsed, so the CSP directives are
-never applied to the script loaded by Cypress. This behavior relies on that
-ordering assumption rather than on any modification of the policy itself.
+required. This works because Cypress loads its `<script>` tags into your
+application before any `<meta>` tag is parsed, so the CSP directives are never
+applied to the script loaded by Cypress. This relies on that ordering rather than
+on any modification of the policy itself.
 
 :::caution
 
-Cypress' CSP handling applies only to policies delivered via HTTP headers, not
-those delivered via a `<meta>` tag:
+Cypress' configurable CSP handling applies **only** to policies delivered via
+HTTP headers, not those delivered via a `<meta>` tag:
 
-- [`experimentalCspAllowList`](/app/references/experiments#Experimental-CSP-Allow-List)
+- [`experimentalCspAllowList`](#allowing-the-header-through-with-experimentalcspallowlist)
   operates exclusively on HTTP headers. It does nothing for a meta-tag CSP, so
   you cannot use the allow list to test a meta-delivered policy.
-- The `nonce` injection described below likewise applies only to headers, never
-  to `<meta>` tags. The "scripts are loaded before the `<meta>` tag is parsed"
-  ordering is the only mechanism that makes meta-tag CSP work with Cypress.
+- The [`nonce` injection](#nonce-injection) described below likewise applies only
+  to headers, never to `<meta>` tags. The "scripts are loaded before the
+  `<meta>` tag is parsed" ordering is the only mechanism that makes meta-tag CSP
+  work with Cypress.
 
 :::
 
-The second implementation requires you to configure Cypress to allow the headers
-to be sent to your application. By default, Cypress will remove both the
-`Content-Security-Policy` and `Content-Security-Policy-Report-Only` headers from
-the response before it is sent to the browser. This is done to prevent Cypress
-from being blocked by the browser's CSP implementation.
+## Allowing the header through with `experimentalCspAllowList`
 
-For most application tests, this should not cause any issues. However, if you
-are testing your application's CSP implementation, you will need to configure
-Cypress to allow the headers to be sent to the browser. You can do this by
-setting the
+By default Cypress strips the CSP header entirely. To keep it — so the browser
+enforces your policy during the test — configure the
 [`experimentalCspAllowList`](/app/references/experiments#Experimental-CSP-Allow-List)
-configuration option.
+option. It accepts three kinds of value:
 
-`experimentalCspAllowList` accepts three kinds of value:
-
-| Value      | Behavior                                                                                                                  |
-| ---------- | ------------------------------------------------------------------------------------------------------------------------- |
-| `false`    | _(default)_ Strip the entire CSP header. The policy is removed completely before the response reaches the browser.        |
-| `true`     | Keep the header, stripping only the directives that would interfere with Cypress (see below).                             |
-| `string[]` | Keep the header and the named directives, stripping everything else that Cypress would otherwise allow.                   |
+| Value      | Behavior                                                                                                            |
+| ---------- | ----------------------------------------------------------------------------------------------------------------- |
+| `false`    | _(default)_ Strip the entire CSP header. The policy is removed completely before the response reaches the browser. |
+| `true`     | Keep the header, stripping only the directives that would interfere with Cypress (see below).                      |
+| `string[]` | Keep the header and the named directives, stripping everything else that Cypress would otherwise allow.            |
 
 When using the array form, the values are validated and must be drawn from
 exactly these six allowable directives:
@@ -80,9 +132,9 @@ exactly these six allowable directives:
 - `script-src-elem`
 - `form-action`
 
-Any other directive name is rejected by validation. Regardless of which mode you
-choose, the [always-stripped directives](#always-stripped-directives) below are
-removed.
+Any other directive name is not accepted by the array. Regardless of which mode
+you choose, the [always-stripped directives](#always-stripped-directives) below
+are removed.
 
 :::caution
 
@@ -133,11 +185,14 @@ allowable values):
 
 :::
 
-Even with `experimentalCspAllowList` enabled, the CSP that reaches the browser
-is **not** byte-identical to your application's original policy — Cypress
-mutates three directives, as described in [Nonce injection](#nonce-injection)
-below. If your test asserts on the exact header value, account for this
-modification.
+:::caution
+
+Even with `experimentalCspAllowList` enabled, the CSP that reaches the browser is
+**not** byte-identical to your application's original policy — Cypress mutates
+three directives, as described in [Nonce injection](#nonce-injection) below. If
+your test asserts on the exact header value, account for this modification.
+
+:::
 
 ## Always-stripped directives
 
@@ -146,8 +201,8 @@ removes the following five directives from allowed CSP headers, because leaving
 them in place would prevent Cypress from functioning. They cannot be allowed
 through the allow list:
 
-| Stripped directive          | Reason                                                            |
-| --------------------------- | ---------------------------------------------------------------- |
+| Stripped directive          | Reason                                                           |
+| --------------------------- | --------------------------------------------------------------- |
 | `frame-ancestors`           | Prevents Cypress from loading a test application into an iframe. |
 | `navigate-to`               | Affects Cypress' ability to navigate to different URLs.          |
 | `require-trusted-types-for` | Might prevent Cypress from rewriting the DOM.                    |
@@ -222,6 +277,9 @@ for more detail.
 
 :::
 
-For more information on CSP, see the
-[Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP)
-documentation on MDN.
+## See also
+
+- [`experimentalCspAllowList`](/app/references/experiments#Experimental-CSP-Allow-List)
+  configuration reference
+- [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP)
+  documentation on MDN

--- a/docs/app/references/content-security-policy.mdx
+++ b/docs/app/references/content-security-policy.mdx
@@ -21,8 +21,8 @@ e2eSpecific: true
 :::
 
 [Content Security Policy (CSP)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP)
-is a browser security feature that restricts the resources — scripts, styles,
-frames, and more — that are allowed to load into a page. It is one of the most
+is a browser security feature that restricts the resources (scripts, styles,
+frames, and more) that are allowed to load into a page. It is one of the most
 effective defenses against cross-site scripting (XSS), but it works by blocking
 anything the page author did not explicitly permit. That is exactly what makes
 it interesting for Cypress.
@@ -40,8 +40,8 @@ To avoid this, **Cypress removes CSP by default.** When a policy is delivered
 over HTTP headers, Cypress strips both the
 `Content-Security-Policy` and `Content-Security-Policy-Report-Only` headers from
 the response before it reaches the browser, so the browser never enforces the
-policy during a test run. For most tests — where you are exercising application
-behavior, not the policy itself — this is invisible and requires no
+policy during a test run. For most tests, where you are exercising application
+behavior rather than the policy itself, this is invisible and requires no
 configuration.
 
 ## Signs you need to configure CSP handling
@@ -56,8 +56,8 @@ directions:
   `Refused to load…` / `Refused to execute…` CSP violation messages in the
   browser console.
 - **You actually want the policy enforced.** If your goal is to _verify your own
-  CSP_ — for example asserting that a violation is reported, or that a forbidden
-  resource is blocked — the default behavior works against you, because the
+  CSP_ (for example asserting that a violation is reported, or that a forbidden
+  resource is blocked), the default behavior works against you, because the
   policy you are trying to test has been removed. You will see your CSP simply
   not taking effect during the test.
 
@@ -75,7 +75,7 @@ no policy at all. This is valuable when:
 - You want your test environment to mirror production as closely as possible.
 
 The trade-off is that Cypress still has to keep itself working, so the enforced
-policy is a _modified_ version of yours rather than a byte-for-byte copy — see
+policy is a _modified_ version of yours rather than a byte-for-byte copy. See
 [Always-stripped directives](#always-stripped-directives) and
 [Nonce injection](#nonce-injection) for exactly what changes.
 
@@ -83,9 +83,9 @@ policy is a _modified_ version of yours rather than a byte-for-byte copy — see
 
 There are two ways to deliver a CSP, and Cypress treats them very differently:
 
-- [HTTP header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy) —
+- [HTTP header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy):
   configurable, and the only form Cypress can allow through for testing.
-- [Meta tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#http-equiv) —
+- [Meta tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#http-equiv):
   supported automatically, but **not** configurable.
 
 Cypress functions with the `<meta>` tag implementation without any configuration
@@ -111,8 +111,8 @@ HTTP headers, not those delivered via a `<meta>` tag:
 
 ## Allowing the header through with `experimentalCspAllowList` {#experimentalcspallowlist}
 
-By default Cypress strips the CSP header entirely. To keep it — so the browser
-enforces your policy during the test — configure the
+By default Cypress strips the CSP header entirely. To keep it, so the browser
+enforces your policy during the test, configure the
 [`experimentalCspAllowList`](/app/references/experiments#Experimental-CSP-Allow-List)
 option. It accepts three kinds of value:
 
@@ -148,13 +148,13 @@ requires restarting the Cypress server (for example, by stopping and relaunching
 
 ### Configuration examples
 
-Strip the entire CSP header (the default — equivalent to omitting the option):
+Strip the entire CSP header (the default, equivalent to omitting the option):
 
 :::cypress-config-example
 
 ```js
 {
-  // false is the default — the entire CSP header is stripped
+  // false is the default; the entire CSP header is stripped
   experimentalCspAllowList: false
 }
 ```
@@ -189,7 +189,7 @@ allowable values):
 :::caution
 
 Even with `experimentalCspAllowList` enabled, the CSP that reaches the browser is
-**not** byte-identical to your application's original policy — Cypress mutates
+**not** byte-identical to your application's original policy. Cypress mutates
 three directives, as described in [Nonce injection](#nonce-injection) below. If
 your test asserts on the exact header value, account for this modification.
 
@@ -247,7 +247,7 @@ your application's original policy. If you are verifying your application's CSP
 implementation, be aware that these three directives are modified by Cypress and
 the delivered header will differ from the one your server originally sent.
 
-Nonce injection applies only to CSP delivered via HTTP headers — it is never
+Nonce injection applies only to CSP delivered via HTTP headers; it is never
 applied to a `<meta>` tag policy.
 
 :::

--- a/docs/app/references/content-security-policy.mdx
+++ b/docs/app/references/content-security-policy.mdx
@@ -84,6 +84,16 @@ Any other directive name is rejected by validation. Regardless of which mode you
 choose, the [always-stripped directives](#always-stripped-directives) below are
 removed.
 
+:::caution
+
+`experimentalCspAllowList` cannot be changed at runtime and cannot be overridden
+per test. Calling `Cypress.config('experimentalCspAllowList', ...)` from within a
+spec has no effect, and there is no per-test override. Changing the value
+requires restarting the Cypress server (for example, by stopping and relaunching
+`cypress open` or `cypress run`) for the new setting to take effect.
+
+:::
+
 Even with `experimentalCspAllowList` enabled, the CSP that reaches the browser
 is **not** byte-identical to your application's original policy — Cypress
 mutates three directives, as described in [Nonce injection](#nonce-injection)

--- a/docs/app/references/content-security-policy.mdx
+++ b/docs/app/references/content-security-policy.mdx
@@ -47,6 +47,18 @@ setting the
 [`experimentalCspAllowList`](/app/references/experiments#Experimental-CSP-Allow-List)
 configuration option.
 
+:::caution
+
+Even with `experimentalCspAllowList` enabled, the CSP that reaches the browser
+is **not** byte-identical to your application's original policy. So that its
+injected scripts can execute, Cypress appends an auto-generated `nonce` value to
+the `default-src`, `script-src`, and `script-src-elem` directives whenever they
+are present and allowed. If you are verifying your application's CSP
+implementation, be aware that these three directives are modified by Cypress and
+the delivered header will differ from the one your server originally sent.
+
+:::
+
 For more information on CSP, see the
 [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP)
 documentation on MDN.

--- a/docs/app/references/content-security-policy.mdx
+++ b/docs/app/references/content-security-policy.mdx
@@ -35,9 +35,10 @@ tags into your application before any `<meta>` tag is parsed. This prevents any
 CSP directives from being applied to the script loaded by Cypress.
 
 The second implementation requires you to configure Cypress to allow the headers
-to be sent to your application. By default, Cypress will remove any CSP headers
-from the response before it is sent to the browser. This is done to prevent
-Cypress from being blocked by the browser's CSP implementation.
+to be sent to your application. By default, Cypress will remove both the
+`Content-Security-Policy` and `Content-Security-Policy-Report-Only` headers from
+the response before it is sent to the browser. This is done to prevent Cypress
+from being blocked by the browser's CSP implementation.
 
 For most application tests, this should not cause any issues. However, if you
 are testing your application's CSP implementation, you will need to configure

--- a/docs/app/references/content-security-policy.mdx
+++ b/docs/app/references/content-security-policy.mdx
@@ -62,6 +62,28 @@ setting the
 [`experimentalCspAllowList`](/app/references/experiments#Experimental-CSP-Allow-List)
 configuration option.
 
+`experimentalCspAllowList` accepts three kinds of value:
+
+| Value      | Behavior                                                                                                                  |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `false`    | _(default)_ Strip the entire CSP header. The policy is removed completely before the response reaches the browser.        |
+| `true`     | Keep the header, stripping only the directives that would interfere with Cypress (see below).                             |
+| `string[]` | Keep the header and the named directives, stripping everything else that Cypress would otherwise allow.                   |
+
+When using the array form, the values are validated and must be drawn from
+exactly these six allowable directives:
+
+- `default-src`
+- `child-src`
+- `frame-src`
+- `script-src`
+- `script-src-elem`
+- `form-action`
+
+Any other directive name is rejected by validation. Regardless of which mode you
+choose, the [always-stripped directives](#always-stripped-directives) below are
+removed.
+
 Even with `experimentalCspAllowList` enabled, the CSP that reaches the browser
 is **not** byte-identical to your application's original policy — Cypress
 mutates three directives, as described in [Nonce injection](#nonce-injection)

--- a/docs/app/references/content-security-policy.mdx
+++ b/docs/app/references/content-security-policy.mdx
@@ -62,6 +62,12 @@ setting the
 [`experimentalCspAllowList`](/app/references/experiments#Experimental-CSP-Allow-List)
 configuration option.
 
+Even with `experimentalCspAllowList` enabled, the CSP that reaches the browser
+is **not** byte-identical to your application's original policy — Cypress
+mutates three directives, as described in [Nonce injection](#nonce-injection)
+below. If your test asserts on the exact header value, account for this
+modification.
+
 ## Nonce injection
 
 To allow its injected `<script>` tags to execute under your policy, Cypress

--- a/docs/app/references/content-security-policy.mdx
+++ b/docs/app/references/content-security-policy.mdx
@@ -147,6 +147,32 @@ applied to a `<meta>` tag policy.
 
 :::
 
+## Interaction with code-modifying options
+
+Cypress options that rewrite your application's HTML or JavaScript can conflict
+with CSP directives that pin scripts by hash (for example a `script-src` value
+containing a `'sha256-...'` source). Because the hash is computed against the
+original code, any rewrite changes the bytes the browser hashes and the policy
+will reject the modified script.
+
+This affects the following options when combined with `experimentalCspAllowList`:
+
+- [`modifyObstructiveCode`](/app/references/configuration#Configuration-Options)
+- [`experimentalModifyObstructiveThirdPartyCode`](/app/references/experiments)
+- [`experimentalSourceRewriting`](/app/references/experiments)
+
+:::caution
+
+If you allow hash-based directives through `experimentalCspAllowList` while any
+of these code-modifying options are enabled, you can hit a mismatch between the
+original hashed value in the directive and the rewritten HTML or JS. If you see
+scripts being blocked, disable the code-modifying option or remove the
+hash-based directive from your allow list. See
+[Experimental CSP Allow List](/app/references/experiments#Experimental-CSP-Allow-List)
+for more detail.
+
+:::
+
 For more information on CSP, see the
 [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP)
 documentation on MDN.

--- a/docs/app/references/content-security-policy.mdx
+++ b/docs/app/references/content-security-policy.mdx
@@ -29,10 +29,25 @@ There are two ways to implement CSP:
 - [Meta tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#http-equiv)
 - [HTTP header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy)
 
-The `<meta>` tag implementation is fully supported by Cypress without any
-configuration required. This is because Cypress loads the necessary `<script>`
-tags into your application before any `<meta>` tag is parsed. This prevents any
-CSP directives from being applied to the script loaded by Cypress.
+Cypress functions with the `<meta>` tag implementation without any configuration
+required. This works because Cypress loads the necessary `<script>` tags into
+your application before any `<meta>` tag is parsed, so the CSP directives are
+never applied to the script loaded by Cypress. This behavior relies on that
+ordering assumption rather than on any modification of the policy itself.
+
+:::caution
+
+Cypress' CSP handling applies only to policies delivered via HTTP headers, not
+those delivered via a `<meta>` tag:
+
+- [`experimentalCspAllowList`](/app/references/experiments#Experimental-CSP-Allow-List)
+  operates exclusively on HTTP headers. It does nothing for a meta-tag CSP, so
+  you cannot use the allow list to test a meta-delivered policy.
+- The `nonce` injection described below likewise applies only to headers, never
+  to `<meta>` tags. The "scripts are loaded before the `<meta>` tag is parsed"
+  ordering is the only mechanism that makes meta-tag CSP work with Cypress.
+
+:::
 
 The second implementation requires you to configure Cypress to allow the headers
 to be sent to your application. By default, Cypress will remove both the

--- a/docs/app/references/content-security-policy.mdx
+++ b/docs/app/references/content-security-policy.mdx
@@ -154,6 +154,7 @@ Strip the entire CSP header (the default — equivalent to omitting the option):
 
 ```js
 {
+  // false is the default — the entire CSP header is stripped
   experimentalCspAllowList: false
 }
 ```

--- a/docs/app/references/content-security-policy.mdx
+++ b/docs/app/references/content-security-policy.mdx
@@ -83,6 +83,15 @@ through the allow list:
 | `sandbox`                   | Can restrict access to script and iframe functionality.          |
 | `trusted-types`             | Could cause Cypress injections to be marked as untrusted.        |
 
+:::caution
+
+This is a hard limitation: because these directives are stripped unconditionally
+and cannot be re-enabled, **you can never test the behavior of these five
+directives using Cypress**. If verifying them is a requirement, you will need to
+do so outside of Cypress.
+
+:::
+
 If your application relies on any of these directives, be aware they will not be
 present in the policy delivered to the browser during a Cypress test run. See
 [Strip Minimum CSP Directives](/app/references/experiments#Experimental-CSP-Allow-List)

--- a/docs/app/references/content-security-policy.mdx
+++ b/docs/app/references/content-security-policy.mdx
@@ -94,6 +94,45 @@ requires restarting the Cypress server (for example, by stopping and relaunching
 
 :::
 
+### Configuration examples
+
+Strip the entire CSP header (the default — equivalent to omitting the option):
+
+:::cypress-config-example
+
+```js
+{
+  experimentalCspAllowList: false
+}
+```
+
+:::
+
+Keep the header, stripping only the directives that interfere with Cypress:
+
+:::cypress-config-example
+
+```js
+{
+  experimentalCspAllowList: true
+}
+```
+
+:::
+
+Keep the header and only the named directives (each must be one of the six
+allowable values):
+
+:::cypress-config-example
+
+```js
+{
+  experimentalCspAllowList: ['default-src', 'script-src', 'script-src-elem']
+}
+```
+
+:::
+
 Even with `experimentalCspAllowList` enabled, the CSP that reaches the browser
 is **not** byte-identical to your application's original policy — Cypress
 mutates three directives, as described in [Nonce injection](#nonce-injection)

--- a/docs/app/references/content-security-policy.mdx
+++ b/docs/app/references/content-security-policy.mdx
@@ -75,11 +75,11 @@ no policy at all. This is valuable when:
 - You want your test environment to mirror production as closely as possible.
 
 The trade-off is that Cypress still has to keep itself working, so the enforced
-policy is a *modified* version of yours rather than a byte-for-byte copy — see
+policy is a _modified_ version of yours rather than a byte-for-byte copy — see
 [Always-stripped directives](#always-stripped-directives) and
 [Nonce injection](#nonce-injection) for exactly what changes.
 
-## How CSP is delivered
+## How CSP is delivered {#how-csp-is-delivered}
 
 There are two ways to deliver a CSP, and Cypress treats them very differently:
 
@@ -99,7 +99,7 @@ on any modification of the policy itself.
 Cypress' configurable CSP handling applies **only** to policies delivered via
 HTTP headers, not those delivered via a `<meta>` tag:
 
-- [`experimentalCspAllowList`](#allowing-the-header-through-with-experimentalcspallowlist)
+- [`experimentalCspAllowList`](#experimentalcspallowlist)
   operates exclusively on HTTP headers. It does nothing for a meta-tag CSP, so
   you cannot use the allow list to test a meta-delivered policy.
 - The [`nonce` injection](#nonce-injection) described below likewise applies only
@@ -109,15 +109,15 @@ HTTP headers, not those delivered via a `<meta>` tag:
 
 :::
 
-## Allowing the header through with `experimentalCspAllowList`
+## Allowing the header through with `experimentalCspAllowList` {#experimentalcspallowlist}
 
 By default Cypress strips the CSP header entirely. To keep it — so the browser
 enforces your policy during the test — configure the
 [`experimentalCspAllowList`](/app/references/experiments#Experimental-CSP-Allow-List)
 option. It accepts three kinds of value:
 
-| Value      | Behavior                                                                                                            |
-| ---------- | ----------------------------------------------------------------------------------------------------------------- |
+| Value      | Behavior                                                                                                           |
+| ---------- | ------------------------------------------------------------------------------------------------------------------ |
 | `false`    | _(default)_ Strip the entire CSP header. The policy is removed completely before the response reaches the browser. |
 | `true`     | Keep the header, stripping only the directives that would interfere with Cypress (see below).                      |
 | `string[]` | Keep the header and the named directives, stripping everything else that Cypress would otherwise allow.            |
@@ -195,7 +195,7 @@ your test asserts on the exact header value, account for this modification.
 
 :::
 
-## Always-stripped directives
+## Always-stripped directives {#always-stripped-directives}
 
 Regardless of your `experimentalCspAllowList` configuration, Cypress always
 removes the following five directives from allowed CSP headers, because leaving
@@ -203,7 +203,7 @@ them in place would prevent Cypress from functioning. They cannot be allowed
 through the allow list:
 
 | Stripped directive          | Reason                                                           |
-| --------------------------- | --------------------------------------------------------------- |
+| --------------------------- | ---------------------------------------------------------------- |
 | `frame-ancestors`           | Prevents Cypress from loading a test application into an iframe. |
 | `navigate-to`               | Affects Cypress' ability to navigate to different URLs.          |
 | `require-trusted-types-for` | Might prevent Cypress from rewriting the DOM.                    |
@@ -224,7 +224,7 @@ present in the policy delivered to the browser during a Cypress test run. See
 [Strip Minimum CSP Directives](/app/references/experiments#Experimental-CSP-Allow-List)
 for the full breakdown.
 
-## Nonce injection
+## Nonce injection {#nonce-injection}
 
 To allow its injected `<script>` tags to execute under your policy, Cypress
 generates a random [`nonce`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/nonce)
@@ -262,7 +262,7 @@ will reject the modified script.
 
 This affects the following options when combined with `experimentalCspAllowList`:
 
-- [`modifyObstructiveCode`](/app/references/configuration#Configuration-Options)
+- [`modifyObstructiveCode`](/app/references/configuration#modifyObstructiveCode)
 - [`experimentalModifyObstructiveThirdPartyCode`](/app/references/experiments)
 - [`experimentalSourceRewriting`](/app/references/experiments)
 

--- a/docs/app/references/content-security-policy.mdx
+++ b/docs/app/references/content-security-policy.mdx
@@ -33,8 +33,8 @@ To drive your application, Cypress injects its own `<script>` tags into the page
 and loads your app inside an iframe. A strict CSP is designed to stop precisely
 this kind of injection: an unmodified policy can block Cypress' scripts from
 executing, forbid the app from being framed, or restrict the DOM rewriting
-Cypress relies on. If Cypress did nothing, a security-conscious application could
-become untestable the moment it shipped a CSP.
+Cypress relies on. In other words, if Cypress left your CSP untouched, adding a
+strict policy to your application would stop Cypress from being able to test it.
 
 To avoid this, **Cypress removes CSP by default.** When a policy is delivered
 over HTTP headers, Cypress strips both the


### PR DESCRIPTION
Cypress removes both the Content-Security-Policy and
Content-Security-Policy-Report-Only headers, not a single header.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FBMb1y5rfsijhv2CF1HdVw

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to MDX; no runtime, config, or test code is modified.
> 
> **Overview**
> **Expands CSP documentation** so default behavior, testing CSP, and limitations are spelled out in one place, with FAQ entries that link to the reference page.
> 
> The **Content Security Policy reference** (`content-security-policy.mdx`) is rewritten from a short overview into a full guide: why Cypress strips CSP by default (including both `Content-Security-Policy` and `Content-Security-Policy-Report-Only`), when to configure handling, HTTP header vs `<meta>` delivery, `experimentalCspAllowList` modes and examples, always-stripped directives, nonce injection, and conflicts with code-modifying options.
> 
> The **FAQ** adds four E2E-only CSP questions—why enforcement is off by default, how to test CSP, why scripts can still be blocked with headers stripped, and why directives like `frame-ancestors` cannot be tested in Cypress—with pointers to the reference doc.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ecc6f75a8f0ecf773b8aaab078c9c438fdf9a60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->