### PR TITLE
docs: rework Advanced Installation page (accuracy fixes + why/value rewrite)

### DIFF
--- a/docs/app/references/advanced-installation.mdx
+++ b/docs/app/references/advanced-installation.mdx
@@ -67,9 +67,7 @@ This two-step model is the "why" behind most of the variables below:
 ## Environment variables
 
 Almost every behavior on this page is driven by a system-level (OS) environment
-variable. These are set in your shell, CI configuration, or `.npmrc`. The table
-below is the quick reference; each links to the section that explains the "why"
-and shows examples.
+variable. These are set in your shell, CI configuration, or `.npmrc`.
 
 | Name                              | Description                                                                                    |
 | --------------------------------- | ---------------------------------------------------------------------------------------------- |

--- a/docs/app/references/advanced-installation.mdx
+++ b/docs/app/references/advanced-installation.mdx
@@ -67,10 +67,9 @@ This two-step model is the "why" behind most of the variables below:
 ## Environment variables
 
 Almost every behavior on this page is driven by a system-level (OS) environment
-variable. These are set in your shell, CI configuration, or `.npmrc`, and are
-distinct from the [Cypress environment variables](/app/guides/environment-variables)
-you reference in tests with `Cypress.env()`. The table below is the quick
-reference; each links to the section that explains the "why" and shows examples.
+variable. These are set in your shell, CI configuration, or `.npmrc`. The table
+below is the quick reference; each links to the section that explains the "why"
+and shows examples.
 
 | Name                              | Description                                                                                    |
 | --------------------------------- | ---------------------------------------------------------------------------------------------- |

--- a/docs/app/references/advanced-installation.mdx
+++ b/docs/app/references/advanced-installation.mdx
@@ -683,7 +683,7 @@ better product.
 If you would like to opt out of sending any exception data to Cypress, you can
 do so by setting `CYPRESS_CRASH_REPORTS=0` in your system environment variables.
 Set the variable before installing Cypress, using the approach for your
-operating system:
+operating system. To make this permanent, add the command to your shell's `~/.profile` (for example, `~/.zshprofile` or `~/.bash_profile`) so it runs on every login.
 
 <Tabs groupId="operating-system">
 <TabItem value="macos" label="macOS" default>
@@ -692,9 +692,6 @@ operating system:
 export CYPRESS_CRASH_REPORTS=0
 ```
 
-To make this permanent, add the command to your shell's `~/.profile`
-(`~/.zprofile`, `~/.bash_profile`, etc.) so it runs on every login.
-
 </TabItem>
 <TabItem value="linux" label="Linux">
 
@@ -702,29 +699,15 @@ To make this permanent, add the command to your shell's `~/.profile`
 export CYPRESS_CRASH_REPORTS=0
 ```
 
-To make this permanent, add the command to your shell's `~/.profile`
-(`~/.bashrc`, `~/.zshrc`, etc.) so it runs on every login.
-
 </TabItem>
 <TabItem value="windows" label="Windows">
 
-In the Command Prompt:
-
-```shell
+```shell title="Command Prompt"
 set CYPRESS_CRASH_REPORTS=0
 ```
 
-In PowerShell:
-
-```shell
+```shell title="PowerShell"
 $env:CYPRESS_CRASH_REPORTS = "0"
-```
-
-To save the `CYPRESS_CRASH_REPORTS` variable for use in all new shells, use
-`setx`:
-
-```shell
-setx CYPRESS_CRASH_REPORTS 0
 ```
 
 </TabItem>

--- a/docs/app/references/advanced-installation.mdx
+++ b/docs/app/references/advanced-installation.mdx
@@ -353,9 +353,26 @@ rely on these being available past 60 days.
 
 ## Installing behind a firewall or mirror
 
-The next four sections all address the same root problem: the machine running
-`npm install` can't download from `https://download.cypress.io` directly. Pick the approach that matches your constraint: a known download URL,
-a full mirror, a custom URL layout, or a private certificate authority.
+These sections all address the same root problem: the machine running
+`npm install` can't download from `https://download.cypress.io` directly. The
+simplest fix is to allowlist the URLs Cypress needs. If that isn't possible, host
+the binary yourself and point Cypress at it with a known download URL, a full
+mirror, a custom URL layout, or a private certificate authority.
+
+### Allowlist URLs for installation
+
+If your VPN, firewall, or proxy only permits traffic to approved hosts, add the
+following to your allowlist so the binary can be downloaded during `npm install`:
+
+| URL                          | Purpose                                                      |
+| ---------------------------- | ----------------------------------------------------------- |
+| `https://download.cypress.io`| Resolves the correct binary for your version and platform   |
+| `https://cdn.cypress.io`     | Serves the actual binary `.zip` (download requests redirect here, and pre-release binaries are hosted here) |
+| `https://registry.npmjs.org` | Installs the `cypress` npm package (or your configured npm registry) |
+
+If you also run tests against Cypress Cloud, you'll need to allow additional
+URLs. See the full list of
+[subdomains to allow on a restrictive VPN](/cloud/faq#Im-working-with-a-restrictive-VPN-Which-subdomains-do-I-have-to-allow-on-my-VPN-for-Cypress-Cloud-to-work-properly).
 
 ### Download URLs
 

--- a/docs/app/references/advanced-installation.mdx
+++ b/docs/app/references/advanced-installation.mdx
@@ -447,6 +447,22 @@ Cypress, add the following to your `.npmrc`:
 cafile=/home/person/certs/ca.crt
 ```
 
+Alternatively, you can supply the certificate inline with the `ca` option
+instead of pointing to a file. This is equivalent to setting the
+`npm_config_ca` environment variable. Newlines in the PEM certificate are
+represented with `\n`:
+
+```ini title=".npmrc"
+ca="-----BEGIN CERTIFICATE-----\nMIID...\n-----END CERTIFICATE-----"
+```
+
+To supply more than one certificate, set `ca` to an array of strings. The same
+value can also be provided through the environment:
+
+```shell
+export npm_config_ca="-----BEGIN CERTIFICATE-----\nMIID...\n-----END CERTIFICATE-----"
+```
+
 If neither `cafile` nor `ca` are set, Cypress looks at the system environment
 variable `NODE_EXTRA_CA_CERTS` and uses the corresponding certificate(s) as an
 extension for the trusted certificate authority when downloading the Cypress

--- a/docs/app/references/advanced-installation.mdx
+++ b/docs/app/references/advanced-installation.mdx
@@ -66,9 +66,11 @@ This two-step model is the "why" behind most of the variables below:
 
 ## Environment variables
 
-Almost every behavior on this page is driven by an environment variable. The
-table below is the quick reference; each links to the section that explains the
-"why" and shows examples.
+Almost every behavior on this page is driven by a system-level (OS) environment
+variable. These are set in your shell, CI configuration, or `.npmrc`, and are
+distinct from the [Cypress environment variables](/app/guides/environment-variables)
+you reference in tests with `Cypress.env()`. The table below is the quick
+reference; each links to the section that explains the "why" and shows examples.
 
 | Name                              | Description                                                                                    |
 | --------------------------------- | ---------------------------------------------------------------------------------------------- |

--- a/docs/app/references/advanced-installation.mdx
+++ b/docs/app/references/advanced-installation.mdx
@@ -682,30 +682,43 @@ better product.
 
 If you would like to opt out of sending any exception data to Cypress, you can
 do so by setting `CYPRESS_CRASH_REPORTS=0` in your system environment variables.
+Set the variable before installing Cypress, using the approach for your
+operating system:
 
-#### Opt out on Linux or macOS
-
-To opt out of sending exception data on Linux or macOS, run the following
-command in a terminal before installing Cypress:
+<Tabs groupId="operating-system" defaultValue="macos" values={[
+  {label: 'macOS', value: 'macos'},
+  {label: 'Linux', value: 'linux'},
+  {label: 'Windows', value: 'windows'},
+]}>
+  <TabItem value="macos">
 
 ```shell
 export CYPRESS_CRASH_REPORTS=0
 ```
 
-To make these changes permanent, you can add this command to your shell's
-`~/.profile` (`~/.zsh_profile`, `~/.bash_profile`, etc.) to run them on every
-login.
+To make this permanent, add the command to your shell's `~/.profile`
+(`~/.zprofile`, `~/.bash_profile`, etc.) so it runs on every login.
 
-#### Opt out on Windows
+  </TabItem>
+  <TabItem value="linux">
 
-To opt out of sending exception data on Windows, run the following command in
-the Command Prompt before installing Cypress:
+```shell
+export CYPRESS_CRASH_REPORTS=0
+```
+
+To make this permanent, add the command to your shell's `~/.profile`
+(`~/.bashrc`, `~/.zshrc`, etc.) so it runs on every login.
+
+  </TabItem>
+  <TabItem value="windows">
+
+In the Command Prompt:
 
 ```shell
 set CYPRESS_CRASH_REPORTS=0
 ```
 
-To accomplish the same thing in PowerShell:
+In PowerShell:
 
 ```shell
 $env:CYPRESS_CRASH_REPORTS = "0"
@@ -717,6 +730,9 @@ To save the `CYPRESS_CRASH_REPORTS` variable for use in all new shells, use
 ```shell
 setx CYPRESS_CRASH_REPORTS 0
 ```
+
+  </TabItem>
+</Tabs>
 
 ### Opt out of Cypress commercial messaging
 

--- a/docs/app/references/advanced-installation.mdx
+++ b/docs/app/references/advanced-installation.mdx
@@ -98,7 +98,7 @@ order, using the first value it finds:
 This means options like `CYPRESS_INSTALL_BINARY`, `CYPRESS_CACHE_FOLDER`, and
 `CYPRESS_DOWNLOAD_MIRROR` can all be configured in `.npmrc`:
 
-```ini title=".npmrc"
+```shell title=".npmrc"
 cypress_install_binary=https://company.domain.com/cypress.zip
 cypress_cache_folder=/path/to/cypress/cache
 cypress_download_mirror=https://company.domain.com
@@ -445,7 +445,7 @@ export CYPRESS_DOWNLOAD_PATH_TEMPLATE='https://software.local/cypress/${platform
 To define `CYPRESS_DOWNLOAD_PATH_TEMPLATE` in `.npmrc`, put a backslash before
 every `$`:
 
-```ini
+```shell
 CYPRESS_DOWNLOAD_PATH_TEMPLATE=\${endpoint}/\${platform}-\${arch}/cypress.zip
 ```
 
@@ -471,7 +471,7 @@ instead of pointing to a file. This is equivalent to setting the
 `npm_config_ca` environment variable. Newlines in the PEM certificate are
 represented with `\n`:
 
-```ini title=".npmrc"
+```shell title=".npmrc"
 ca="-----BEGIN CERTIFICATE-----\nMIID...\n-----END CERTIFICATE-----"
 ```
 

--- a/docs/app/references/advanced-installation.mdx
+++ b/docs/app/references/advanced-installation.mdx
@@ -685,12 +685,8 @@ do so by setting `CYPRESS_CRASH_REPORTS=0` in your system environment variables.
 Set the variable before installing Cypress, using the approach for your
 operating system:
 
-<Tabs groupId="operating-system" defaultValue="macos" values={[
-  {label: 'macOS', value: 'macos'},
-  {label: 'Linux', value: 'linux'},
-  {label: 'Windows', value: 'windows'},
-]}>
-  <TabItem value="macos">
+<Tabs groupId="operating-system">
+<TabItem value="macos" label="macOS" default>
 
 ```shell
 export CYPRESS_CRASH_REPORTS=0
@@ -699,8 +695,8 @@ export CYPRESS_CRASH_REPORTS=0
 To make this permanent, add the command to your shell's `~/.profile`
 (`~/.zprofile`, `~/.bash_profile`, etc.) so it runs on every login.
 
-  </TabItem>
-  <TabItem value="linux">
+</TabItem>
+<TabItem value="linux" label="Linux">
 
 ```shell
 export CYPRESS_CRASH_REPORTS=0
@@ -709,8 +705,8 @@ export CYPRESS_CRASH_REPORTS=0
 To make this permanent, add the command to your shell's `~/.profile`
 (`~/.bashrc`, `~/.zshrc`, etc.) so it runs on every login.
 
-  </TabItem>
-  <TabItem value="windows">
+</TabItem>
+<TabItem value="windows" label="Windows">
 
 In the Command Prompt:
 
@@ -731,7 +727,7 @@ To save the `CYPRESS_CRASH_REPORTS` variable for use in all new shells, use
 setx CYPRESS_CRASH_REPORTS 0
 ```
 
-  </TabItem>
+</TabItem>
 </Tabs>
 
 ### Opt out of Cypress commercial messaging

--- a/docs/app/references/advanced-installation.mdx
+++ b/docs/app/references/advanced-installation.mdx
@@ -410,6 +410,20 @@ binary.
 Note that the npm config is used as a replacement, and the node environment
 variable is used as an extension.
 
+:::caution
+
+<strong>Deprecation: `CYPRESS_DOWNLOAD_USE_CA`</strong>
+
+Older guides, GitHub issues, and `.npmrc`/CI configurations may reference the
+`CYPRESS_DOWNLOAD_USE_CA` environment variable to opt into using the `ca` and
+`cafile` options from your npm config. This variable is **deprecated and no
+longer required to be set** — Cypress now reads these options automatically, as
+described above. Setting it has no effect and the Cypress CLI will print a
+warning that it is no longer required to be set. You can safely remove it from
+your configuration.
+
+:::
+
 ## Opt out of sending exception data to Cypress
 
 When an exception is thrown regarding Cypress, we send along the exception data

--- a/docs/app/references/advanced-installation.mdx
+++ b/docs/app/references/advanced-installation.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Advanced Installation Instructions for Cypress'
-description: 'Learn how to install Cypress with a custom binary, skip the installation of the Cypress binary, change the Cypress binary cache location or download URL and more'
+title: 'Cypress Advanced Installation: Custom Binary, Cache & Proxy'
+description: 'Configure advanced Cypress installation: install a custom binary or version, change the cache folder, install behind a proxy, mirror, or custom CA, and skip the binary download.'
 sidebar_label: 'Advanced Installation'
 ---
 

--- a/docs/app/references/advanced-installation.mdx
+++ b/docs/app/references/advanced-installation.mdx
@@ -79,6 +79,38 @@ variable. These are set in your shell, CI configuration, or `.npmrc`.
 | `CYPRESS_VERIFY_TIMEOUT`          | Overrides the timeout duration for the `verify` command. The default value is 30000.           |
 | `CYPRESS_SKIP_VERIFY`             | Skips the [`verify` command](command-line#cypress-verify) when set to `true`                   |
 
+### When you'd reach for each
+
+The descriptions above say what each variable does. Here is the problem each one
+typically solves, so you can find the right tool for your situation:
+
+- **`CYPRESS_INSTALL_BINARY`**: Use this when the binary npm would install isn't
+  the one you want. Common goals: pin a binary version that differs from the npm
+  package, install from an internal URL when `download.cypress.io` is blocked, or
+  install from a local `.zip` on an offline machine. Setting it to `0` skips the
+  binary download entirely, which is handy for building base Docker images or
+  splitting install and download into separate, debuggable steps.
+- **`CYPRESS_DOWNLOAD_MIRROR`**: Use this when your network blocks the public
+  download server but you host an internal copy of it. It swaps the download host
+  for your mirror while keeping the same URL layout, so many machines can install
+  without each pinning a one-off URL.
+- **`CYPRESS_DOWNLOAD_PATH_TEMPLATE`**: Use this when your internal artifact
+  store doesn't match the `download.cypress.io` URL layout. It lets you describe
+  exactly how your server lays out files so Cypress can build the correct URL per
+  platform and version.
+- **`CYPRESS_CACHE_FOLDER`**: Use this to control where the downloaded binary is
+  stored. The most common goal is faster CI: point it at a directory your CI
+  provider caches between runs so the download becomes a cache hit. It's also
+  useful on locked-down machines where the default cache location isn't writable.
+- **`CYPRESS_RUN_BINARY`**: Use this when you want to launch a specific binary
+  already on disk instead of the one resolved from the cache, for example a
+  binary you unzipped to a known location.
+- **`CYPRESS_VERIFY_TIMEOUT`**: Use this when the one-time binary verification
+  step times out, which can happen on slow or heavily loaded machines.
+- **`CYPRESS_SKIP_VERIFY`**: Use this to skip binary verification, for example
+  when the binary lives in a read-only location and verification can't write its
+  results.
+
 ### Setting variables via npm config or package.json
 
 You don't have to export a shell variable to configure these options. This is

--- a/docs/app/references/advanced-installation.mdx
+++ b/docs/app/references/advanced-installation.mdx
@@ -14,7 +14,7 @@ Cypress downloads the right binary for your operating system, caches it so it ca
 be reused across projects, and launches it when you run a test.
 
 This guide is for the situations where those defaults don't fit. It exists
-because real-world environments are messy — corporate proxies, air-gapped CI,
+because real-world environments are messy: corporate proxies, air-gapped CI,
 locked-down certificate stores, disk-constrained build agents, and containerized
 editors all change how (and whether) Cypress can reach the internet and where it
 can write files. Each setting below is an escape hatch for one of those
@@ -24,16 +24,16 @@ constraints.
 
 ##### <Icon name="question-circle" color="#4BBFD2" /> What you'll learn
 
-- **How Cypress installs** — the npm module vs. the binary, and why that split
+- **How Cypress installs**: the npm module vs. the binary, and why that split
   matters
-- **Controlling the install** — installing a custom version, URL, or local file,
+- **Controlling the install**: installing a custom version, URL, or local file,
   or skipping the binary entirely
-- **Installing behind a firewall or mirror** — proxies, download mirrors, custom
+- **Installing behind a firewall or mirror**: proxies, download mirrors, custom
   URL templates, and custom certificate authorities
-- **Managing the binary cache** — where binaries live, how to relocate them, and
+- **Managing the binary cache**: where binaries live, how to relocate them, and
   how to prune or clear them
-- **Privacy controls** — opting out of crash reports and commercial messaging
-- **Environment-specific setup** — WSL, Dev Containers, and GitHub Codespaces
+- **Privacy controls**: opting out of crash reports and commercial messaging
+- **Environment-specific setup**: WSL, Dev Containers, and GitHub Codespaces
 
 :::
 
@@ -43,7 +43,7 @@ Understanding the install model makes almost every setting on this page
 self-explanatory. Installing Cypress happens in two distinct steps:
 
 1. **The npm module** (`cypress`) is added to your project like any other
-   dependency. This package is small — it's the command-line wrapper, TypeScript
+   dependency. This package is small: it's the command-line wrapper, TypeScript
    types, and the `cypress` binary launcher. It is _not_ the Cypress application
    itself.
 2. **The binary** (the actual Cypress application, including the bundled
@@ -59,12 +59,12 @@ matching binary in the cache and launches it.
 This two-step model is the "why" behind most of the variables below:
 
 - Because the binary is downloaded separately, you can point that download at a
-  different version, URL, or local file — see [Install binary](#Install-binary).
+  different version, URL, or local file. See [Install binary](#Install-binary).
 - Because it comes over the network, restricted environments need a way to route
   through a [proxy](#Proxy-configuration), a [mirror](#Mirroring), or a
   [custom CA](#Using-a-custom-certificate-authority-CA).
 - Because it lives in a shared cache, you can relocate, inspect, and prune that
-  cache — see [Binary cache](#Binary-cache).
+  cache. See [Binary cache](#Binary-cache).
 
 ## Environment variables
 
@@ -87,7 +87,7 @@ table below is the quick reference; each links to the section that explains the
 
 You don't have to export a shell variable to configure these options. This is
 valuable because shell exports don't persist across machines or CI agents,
-whereas committing the setting to your repo does — so the whole team and your CI
+whereas committing the setting to your repo does, so the whole team and your CI
 get the same behavior automatically.
 
 Every `CYPRESS_*` variable above can be set as a real environment variable, or
@@ -95,9 +95,9 @@ through your npm configuration. Cypress resolves each variable in the following
 order, using the first value it finds:
 
 1. The actual environment variable (e.g. `CYPRESS_INSTALL_BINARY`)
-2. `npm_config_<name>` — set via `.npmrc` or `npm config`
+2. `npm_config_<name>` (set via `.npmrc` or `npm config`)
 3. The lowercase `npm_config_<name>`
-4. `npm_package_config_<name>` — set via a `config` block in `package.json`
+4. `npm_package_config_<name>` (set via a `config` block in `package.json`)
 
 This means options like `CYPRESS_INSTALL_BINARY`, `CYPRESS_CACHE_FOLDER`, and
 `CYPRESS_DOWNLOAD_MIRROR` can all be configured in `.npmrc`:
@@ -163,11 +163,11 @@ In all cases, the fact that the binary was installed from a custom location _is
 not saved in your `package.json` file_. Every repeated installation needs to use
 the same environment variable to install the same binary. (This is exactly the
 problem [npm config / package.json](#Setting-variables-via-npm-config-or-packagejson)
-solves — commit the setting so it's applied on every install.)
+solves: commit the setting so it's applied on every install.)
 
 ### Skipping installation
 
-Sometimes you want the npm module without the binary download — for example, to
+Sometimes you want the npm module without the binary download, for example, to
 build a base Docker image and add the binary in a later layer, or to install the
 binary yourself with debug output. Setting `CYPRESS_INSTALL_BINARY=0` skips the
 download entirely.
@@ -298,12 +298,12 @@ CDN. If you are scripting pre-release installs, the URLs follow this pattern:
 https://cdn.cypress.io/beta/binary/<version>/<platform>-<arch>/<branch>-<sha>/cypress.zip
 ```
 
-- `<version>` — the Cypress version being built (e.g. `15.16.0`)
-- `<platform>-<arch>` — one of the supported
+- `<version>`: the Cypress version being built (e.g. `15.16.0`)
+- `<platform>-<arch>`: one of the supported
   [platform/architecture combinations](#Mirroring) (e.g. `darwin-arm64`,
   `linux-x64`)
-- `<branch>` — the branch the binary was built from (e.g. `develop`)
-- `<sha>` — the full commit SHA
+- `<branch>`: the branch the binary was built from (e.g. `develop`)
+- `<sha>`: the full commit SHA
 
 You can install a pre-release binary directly by pointing
 [`CYPRESS_INSTALL_BINARY`](#Install-binary) at one of these URLs:
@@ -319,7 +319,7 @@ rely on these being available past 60 days.
 
 The next four sections all address the same root problem: the machine running
 `npm install` can't (or shouldn't) download from `https://download.cypress.io`
-directly. Pick the approach that matches your constraint — a known download URL,
+directly. Pick the approach that matches your constraint: a known download URL,
 a full mirror, a custom URL layout, or a private certificate authority.
 
 ### Download URLs
@@ -498,7 +498,7 @@ variable is used as an extension.
 
 Once downloaded, the binary lives in a global cache so it can be reused across
 projects and CI runs instead of being re-downloaded every time. Knowing where
-that cache is — and being able to move it — is what makes Cypress fast in CI and
+that cache is (and being able to move it) is what makes Cypress fast in CI and
 predictable on shared machines.
 
 By default, global cache folders are:
@@ -548,8 +548,8 @@ ensure this, consider exporting this environment variable. For example, in a
 <strong>Relative paths resolve against the project root</strong>
 
 If you set `CYPRESS_CACHE_FOLDER` (or a local-file `CYPRESS_INSTALL_BINARY`) to
-a relative path, it is resolved relative to your **project root** — the
-directory containing `package.json` — and _not_ relative to
+a relative path, it is resolved relative to your **project root** (the
+directory containing `package.json`) and _not_ relative to
 `node_modules/cypress`. This is because Cypress installs the binary from a
 `postinstall` hook, where the current working directory is the package
 directory.
@@ -697,7 +697,7 @@ variables.
 ## Environment-specific setup
 
 These environments need extra setup because they don't provide a graphical
-display the way a normal desktop OS does — which is what the interactive Test
+display the way a normal desktop OS does, which is what the interactive Test
 Runner needs.
 
 ### Windows Subsystem for Linux

--- a/docs/app/references/advanced-installation.mdx
+++ b/docs/app/references/advanced-installation.mdx
@@ -450,18 +450,16 @@ URL for the platform and version being installed.
 
 **The following replacements are supported:**
 
-- `${endpoint}` is replaced with the full base URL including the version path
-  segment: `<base>/desktop/<version>` (e.g.
-  `https://download.cypress.io/desktop/15.16.0`).
-  If `CYPRESS_DOWNLOAD_MIRROR` is set, its value is used as `<base>` instead of
-  `https://download.cypress.io` (note that `/desktop/<version>` is still
-  appended).
-- `${platform}` is replaced with the platform the installation is running on
-  (e.g. `win32`, `linux`, `darwin`)
-- `${arch}` is replaced with the architecture the installation is running on
-  (e.g. `x64`, `arm64`). On Windows ARM64, this is always `x64`.
-- `${version}` is replaced with the version number
-  that's being installed (e.g. `15.16.0`)
+| Placeholder    | Replaced with                                  | Example                                       |
+| -------------- | ---------------------------------------------- | --------------------------------------------- |
+| `${endpoint}`  | The full base URL, including the version path  | `https://download.cypress.io/desktop/15.16.0` |
+| `${platform}`  | The platform being installed on                | `win32`, `linux`, `darwin`                    |
+| `${arch}`      | The architecture being installed on            | `x64`, `arm64` (always `x64` on Windows ARM64)|
+| `${version}`   | The version number being installed             | `15.16.0`                                     |
+
+`${endpoint}` expands to `<base>/desktop/<version>`. If `CYPRESS_DOWNLOAD_MIRROR`
+is set, its value is used as `<base>` instead of `https://download.cypress.io`,
+but `/desktop/<version>` is still appended.
 
 **Examples:**
 

--- a/docs/app/references/advanced-installation.mdx
+++ b/docs/app/references/advanced-installation.mdx
@@ -180,7 +180,6 @@ To override what is installed, you set `CYPRESS_INSTALL_BINARY` alongside the
   `cypress` version committed in your `package.json`. This is useful for quickly
   testing a different version locally or in CI without changing committed files.
   ```shell
-  # Downloads this binary version for this install only; package.json is untouched
   CYPRESS_INSTALL_BINARY=15.16.0 npm install
   ```
 - Specify an external URL (to bypass a corporate firewall).
@@ -381,7 +380,7 @@ If you want to download a specific Cypress version for a given platform
 air-gapped installs: download the `.zip` once, host it internally, and point
 `CYPRESS_INSTALL_BINARY` at it.
 
-The download server URL is `https://download.cypress.io`.
+**The download server URL is `https://download.cypress.io`.**
 
 We currently have the following downloads available:
 
@@ -439,20 +438,16 @@ and `arch` query parameters, and serve the appropriate Cypress binary as a
 | `darwin`   | `arm64` | macOS Apple Silicon                                           |
 | `win32`    | `x64`   | Windows; also used for ARM64 Windows (no native ARM64 binary) |
 
-:::note
 On Windows ARM64 machines, Cypress automatically substitutes `arm64` with `x64`
 when building the download URL, so your mirror will only ever receive `win32`
 requests with `arch=x64`.
-:::
 
-:::note
 On macOS, Cypress detects the machine's real architecture rather than relying on
 `process.arch`. If an x64 build of Node is running under Rosetta on Apple
 Silicon, Cypress still requests the native `darwin-arm64` binary. This is why the
 downloaded architecture can differ from `process.arch` (which would report
 `x64`), and your mirror may receive `arch=arm64` requests from an x64 Node
 process.
-:::
 
 If your mirror uses a different URL structure than `download.cypress.io`, use
 `CYPRESS_DOWNLOAD_PATH_TEMPLATE` together with `CYPRESS_DOWNLOAD_MIRROR`.
@@ -478,28 +473,81 @@ URL for the platform and version being installed.
 is set, its value is used as `<base>` instead of `https://download.cypress.io`,
 but `/desktop/<version>` is still appended.
 
-**Examples:**
+#### Examples:
 
 To install the binary from a download mirror that matches the exact file
 structure of `https://cdn.cypress.io`:
 
+<Tabs groupId="operating-system">
+<TabItem value="macos" label="macOS" default>
+
 ```shell
 export CYPRESS_DOWNLOAD_MIRROR=https://cypress-download.local
 export CYPRESS_DOWNLOAD_PATH_TEMPLATE='${endpoint}/${platform}-${arch}/cypress.zip'
-# Example of a resulting URL: https://cypress-download.local/desktop/15.16.0/linux-x64/cypress.zip
 ```
+
+</TabItem>
+<TabItem value="linux" label="Linux">
+
+```shell
+export CYPRESS_DOWNLOAD_MIRROR=https://cypress-download.local
+export CYPRESS_DOWNLOAD_PATH_TEMPLATE='${endpoint}/${platform}-${arch}/cypress.zip'
+```
+
+</TabItem>
+<TabItem value="windows" label="Windows">
+
+```shell title="Command Prompt"
+set CYPRESS_DOWNLOAD_MIRROR=https://cypress-download.local
+set CYPRESS_DOWNLOAD_PATH_TEMPLATE='${endpoint}/${platform}-${arch}/cypress.zip'
+```
+
+```shell title="PowerShell"
+$env:CYPRESS_DOWNLOAD_MIRROR = "https://cypress-download.local"
+$env:CYPRESS_DOWNLOAD_PATH_TEMPLATE = '${endpoint}/${platform}-${arch}/cypress.zip'
+```
+
+</TabItem>
+</Tabs>
+
+**Example of a resulting URL:** `https://cypress-download.local/desktop/15.16.0/linux-x64/cypress.zip`
 
 To install the binary from a download server with a custom file structure:
 
+<Tabs groupId="operating-system">
+<TabItem value="macos" label="macOS" default>
+
 ```shell
-export CYPRESS_DOWNLOAD_PATH_TEMPLATE='https://software.local/cypress/${platform}/${arch}/${version}/cypress.zip'
-# Example of a resulting URL: https://software.local/cypress/linux/x64/15.16.0/cypress.zip
+export CYPRESS_DOWNLOAD_PATH_TEMPLATE='${endpoint}/${platform}-${arch}/cypress.zip'
 ```
+
+</TabItem>
+<TabItem value="linux" label="Linux">
+
+```shell
+export CYPRESS_DOWNLOAD_PATH_TEMPLATE='${endpoint}/${platform}-${arch}/cypress.zip'
+```
+
+</TabItem>
+<TabItem value="windows" label="Windows">
+
+```shell title="Command Prompt"
+set CYPRESS_DOWNLOAD_PATH_TEMPLATE='${endpoint}/${platform}-${arch}/cypress.zip'
+```
+
+```shell title="PowerShell"
+$env:CYPRESS_DOWNLOAD_PATH_TEMPLATE = '${endpoint}/${platform}-${arch}/cypress.zip'
+```
+
+</TabItem>
+</Tabs>
+
+**Example of a resulting URL:** `https://software.local/cypress/linux/x64/15.16.0/cypress.zip`
 
 To define `CYPRESS_DOWNLOAD_PATH_TEMPLATE` in `.npmrc`, put a backslash before
 every `$`:
 
-```shell
+```shell title=".npmrc"
 CYPRESS_DOWNLOAD_PATH_TEMPLATE=\${endpoint}/\${platform}-\${arch}/cypress.zip
 ```
 
@@ -532,9 +580,33 @@ ca="-----BEGIN CERTIFICATE-----\nMIID...\n-----END CERTIFICATE-----"
 To supply more than one certificate, set `ca` to an array of strings. The same
 value can also be provided through the environment:
 
+<Tabs groupId="operating-system">
+<TabItem value="macos" label="macOS" default>
+
 ```shell
 export npm_config_ca="-----BEGIN CERTIFICATE-----\nMIID...\n-----END CERTIFICATE-----"
 ```
+
+</TabItem>
+<TabItem value="linux" label="Linux">
+
+```shell
+export npm_config_ca="-----BEGIN CERTIFICATE-----\nMIID...\n-----END CERTIFICATE-----"
+```
+
+</TabItem>
+<TabItem value="windows" label="Windows">
+
+```shell title="Command Prompt"
+set npm_config_ca="-----BEGIN CERTIFICATE-----\nMIID...\n-----END CERTIFICATE-----"
+```
+
+```shell title="PowerShell"
+$env:npm_config_ca = "-----BEGIN CERTIFICATE-----\nMIID...\n-----END CERTIFICATE-----"
+```
+
+</TabItem>
+</Tabs>
 
 If neither `cafile` nor `ca` are set, Cypress looks at the system environment
 variable `NODE_EXTRA_CA_CERTS` and uses the corresponding certificate(s) as an
@@ -562,13 +634,33 @@ The most common reason to relocate the cache is CI caching: pointing
 turns a multi-minute download into a cache hit. Set the environment variable to
 override the default:
 
-```shell
-CYPRESS_CACHE_FOLDER=~/Desktop/cypress_cache npm install
-```
+<Tabs groupId="operating-system">
+<TabItem value="macos" label="macOS" default>
 
 ```shell
-CYPRESS_CACHE_FOLDER=~/Desktop/cypress_cache npm run test
+export CYPRESS_CACHE_FOLDER=~/Desktop/cypress_cache
 ```
+
+</TabItem>
+<TabItem value="linux" label="Linux">
+
+```shell
+export CYPRESS_CACHE_FOLDER=~/.cache/Cypress
+```
+
+</TabItem>
+<TabItem value="windows" label="Windows">
+
+```shell title="Command Prompt"
+set CYPRESS_CACHE_FOLDER=~/.cache/Cypress
+```
+
+```shell title="PowerShell"
+$env:CYPRESS_CACHE_FOLDER = "~/.cache/Cypress"
+```
+
+</TabItem>
+</Tabs>
 
 Cypress will automatically replace the `~` with the user's home directory. So
 you can pass `CYPRESS_CACHE_FOLDER` as a string from CI configuration files, for
@@ -641,32 +733,62 @@ See [How to run commands](./command-line.mdx#How-to-run-commands).
 
 :::
 
-#### Mac
+<Tabs groupId="operating-system">
+<TabItem value="macos" label="macOS" default>
 
 ```shell
 CYPRESS_RUN_BINARY=~/Downloads/Cypress.app/Contents/MacOS/Cypress npx cypress run
 ```
 
-#### Linux
+</TabItem>
+<TabItem value="linux" label="Linux">
 
 ```shell
 CYPRESS_RUN_BINARY=~/Downloads/Cypress/Cypress npx cypress run
 ```
 
-#### Windows
+</TabItem>
+<TabItem value="windows" label="Windows">
 
 ```shell
-CYPRESS_RUN_BINARY=~/Downloads/Cypress/Cypress.exe npx cypress run
+CYPRESS_RUN_BINARY=C:\Users\YourUsername\Downloads\Cypress\Cypress.exe npx cypress run
 ```
 
-:::tip
+</TabItem>
+</Tabs>
 
 Cypress assumes that `CYPRESS_RUN_BINARY` points to a writeable directory structure so that it can save and re-use
 the results of verifying the Cypress binary.
 If you encounter a `permission denied` failure message from [cypress verify](./command-line.mdx#cypress-verify),
 you may be able to work around the failure by setting the environment variable `CYPRESS_SKIP_VERIFY` to `true`.
 
-:::
+<Tabs groupId="operating-system">
+<TabItem value="macos" label="macOS" default>
+
+```shell
+export CYPRESS_SKIP_VERIFY=true
+```
+
+</TabItem>
+<TabItem value="linux" label="Linux">
+
+```shell
+export CYPRESS_SKIP_VERIFY=true
+```
+
+</TabItem>
+<TabItem value="windows" label="Windows">
+
+```shell title="Command Prompt"
+set CYPRESS_SKIP_VERIFY=true
+```
+
+```shell title="PowerShell"
+$env:CYPRESS_SKIP_VERIFY = "true"
+```
+
+</TabItem>
+</Tabs>
 
 ## Privacy and messaging
 
@@ -722,6 +844,34 @@ If you would like to opt out of all commercial messaging, you can do so by
 setting `CYPRESS_COMMERCIAL_RECOMMENDATIONS=0` in your system environment
 variables.
 
+<Tabs groupId="operating-system">
+<TabItem value="macos" label="macOS" default>
+
+```shell
+export CYPRESS_COMMERCIAL_RECOMMENDATIONS=0
+```
+
+</TabItem>
+<TabItem value="linux" label="Linux">
+
+```shell
+export CYPRESS_COMMERCIAL_RECOMMENDATIONS=0
+```
+
+</TabItem>
+<TabItem value="windows" label="Windows">
+
+```shell title="Command Prompt"
+set CYPRESS_COMMERCIAL_RECOMMENDATIONS=0
+```
+
+```shell title="PowerShell"
+$env:CYPRESS_COMMERCIAL_RECOMMENDATIONS = "0"
+```
+
+</TabItem>
+</Tabs>
+
 ## Environment-specific setup
 
 These environments need extra setup because they don't provide a graphical
@@ -752,7 +902,7 @@ Cypress.io does not specifically support the use of Cypress under Windows Subsys
 
 Add the feature to your `devcontainer.json` and forward the necessary ports:
 
-```json
+```json title="devcontainer.json"
 {
   "image": "cypress/included",
   "forwardPorts": [6080, 5901],
@@ -829,10 +979,19 @@ To remove only the older cached versions while keeping the one currently in use,
 Alternatively, delete the [Cypress binary cache](#Binary-cache) (see above) manually.
 See [Managing the binary cache](#Managing-the-binary-cache) for the full set of cache commands.
 
-To delete cached [Cypress App Data](./troubleshooting#Clear-App-Data), manually delete the following directories / folders:
+**To delete cached [Cypress App Data](./troubleshooting#Clear-App-Data), manually delete the following directories / folders:**
 
 - macOS: `~/Library/Application Support/Cypress`
 - Linux: `~/.config/Cypress`
 - Windows: `$APPDATA/Cypress` (POSIX-syntax) or `%APPDATA%\Cypress` (Windows-syntax)
 
 Refer to your package manager documentation for details of package manager `cache clean` commands to remove other packages cached by npm, Yarn, pnpm or Bun.
+
+## See also
+
+- [Install Cypress](/app/get-started/install-cypress)
+- [Command Line](/app/references/command-line) - `cypress cache`, `cypress verify`, and
+  `cypress install`
+- [Troubleshooting](/app/references/troubleshooting)
+- [Continuous Integration Overview](/app/continuous-integration/overview) - caching the
+  binary and Cypress Docker images

--- a/docs/app/references/advanced-installation.mdx
+++ b/docs/app/references/advanced-installation.mdx
@@ -69,15 +69,15 @@ This two-step model is the "why" behind most of the variables below:
 Almost every behavior on this page is driven by a system-level (OS) environment
 variable. These are set in your shell, CI configuration, or `.npmrc`.
 
-| Name                              | Description                                                                                    |
-| --------------------------------- | ---------------------------------------------------------------------------------------------- |
-| `CYPRESS_INSTALL_BINARY`          | [Sets which Cypress binary to install: a version, URL, or local file](#Install-binary)          |
-| `CYPRESS_DOWNLOAD_MIRROR`         | [Downloads the Cypress binary from a mirror server](#Mirroring)                                |
-| `CYPRESS_DOWNLOAD_PATH_TEMPLATE`  | [Builds a custom URL to download the Cypress binary from](#Download-path-template)             |
-| `CYPRESS_CACHE_FOLDER`            | [Changes the location of the Cypress binary cache](#Binary-cache)                              |
-| `CYPRESS_RUN_BINARY`              | [Sets the path to the Cypress binary to launch at run time](#Run-binary)                       |
-| `CYPRESS_VERIFY_TIMEOUT`          | Overrides the timeout duration for the `verify` command. The default value is 30000.           |
-| `CYPRESS_SKIP_VERIFY`             | Skips the [`verify` command](command-line#cypress-verify) when set to `true`                   |
+| Name                             | Description                                                                            |
+| -------------------------------- | -------------------------------------------------------------------------------------- |
+| `CYPRESS_INSTALL_BINARY`         | [Sets which Cypress binary to install: a version, URL, or local file](#Install-binary) |
+| `CYPRESS_DOWNLOAD_MIRROR`        | [Downloads the Cypress binary from a mirror server](#Mirroring)                        |
+| `CYPRESS_DOWNLOAD_PATH_TEMPLATE` | [Builds a custom URL to download the Cypress binary from](#Download-path-template)     |
+| `CYPRESS_CACHE_FOLDER`           | [Changes the location of the Cypress binary cache](#Binary-cache)                      |
+| `CYPRESS_RUN_BINARY`             | [Sets the path to the Cypress binary to launch at run time](#Run-binary)               |
+| `CYPRESS_VERIFY_TIMEOUT`         | Overrides the timeout duration for the `verify` command. The default value is 30000.   |
+| `CYPRESS_SKIP_VERIFY`            | Skips the [`verify` command](command-line#cypress-verify) when set to `true`           |
 
 ### When you'd reach for each
 
@@ -364,11 +364,11 @@ mirror, a custom URL layout, or a private certificate authority.
 If your VPN, firewall, or proxy only permits traffic to approved hosts, add the
 following to your allowlist so the binary can be downloaded during `npm install`:
 
-| URL                          | Purpose                                                      |
-| ---------------------------- | ----------------------------------------------------------- |
-| `https://download.cypress.io`| Resolves the correct binary for your version and platform   |
-| `https://cdn.cypress.io`     | Serves the actual binary `.zip` (download requests redirect here, and pre-release binaries are hosted here) |
-| `https://registry.npmjs.org` | Installs the `cypress` npm package (or your configured npm registry) |
+| URL                           | Purpose                                                                                                     |
+| ----------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `https://download.cypress.io` | Resolves the correct binary for your version and platform                                                   |
+| `https://cdn.cypress.io`      | Serves the actual binary `.zip` (download requests redirect here, and pre-release binaries are hosted here) |
+| `https://registry.npmjs.org`  | Installs the `cypress` npm package (or your configured npm registry)                                        |
 
 If you also run tests against Cypress Cloud, you'll need to allow additional
 URLs. See the full list of
@@ -467,12 +467,12 @@ URL for the platform and version being installed.
 
 **The following replacements are supported:**
 
-| Placeholder    | Replaced with                                  | Example                                       |
-| -------------- | ---------------------------------------------- | --------------------------------------------- |
-| `${endpoint}`  | The full base URL, including the version path  | `https://download.cypress.io/desktop/15.16.0` |
-| `${platform}`  | The platform being installed on                | `win32`, `linux`, `darwin`                    |
-| `${arch}`      | The architecture being installed on            | `x64`, `arm64` (always `x64` on Windows ARM64)|
-| `${version}`   | The version number being installed             | `15.16.0`                                     |
+| Placeholder   | Replaced with                                 | Example                                        |
+| ------------- | --------------------------------------------- | ---------------------------------------------- |
+| `${endpoint}` | The full base URL, including the version path | `https://download.cypress.io/desktop/15.16.0`  |
+| `${platform}` | The platform being installed on               | `win32`, `linux`, `darwin`                     |
+| `${arch}`     | The architecture being installed on           | `x64`, `arm64` (always `x64` on Windows ARM64) |
+| `${version}`  | The version number being installed            | `15.16.0`                                      |
 
 `${endpoint}` expands to `<base>/desktop/<version>`. If `CYPRESS_DOWNLOAD_MIRROR`
 is set, its value is used as `<base>` instead of `https://download.cypress.io`,
@@ -597,16 +597,16 @@ ensure this, consider exporting this environment variable. For example, in a
 
 Over time the cache accumulates a binary per Cypress version you've used, which
 can quietly consume disk space on CI agents and developer machines. The
-[`cypress cache`](./command-line#cypress-cache) command lets you inspect and
+[`cypress cache`](./command-line#cypress-cache-command) command lets you inspect and
 prune it. Run these with the appropriate package manager prefix described in
 [How to run commands](./command-line#How-to-run-commands).
 
-| Command                                                       | Description                                                                          |
-| ------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| [`cypress cache list`](./command-line#cypress-cache-list)     | Lists the cached Cypress versions. Add `--size` to also report each version's size.  |
-| [`cypress cache path`](./command-line#cypress-cache-path)     | Prints the path to the Cypress binary cache.                                         |
-| [`cypress cache prune`](./command-line#cypress-cache-prune)   | Deletes every cached binary except the version currently in use.                     |
-| [`cypress cache clear`](./command-line#cypress-cache-clear)   | Deletes all cached Cypress binaries.                                                 |
+| Command                                                     | Description                                                                         |
+| ----------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| [`cypress cache list`](./command-line#cypress-cache-list)   | Lists the cached Cypress versions. Add `--size` to also report each version's size. |
+| [`cypress cache path`](./command-line#cypress-cache-path)   | Prints the path to the Cypress binary cache.                                        |
+| [`cypress cache prune`](./command-line#cypress-cache-prune) | Deletes every cached binary except the version currently in use.                    |
+| [`cypress cache clear`](./command-line#cypress-cache-clear) | Deletes all cached Cypress binaries.                                                |
 
 ### Run binary
 

--- a/docs/app/references/advanced-installation.mdx
+++ b/docs/app/references/advanced-installation.mdx
@@ -402,6 +402,15 @@ when building the download URL, so your mirror will only ever receive `win32`
 requests with `arch=x64`.
 :::
 
+:::note
+On macOS, Cypress detects the machine's real architecture rather than relying on
+`process.arch`. If an x64 build of Node is running under Rosetta on Apple
+Silicon, Cypress still requests the native `darwin-arm64` binary. This is why the
+downloaded architecture can differ from `process.arch` (which would report
+`x64`), and your mirror may receive `arch=arm64` requests from an x64 Node
+process.
+:::
+
 If your mirror uses a different URL structure than `download.cypress.io`, use
 `CYPRESS_DOWNLOAD_PATH_TEMPLATE` together with `CYPRESS_DOWNLOAD_MIRROR`.
 See [Download path template](#Download-path-template) for examples.

--- a/docs/app/references/advanced-installation.mdx
+++ b/docs/app/references/advanced-installation.mdx
@@ -354,8 +354,7 @@ rely on these being available past 60 days.
 ## Installing behind a firewall or mirror
 
 The next four sections all address the same root problem: the machine running
-`npm install` can't (or shouldn't) download from `https://download.cypress.io`
-directly. Pick the approach that matches your constraint: a known download URL,
+`npm install` can't download from `https://download.cypress.io` directly. Pick the approach that matches your constraint: a known download URL,
 a full mirror, a custom URL layout, or a private certificate authority.
 
 ### Download URLs

--- a/docs/app/references/advanced-installation.mdx
+++ b/docs/app/references/advanced-installation.mdx
@@ -178,7 +178,7 @@ To override what is installed, you set `CYPRESS_INSTALL_BINARY` alongside the
 
 - Install a version different than the default npm package.
   ```shell
-  CYPRESS_INSTALL_BINARY=13.7.0 npm install cypress@13.7.1
+  CYPRESS_INSTALL_BINARY=15.16.0 npm install cypress@15.16.1
   ```
 - Specify an external URL (to bypass a corporate firewall).
   ```shell

--- a/docs/app/references/advanced-installation.mdx
+++ b/docs/app/references/advanced-installation.mdx
@@ -246,6 +246,23 @@ ensure this, consider exporting this environment variable. For example, in a
 
 :::
 
+:::caution
+
+<strong>Relative paths resolve against the project root</strong>
+
+If you set `CYPRESS_CACHE_FOLDER` (or a local-file `CYPRESS_INSTALL_BINARY`) to
+a relative path, it is resolved relative to your **project root** — the
+directory containing `package.json` — and _not_ relative to
+`node_modules/cypress`. This is because Cypress installs the binary from a
+`postinstall` hook, where the current working directory is the package
+directory.
+
+For example, `CYPRESS_CACHE_FOLDER=.cache/Cypress` resolves to
+`<project-root>/.cache/Cypress`. To avoid ambiguity, prefer an absolute path
+(or one anchored with `~`, which Cypress expands to the user's home directory).
+
+:::
+
 ### Managing the binary cache
 
 The [`cypress cache`](./command-line#cypress-cache) command lets you inspect and

--- a/docs/app/references/advanced-installation.mdx
+++ b/docs/app/references/advanced-installation.mdx
@@ -41,7 +41,7 @@ Understanding the install model makes almost every setting on this page
 self-explanatory. Installing Cypress happens in two distinct steps:
 
 1. **The npm module** (`cypress`) is added to your project like any other
-   dependency. This package is small: it's the command-line wrapper, TypeScript
+   dependency. This package is small: it's the CLI, TypeScript
    types, and the `cypress` binary launcher. It is _not_ the Cypress application
    itself.
 2. **The binary** (the actual Cypress application, including the bundled

--- a/docs/app/references/advanced-installation.mdx
+++ b/docs/app/references/advanced-installation.mdx
@@ -105,8 +105,10 @@ typically solves, so you can find the right tool for your situation:
 - **`CYPRESS_RUN_BINARY`**: Use this when you want to launch a specific binary
   already on disk instead of the one resolved from the cache, for example a
   binary you unzipped to a known location.
-- **`CYPRESS_VERIFY_TIMEOUT`**: Use this when the one-time binary verification
-  step times out, which can happen on slow or heavily loaded machines.
+- **`CYPRESS_VERIFY_TIMEOUT`**: Use this to adjust how long Cypress waits for the
+  one-time binary verification step before timing out. The default is 30 seconds
+  (`30000` ms); raise it on slow or heavily loaded machines where verification
+  needs more time.
 - **`CYPRESS_SKIP_VERIFY`**: Use this to skip binary verification, for example
   when the binary lives in a read-only location and verification can't write its
   results.

--- a/docs/app/references/advanced-installation.mdx
+++ b/docs/app/references/advanced-installation.mdx
@@ -386,10 +386,10 @@ for all available platforms.
 | `GET`  | `/desktop/:version`                   | Download Cypress with a specified version                                  |
 | `GET`  | `/desktop/:version?platform=p&arch=a` | Download Cypress with a specified version and platform and/or architecture |
 
-**Example of downloading Cypress `12.17.4` for Windows 64-bit:**
+**Example of downloading Cypress `15.16.0` for Windows 64-bit:**
 
 ```text
-https://download.cypress.io/desktop/12.17.4?platform=win32&arch=x64
+https://download.cypress.io/desktop/15.16.0?platform=win32&arch=x64
 ```
 
 ### Mirroring

--- a/docs/app/references/advanced-installation.mdx
+++ b/docs/app/references/advanced-installation.mdx
@@ -24,16 +24,14 @@ constraints.
 
 ##### <Icon name="question-circle" color="#4BBFD2" /> What you'll learn
 
-- **How Cypress installs**: the npm module vs. the binary, and why that split
-  matters
-- **Controlling the install**: installing a custom version, URL, or local file,
-  or skipping the binary entirely
-- **Installing behind a firewall or mirror**: proxies, download mirrors, custom
-  URL templates, and custom certificate authorities
-- **Managing the binary cache**: where binaries live, how to relocate them, and
-  how to prune or clear them
-- **Privacy controls**: opting out of crash reports and commercial messaging
-- **Environment-specific setup**: WSL, Dev Containers, and GitHub Codespaces
+- How Cypress installs the npm module and the binary, and why that split matters
+- How to install a custom version, URL, or local file, or skip the binary
+  entirely
+- How to install behind a proxy, download mirror, custom URL template, or custom
+  certificate authority
+- How to relocate, inspect, and prune the binary cache
+- How to opt out of crash reports and commercial messaging
+- How to set up Cypress in WSL, Dev Containers, and GitHub Codespaces
 
 :::
 

--- a/docs/app/references/advanced-installation.mdx
+++ b/docs/app/references/advanced-installation.mdx
@@ -568,6 +568,27 @@ functionality that has not yet been released, here is how:
    operating system and CPU architecture, and follow the instructions there to
    install the pre-release.
 
+The `cypress-bot` comments point at pre-release binaries hosted on the Cypress
+CDN. If you are scripting pre-release installs, the URLs follow this pattern:
+
+```text
+https://cdn.cypress.io/beta/binary/<version>/<platform>-<arch>/<branch>-<sha>/cypress.zip
+```
+
+- `<version>` — the Cypress version being built (e.g. `15.16.0`)
+- `<platform>-<arch>` — one of the supported
+  [platform/architecture combinations](#Mirroring) (e.g. `darwin-arm64`,
+  `linux-x64`)
+- `<branch>` — the branch the binary was built from (e.g. `develop`)
+- `<sha>` — the full commit SHA
+
+You can install a pre-release binary directly by pointing
+[`CYPRESS_INSTALL_BINARY`](#Install-binary) at one of these URLs:
+
+```shell
+CYPRESS_INSTALL_BINARY=https://cdn.cypress.io/beta/binary/15.16.0/darwin-arm64/develop-abcdef1234567890/cypress.zip npm install cypress
+```
+
 Cypress pre-releases are only available for 60 days after they are built. Do not
 rely on these being available past 60 days.
 

--- a/docs/app/references/advanced-installation.mdx
+++ b/docs/app/references/advanced-installation.mdx
@@ -576,23 +576,6 @@ ensure this, consider exporting this environment variable. For example, in a
 
 :::
 
-:::caution
-
-<strong>Relative paths resolve against the project root</strong>
-
-If you set `CYPRESS_CACHE_FOLDER` (or a local-file `CYPRESS_INSTALL_BINARY`) to
-a relative path, it is resolved relative to your **project root** (the
-directory containing `package.json`) and _not_ relative to
-`node_modules/cypress`. This is because Cypress installs the binary from a
-`postinstall` hook, where the current working directory is the package
-directory.
-
-For example, `CYPRESS_CACHE_FOLDER=.cache/Cypress` resolves to
-`<project-root>/.cache/Cypress`. To avoid ambiguity, prefer an absolute path
-(or one anchored with `~`, which Cypress expands to the user's home directory).
-
-:::
-
 ### Managing the binary cache
 
 Over time the cache accumulates a binary per Cypress version you've used, which

--- a/docs/app/references/advanced-installation.mdx
+++ b/docs/app/references/advanced-installation.mdx
@@ -71,14 +71,14 @@ variable. These are set in your shell, CI configuration, or `.npmrc`.
 
 | Name                              | Description                                                                                    |
 | --------------------------------- | ---------------------------------------------------------------------------------------------- |
-| `CYPRESS_INSTALL_BINARY`          | [Destination of Cypress binary that's downloaded and installed](#Install-binary)               |
+| `CYPRESS_INSTALL_BINARY`          | [Sets which Cypress binary to install: a version, URL, or local file](#Install-binary)          |
 | `CYPRESS_CONNECT_RETRY_THRESHOLD` | Overrides the maximum number of retries when connecting to a browser. The default value is 62. |
-| `CYPRESS_DOWNLOAD_MIRROR`         | [Downloads the Cypress binary through a mirror server](#Mirroring)                             |
-| `CYPRESS_DOWNLOAD_PATH_TEMPLATE`  | [Allows generating a custom URL to download the Cypress binary from](#Download-path-template)  |
-| `CYPRESS_CACHE_FOLDER`            | [Changes the Cypress binary cache location](#Binary-cache)                                     |
-| `CYPRESS_RUN_BINARY`              | [Location of Cypress binary at run-time](#Run-binary)                                          |
+| `CYPRESS_DOWNLOAD_MIRROR`         | [Downloads the Cypress binary from a mirror server](#Mirroring)                                |
+| `CYPRESS_DOWNLOAD_PATH_TEMPLATE`  | [Builds a custom URL to download the Cypress binary from](#Download-path-template)             |
+| `CYPRESS_CACHE_FOLDER`            | [Changes the location of the Cypress binary cache](#Binary-cache)                              |
+| `CYPRESS_RUN_BINARY`              | [Sets the path to the Cypress binary to launch at run time](#Run-binary)                       |
 | `CYPRESS_VERIFY_TIMEOUT`          | Overrides the timeout duration for the `verify` command. The default value is 30000.           |
-| `CYPRESS_SKIP_VERIFY`             | Skips the [`verify` command](command-line#cypress-verify) when `true`                          |
+| `CYPRESS_SKIP_VERIFY`             | Skips the [`verify` command](command-line#cypress-verify) when set to `true`                   |
 
 ### Setting variables via npm config or package.json
 

--- a/docs/app/references/advanced-installation.mdx
+++ b/docs/app/references/advanced-installation.mdx
@@ -246,6 +246,19 @@ ensure this, consider exporting this environment variable. For example, in a
 
 :::
 
+### Managing the binary cache
+
+The [`cypress cache`](./command-line#cypress-cache) command lets you inspect and
+manage the binary cache. Run these with the appropriate package manager prefix
+described in [How to run commands](./command-line#How-to-run-commands).
+
+| Command                                                       | Description                                                                          |
+| ------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| [`cypress cache list`](./command-line#cypress-cache-list)     | Lists the cached Cypress versions. Add `--size` to also report each version's size.  |
+| [`cypress cache path`](./command-line#cypress-cache-path)     | Prints the path to the Cypress binary cache.                                         |
+| [`cypress cache prune`](./command-line#cypress-cache-prune)   | Deletes every cached binary except the version currently in use.                     |
+| [`cypress cache clear`](./command-line#cypress-cache-clear)   | Deletes all cached Cypress binaries.                                                 |
+
 ## Run binary
 
 Setting the environment variable `CYPRESS_RUN_BINARY` overrides where the npm
@@ -609,7 +622,9 @@ bun remove cypress
 </Tabs>
 
 To uninstall all cached Cypress binary versions, use the [cypress cache clear](./command-line#cypress-cache-clear) command with the appropriate package manager prefix described in [How to run commands](./command-line#How-to-run-commands).
+To remove only the older cached versions while keeping the one currently in use, use [cypress cache prune](./command-line#cypress-cache-prune) instead.
 Alternatively, delete the [Cypress binary cache](#Binary-cache) (see above) manually.
+See [Managing the binary cache](#Managing-the-binary-cache) for the full set of cache commands.
 
 To delete cached [Cypress App Data](./troubleshooting#Clear-App-Data), manually delete the following directories / folders:
 

--- a/docs/app/references/advanced-installation.mdx
+++ b/docs/app/references/advanced-installation.mdx
@@ -410,20 +410,6 @@ binary.
 Note that the npm config is used as a replacement, and the node environment
 variable is used as an extension.
 
-:::caution
-
-<strong>Deprecation: `CYPRESS_DOWNLOAD_USE_CA`</strong>
-
-Older guides, GitHub issues, and `.npmrc`/CI configurations may reference the
-`CYPRESS_DOWNLOAD_USE_CA` environment variable to opt into using the `ca` and
-`cafile` options from your npm config. This variable is **deprecated and no
-longer required to be set** — Cypress now reads these options automatically, as
-described above. Setting it has no effect and the Cypress CLI will print a
-warning that it is no longer required to be set. You can safely remove it from
-your configuration.
-
-:::
-
 ## Opt out of sending exception data to Cypress
 
 When an exception is thrown regarding Cypress, we send along the exception data

--- a/docs/app/references/advanced-installation.mdx
+++ b/docs/app/references/advanced-installation.mdx
@@ -328,7 +328,8 @@ and `arch` query parameters, and serve the appropriate Cypress binary as a
 
 | `platform` | `arch`  | Notes                                                         |
 | ---------- | ------- | ------------------------------------------------------------- |
-| `linux`    | `x64`   |                                                               |
+| `linux`    | `x64`   | Linux Intel/AMD 64-bit                                        |
+| `linux`    | `arm64` | Linux ARM64 (e.g. AWS Graviton, Apple Silicon containers)     |
 | `darwin`   | `x64`   | macOS Intel                                                   |
 | `darwin`   | `arm64` | macOS Apple Silicon                                           |
 | `win32`    | `x64`   | Windows; also used for ARM64 Windows (no native ARM64 binary) |

--- a/docs/app/references/advanced-installation.mdx
+++ b/docs/app/references/advanced-installation.mdx
@@ -72,7 +72,6 @@ variable. These are set in your shell, CI configuration, or `.npmrc`.
 | Name                              | Description                                                                                    |
 | --------------------------------- | ---------------------------------------------------------------------------------------------- |
 | `CYPRESS_INSTALL_BINARY`          | [Sets which Cypress binary to install: a version, URL, or local file](#Install-binary)          |
-| `CYPRESS_CONNECT_RETRY_THRESHOLD` | Overrides the maximum number of retries when connecting to a browser. The default value is 62. |
 | `CYPRESS_DOWNLOAD_MIRROR`         | [Downloads the Cypress binary from a mirror server](#Mirroring)                                |
 | `CYPRESS_DOWNLOAD_PATH_TEMPLATE`  | [Builds a custom URL to download the Cypress binary from](#Download-path-template)             |
 | `CYPRESS_CACHE_FOLDER`            | [Changes the location of the Cypress binary cache](#Binary-cache)                              |

--- a/docs/app/references/advanced-installation.mdx
+++ b/docs/app/references/advanced-installation.mdx
@@ -309,8 +309,10 @@ DEBUG=cypress:cli* bunx cypress install
 ### Install pre-release version
 
 Occasionally you'll want to verify a fix or try a feature before it ships in an
-official release. Cypress publishes a pre-release binary for individual commits
-on `develop`, which you can install the same way as any custom binary.
+official release. The Cypress team may also ask you to install a pre-release to
+confirm that an issue you reported is resolved before it's released. Cypress
+publishes a pre-release binary for individual commits on `develop`, which you can
+install the same way as any custom binary.
 
 1. Open up the list of commits to `develop` on the Cypress repo:
    [https://github.com/cypress-io/cypress/commits/develop](https://github.com/cypress-io/cypress/commits/develop)

--- a/docs/app/references/advanced-installation.mdx
+++ b/docs/app/references/advanced-installation.mdx
@@ -8,19 +8,69 @@ sidebar_label: 'Advanced Installation'
 
 # Advanced Installation
 
+Most people install Cypress with a single `npm install cypress --save-dev` and
+never need anything on this page. The defaults are designed to "just work":
+Cypress downloads the right binary for your operating system, caches it so it can
+be reused across projects, and launches it when you run a test.
+
+This guide is for the situations where those defaults don't fit. It exists
+because real-world environments are messy — corporate proxies, air-gapped CI,
+locked-down certificate stores, disk-constrained build agents, and containerized
+editors all change how (and whether) Cypress can reach the internet and where it
+can write files. Each setting below is an escape hatch for one of those
+constraints.
+
 :::info
 
 ##### <Icon name="question-circle" color="#4BBFD2" /> What you'll learn
 
-- How to install Cypress with a custom binary
-- How to skip the installation of the Cypress binary
-- How to change the Cypress binary cache location or download URL
-- How to use a custom certificate authority (CA)
-- How to opt out of sending exception data to Cypress
+- **How Cypress installs** — the npm module vs. the binary, and why that split
+  matters
+- **Controlling the install** — installing a custom version, URL, or local file,
+  or skipping the binary entirely
+- **Installing behind a firewall or mirror** — proxies, download mirrors, custom
+  URL templates, and custom certificate authorities
+- **Managing the binary cache** — where binaries live, how to relocate them, and
+  how to prune or clear them
+- **Privacy controls** — opting out of crash reports and commercial messaging
+- **Environment-specific setup** — WSL, Dev Containers, and GitHub Codespaces
 
 :::
 
+## How Cypress installs
+
+Understanding the install model makes almost every setting on this page
+self-explanatory. Installing Cypress happens in two distinct steps:
+
+1. **The npm module** (`cypress`) is added to your project like any other
+   dependency. This package is small — it's the command-line wrapper, TypeScript
+   types, and the `cypress` binary launcher. It is _not_ the Cypress application
+   itself.
+2. **The binary** (the actual Cypress application, including the bundled
+   browsers' automation layer) is downloaded in a
+   [`postinstall`](https://docs.npmjs.com/cli/using-npm/scripts) step. Because
+   the binary is large and platform-specific, it is stored in a **global cache**
+   outside `node_modules` so a single download can be shared by every project on
+   the machine.
+
+When you later run `cypress open` or `cypress run`, the npm module locates the
+matching binary in the cache and launches it.
+
+This two-step model is the "why" behind most of the variables below:
+
+- Because the binary is downloaded separately, you can point that download at a
+  different version, URL, or local file — see [Install binary](#Install-binary).
+- Because it comes over the network, restricted environments need a way to route
+  through a [proxy](#Proxy-configuration), a [mirror](#Mirroring), or a
+  [custom CA](#Using-a-custom-certificate-authority-CA).
+- Because it lives in a shared cache, you can relocate, inspect, and prune that
+  cache — see [Binary cache](#Binary-cache).
+
 ## Environment variables
+
+Almost every behavior on this page is driven by an environment variable. The
+table below is the quick reference; each links to the section that explains the
+"why" and shows examples.
 
 | Name                              | Description                                                                                    |
 | --------------------------------- | ---------------------------------------------------------------------------------------------- |
@@ -34,6 +84,11 @@ sidebar_label: 'Advanced Installation'
 | `CYPRESS_SKIP_VERIFY`             | Skips the [`verify` command](command-line#cypress-verify) when `true`                          |
 
 ### Setting variables via npm config or package.json
+
+You don't have to export a shell variable to configure these options. This is
+valuable because shell exports don't persist across machines or CI agents,
+whereas committing the setting to your repo does — so the whole team and your CI
+get the same behavior automatically.
 
 Every `CYPRESS_*` variable above can be set as a real environment variable, or
 through your npm configuration. Cypress resolves each variable in the following
@@ -67,6 +122,11 @@ or in a `config` block of your `package.json`:
 
 ## Proxy configuration
 
+Corporate networks frequently force outbound traffic through a proxy. Because the
+binary download happens outside your application code (in npm's `postinstall`),
+Cypress reads the proxy settings npm and the OS already use, so you usually don't
+have to configure anything Cypress-specific.
+
 System [proxy properties](/app/references/proxy-configuration) `http_proxy`, `https_proxy` and `no_proxy` are respected
 for the download of the Cypress binary.
 You can also use the npm properties
@@ -76,9 +136,13 @@ they will only be used if the system properties are being resolved to not use a 
 
 ## Install binary
 
-Using the `CYPRESS_INSTALL_BINARY` environment variable, you can control how
-Cypress is installed. To override what is installed, you set
-`CYPRESS_INSTALL_BINARY` alongside the `npm install` command.
+`CYPRESS_INSTALL_BINARY` controls **which** binary the `postinstall` step
+fetches. This is the most common reason to visit this page: the version in npm
+isn't the one you want, or the public download server isn't reachable from where
+you're installing.
+
+To override what is installed, you set `CYPRESS_INSTALL_BINARY` alongside the
+`npm install` command.
 
 **This is helpful if you want to:**
 
@@ -97,13 +161,16 @@ Cypress is installed. To override what is installed, you set
 
 In all cases, the fact that the binary was installed from a custom location _is
 not saved in your `package.json` file_. Every repeated installation needs to use
-the same environment variable to install the same binary.
+the same environment variable to install the same binary. (This is exactly the
+problem [npm config / package.json](#Setting-variables-via-npm-config-or-packagejson)
+solves — commit the setting so it's applied on every install.)
 
 ### Skipping installation
 
-You can also force Cypress to skip the installation of the binary application by
-setting `CYPRESS_INSTALL_BINARY=0`. This could be useful if you want to prevent
-Cypress from downloading the Cypress binary at the time of `npm install`.
+Sometimes you want the npm module without the binary download — for example, to
+build a base Docker image and add the binary in a later layer, or to install the
+binary yourself with debug output. Setting `CYPRESS_INSTALL_BINARY=0` skips the
+download entirely.
 
 ```shell
 CYPRESS_INSTALL_BINARY=0 npm install
@@ -113,7 +180,10 @@ Now Cypress will skip its install phase once the npm module is installed.
 
 ### Troubleshoot installation
 
-The Cypress [Life Cycle script](https://docs.npmjs.com/cli/using-npm/scripts) `postinstall` installs the Cypress binary after the [Cypress npm module](https://www.npmjs.com/package/cypress) has been installed. Package managers however execute the `postinstall` step in the background by default which hides the debug output. Execute `cypress install` separately with [debug logging](./troubleshooting#Log-sources) enabled to view the debug logs.
+When an install fails, the useful output is usually hidden: package managers run
+`postinstall` in the background by default. The fix is to run `cypress install`
+on its own with [debug logging](./troubleshooting#Log-sources) enabled so you can
+see exactly where the download or unzip step breaks.
 
 <Tabs groupId="package-manager"
   defaultValue="npm"
@@ -202,18 +272,245 @@ DEBUG=cypress:cli* bunx cypress install
   </TabItem>
 </Tabs>
 
+### Install pre-release version
+
+Occasionally you'll want to verify a fix or try a feature before it ships in an
+official release. Cypress publishes a pre-release binary for individual commits
+on `develop`, which you can install the same way as any custom binary.
+
+1. Open up the list of commits to `develop` on the Cypress repo:
+   [https://github.com/cypress-io/cypress/commits/develop](https://github.com/cypress-io/cypress/commits/develop)
+2. Find the commit that you would like to install the pre-release version of.
+   Click the comment icon (highlighted in red below):
+   <DocsImage
+     src="/img/app/install/develop-commit-comment-link.png"
+     alt="Example of a commit for which pre-releases are available. Comment link highlighted in red."
+   />
+3. You should see several comments from the `cypress-bot` user with instructions
+   for installing Cypress pre-releases. Pick the one that corresponds to your
+   operating system and CPU architecture, and follow the instructions there to
+   install the pre-release.
+
+The `cypress-bot` comments point at pre-release binaries hosted on the Cypress
+CDN. If you are scripting pre-release installs, the URLs follow this pattern:
+
+```text
+https://cdn.cypress.io/beta/binary/<version>/<platform>-<arch>/<branch>-<sha>/cypress.zip
+```
+
+- `<version>` — the Cypress version being built (e.g. `15.16.0`)
+- `<platform>-<arch>` — one of the supported
+  [platform/architecture combinations](#Mirroring) (e.g. `darwin-arm64`,
+  `linux-x64`)
+- `<branch>` — the branch the binary was built from (e.g. `develop`)
+- `<sha>` — the full commit SHA
+
+You can install a pre-release binary directly by pointing
+[`CYPRESS_INSTALL_BINARY`](#Install-binary) at one of these URLs:
+
+```shell
+CYPRESS_INSTALL_BINARY=https://cdn.cypress.io/beta/binary/15.16.0/darwin-arm64/develop-abcdef1234567890/cypress.zip npm install cypress
+```
+
+Cypress pre-releases are only available for 60 days after they are built. Do not
+rely on these being available past 60 days.
+
+## Installing behind a firewall or mirror
+
+The next four sections all address the same root problem: the machine running
+`npm install` can't (or shouldn't) download from `https://download.cypress.io`
+directly. Pick the approach that matches your constraint — a known download URL,
+a full mirror, a custom URL layout, or a private certificate authority.
+
+### Download URLs
+
+If you want to download a specific Cypress version for a given platform
+(Operating System), you can get it from our CDN. This is the building block for
+air-gapped installs: download the `.zip` once, host it internally, and point
+`CYPRESS_INSTALL_BINARY` at it.
+
+The download server URL is `https://download.cypress.io`.
+
+We currently have the following downloads available:
+
+- Windows 64-bit (`?platform=win32&arch=x64`)
+- Linux 64-bit (`?platform=linux`)
+- macOS 64-bit (`?platform=darwin`)
+
+Here are the available download URLs:
+
+See
+[https://download.cypress.io/desktop.json](https://download.cypress.io/desktop.json)
+for all available platforms.
+
+| Method | URL                                   | Description                                                                |
+| ------ | ------------------------------------- | -------------------------------------------------------------------------- |
+| `GET`  | `/desktop`                            | Download Cypress at latest version (platform auto-detected)                |
+| `GET`  | `/desktop.json`                       | Returns JSON containing latest available CDN destinations                  |
+| `GET`  | `/desktop?platform=p&arch=a`          | Download Cypress for a specific platform and/or architecture               |
+| `GET`  | `/desktop/:version`                   | Download Cypress with a specified version                                  |
+| `GET`  | `/desktop/:version?platform=p&arch=a` | Download Cypress with a specified version and platform and/or architecture |
+
+**Example of downloading Cypress `12.17.4` for Windows 64-bit:**
+
+```text
+https://download.cypress.io/desktop/12.17.4?platform=win32&arch=x64
+```
+
+### Mirroring
+
+When many machines install Cypress from inside a restricted network, hosting a
+mirror is more maintainable than pinning every project to a one-off URL. Set
+`CYPRESS_DOWNLOAD_MIRROR` to replace the download server URL
+`https://download.cypress.io` with your own mirror.
+
+For example:
+
+```shell
+CYPRESS_DOWNLOAD_MIRROR="https://www.example.com" cypress install
+```
+
+Cypress will then attempt to download a binary with this format:
+`https://www.example.com/desktop/:version?platform=p&arch=a`
+
+Your mirror server must handle requests to `/desktop/:version` with `platform`
+and `arch` query parameters, and serve the appropriate Cypress binary as a
+`.zip` file.
+
+**Supported platform and architecture combinations:**
+
+| `platform` | `arch`  | Notes                                                         |
+| ---------- | ------- | ------------------------------------------------------------- |
+| `linux`    | `x64`   | Linux Intel/AMD 64-bit                                        |
+| `linux`    | `arm64` | Linux ARM64 (e.g. AWS Graviton, Apple Silicon containers)     |
+| `darwin`   | `x64`   | macOS Intel                                                   |
+| `darwin`   | `arm64` | macOS Apple Silicon                                           |
+| `win32`    | `x64`   | Windows; also used for ARM64 Windows (no native ARM64 binary) |
+
+:::note
+On Windows ARM64 machines, Cypress automatically substitutes `arm64` with `x64`
+when building the download URL, so your mirror will only ever receive `win32`
+requests with `arch=x64`.
+:::
+
+:::note
+On macOS, Cypress detects the machine's real architecture rather than relying on
+`process.arch`. If an x64 build of Node is running under Rosetta on Apple
+Silicon, Cypress still requests the native `darwin-arm64` binary. This is why the
+downloaded architecture can differ from `process.arch` (which would report
+`x64`), and your mirror may receive `arch=arm64` requests from an x64 Node
+process.
+:::
+
+If your mirror uses a different URL structure than `download.cypress.io`, use
+`CYPRESS_DOWNLOAD_PATH_TEMPLATE` together with `CYPRESS_DOWNLOAD_MIRROR`.
+See [Download path template](#Download-path-template) for examples.
+
+### Download path template
+
+A plain mirror assumes your server mimics the `download.cypress.io` layout.
+`CYPRESS_DOWNLOAD_PATH_TEMPLATE` removes that assumption: it lets you describe
+exactly how your artifact store lays out files, so Cypress can build the right
+URL for the platform and version being installed.
+
+**The following replacements are supported:**
+
+- `${endpoint}` is replaced with the full base URL including the version path
+  segment: `<base>/desktop/<version>` (e.g.
+  `https://download.cypress.io/desktop/15.16.0`).
+  If `CYPRESS_DOWNLOAD_MIRROR` is set, its value is used as `<base>` instead of
+  `https://download.cypress.io` (note that `/desktop/<version>` is still
+  appended).
+- `${platform}` is replaced with the platform the installation is running on
+  (e.g. `win32`, `linux`, `darwin`)
+- `${arch}` is replaced with the architecture the installation is running on
+  (e.g. `x64`, `arm64`). On Windows ARM64, this is always `x64`.
+- `${version}` is replaced with the version number
+  that's being installed (e.g. `15.16.0`)
+
+**Examples:**
+
+To install the binary from a download mirror that matches the exact file
+structure of `https://cdn.cypress.io`:
+
+```shell
+export CYPRESS_DOWNLOAD_MIRROR=https://cypress-download.local
+export CYPRESS_DOWNLOAD_PATH_TEMPLATE='${endpoint}/${platform}-${arch}/cypress.zip'
+# Example of a resulting URL: https://cypress-download.local/desktop/15.16.0/linux-x64/cypress.zip
+```
+
+To install the binary from a download server with a custom file structure:
+
+```shell
+export CYPRESS_DOWNLOAD_PATH_TEMPLATE='https://software.local/cypress/${platform}/${arch}/${version}/cypress.zip'
+# Example of a resulting URL: https://software.local/cypress/linux/x64/15.16.0/cypress.zip
+```
+
+To define `CYPRESS_DOWNLOAD_PATH_TEMPLATE` in `.npmrc`, put a backslash before
+every `$`:
+
+```ini
+CYPRESS_DOWNLOAD_PATH_TEMPLATE=\${endpoint}/\${platform}-\${arch}/cypress.zip
+```
+
+### Using a custom certificate authority (CA)
+
+Networks that intercept TLS (or serve downloads from an internal host with a
+private certificate) will cause the download to fail certificate validation.
+Pointing Cypress at your organization's CA lets the download succeed without
+disabling TLS verification.
+
+Cypress can be configured to use the `ca` and `cafile` options from your npm
+config file to download the Cypress binary.
+
+For example, to use the CA at `/home/person/certs/ca.crt` when downloading
+Cypress, add the following to your `.npmrc`:
+
+```shell title=".npmrc"
+cafile=/home/person/certs/ca.crt
+```
+
+Alternatively, you can supply the certificate inline with the `ca` option
+instead of pointing to a file. This is equivalent to setting the
+`npm_config_ca` environment variable. Newlines in the PEM certificate are
+represented with `\n`:
+
+```ini title=".npmrc"
+ca="-----BEGIN CERTIFICATE-----\nMIID...\n-----END CERTIFICATE-----"
+```
+
+To supply more than one certificate, set `ca` to an array of strings. The same
+value can also be provided through the environment:
+
+```shell
+export npm_config_ca="-----BEGIN CERTIFICATE-----\nMIID...\n-----END CERTIFICATE-----"
+```
+
+If neither `cafile` nor `ca` are set, Cypress looks at the system environment
+variable `NODE_EXTRA_CA_CERTS` and uses the corresponding certificate(s) as an
+extension for the trusted certificate authority when downloading the Cypress
+binary.
+
+Note that the npm config is used as a replacement, and the node environment
+variable is used as an extension.
+
 ## Binary cache
 
-Cypress downloads the matching Cypress binary to the global
-system cache, so that the binary can be shared between projects. By default,
-global cache folders are:
+Once downloaded, the binary lives in a global cache so it can be reused across
+projects and CI runs instead of being re-downloaded every time. Knowing where
+that cache is — and being able to move it — is what makes Cypress fast in CI and
+predictable on shared machines.
+
+By default, global cache folders are:
 
 - **MacOS**: `~/Library/Caches/Cypress`
 - **Linux**: `~/.cache/Cypress`
 - **Windows**: `/AppData/Local/Cypress/Cache`
 
-To override the default cache folder, set the environment variable
-`CYPRESS_CACHE_FOLDER`.
+The most common reason to relocate the cache is CI caching: pointing
+`CYPRESS_CACHE_FOLDER` at a directory your CI provider persists between runs
+turns a multi-minute download into a cache hit. Set the environment variable to
+override the default:
 
 ```shell
 CYPRESS_CACHE_FOLDER=~/Desktop/cypress_cache npm install
@@ -265,9 +562,11 @@ For example, `CYPRESS_CACHE_FOLDER=.cache/Cypress` resolves to
 
 ### Managing the binary cache
 
-The [`cypress cache`](./command-line#cypress-cache) command lets you inspect and
-manage the binary cache. Run these with the appropriate package manager prefix
-described in [How to run commands](./command-line#How-to-run-commands).
+Over time the cache accumulates a binary per Cypress version you've used, which
+can quietly consume disk space on CI agents and developer machines. The
+[`cypress cache`](./command-line#cypress-cache) command lets you inspect and
+prune it. Run these with the appropriate package manager prefix described in
+[How to run commands](./command-line#How-to-run-commands).
 
 | Command                                                       | Description                                                                          |
 | ------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
@@ -276,10 +575,12 @@ described in [How to run commands](./command-line#How-to-run-commands).
 | [`cypress cache prune`](./command-line#cypress-cache-prune)   | Deletes every cached binary except the version currently in use.                     |
 | [`cypress cache clear`](./command-line#cypress-cache-clear)   | Deletes all cached Cypress binaries.                                                 |
 
-## Run binary
+### Run binary
 
-Setting the environment variable `CYPRESS_RUN_BINARY` overrides where the npm
-module finds the Cypress binary.
+`CYPRESS_RUN_BINARY` is the run-time counterpart to the install-time settings
+above: it tells the npm module to launch a specific binary on disk instead of the
+one it would normally resolve from the cache. This is useful when you've unzipped
+a binary to a known location and want to run it directly.
 
 `CYPRESS_RUN_BINARY` should be a path to an already unzipped Cypress binary executable.
 The Cypress commands [open](./command-line#cypress-open), [run](./command-line#cypress-run) and [verify](command-line#cypress-verify)
@@ -307,19 +608,19 @@ See [How to run commands](./command-line.mdx#How-to-run-commands).
 
 :::
 
-### Mac
+#### Mac
 
 ```shell
 CYPRESS_RUN_BINARY=~/Downloads/Cypress.app/Contents/MacOS/Cypress npx cypress run
 ```
 
-### Linux
+#### Linux
 
 ```shell
 CYPRESS_RUN_BINARY=~/Downloads/Cypress/Cypress npx cypress run
 ```
 
-### Windows
+#### Windows
 
 ```shell
 CYPRESS_RUN_BINARY=~/Downloads/Cypress/Cypress.exe npx cypress run
@@ -334,170 +635,13 @@ you may be able to work around the failure by setting the environment variable `
 
 :::
 
-## Download URLs
+## Privacy and messaging
 
-If you want to download a specific Cypress version for a given platform
-(Operating System), you can get it from our CDN.
+Cypress sends a small amount of data outbound and occasionally surfaces
+commercial messages. Both are off-switches you may want in privacy-sensitive or
+noise-sensitive environments.
 
-The download server URL is `https://download.cypress.io`.
-
-We currently have the following downloads available:
-
-- Windows 64-bit (`?platform=win32&arch=x64`)
-- Linux 64-bit (`?platform=linux`)
-- macOS 64-bit (`?platform=darwin`)
-
-Here are the available download URLs:
-
-See
-[https://download.cypress.io/desktop.json](https://download.cypress.io/desktop.json)
-for all available platforms.
-
-| Method | URL                                   | Description                                                                |
-| ------ | ------------------------------------- | -------------------------------------------------------------------------- |
-| `GET`  | `/desktop`                            | Download Cypress at latest version (platform auto-detected)                |
-| `GET`  | `/desktop.json`                       | Returns JSON containing latest available CDN destinations                  |
-| `GET`  | `/desktop?platform=p&arch=a`          | Download Cypress for a specific platform and/or architecture               |
-| `GET`  | `/desktop/:version`                   | Download Cypress with a specified version                                  |
-| `GET`  | `/desktop/:version?platform=p&arch=a` | Download Cypress with a specified version and platform and/or architecture |
-
-**Example of downloading Cypress `12.17.4` for Windows 64-bit:**
-
-```text
-https://download.cypress.io/desktop/12.17.4?platform=win32&arch=x64
-```
-
-## Mirroring
-
-If you choose to mirror the Cypress download site, you can specify
-`CYPRESS_DOWNLOAD_MIRROR` to set the download server URL from
-`https://download.cypress.io` to your own mirror.
-
-For example:
-
-```shell
-CYPRESS_DOWNLOAD_MIRROR="https://www.example.com" cypress install
-```
-
-Cypress will then attempt to download a binary with this format:
-`https://www.example.com/desktop/:version?platform=p&arch=a`
-
-Your mirror server must handle requests to `/desktop/:version` with `platform`
-and `arch` query parameters, and serve the appropriate Cypress binary as a
-`.zip` file.
-
-**Supported platform and architecture combinations:**
-
-| `platform` | `arch`  | Notes                                                         |
-| ---------- | ------- | ------------------------------------------------------------- |
-| `linux`    | `x64`   | Linux Intel/AMD 64-bit                                        |
-| `linux`    | `arm64` | Linux ARM64 (e.g. AWS Graviton, Apple Silicon containers)     |
-| `darwin`   | `x64`   | macOS Intel                                                   |
-| `darwin`   | `arm64` | macOS Apple Silicon                                           |
-| `win32`    | `x64`   | Windows; also used for ARM64 Windows (no native ARM64 binary) |
-
-:::note
-On Windows ARM64 machines, Cypress automatically substitutes `arm64` with `x64`
-when building the download URL, so your mirror will only ever receive `win32`
-requests with `arch=x64`.
-:::
-
-:::note
-On macOS, Cypress detects the machine's real architecture rather than relying on
-`process.arch`. If an x64 build of Node is running under Rosetta on Apple
-Silicon, Cypress still requests the native `darwin-arm64` binary. This is why the
-downloaded architecture can differ from `process.arch` (which would report
-`x64`), and your mirror may receive `arch=arm64` requests from an x64 Node
-process.
-:::
-
-If your mirror uses a different URL structure than `download.cypress.io`, use
-`CYPRESS_DOWNLOAD_PATH_TEMPLATE` together with `CYPRESS_DOWNLOAD_MIRROR`.
-See [Download path template](#Download-path-template) for examples.
-
-## Download path template
-
-You can use the `CYPRESS_DOWNLOAD_PATH_TEMPLATE`
-environment variable to download the Cypress binary from a custom URL that's
-generated based on endpoint, version, platform and architecture.
-
-**The following replacements are supported:**
-
-- `${endpoint}` is replaced with the full base URL including the version path
-  segment: `<base>/desktop/<version>` (e.g.
-  `https://download.cypress.io/desktop/15.16.0`).
-  If `CYPRESS_DOWNLOAD_MIRROR` is set, its value is used as `<base>` instead of
-  `https://download.cypress.io` (note that `/desktop/<version>` is still
-  appended).
-- `${platform}` is replaced with the platform the installation is running on
-  (e.g. `win32`, `linux`, `darwin`)
-- `${arch}` is replaced with the architecture the installation is running on
-  (e.g. `x64`, `arm64`). On Windows ARM64, this is always `x64`.
-- `${version}` is replaced with the version number
-  that's being installed (e.g. `15.16.0`)
-
-**Examples:**
-
-To install the binary from a download mirror that matches the exact file
-structure of `https://cdn.cypress.io`:
-
-```shell
-export CYPRESS_DOWNLOAD_MIRROR=https://cypress-download.local
-export CYPRESS_DOWNLOAD_PATH_TEMPLATE='${endpoint}/${platform}-${arch}/cypress.zip'
-# Example of a resulting URL: https://cypress-download.local/desktop/15.16.0/linux-x64/cypress.zip
-```
-
-To install the binary from a download server with a custom file structure:
-
-```shell
-export CYPRESS_DOWNLOAD_PATH_TEMPLATE='https://software.local/cypress/${platform}/${arch}/${version}/cypress.zip'
-# Example of a resulting URL: https://software.local/cypress/linux/x64/15.16.0/cypress.zip
-```
-
-To define `CYPRESS_DOWNLOAD_PATH_TEMPLATE` in `.npmrc`, put a backslash before
-every `$`:
-
-```ini
-CYPRESS_DOWNLOAD_PATH_TEMPLATE=\${endpoint}/\${platform}-\${arch}/cypress.zip
-```
-
-## Using a custom certificate authority (CA)
-
-Cypress can be configured to use the `ca` and `cafile` options from your npm
-config file to download the Cypress binary.
-
-For example, to use the CA at `/home/person/certs/ca.crt` when downloading
-Cypress, add the following to your `.npmrc`:
-
-```shell title=".npmrc"
-cafile=/home/person/certs/ca.crt
-```
-
-Alternatively, you can supply the certificate inline with the `ca` option
-instead of pointing to a file. This is equivalent to setting the
-`npm_config_ca` environment variable. Newlines in the PEM certificate are
-represented with `\n`:
-
-```ini title=".npmrc"
-ca="-----BEGIN CERTIFICATE-----\nMIID...\n-----END CERTIFICATE-----"
-```
-
-To supply more than one certificate, set `ca` to an array of strings. The same
-value can also be provided through the environment:
-
-```shell
-export npm_config_ca="-----BEGIN CERTIFICATE-----\nMIID...\n-----END CERTIFICATE-----"
-```
-
-If neither `cafile` nor `ca` are set, Cypress looks at the system environment
-variable `NODE_EXTRA_CA_CERTS` and uses the corresponding certificate(s) as an
-extension for the trusted certificate authority when downloading the Cypress
-binary.
-
-Note that the npm config is used as a replacement, and the node environment
-variable is used as an extension.
-
-## Opt out of sending exception data to Cypress
+### Opt out of sending exception data to Cypress
 
 When an exception is thrown regarding Cypress, we send along the exception data
 to `https://api.cypress.io`. We solely use this information to help develop a
@@ -506,7 +650,7 @@ better product.
 If you would like to opt out of sending any exception data to Cypress, you can
 do so by setting `CYPRESS_CRASH_REPORTS=0` in your system environment variables.
 
-### Opt out on Linux or macOS
+#### Opt out on Linux or macOS
 
 To opt out of sending exception data on Linux or macOS, run the following
 command in a terminal before installing Cypress:
@@ -519,7 +663,7 @@ To make these changes permanent, you can add this command to your shell's
 `~/.profile` (`~/.zsh_profile`, `~/.bash_profile`, etc.) to run them on every
 login.
 
-### Opt out on Windows
+#### Opt out on Windows
 
 To opt out of sending exception data on Windows, run the following command in
 the Command Prompt before installing Cypress:
@@ -541,7 +685,7 @@ To save the `CYPRESS_CRASH_REPORTS` variable for use in all new shells, use
 setx CYPRESS_CRASH_REPORTS 0
 ```
 
-## Opt out of Cypress commercial messaging
+### Opt out of Cypress commercial messaging
 
 Cypress may occasionally display messages in your CI logs related to our
 commercial offerings and how they could benefit you during your workflows.
@@ -550,49 +694,13 @@ If you would like to opt out of all commercial messaging, you can do so by
 setting `CYPRESS_COMMERCIAL_RECOMMENDATIONS=0` in your system environment
 variables.
 
-## Install pre-release version
+## Environment-specific setup
 
-If you would like to install a pre-release version of Cypress to test out
-functionality that has not yet been released, here is how:
+These environments need extra setup because they don't provide a graphical
+display the way a normal desktop OS does — which is what the interactive Test
+Runner needs.
 
-1. Open up the list of commits to `develop` on the Cypress repo:
-   [https://github.com/cypress-io/cypress/commits/develop](https://github.com/cypress-io/cypress/commits/develop)
-2. Find the commit that you would like to install the pre-release version of.
-   Click the comment icon (highlighted in red below):
-   <DocsImage
-     src="/img/app/install/develop-commit-comment-link.png"
-     alt="Example of a commit for which pre-releases are available. Comment link highlighted in red."
-   />
-3. You should see several comments from the `cypress-bot` user with instructions
-   for installing Cypress pre-releases. Pick the one that corresponds to your
-   operating system and CPU architecture, and follow the instructions there to
-   install the pre-release.
-
-The `cypress-bot` comments point at pre-release binaries hosted on the Cypress
-CDN. If you are scripting pre-release installs, the URLs follow this pattern:
-
-```text
-https://cdn.cypress.io/beta/binary/<version>/<platform>-<arch>/<branch>-<sha>/cypress.zip
-```
-
-- `<version>` — the Cypress version being built (e.g. `15.16.0`)
-- `<platform>-<arch>` — one of the supported
-  [platform/architecture combinations](#Mirroring) (e.g. `darwin-arm64`,
-  `linux-x64`)
-- `<branch>` — the branch the binary was built from (e.g. `develop`)
-- `<sha>` — the full commit SHA
-
-You can install a pre-release binary directly by pointing
-[`CYPRESS_INSTALL_BINARY`](#Install-binary) at one of these URLs:
-
-```shell
-CYPRESS_INSTALL_BINARY=https://cdn.cypress.io/beta/binary/15.16.0/darwin-arm64/develop-abcdef1234567890/cypress.zip npm install cypress
-```
-
-Cypress pre-releases are only available for 60 days after they are built. Do not
-rely on these being available past 60 days.
-
-## Windows Subsystem for Linux
+### Windows Subsystem for Linux
 
 Cypress requires an [X-server](https://en.wikipedia.org/wiki/X.Org_Server) (X11) to display the Cypress UI from a Windows Subsystem for Linux installation. This requirement is met by current versions of Windows Subsystem for Linux (WSL2) with X11 support being included through Windows Subsystem for Linux GUI (WSLg).
 
@@ -606,7 +714,7 @@ Cypress.io does not specifically support the use of Cypress under Windows Subsys
 
 :::
 
-## Dev Containers and GitHub Codespaces
+### Dev Containers and GitHub Codespaces
 
 [Dev Containers](https://containers.dev/) (VS Code Dev Containers) and [GitHub Codespaces](https://github.com/features/codespaces) provide containerized Linux development environments.
 
@@ -643,6 +751,10 @@ Cypress.io does not specifically support the use of Cypress in Dev Containers or
 :::
 
 ## Uninstall Cypress
+
+Removing Cypress is two-sided because of the install model: uninstalling the npm
+module removes it from your project, but the cached binaries and app data persist
+on disk until you remove them too.
 
 To uninstall Cypress from a project, use the same package manager you used to [install Cypress](/app/get-started/install-cypress):
 

--- a/docs/app/references/advanced-installation.mdx
+++ b/docs/app/references/advanced-installation.mdx
@@ -167,9 +167,9 @@ they will only be used if the system properties are being resolved to not use a 
 ## Install binary
 
 `CYPRESS_INSTALL_BINARY` controls **which** binary the `postinstall` step
-fetches. This is the most common reason to visit this page: the version in npm
-isn't the one you want, or the public download server isn't reachable from where
-you're installing.
+fetches. People most often need this when the version published to npm isn't the
+one they want, or when the public download server isn't reachable from where
+they're installing.
 
 To override what is installed, you set `CYPRESS_INSTALL_BINARY` alongside the
 `npm install` command.

--- a/docs/app/references/advanced-installation.mdx
+++ b/docs/app/references/advanced-installation.mdx
@@ -33,6 +33,38 @@ sidebar_label: 'Advanced Installation'
 | `CYPRESS_VERIFY_TIMEOUT`          | Overrides the timeout duration for the `verify` command. The default value is 30000.           |
 | `CYPRESS_SKIP_VERIFY`             | Skips the [`verify` command](command-line#cypress-verify) when `true`                          |
 
+### Setting variables via npm config or package.json
+
+Every `CYPRESS_*` variable above can be set as a real environment variable, or
+through your npm configuration. Cypress resolves each variable in the following
+order, using the first value it finds:
+
+1. The actual environment variable (e.g. `CYPRESS_INSTALL_BINARY`)
+2. `npm_config_<name>` — set via `.npmrc` or `npm config`
+3. The lowercase `npm_config_<name>`
+4. `npm_package_config_<name>` — set via a `config` block in `package.json`
+
+This means options like `CYPRESS_INSTALL_BINARY`, `CYPRESS_CACHE_FOLDER`, and
+`CYPRESS_DOWNLOAD_MIRROR` can all be configured in `.npmrc`:
+
+```ini title=".npmrc"
+cypress_install_binary=https://company.domain.com/cypress.zip
+cypress_cache_folder=/path/to/cypress/cache
+cypress_download_mirror=https://company.domain.com
+```
+
+or in a `config` block of your `package.json`:
+
+```json title="package.json"
+{
+  "config": {
+    "cypress_install_binary": "https://company.domain.com/cypress.zip",
+    "cypress_cache_folder": "/path/to/cypress/cache",
+    "cypress_download_mirror": "https://company.domain.com"
+  }
+}
+```
+
 ## Proxy configuration
 
 System [proxy properties](/app/references/proxy-configuration) `http_proxy`, `https_proxy` and `no_proxy` are respected

--- a/docs/app/references/advanced-installation.mdx
+++ b/docs/app/references/advanced-installation.mdx
@@ -194,9 +194,10 @@ To override what is installed, you set `CYPRESS_INSTALL_BINARY` alongside the
 
 In all cases, the fact that the binary was installed from a custom location _is
 not saved in your `package.json` file_. Every repeated installation needs to use
-the same environment variable to install the same binary. (This is exactly the
-problem [npm config / package.json](#Setting-variables-via-npm-config-or-packagejson)
-solves: commit the setting so it's applied on every install.)
+the same environment variable to install the same binary. If you'd rather not
+repeat the variable each time, set it in
+[npm config or `package.json`](#Setting-variables-via-npm-config-or-packagejson)
+so it's applied automatically on every install.
 
 ### Skipping installation
 

--- a/docs/app/references/advanced-installation.mdx
+++ b/docs/app/references/advanced-installation.mdx
@@ -176,9 +176,12 @@ To override what is installed, you set `CYPRESS_INSTALL_BINARY` alongside the
 
 **This is helpful if you want to:**
 
-- Install a version different than the default npm package.
+- Override the installed binary version for a single install, without editing the
+  `cypress` version committed in your `package.json`. This is useful for quickly
+  testing a different version locally or in CI without changing committed files.
   ```shell
-  CYPRESS_INSTALL_BINARY=15.16.0 npm install cypress@15.16.1
+  # Downloads this binary version for this install only; package.json is untouched
+  CYPRESS_INSTALL_BINARY=15.16.0 npm install
   ```
 - Specify an external URL (to bypass a corporate firewall).
   ```shell


### PR DESCRIPTION
## Overview

Documentation-only changes to `docs/app/references/advanced-installation.mdx`. This started as a set of accuracy fixes against the actual install code and grew into a why/value-oriented rewrite and reorganization of the page. No runtime, install, or behavior changes.

## Accuracy fixes (verified against the install source)

- **Added `linux` | `arm64`** to the supported platform/architecture table. Cypress ships a native Linux ARM64 binary: the install OS regex allows `linux-arm64`, and `getRealArch()` maps Linux `aarch64`/`armv8*` to a real `arm64` build (not an x64 fallback like Windows ARM64).
- **macOS Rosetta detection** note: Cypress detects the machine's real architecture, so an x64 Node under Rosetta still gets the native `darwin-arm64` binary, and the downloaded arch can differ from `process.arch`.
- **Setting `CYPRESS_*` via npm config / `package.json`**: documented the resolution order (real env var → `npm_config_<name>` → lowercase → `npm_package_config_<name>`) with `.npmrc` and `package.json` `config` examples.
- **Inline CA**: documented supplying a raw certificate via the `ca` option / `npm_config_ca`, alongside the existing `cafile`.
- **Full `cypress cache` command set**: added a table covering `list` (with `--size`), `path`, `prune`, and `clear` (previously only `clear` was referenced).
- **Pre-release binary CDN URL pattern**: documented `https://cdn.cypress.io/beta/binary/<version>/<platform>-<arch>/<branch>-<sha>/cypress.zip` for scripting pre-release installs, and noted the Cypress team may ask reporters to test a pre-release.
- **Install allowlist URLs**: added a table of hosts needed during install (`download.cypress.io`, `cdn.cypress.io`, npm registry) for restrictive VPNs/firewalls, with a link to the full Cloud allowlist FAQ.
- Removed `CYPRESS_CONNECT_RETRY_THRESHOLD` from the env var table (it's a runtime browser-connection setting, not an install/download option).
- Tightened the env var table descriptions for accuracy and consistency (notably `CYPRESS_INSTALL_BINARY`, which previously read as a "destination").

## Rewrite & reorganization

- New scenario-driven intro plus a **"How Cypress installs"** section explaining the npm-module-vs-binary split and the shared global cache (the "why" behind most settings).
- Added a **"When you'd reach for each"** section describing the problem each `CYPRESS_*` variable solves.
- Regrouped sections: **Installing behind a firewall or mirror** (allowlist, download URLs, mirroring, path template, custom CA), **Privacy and messaging**, and **Environment-specific setup** (WSL, Dev Containers/Codespaces). Pre-release install moved next to Install binary.
- Reframed the install-version example as a one-time override that doesn't touch committed `package.json`; converted the download-path-template placeholder list into a table.
- SEO-friendly `title` and `description`; updated version examples to **15.16.0**.

## Notes for reviewers

- Section heading text that is linked from other docs pages (e.g. `Binary cache`, `Install binary`, `Mirroring`, `Environment variables`, `Uninstall Cypress`) was preserved so existing anchor links keep resolving.
- Verified locally with `npm run build` (exit 0, `[SUCCESS] Generated static files`), which also fixed a broken `cypress cache` anchor caught by Docusaurus's broken-anchor check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to user-facing documentation in a single MDX file; no runtime, install, or CI product code is modified.
> 
> **Overview**
> **Documentation-only** overhaul of `advanced-installation.mdx`: no product or install behavior changes.
> 
> The page is reframed around **why** advanced install exists (npm module vs binary, global cache) and reorganized into scenario-driven sections—firewall/mirror installs, privacy/messaging, and WSL/Dev Containers/Codespaces—with updated SEO **title**/**description** and examples bumped to **15.16.0**.
> 
> **Accuracy and coverage additions** include: **`linux`/`arm64`** in the platform table plus macOS Rosetta/real-arch notes; install **allowlist** hosts; pre-release **CDN URL** pattern; full **`cypress cache`** command table; **`CYPRESS_*` via `.npmrc` / `package.json`** resolution order; inline **`ca` / `npm_config_ca`**; removal of **`CYPRESS_CONNECT_RETRY_THRESHOLD`** from the install env table; OS tabs for path template, cache, run binary, and opt-out vars; and a **See also** / expanded uninstall (prune) section. Key heading anchors are preserved for cross-doc links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2bfbc6cb4c57eb08b4d9b2718c968c3d1f74a21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->