### PR TITLE
docs: overhaul Launching Browsers page and related browser launch docs

### DIFF
--- a/docs/api/node-events/browser-launch-api.mdx
+++ b/docs/api/node-events/browser-launch-api.mdx
@@ -114,7 +114,7 @@ on('before:browser:launch', (browser = {}, launchOptions) => {
 **Limitations:**
 
 - Headless Chrome does not support loading extensions.
-- Chrome-branded browsers (e.g., standard Chrome) version 137 and above no longer support extension loading via this API, due to the removal of the `--load-extension` flag by Chrome. We recommend using Chrome for Testing or Chromium instead. See Cypress Docker image examples for [Chrome for Testing](https://github.com/cypress-io/cypress-docker-images/tree/master/examples/chrome-for-testing) and [Chromium](https://github.com/cypress-io/cypress-docker-images/tree/master/examples/chromium).
+- Chrome-branded browsers (e.g., standard Chrome) version 137 and above no longer support extension loading via this API, due to the removal of the `--load-extension` flag by Chrome. We recommend using [Chrome for Testing](/app/references/launching-browsers#Chrome-Browsers) or Chromium instead. See Cypress Docker image examples for [Chrome for Testing](https://github.com/cypress-io/cypress-docker-images/tree/master/examples/chrome-for-testing) and [Chromium](https://github.com/cypress-io/cypress-docker-images/tree/master/examples/chromium).
 - Electron currently supports only Chrome DevTools extensions.
 
 :::cypress-config-plugin-example

--- a/docs/api/node-events/overview.mdx
+++ b/docs/api/node-events/overview.mdx
@@ -204,8 +204,7 @@ You can use the `before:browser:launch` event to do things like:
 Standard, Chrome-branded browsers (for example, regular Google Chrome) version
 137 and above can no longer load extensions through the `before:browser:launch`
 event. This is because Chrome removed support for the `--load-extension` command
-line flag that Cypress relied on to load extensions. In an affected version of
-Chrome, Cypress will display a warning and the extension will not be loaded.
+line flag that Cypress relied on to load extensions.
 
 To continue loading extensions, run your tests in
 [Chrome for Testing](/app/references/launching-browsers#Chrome-Browsers) or

--- a/docs/api/node-events/overview.mdx
+++ b/docs/api/node-events/overview.mdx
@@ -193,7 +193,10 @@ each particular browser.
 
 You can use the `before:browser:launch` event to do things like:
 
-- Load a Chrome extension
+- Load a Chrome extension (note that standard Chrome 137+ can no longer load
+  extensions this way; we recommend
+  [Chrome for Testing](/app/references/launching-browsers#Chrome-Browsers) or
+  Chromium)
 - Enable or disable experimental chrome features
 - Control which Chrome components are loaded
 

--- a/docs/api/node-events/overview.mdx
+++ b/docs/api/node-events/overview.mdx
@@ -193,12 +193,25 @@ each particular browser.
 
 You can use the `before:browser:launch` event to do things like:
 
-- Load a Chrome extension (note that standard Chrome 137+ can no longer load
-  extensions this way; we recommend
-  [Chrome for Testing](/app/references/launching-browsers#Chrome-Browsers) or
-  Chromium)
+- Load a Chrome extension
 - Enable or disable experimental chrome features
 - Control which Chrome components are loaded
+
+:::caution
+
+<strong>Loading extensions in Chrome 137 and above</strong>
+
+Standard, Chrome-branded browsers (for example, regular Google Chrome) version
+137 and above can no longer load extensions through the `before:browser:launch`
+event. This is because Chrome removed support for the `--load-extension` command
+line flag that Cypress relied on to load extensions. In an affected version of
+Chrome, Cypress will display a warning and the extension will not be loaded.
+
+To continue loading extensions, run your tests in
+[Chrome for Testing](/app/references/launching-browsers#Chrome-Browsers) or
+Chromium, which still support extension loading.
+
+:::
 
 Check out our [Browser Launch API docs](/api/node-events/browser-launch-api) which
 describe how to use this event.

--- a/docs/app/faq.mdx
+++ b/docs/app/faq.mdx
@@ -1202,7 +1202,13 @@ rendering as expected. For more information, check out the
 ### <Icon name="angle-right" /> Can I test a chrome extension? How do I load my chrome extension?
 
 Yes. You can test your extensions by
-[loading them when we launch the browser](/api/node-events/browser-launch-api).
+[loading them when we launch the browser](/api/node-events/browser-launch-api#Add-browser-extensions).
+
+Note that standard, Chrome-branded browsers version 137 and above can no longer
+load extensions this way, because Chrome removed the `--load-extension` flag. To
+keep loading extensions, we recommend using
+[Chrome for Testing](/app/references/launching-browsers#Chrome-Browsers) or
+Chromium instead.
 
 ### <Icon name="angle-right" /> Can I test my Electron app?
 

--- a/docs/app/references/launching-browsers.mdx
+++ b/docs/app/references/launching-browsers.mdx
@@ -158,6 +158,40 @@ If this is not the case, then Cypress will timeout, returning an `ECONNREFUSED` 
 Chrome policy is generally applied to a Chrome-branded browser only, not to Chromium or Chrome for Testing browsers.
 Check by browsing to **chrome://policy**.
 
+#### Skipping Chrome preference reads/writes
+
+To set up a consistent testing environment, Cypress reads and writes Chrome
+preference files inside its [isolated profile](#Cypress-Profile) in the browser's
+user-data directory (the `Preferences`, `Secure Preferences`, and `Local State`
+files). This is how Cypress applies preference-based settings — for example,
+disabling password saving and autofill, configuring the
+[downloads behavior](#Downloading-Files), and any preferences you set through the
+[`before:browser:launch`](/api/node-events/browser-launch-api#Change-browser-preferences)
+event.
+
+Some applications and environments **encrypt the user-data directory** (for
+example, certain enterprise security tooling). In that case, Cypress reading or
+writing the preference files can fail or corrupt the encrypted profile. To work
+around this, set the `IGNORE_CHROME_PREFERENCES` system environment variable,
+which tells Cypress to skip reading and writing Chrome preferences entirely:
+
+```shell
+IGNORE_CHROME_PREFERENCES=1 cypress run --browser chrome
+```
+
+:::caution
+
+When `IGNORE_CHROME_PREFERENCES` is set, Cypress no longer manages Chrome
+preferences, so any behavior controlled through preferences will not be applied.
+This includes preferences you set via `launchOptions.preferences` in the
+[`before:browser:launch`](/api/node-events/browser-launch-api#Change-browser-preferences)
+event, as well as Cypress's own preference-based defaults (such as disabling
+password saving/autofill and configuring the downloads folder). Settings applied
+through command-line switches are unaffected. Only use this escape hatch if your
+environment requires it.
+
+:::
+
 ### Edge Browsers
 
 Microsoft Edge-family (Chromium-based) browsers are supported by Cypress.

--- a/docs/app/references/launching-browsers.mdx
+++ b/docs/app/references/launching-browsers.mdx
@@ -587,11 +587,12 @@ the browser is **always headed** so you can watch and debug interactively.
 
 How each browser is launched headlessly differs slightly:
 
-| Browser                  | Default during `cypress run` | How it runs headless            |
-| ------------------------ | ---------------------------- | ------------------------------- |
-| Electron                 | Headless                     | Internal Electron headless mode |
-| Chrome / Chromium / Edge | Headless                     | Launched with `--headless=new`  |
-| Firefox                  | Headless                     | Launched with `-headless`       |
+| Browser                  | Default during `cypress run` | How it runs headless             |
+| ------------------------ | ---------------------------- | -------------------------------- |
+| Electron                 | Headless                     | Internal Electron headless mode  |
+| Chrome / Chromium / Edge | Headless                     | Launched with `--headless=new`   |
+| Firefox                  | Headless                     | Launched with `-headless`        |
+| WebKit (Experimental)    | Headless                     | Launched headless via Playwright |
 
 To show the browser while running `cypress run`, pass the
 [`--headed`](/app/references/command-line#cypress-run-headed) flag:

--- a/docs/app/references/launching-browsers.mdx
+++ b/docs/app/references/launching-browsers.mdx
@@ -62,6 +62,15 @@ browser by using the drop down near the top right corner:
 Cypress officially supports the latest 3 major versions of Chrome, Firefox, and Edge.
 (For example, if the stable release of Chrome was 130, Cypress would officially support Chrome 128, 129, and 130.)
 
+:::info
+
+Cypress requires **Firefox 135 or newer**. Cypress automates Firefox through
+[WebDriver BiDi](https://w3c.github.io/webdriver-bidi/), which is only available
+in Firefox 135 and above. Attempting to run an older version of Firefox will
+result in an error. See [Firefox Browsers](#Firefox-Browsers) for details.
+
+:::
+
 See each browser's official release schedule for more information.
 
 - [Chrome Release Schedule](https://chromiumdash.appspot.com/schedule)
@@ -185,6 +194,14 @@ Check by browsing to **edge://policy**.
 ### Firefox Browsers
 
 Firefox-family browsers are supported by Cypress.
+
+:::caution
+
+Cypress requires **Firefox 135 or newer**. Starting with Firefox 135, Cypress
+automates Firefox using [WebDriver BiDi](https://w3c.github.io/webdriver-bidi/).
+Older versions of Firefox are not supported and will fail to launch.
+
+:::
 
 You can launch Firefox like this:
 

--- a/docs/app/references/launching-browsers.mdx
+++ b/docs/app/references/launching-browsers.mdx
@@ -255,12 +255,13 @@ You can launch Firefox like this:
 
 <CypressCommandTabs command="run --browser firefox" />
 
-Or Firefox Developer/Nightly Edition:
+Or Firefox Developer Edition:
 
-<CypressCommandTabs
-  command={`run --browser firefox:dev
-run --browser firefox:nightly`}
-/>
+<CypressCommandTabs command="run --browser firefox:dev" />
+
+Or Firefox Nightly:
+
+<CypressCommandTabs command="run --browser firefox:nightly" />
 
 To use this command in CI, you need to install these other browsers - or use one
 of our [docker images](/app/continuous-integration/overview#Cypress-Docker-Images).

--- a/docs/app/references/launching-browsers.mdx
+++ b/docs/app/references/launching-browsers.mdx
@@ -33,8 +33,8 @@ instance so it can guarantee two things that make automated testing trustworthy:
    directly is how Cypress reads and controls your application reliably, takes
    screenshots and video, stubs the network, and more.
 
-Cypress currently supports Firefox and Chrome-family browsers (including Edge and
-Electron), plus experimental WebKit. Testing across the browsers your users
+Cypress currently supports Chrome-family browsers (including Edge and Electron)
+and Firefox, plus experimental WebKit. Testing across the browsers your users
 actually use gives you cross-browser confidence. For strategies to do this
 efficiently in CI, see the
 [Cross Browser Testing](/app/guides/cross-browser-testing) guide.

--- a/docs/app/references/launching-browsers.mdx
+++ b/docs/app/references/launching-browsers.mdx
@@ -553,24 +553,6 @@ This enables you to do things like:
 
 [This part of the API is documented here.](/api/node-events/browser-launch-api)
 
-:::caution
-
-<strong>Loading extensions in Chrome 137 and above</strong>
-
-Chrome-branded browsers (e.g., standard Chrome) version 137 and above no longer
-support loading extensions via the [Browser Launch API](/api/node-events/browser-launch-api#Add-browser-extensions),
-because Chrome removed support for the `--load-extension` flag. If you attempt to
-load an extension in an affected Chrome version, Cypress will display a warning and
-the extension will not be loaded.
-
-To continue loading extensions, use
-[Chrome for Testing](#Chrome-Browsers) or [Chromium](#Chrome-Browsers) instead.
-See the Cypress Docker image examples for
-[Chrome for Testing](https://github.com/cypress-io/cypress-docker-images/tree/master/examples/chrome-for-testing)
-and [Chromium](https://github.com/cypress-io/cypress-docker-images/tree/master/examples/chromium).
-
-:::
-
 ### Distinguishing the Cypress browser
 
 You might notice that if you already have the browser open you will see two of

--- a/docs/app/references/launching-browsers.mdx
+++ b/docs/app/references/launching-browsers.mdx
@@ -44,10 +44,10 @@ efficiently in CI, see the
 When Cypress is launched, you can choose to test your application using a number
 of browsers, including:
 
+- [Chrome for Testing](https://github.com/GoogleChromeLabs/chrome-for-testing/)
 - [Chrome](https://www.google.com/chrome/)
 - [Chrome Beta](https://www.google.com/chrome/beta/)
 - [Chrome Canary](https://www.google.com/chrome/canary/)
-- [Chrome for Testing](https://github.com/GoogleChromeLabs/chrome-for-testing/)
 - [Chromium](https://www.chromium.org/Home)
 - [Edge](https://www.microsoft.com/edge)
 - [Edge Beta](https://www.microsoftedgeinsider.com/download)

--- a/docs/app/references/launching-browsers.mdx
+++ b/docs/app/references/launching-browsers.mdx
@@ -358,8 +358,6 @@ npx playwright install-deps webkit
 If a browser isn't auto-detected, for example a portable install or a custom
 build, you can launch any supported browser by specifying a path to the binary:
 
-<CypressCommandTabs command="run --browser /usr/bin/chromium" />
-
 <CypressCommandTabs command="open --browser /usr/bin/chromium" />
 
 Cypress will automatically detect the type of browser supplied and launch it for

--- a/docs/app/references/launching-browsers.mdx
+++ b/docs/app/references/launching-browsers.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Launching Browsers in Cypress'
-description: 'Learn how Cypress launches and controls browsers, how to choose and customize the browsers available to your tests, how headless mode and downloads work, and how to troubleshoot browser launching issues.'
+title: 'Launching Browsers in Cypress: Chrome, Firefox, Edge & WebKit'
+description: 'Learn how Cypress launches and controls Chrome, Firefox, Edge, Electron, and WebKit. Choose and customize browsers, run headless, and fix launch issues.'
 sidebar_label: 'Launching Browsers'
 ---
 

--- a/docs/app/references/launching-browsers.mdx
+++ b/docs/app/references/launching-browsers.mdx
@@ -84,8 +84,7 @@ lets Cypress rely on stable, modern automation APIs.
 Regardless of the above, Cypress cannot launch **Firefox versions older than 135**.
 Cypress automates Firefox through
 [WebDriver BiDi](https://w3c.github.io/webdriver-bidi/), which is only available
-in Firefox 135 and above, so older versions will fail with an error. See
-[Firefox Browsers](#Firefox-Browsers) for details.
+in Firefox 135 and above, so older versions will fail with an error.
 
 :::
 
@@ -270,15 +269,6 @@ for more.
 ### Firefox Browsers
 
 Firefox-family browsers are supported by Cypress.
-
-:::caution
-
-Cypress automates Firefox using [WebDriver BiDi](https://w3c.github.io/webdriver-bidi/),
-which is only available starting in Firefox 135. **Firefox versions older than 135
-will fail to launch.** (Official support remains the latest 3 major versions; see
-[Browser versions supported](#Browser-versions-supported).)
-
-:::
 
 You can launch Firefox like this:
 

--- a/docs/app/references/launching-browsers.mdx
+++ b/docs/app/references/launching-browsers.mdx
@@ -429,6 +429,24 @@ This enables you to do things like:
 
 [This part of the API is documented here.](/api/node-events/browser-launch-api)
 
+:::caution
+
+<strong>Loading extensions in Chrome 137 and above</strong>
+
+Chrome-branded browsers (e.g., standard Chrome) version 137 and above no longer
+support loading extensions via the [Browser Launch API](/api/node-events/browser-launch-api#Add-browser-extensions),
+because Chrome removed support for the `--load-extension` flag. If you attempt to
+load an extension in an affected Chrome version, Cypress will display a warning and
+the extension will not be loaded.
+
+To continue loading extensions, use
+[Chrome for Testing](#Chrome-Browsers) or [Chromium](#Chrome-Browsers) instead.
+See the Cypress Docker image examples for
+[Chrome for Testing](https://github.com/cypress-io/cypress-docker-images/tree/master/examples/chrome-for-testing)
+and [Chromium](https://github.com/cypress-io/cypress-docker-images/tree/master/examples/chromium).
+
+:::
+
 ### Cypress Profile
 
 Cypress generates its own isolated profile apart from your normal browser

--- a/docs/app/references/launching-browsers.mdx
+++ b/docs/app/references/launching-browsers.mdx
@@ -643,33 +643,6 @@ download shelf. This is what makes downloads testable end-to-end: a native
 file-picker dialog would block an unattended run, so Cypress routes downloads to a
 known folder where you can assert on them directly from disk.
 
-### Asserting on a downloaded file
-
-Because downloads are saved to a known folder, you can read a file back and
-assert on its contents with [`cy.readFile()`](/api/commands/readfile):
-
-```js
-it('downloads a CSV file', () => {
-  cy.visit('/')
-  cy.get('[data-testid="download-csv"]').click()
-
-  // cypress/downloads/records.csv
-  cy.readFile('cypress/downloads/records.csv').should(
-    'contain',
-    'id,name,email'
-  )
-})
-```
-
-:::info
-
-For a complete example, see the
-[recipe showing how to download and validate CSV and Excel files](/app/references/recipes#Testing-the-DOM).
-If you need Cypress to recognize a download with an uncommon mime type, see
-[Support unique file download mime types](/api/node-events/browser-launch-api#Support-unique-file-download-mime-types).
-
-:::
-
 ## Troubleshooting
 
 [Having issues launching installed browsers? Read more about troubleshooting browser launching](/app/references/troubleshooting#Launching-browsers)

--- a/docs/app/references/launching-browsers.mdx
+++ b/docs/app/references/launching-browsers.mdx
@@ -113,8 +113,7 @@ with [Electron](https://electron.atom.io/).
 The Electron browser comes bundled with Cypress, so it requires no separate
 installation and is always available. For this reason it is the default browser
 when running from the CLI. That said, because Electron is not a browser your end
-users run, we generally recommend testing in another browser, such as
-[Chrome for Testing](#Chrome-Browsers).
+users run, we generally recommend testing in another browser.
 
 By default, when running [cypress run](/app/references/command-line#cypress-run)
 from the CLI, Cypress launches all browsers headlessly. See

--- a/docs/app/references/launching-browsers.mdx
+++ b/docs/app/references/launching-browsers.mdx
@@ -296,6 +296,7 @@ npx playwright install-deps webkit
 #### Known Issues with `experimentalWebKitSupport`
 
 - `cy.origin()` is not yet supported.
+- [Test Replay](/cloud/features/test-replay) is not supported.
 - `cy.intercept()`'s `forceNetworkError` option is disabled.
 - When using `experimentalSingleTabRunMode` with video recording in WebKit, only
   the video for the first spec is recorded.

--- a/docs/app/references/launching-browsers.mdx
+++ b/docs/app/references/launching-browsers.mdx
@@ -433,6 +433,64 @@ in the **Settings** tab.
 
 Some browsers such as Internet Explorer are not currently supported.
 
+## Headless Mode
+
+When running [cypress run](/app/references/command-line#cypress-run) from the
+CLI, Cypress launches browsers **headlessly** by default — the browser runs
+without a visible UI, which is well suited to Continuous Integration. When
+running [cypress open](/app/references/command-line#cypress-open), the browser
+is **always headed**.
+
+How each browser is launched headlessly differs slightly:
+
+| Browser                | Default during `cypress run`                       | How it runs headless                |
+| ---------------------- | -------------------------------------------------- | ----------------------------------- |
+| Electron               | Headless (the default browser, typically used in CI) | Internal Electron headless mode   |
+| Chrome / Chromium / Edge | Headless                                          | Launched with `--headless=new`      |
+| Firefox                | Headless                                            | Launched with `-headless`           |
+
+To show the browser while running `cypress run`, pass the
+[`--headed`](/app/references/command-line#cypress-run-headed) flag:
+
+```shell
+cypress run --headed
+```
+
+Because Electron is the default browser, it is typically the one running in CI.
+You can also explicitly hide a headed browser with `--headless`.
+
+### Headless rendering defaults
+
+When a browser runs headlessly, there is no physical display, so Cypress uses
+the following defaults for rendering:
+
+- A default screen size of **1280x720**.
+- A device pixel ratio (DPR) forced to **1**.
+
+These defaults affect the size and resolution of screenshots and videos captured
+during the run. You can override them in the
+[`before:browser:launch`](/api/node-events/browser-launch-api#Set-screen-size-when-running-headless)
+event — for example, to change the window size or force a retina-like DPR for
+higher-resolution output.
+
+### Debugging headless-only failures
+
+Occasionally a test passes when the browser is headed but fails when run
+headlessly (or vice versa). When this happens, the quickest way to debug is to
+reproduce the failure locally with the browser shown:
+
+```shell
+cypress run --headed --no-exit --browser chrome
+```
+
+The `--headed` flag shows the browser so you can watch the run, and `--no-exit`
+keeps Cypress open afterward so you can inspect the
+[command log](/app/core-concepts/open-mode#Command-Log) and the application's
+final state. Comparing a headed run against a headless one — along with the
+recorded screenshots and videos — usually surfaces the difference, which is
+often related to the headless rendering defaults above (viewport/screen size or
+device pixel ratio).
+
 ## Browser Environment
 
 Cypress launches the browser in a way that's different from a regular browser

--- a/docs/app/references/launching-browsers.mdx
+++ b/docs/app/references/launching-browsers.mdx
@@ -113,7 +113,7 @@ with [Electron](https://electron.atom.io/).
 The Electron browser comes bundled with Cypress, so it requires no separate
 installation and is always available. For this reason it is the default browser
 when running from the CLI. That said, because Electron is not a browser your end
-users run, we generally recommend testing in a browser they actually use, such as
+users run, we generally recommend testing in another browser, such as
 [Chrome for Testing](#Chrome-Browsers).
 
 By default, when running [cypress run](/app/references/command-line#cypress-run)

--- a/docs/app/references/launching-browsers.mdx
+++ b/docs/app/references/launching-browsers.mdx
@@ -84,9 +84,7 @@ lets Cypress rely on stable, modern automation APIs.
 Regardless of the above, Cypress cannot launch **Firefox versions older than 135**.
 Cypress automates Firefox through
 [WebDriver BiDi](https://w3c.github.io/webdriver-bidi/), which is only available
-in Firefox 135 and above, so older versions will fail with an error. Note this is
-a hard technical minimum, not an extension of official support. Cypress still
-officially supports only the latest 3 major versions. See
+in Firefox 135 and above, so older versions will fail with an error. See
 [Firefox Browsers](#Firefox-Browsers) for details.
 
 :::

--- a/docs/app/references/launching-browsers.mdx
+++ b/docs/app/references/launching-browsers.mdx
@@ -587,11 +587,11 @@ the browser is **always headed** so you can watch and debug interactively.
 
 How each browser is launched headlessly differs slightly:
 
-| Browser                  | Default during `cypress run`                         | How it runs headless            |
-| ------------------------ | ---------------------------------------------------- | ------------------------------- |
-| Electron                 | Headless (the default browser, typically used in CI) | Internal Electron headless mode |
-| Chrome / Chromium / Edge | Headless                                             | Launched with `--headless=new`  |
-| Firefox                  | Headless                                             | Launched with `-headless`       |
+| Browser                  | Default during `cypress run` | How it runs headless            |
+| ------------------------ | ---------------------------- | ------------------------------- |
+| Electron                 | Headless                     | Internal Electron headless mode |
+| Chrome / Chromium / Edge | Headless                     | Launched with `--headless=new`  |
+| Firefox                  | Headless                     | Launched with `-headless`       |
 
 To show the browser while running `cypress run`, pass the
 [`--headed`](/app/references/command-line#cypress-run-headed) flag:

--- a/docs/app/references/launching-browsers.mdx
+++ b/docs/app/references/launching-browsers.mdx
@@ -190,9 +190,9 @@ has a few advantages over a standard, day-to-day Chrome install:
   [policies](#Chrome-policy) often applied to branded Chrome (such as disabling
   remote debugging), which removes a common cause of launch failures.
 - **Extension loading still works.** Standard Chrome 137 and above can no longer
-  load extensions via the Browser Launch API (see
-  [Customize the browser launch](#Customize-the-browser-launch)), but Chrome for
-  Testing and Chromium still can.
+  load extensions via the
+  [Browser Launch API](/api/node-events/browser-launch-api#Add-browser-extensions),
+  but Chrome for Testing and Chromium still can.
 
 :::
 

--- a/docs/app/references/launching-browsers.mdx
+++ b/docs/app/references/launching-browsers.mdx
@@ -524,10 +524,6 @@ profile. This means things like `history` entries, `cookies`, and
 `3rd party extensions` from your regular browsing session will not affect your
 tests in Cypress.
 
-The value here is isolation: tests start from a predictable, clean slate and
-can't be influenced (or broken) by the state of your personal browser, which is a
-common source of "passes locally, fails in CI" surprises.
-
 :::caution
 
 <strong>Wait, I need my developer extensions!</strong>

--- a/docs/app/references/launching-browsers.mdx
+++ b/docs/app/references/launching-browsers.mdx
@@ -64,10 +64,13 @@ Cypress officially supports the latest 3 major versions of Chrome, Firefox, and 
 
 :::info
 
-Cypress requires **Firefox 135 or newer**. Cypress automates Firefox through
+Regardless of the above, Cypress cannot launch **Firefox versions older than 135**.
+Cypress automates Firefox through
 [WebDriver BiDi](https://w3c.github.io/webdriver-bidi/), which is only available
-in Firefox 135 and above. Attempting to run an older version of Firefox will
-result in an error. See [Firefox Browsers](#Firefox-Browsers) for details.
+in Firefox 135 and above, so older versions will fail with an error. Note this is
+a hard technical minimum, not an extension of official support — Cypress still
+officially supports only the latest 3 major versions. See
+[Firefox Browsers](#Firefox-Browsers) for details.
 
 :::
 
@@ -197,9 +200,10 @@ Firefox-family browsers are supported by Cypress.
 
 :::caution
 
-Cypress requires **Firefox 135 or newer**. Starting with Firefox 135, Cypress
-automates Firefox using [WebDriver BiDi](https://w3c.github.io/webdriver-bidi/).
-Older versions of Firefox are not supported and will fail to launch.
+Cypress automates Firefox using [WebDriver BiDi](https://w3c.github.io/webdriver-bidi/),
+which is only available starting in Firefox 135. **Firefox versions older than 135
+will fail to launch.** (Official support remains the latest 3 major versions — see
+[Browser versions supported](#Browser-versions-supported).)
 
 :::
 

--- a/docs/app/references/launching-browsers.mdx
+++ b/docs/app/references/launching-browsers.mdx
@@ -728,3 +728,6 @@ browser launch problems.
 
 - [Browser Launch API](/api/node-events/browser-launch-api)
 - [Cross browser Testing](/app/guides/cross-browser-testing)
+- [Command Line](/app/references/command-line)
+- [Configuration](/app/references/configuration)
+- [Troubleshooting](/app/references/troubleshooting#Launching-browsers)

--- a/docs/app/references/launching-browsers.mdx
+++ b/docs/app/references/launching-browsers.mdx
@@ -557,6 +557,49 @@ ignoring certificate errors, allowing blocked pop-ups, and disabling things like
 password saving, autofill, session restoring, background throttling, and device
 permission prompts.
 
+## Downloading Files
+
+When your application downloads a file, Cypress automatically saves it to the
+[`downloadsFolder`](/app/references/configuration#Downloads) (by default
+`cypress/downloads`) without showing the browser's native "Save As" prompt or
+download shelf. This lets you download a file during a test and then assert on
+its contents directly from disk.
+
+How Cypress configures automatic downloads depends on the browser family:
+
+| Browser family            | Mechanism                                                                                                                                  |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| Chrome / Edge / Electron  | The [Chrome DevTools Protocol](https://chromedevtools.github.io/devtools-protocol/) `Page.setDownloadBehavior` command, pointed at the `downloadsFolder`. |
+| Firefox                   | The `browser.download.*` preferences (e.g. `browser.download.dir` and `browser.download.folderList`) set on the browser profile.            |
+| WebKit (Experimental)     | [Playwright](https://playwright.dev/) download events, which save the downloaded file to the `downloadsFolder`.                             |
+
+### Asserting on a downloaded file
+
+Because downloads are saved to a known folder, you can read a file back and
+assert on its contents with [`cy.readFile()`](/api/commands/readfile):
+
+```js
+it('downloads a CSV file', () => {
+  cy.visit('/')
+  cy.get('[data-testid="download-csv"]').click()
+
+  // cypress/downloads/records.csv
+  cy.readFile('cypress/downloads/records.csv').should(
+    'contain',
+    'id,name,email'
+  )
+})
+```
+
+:::info
+
+For a complete example, see the
+[recipe showing how to download and validate CSV and Excel files](/app/references/recipes#Testing-the-DOM).
+If you need Cypress to recognize a download with an uncommon mime type, see
+[Support unique file download mime types](/api/node-events/browser-launch-api#Support-unique-file-download-mime-types).
+
+:::
+
 ## Browser Icon
 
 You might notice that if you already have the browser open you will see two of

--- a/docs/app/references/launching-browsers.mdx
+++ b/docs/app/references/launching-browsers.mdx
@@ -168,6 +168,34 @@ Or Chrome for Testing:
 cypress run --browser chrome-for-testing
 ```
 
+:::tip
+
+<strong>Prefer Chrome for Testing for reliable, reproducible runs</strong>
+
+Where possible, we recommend running your tests in
+[Chrome for Testing](https://developer.chrome.com/blog/chrome-for-testing). It is
+a dedicated Chrome flavor that Google builds specifically for automation, and it
+has a few advantages over a standard, day-to-day Chrome install:
+
+- **No auto-update.** Regular Chrome is evergreen and silently updates itself,
+  which can change browser behavior between runs and cause tests that passed
+  yesterday to fail today. Chrome for Testing is pinned to a specific version and
+  never updates on its own, so your environment stays deterministic.
+- **Versioned, reproducible binaries.** A matching build is published for every
+  Chrome version and every major OS, so you can install the exact same browser
+  locally and in CI. See
+  [Download specific Chrome version](#Download-specific-Chrome-version).
+- **Built for automation, not browsing.** Because it is intended only for
+  testing, it is not subject to the enterprise/group
+  [policies](#Chrome-policy) often applied to branded Chrome (such as disabling
+  remote debugging), which removes a common cause of launch failures.
+- **Extension loading still works.** Standard Chrome 137 and above can no longer
+  load extensions via the Browser Launch API (see
+  [Customize the browser launch](#Customize-the-browser-launch)), but Chrome for
+  Testing and Chromium still can.
+
+:::
+
 #### Chrome policy
 
 If Chrome policy is set, ensure that

--- a/docs/app/references/launching-browsers.mdx
+++ b/docs/app/references/launching-browsers.mdx
@@ -466,10 +466,6 @@ If you modify the list of browsers, you can see the
 [resolved configuration](/app/references/configuration#Resolved-Configuration)
 in the **Settings** tab.
 
-### Unsupported Browsers
-
-Some browsers such as Internet Explorer are not currently supported.
-
 ## Browser environment
 
 Cypress launches the browser in a way that's different from a regular browser

--- a/docs/app/references/launching-browsers.mdx
+++ b/docs/app/references/launching-browsers.mdx
@@ -73,7 +73,7 @@ flag.
 ### Browser versions supported
 
 Cypress officially supports the latest 3 major versions of Chrome, Firefox, and Edge.
-(For example, if the stable release of Chrome was 130, Cypress would officially support Chrome 128, 129, and 130.)
+(For example, if the stable release of Chrome was 150, Cypress would officially support Chrome 148, 149, and 150.)
 
 Sticking to recent versions matters because these browsers are evergreen and
 their automation interfaces evolve quickly, so supporting the latest versions

--- a/docs/app/references/launching-browsers.mdx
+++ b/docs/app/references/launching-browsers.mdx
@@ -229,19 +229,6 @@ which tells Cypress to skip reading and writing Chrome preferences entirely:
 IGNORE_CHROME_PREFERENCES=1 cypress run --browser chrome
 ```
 
-:::caution
-
-When `IGNORE_CHROME_PREFERENCES` is set, Cypress no longer manages Chrome
-preferences, so any behavior controlled through preferences will not be applied.
-This includes preferences you set via `launchOptions.preferences` in the
-[`before:browser:launch`](/api/node-events/browser-launch-api#Change-browser-preferences)
-event, as well as Cypress's own preference-based defaults (such as disabling
-password saving/autofill and configuring the downloads folder). Settings applied
-through command-line switches are unaffected. Only use this escape hatch if your
-environment requires it.
-
-:::
-
 ### Edge Browsers
 
 Microsoft Edge-family (Chromium-based) browsers are supported by Cypress.

--- a/docs/app/references/launching-browsers.mdx
+++ b/docs/app/references/launching-browsers.mdx
@@ -567,13 +567,7 @@ Because Cypress runs in its own profile, it can be difficult to tell its browser
 apart from your normal one, and accidentally treating the Cypress browser like a
 regular one (or vice versa) leads to confusion.
 
-To make them easier to tell apart, you may find downloading and using a browser's
-release channel versions (Dev, Canary, etc.) useful. These browsers have
-different icons from the standard stable browser, making them more
-distinguishable. You can also use the bundled
-[Electron browser](#Electron-Browser), which does not have a dock icon.
-
-Additionally, in Chrome-based browsers, we've made the browser spawned by
+In Chrome-based browsers, we've made the browser spawned by
 Cypress look different than regular sessions. You'll see a darker theme around
 the chrome of the browser, so you'll always be able to visually distinguish them.
 

--- a/docs/app/references/launching-browsers.mdx
+++ b/docs/app/references/launching-browsers.mdx
@@ -120,9 +120,7 @@ from the CLI, Cypress launches all browsers headlessly. See
 
 #### You can also launch Electron headed:
 
-```shell
-cypress run --headed
-```
+<CypressCommandTabs command="run --headed" />
 
 Because Electron is the default browser, it is typically the one running in CI.
 If you are seeing failures in CI, an easy first debugging step is to run locally
@@ -134,9 +132,7 @@ All Chrome\* flavored browsers are detected and supported by Cypress.
 
 You can launch Chrome like this:
 
-```shell
-cypress run --browser chrome
-```
+<CypressCommandTabs command="run --browser chrome" />
 
 To use this command in CI, you need to install the browser you want - or use one
 of our [docker images](/app/continuous-integration/overview#Cypress-Docker-Images).
@@ -146,27 +142,19 @@ Chrome headed, you can pass the `--headed` argument to `cypress run`.
 
 You can also launch Chromium:
 
-```shell
-cypress run --browser chromium
-```
+<CypressCommandTabs command="run --browser chromium" />
 
 Or Chrome Beta:
 
-```shell
-cypress run --browser chrome:beta
-```
+<CypressCommandTabs command="run --browser chrome:beta" />
 
 Or Chrome Canary:
 
-```shell
-cypress run --browser chrome:canary
-```
+<CypressCommandTabs command="run --browser chrome:canary" />
 
 Or Chrome for Testing:
 
-```shell
-cypress run --browser chrome-for-testing
-```
+<CypressCommandTabs command="run --browser chrome-for-testing" />
 
 :::tip
 
@@ -224,9 +212,10 @@ writing the preference files can fail or corrupt the encrypted profile. To work
 around this, set the `IGNORE_CHROME_PREFERENCES` system environment variable,
 which tells Cypress to skip reading and writing Chrome preferences entirely:
 
-```shell
-IGNORE_CHROME_PREFERENCES=1 cypress run --browser chrome
-```
+<CypressCommandTabs
+  env="IGNORE_CHROME_PREFERENCES=1"
+  command="run --browser chrome"
+/>
 
 ### Edge Browsers
 
@@ -234,27 +223,19 @@ Microsoft Edge-family (Chromium-based) browsers are supported by Cypress.
 
 You can launch Microsoft Edge like this:
 
-```shell
-cypress run --browser edge
-```
+<CypressCommandTabs command="run --browser edge" />
 
 Or Microsoft Edge Beta:
 
-```shell
-cypress run --browser edge:beta
-```
+<CypressCommandTabs command="run --browser edge:beta" />
 
 Or Microsoft Edge Canary:
 
-```shell
-cypress run --browser edge:canary
-```
+<CypressCommandTabs command="run --browser edge:canary" />
 
 Or Microsoft Edge Dev:
 
-```shell
-cypress run --browser edge:dev
-```
+<CypressCommandTabs command="run --browser edge:dev" />
 
 #### Edge policy
 
@@ -272,16 +253,14 @@ Firefox-family browsers are supported by Cypress.
 
 You can launch Firefox like this:
 
-```shell
-cypress run --browser firefox
-```
+<CypressCommandTabs command="run --browser firefox" />
 
 Or Firefox Developer/Nightly Edition:
 
-```shell
-cypress run --browser firefox:dev
-cypress run --browser firefox:nightly
-```
+<CypressCommandTabs
+  command={`run --browser firefox:dev
+run --browser firefox:nightly`}
+/>
 
 To use this command in CI, you need to install these other browsers - or use one
 of our [docker images](/app/continuous-integration/overview#Cypress-Docker-Images).
@@ -335,9 +314,8 @@ behaves in Safari from Windows, Linux, or CI, without needing a Mac. To opt-in t
    ```
 4. Now, you should be able to use WebKit like any other browser. For example, to
    record with WebKit in CI:
-   ```shell
-   cypress run --browser webkit --record
-   ```
+
+<CypressCommandTabs command="run --browser webkit --record" />
 
 We built this experiment on top of the Playwright WebKit browser as a
 stepping stone towards creating a better UX with Cypress-provided browsers
@@ -379,13 +357,9 @@ npx playwright install-deps webkit
 If a browser isn't auto-detected, for example a portable install or a custom
 build, you can launch any supported browser by specifying a path to the binary:
 
-```shell
-cypress run --browser /usr/bin/chromium
-```
+<CypressCommandTabs command="run --browser /usr/bin/chromium" />
 
-```shell
-cypress open --browser /usr/bin/chromium
-```
+<CypressCommandTabs command="open --browser /usr/bin/chromium" />
 
 Cypress will automatically detect the type of browser supplied and launch it for
 you.
@@ -597,9 +571,7 @@ How each browser is launched headlessly differs slightly:
 To show the browser while running `cypress run`, pass the
 [`--headed`](/app/references/command-line#cypress-run-headed) flag:
 
-```shell
-cypress run --headed
-```
+<CypressCommandTabs command="run --headed" />
 
 Because Electron is the default browser, it is typically the one running in CI.
 You can also explicitly hide a headed browser with `--headless`.
@@ -624,9 +596,7 @@ Occasionally a test passes when the browser is headed but fails when run
 headlessly (or vice versa). When this happens, the quickest way to debug is to
 reproduce the failure locally with the browser shown:
 
-```shell
-cypress run --headed --no-exit --browser chrome
-```
+<CypressCommandTabs command="run --headed --no-exit --browser chrome" />
 
 The `--headed` flag shows the browser so you can watch the run, and `--no-exit`
 keeps Cypress open afterward so you can inspect the

--- a/docs/app/references/launching-browsers.mdx
+++ b/docs/app/references/launching-browsers.mdx
@@ -110,9 +110,11 @@ In addition to the browsers found on your system, you'll notice that Electron is
 an available browser. The Electron browser is a version of Chromium that comes
 with [Electron](https://electron.atom.io/).
 
-The Electron browser's biggest advantage is that it comes baked into Cypress, so
-it requires no separate installation. That makes it a dependable default in CI,
-where you want a browser that is always present and version-matched to Cypress.
+The Electron browser comes bundled with Cypress, so it requires no separate
+installation and is always available. For this reason it is the default browser
+when running from the CLI. That said, because Electron is not a browser your end
+users run, we generally recommend testing in a browser they actually use, such as
+[Chrome for Testing](#Chrome-Browsers).
 
 By default, when running [cypress run](/app/references/command-line#cypress-run)
 from the CLI, Cypress launches all browsers headlessly. See

--- a/docs/app/references/launching-browsers.mdx
+++ b/docs/app/references/launching-browsers.mdx
@@ -632,9 +632,7 @@ The `--headed` flag shows the browser so you can watch the run, and `--no-exit`
 keeps Cypress open afterward so you can inspect the
 [command log](/app/core-concepts/open-mode#Command-Log) and the application's
 final state. Comparing a headed run against a headless one, along with the
-recorded screenshots and videos, usually surfaces the difference, which is
-often related to the headless rendering defaults above (viewport/screen size or
-device pixel ratio).
+recorded screenshots and videos, usually surfaces the difference.
 
 ## Downloading files
 

--- a/docs/app/references/launching-browsers.mdx
+++ b/docs/app/references/launching-browsers.mdx
@@ -14,7 +14,7 @@ sidebar_label: 'Launching Browsers'
 
 - Why Cypress launches and controls its own browser
 - Which browsers Cypress supports and how to choose between them
-- How the Cypress browser environment differs from a regular browser — and why
+- How the Cypress browser environment differs from a regular browser, and why
 - How headless mode and file downloads work
 - How to troubleshoot browser launching issues
 
@@ -25,16 +25,17 @@ than attaching to a browser you already have open, Cypress starts its own
 instance so it can guarantee two things that make automated testing trustworthy:
 
 1. **A clean, pristine testing environment.** Every run starts from a known,
-   isolated state — no leftover cookies, history, cached logins, or third-party
-   extensions from your day-to-day browsing leaking into your tests. This is what
-   keeps runs reproducible and prevents "works on my machine" flakiness.
+   isolated state, with no leftover cookies, history, cached logins, or
+   third-party extensions from your day-to-day browsing leaking into your tests.
+   This is what keeps runs reproducible and prevents "works on my machine"
+   flakiness.
 2. **Access to privileged browser automation APIs.** Driving the browser
    directly is how Cypress reads and controls your application reliably, takes
    screenshots and video, stubs the network, and more.
 
 Cypress currently supports Firefox and Chrome-family browsers (including Edge and
 Electron), plus experimental WebKit. Testing across the browsers your users
-actually use gives you cross-browser confidence — for strategies to do this
+actually use gives you cross-browser confidence. For strategies to do this
 efficiently in CI, see the
 [Cross Browser Testing](/app/guides/cross-browser-testing) guide.
 
@@ -75,8 +76,8 @@ Cypress officially supports the latest 3 major versions of Chrome, Firefox, and 
 (For example, if the stable release of Chrome was 130, Cypress would officially support Chrome 128, 129, and 130.)
 
 Sticking to recent versions matters because these browsers are evergreen and
-their automation interfaces evolve quickly — supporting the latest versions lets
-Cypress rely on stable, modern automation APIs.
+their automation interfaces evolve quickly, so supporting the latest versions
+lets Cypress rely on stable, modern automation APIs.
 
 :::info
 
@@ -84,7 +85,7 @@ Regardless of the above, Cypress cannot launch **Firefox versions older than 135
 Cypress automates Firefox through
 [WebDriver BiDi](https://w3c.github.io/webdriver-bidi/), which is only available
 in Firefox 135 and above, so older versions will fail with an error. Note this is
-a hard technical minimum, not an extension of official support — Cypress still
+a hard technical minimum, not an extension of official support. Cypress still
 officially supports only the latest 3 major versions. See
 [Firefox Browsers](#Firefox-Browsers) for details.
 
@@ -185,7 +186,7 @@ for more.
 To set up a consistent testing environment, Cypress reads and writes Chrome
 preference files inside its [isolated profile](#Cypress-Profile) in the browser's
 user-data directory (the `Preferences`, `Secure Preferences`, and `Local State`
-files). This is how Cypress applies preference-based settings — for example,
+files). This is how Cypress applies preference-based settings, for example,
 disabling password saving and autofill, configuring the
 [downloads behavior](#Downloading-files), and any preferences you set through the
 [`before:browser:launch`](/api/node-events/browser-launch-api#Change-browser-preferences)
@@ -260,7 +261,7 @@ Firefox-family browsers are supported by Cypress.
 
 Cypress automates Firefox using [WebDriver BiDi](https://w3c.github.io/webdriver-bidi/),
 which is only available starting in Firefox 135. **Firefox versions older than 135
-will fail to launch.** (Official support remains the latest 3 major versions — see
+will fail to launch.** (Official support remains the latest 3 major versions; see
 [Browser versions supported](#Browser-versions-supported).)
 
 :::
@@ -317,7 +318,7 @@ Download the Mozilla geckodriver from the
 Cypress has [experimental](/app/references/experiments) support for WebKit,
 Safari's browser engine. Because Apple does not ship Safari's automation on every
 platform, testing against WebKit is the practical way to validate how your app
-behaves in Safari from Windows, Linux, or CI — without needing a Mac. To opt-in to
+behaves in Safari from Windows, Linux, or CI, without needing a Mac. To opt-in to
 `experimentalWebKitSupport`, follow these steps:
 
 1. Add `experimentalWebKitSupport: true` to your
@@ -371,8 +372,8 @@ npx playwright install-deps webkit
 
 ### Launching by a path
 
-If a browser isn't auto-detected — for example a portable install or a custom
-build — you can launch any supported browser by specifying a path to the binary:
+If a browser isn't auto-detected, for example a portable install or a custom
+build, you can launch any supported browser by specifying a path to the binary:
 
 ```shell
 cypress run --browser /usr/bin/chromium
@@ -527,13 +528,13 @@ launches so all of your configuration will be preserved.
 
 Cypress automatically disables certain functionality in the Cypress launched
 browser that tend to get in the way of automated testing. This includes various
-features and prompts that are commonly disabled in automation — for example,
+features and prompts that are commonly disabled in automation, for example,
 ignoring certificate errors, allowing blocked pop-ups, and disabling things like
 password saving, autofill, session restoring, background throttling, and device
 permission prompts.
 
 The goal is to keep these native browser behaviors from interrupting an
-unattended run — a "Save password?" dialog or a throttled background tab can
+unattended run. A "Save password?" dialog or a throttled background tab can
 stall or destabilize a test, so Cypress turns them off up front.
 
 ### Extra Tabs
@@ -584,7 +585,7 @@ the same browser icons in your dock.
 />
 
 Because Cypress runs in its own profile, it can be difficult to tell its browser
-apart from your normal one — and accidentally treating the Cypress browser like a
+apart from your normal one, and accidentally treating the Cypress browser like a
 regular one (or vice versa) leads to confusion.
 
 To make them easier to tell apart, you may find downloading and using a browser's
@@ -605,7 +606,7 @@ the chrome of the browser, so you'll always be able to visually distinguish them
 ## Headless mode
 
 When running [cypress run](/app/references/command-line#cypress-run) from the
-CLI, Cypress launches browsers **headlessly** by default — the browser runs
+CLI, Cypress launches browsers **headlessly** by default. The browser runs
 without a visible UI. This is what makes Cypress well suited to Continuous
 Integration, where there is no display to render to and headless runs are faster
 and lighter. When running [cypress open](/app/references/command-line#cypress-open),
@@ -640,7 +641,7 @@ the following defaults for rendering:
 Knowing these defaults matters because they determine the size and resolution of
 the screenshots and videos captured during the run. You can override them in the
 [`before:browser:launch`](/api/node-events/browser-launch-api#Set-screen-size-when-running-headless)
-event — for example, to change the window size or force a retina-like DPR for
+event, for example, to change the window size or force a retina-like DPR for
 higher-resolution output.
 
 ### Debugging headless-only failures
@@ -656,8 +657,8 @@ cypress run --headed --no-exit --browser chrome
 The `--headed` flag shows the browser so you can watch the run, and `--no-exit`
 keeps Cypress open afterward so you can inspect the
 [command log](/app/core-concepts/open-mode#Command-Log) and the application's
-final state. Comparing a headed run against a headless one — along with the
-recorded screenshots and videos — usually surfaces the difference, which is
+final state. Comparing a headed run against a headless one, along with the
+recorded screenshots and videos, usually surfaces the difference, which is
 often related to the headless rendering defaults above (viewport/screen size or
 device pixel ratio).
 
@@ -740,8 +741,8 @@ without it. To check:
    disabled, Cypress will not be able to connect (this typically surfaces as an
    `ECONNREFUSED` error).
 
-This policy applies only to the standalone Chrome and Edge browsers — it does not
-affect the bundled [Electron browser](#Electron-Browser), so switching to
+This policy applies only to the standalone Chrome and Edge browsers, and it does
+not affect the bundled [Electron browser](#Electron-Browser), so switching to
 `--browser electron` is a useful way to confirm whether a policy is the cause:
 
 ```shell
@@ -756,7 +757,7 @@ If the policy is not the issue:
 
 - **Network/firewall rules blocking `127.0.0.1` connections** on the remote
   debugging port. A proxy or VPN that intercepts `localhost`/`127.0.0.1` traffic
-  will also prevent Cypress from connecting — allow local connections, or exclude
+  will also prevent Cypress from connecting. Allow local connections, or exclude
   `localhost` and `127.0.0.1` from any proxy.
 - **Security software that closes or sandboxes the browser process** immediately
   after launch. Antivirus or endpoint protection may terminate the browser before

--- a/docs/app/references/launching-browsers.mdx
+++ b/docs/app/references/launching-browsers.mdx
@@ -480,13 +480,14 @@ profile. This means things like `history` entries, `cookies`, and
 `3rd party extensions` from your regular browsing session will not affect your
 tests in Cypress.
 
-:::caution
+:::info
 
-<strong>Wait, I need my developer extensions!</strong>
+<strong>Using your developer extensions</strong>
 
-That's no problem - you have to reinstall them **once** in the Cypress launched
-browser. We'll continue to use this Cypress testing profile on subsequent
-launches so all of your configuration will be preserved.
+Because Cypress runs in its own profile, your usual extensions won't carry over
+automatically. If you rely on developer extensions, install them once in the
+Cypress-launched browser. Cypress reuses the same testing profile on every
+subsequent launch, so your extensions and other configuration are preserved.
 
 :::
 

--- a/docs/app/references/launching-browsers.mdx
+++ b/docs/app/references/launching-browsers.mdx
@@ -204,7 +204,7 @@ is either undefined or set to `true`.
 If this is not the case, then Cypress will timeout, returning an `ECONNREFUSED` error, attempting to connect to the browser.
 Chrome policy is generally applied to a Chrome-branded browser only, not to Chromium or Chrome for Testing browsers.
 Check by browsing to **chrome://policy**. See
-[Cypress failed to make a connection to the Chrome DevTools Protocol](#Cypress-failed-to-make-a-connection-to-the-Chrome-DevTools-Protocol)
+[Cypress failed to make a connection to the Chrome DevTools Protocol](/app/references/troubleshooting#Cypress-failed-to-make-a-connection-to-the-Chrome-DevTools-Protocol)
 for more.
 
 #### Skipping Chrome preference reads/writes
@@ -263,7 +263,7 @@ If Edge policy is set, ensure that
 is either undefined or set to `true`.
 If this is not the case, then Cypress will timeout, returning an `ECONNREFUSED` error, attempting to connect to the browser.
 Check by browsing to **edge://policy**. See
-[Cypress failed to make a connection to the Chrome DevTools Protocol](#Cypress-failed-to-make-a-connection-to-the-Chrome-DevTools-Protocol)
+[Cypress failed to make a connection to the Chrome DevTools Protocol](/app/references/troubleshooting#Cypress-failed-to-make-a-connection-to-the-Chrome-DevTools-Protocol)
 for more.
 
 ### Firefox Browsers
@@ -646,69 +646,6 @@ known folder where you can assert on them directly from disk.
 ## Troubleshooting
 
 [Having issues launching installed browsers? Read more about troubleshooting browser launching](/app/references/troubleshooting#Launching-browsers)
-
-### Cypress failed to make a connection to the Chrome DevTools Protocol
-
-Cypress controls Chrome, Chromium, and Edge through the
-[Chrome DevTools Protocol](https://chromedevtools.github.io/devtools-protocol/)
-(CDP) over a remote debugging port. After launching the browser, Cypress retries
-the CDP connection for up to 50 seconds; if it never connects, the run fails with
-an error like:
-
-```
-Cypress failed to make a connection to the Chrome DevTools Protocol
-after retrying for 50 seconds.
-```
-
-This means the browser launched but Cypress could not reach it on the remote
-debugging port.
-
-#### Check for a remote debugging policy
-
-The most common cause in managed/enterprise environments is remote debugging
-being disabled by an enterprise or group policy. Cypress cannot drive the browser
-without it. To check:
-
-1. Open **chrome://policy** (or **edge://policy** for Edge) in the affected
-   browser.
-2. Look for the
-   [`RemoteDebuggingAllowed`](https://chromeenterprise.google/policies/#RemoteDebuggingAllowed)
-   policy.
-3. Ensure it is either undefined or set to enabled/`true`. If it is set to
-   disabled, Cypress will not be able to connect (this typically surfaces as an
-   `ECONNREFUSED` error).
-
-This policy applies only to the standalone Chrome and Edge browsers, and it does
-not affect the bundled [Electron browser](#Electron-Browser), so switching to
-`--browser electron` is a useful way to confirm whether a policy is the cause:
-
-```shell
-cypress run --browser electron
-```
-
-This policy is also generally not applied to Chromium or
-[Chrome for Testing](#Chrome-Browsers), so running your tests in Chrome for
-Testing is another way to avoid policy-related connection failures.
-
-See [Chrome policy](#Chrome-policy) and [Edge policy](#Edge-policy) for more.
-
-#### Other things to check
-
-If the policy is not the issue:
-
-- **Network/firewall rules blocking `127.0.0.1` connections** on the remote
-  debugging port. A proxy or VPN that intercepts `localhost`/`127.0.0.1` traffic
-  will also prevent Cypress from connecting. Allow local connections, or exclude
-  `localhost` and `127.0.0.1` from any proxy.
-- **Security software that closes or sandboxes the browser process** immediately
-  after launch. Antivirus or endpoint protection may terminate the browser before
-  Cypress can connect.
-- **A custom `before:browser:launch` argument** preventing the browser from
-  starting. If you modify launch arguments, temporarily remove your
-  customizations to rule them out.
-
-See [Troubleshooting](/app/references/troubleshooting#Launching-browsers) for more
-browser launch problems.
 
 ## See also
 

--- a/docs/app/references/launching-browsers.mdx
+++ b/docs/app/references/launching-browsers.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Launching Browsers in Cypress'
-description: 'Learn how to launch browsers in Cypress, customize the list of available browsers, and troubleshoot browser launching issues.'
+description: 'Learn how Cypress launches and controls browsers, how to choose and customize the browsers available to your tests, how headless mode and downloads work, and how to troubleshoot browser launching issues.'
 sidebar_label: 'Launching Browsers'
 ---
 
@@ -12,27 +12,36 @@ sidebar_label: 'Launching Browsers'
 
 ##### <Icon name="question-circle" color="#4BBFD2" /> What you'll learn
 
-- How to launch browsers in Cypress
-- How to customize the list of available browsers
+- Why Cypress launches and controls its own browser
+- Which browsers Cypress supports and how to choose between them
+- How the Cypress browser environment differs from a regular browser — and why
+- How headless mode and file downloads work
 - How to troubleshoot browser launching issues
-- Differences between Cypress browsers and regular browser environments
 
 :::
 
-When you run tests in Cypress, we launch a browser for you. This enables us to:
+When you run tests, Cypress launches and controls a real browser for you. Rather
+than attaching to a browser you already have open, Cypress starts its own
+instance so it can guarantee two things that make automated testing trustworthy:
 
-1. Create a clean, pristine testing environment.
-2. Access the privileged browser APIs for automation.
+1. **A clean, pristine testing environment.** Every run starts from a known,
+   isolated state — no leftover cookies, history, cached logins, or third-party
+   extensions from your day-to-day browsing leaking into your tests. This is what
+   keeps runs reproducible and prevents "works on my machine" flakiness.
+2. **Access to privileged browser automation APIs.** Driving the browser
+   directly is how Cypress reads and controls your application reliably, takes
+   screenshots and video, stubs the network, and more.
 
-Cypress currently supports Firefox and Chrome-family browsers (including Edge
-and Electron). To run tests optimally across these browsers in CI, check out the
-strategies demonstrated in the
-[cross browser Testing](/app/guides/cross-browser-testing) guide.
+Cypress currently supports Firefox and Chrome-family browsers (including Edge and
+Electron), plus experimental WebKit. Testing across the browsers your users
+actually use gives you cross-browser confidence — for strategies to do this
+efficiently in CI, see the
+[Cross Browser Testing](/app/guides/cross-browser-testing) guide.
 
-## Browsers
+## Supported browsers
 
-When Cypress is initially launched, you can choose to test your application
-using number of browsers including:
+When Cypress is launched, you can choose to test your application using a number
+of browsers, including:
 
 - [Chrome](https://www.google.com/chrome/)
 - [Chrome Beta](https://www.google.com/chrome/beta/)
@@ -49,8 +58,11 @@ using number of browsers including:
 - [Firefox Nightly](https://www.mozilla.org/firefox/nightly/)
 - [WebKit (Experimental)](#WebKit-Experimental)
 
-Cypress automatically detects available browsers on your OS. You can switch the
-browser by using the drop down near the top right corner:
+Cypress automatically detects the browsers installed on your OS so you don't have
+to configure paths by hand. In `cypress open`, switch browsers using the drop
+down near the top right corner; in `cypress run`, choose one with the
+[`--browser`](/app/references/command-line#cypress-run-browser-lt-browser-name-or-path-gt)
+flag.
 
 <DocsImage
   src="/img/app/launching-browsers/browser-list-dropdown.png"
@@ -61,6 +73,10 @@ browser by using the drop down near the top right corner:
 
 Cypress officially supports the latest 3 major versions of Chrome, Firefox, and Edge.
 (For example, if the stable release of Chrome was 130, Cypress would officially support Chrome 128, 129, and 130.)
+
+Sticking to recent versions matters because these browsers are evergreen and
+their automation interfaces evolve quickly — supporting the latest versions lets
+Cypress rely on stable, modern automation APIs.
 
 :::info
 
@@ -83,7 +99,9 @@ See each browser's official release schedule for more information.
 ### Download specific Chrome version
 
 The Chrome browser is evergreen - meaning it will automatically update itself,
-sometimes causing a breaking change in your automated tests.
+sometimes causing a breaking change in your automated tests. To keep your test
+runs deterministic, you can pin a fixed browser version instead of letting it
+drift.
 You can use the information in [Download Chromium](https://on.cypress.io/chromium-downloads) to download a
 specific released version of Chrome for Testing or Chromium for every platform.
 
@@ -93,11 +111,13 @@ In addition to the browsers found on your system, you'll notice that Electron is
 an available browser. The Electron browser is a version of Chromium that comes
 with [Electron](https://electron.atom.io/).
 
-The Electron browser has the advantage of coming baked into Cypress and does not
-need to be installed separately.
+The Electron browser's biggest advantage is that it comes baked into Cypress, so
+it requires no separate installation. That makes it a dependable default in CI,
+where you want a browser that is always present and version-matched to Cypress.
 
 By default, when running [cypress run](/app/references/command-line#cypress-run)
-from the CLI, we will launch all browsers headlessly.
+from the CLI, Cypress launches all browsers headlessly. See
+[Headless mode](#Headless-mode) for details.
 
 #### You can also launch Electron headed:
 
@@ -105,9 +125,9 @@ from the CLI, we will launch all browsers headlessly.
 cypress run --headed
 ```
 
-Because Electron is the default browser - it is typically run in CI. If you are
-seeing failures in CI, to easily debug them you may want to run locally with the
-`--headed` option.
+Because Electron is the default browser, it is typically the one running in CI.
+If you are seeing failures in CI, an easy first debugging step is to run locally
+with the `--headed` option so you can watch what happens.
 
 ### Chrome Browsers
 
@@ -156,7 +176,9 @@ If Chrome policy is set, ensure that
 is either undefined or set to `true`.
 If this is not the case, then Cypress will timeout, returning an `ECONNREFUSED` error, attempting to connect to the browser.
 Chrome policy is generally applied to a Chrome-branded browser only, not to Chromium or Chrome for Testing browsers.
-Check by browsing to **chrome://policy**.
+Check by browsing to **chrome://policy**. See
+[Cypress failed to make a connection to the Chrome DevTools Protocol](#Cypress-failed-to-make-a-connection-to-the-Chrome-DevTools-Protocol)
+for more.
 
 #### Skipping Chrome preference reads/writes
 
@@ -165,7 +187,7 @@ preference files inside its [isolated profile](#Cypress-Profile) in the browser'
 user-data directory (the `Preferences`, `Secure Preferences`, and `Local State`
 files). This is how Cypress applies preference-based settings — for example,
 disabling password saving and autofill, configuring the
-[downloads behavior](#Downloading-Files), and any preferences you set through the
+[downloads behavior](#Downloading-files), and any preferences you set through the
 [`before:browser:launch`](/api/node-events/browser-launch-api#Change-browser-preferences)
 event.
 
@@ -226,7 +248,9 @@ If Edge policy is set, ensure that
 [RemoteDebuggingAllowed](https://learn.microsoft.com/en-us/deployedge/microsoft-edge-browser-policies/remotedebuggingallowed)
 is either undefined or set to `true`.
 If this is not the case, then Cypress will timeout, returning an `ECONNREFUSED` error, attempting to connect to the browser.
-Check by browsing to **edge://policy**.
+Check by browsing to **edge://policy**. See
+[Cypress failed to make a connection to the Chrome DevTools Protocol](#Cypress-failed-to-make-a-connection-to-the-Chrome-DevTools-Protocol)
+for more.
 
 ### Firefox Browsers
 
@@ -291,9 +315,10 @@ Download the Mozilla geckodriver from the
 ### WebKit (Experimental)
 
 Cypress has [experimental](/app/references/experiments) support for WebKit,
-Safari's browser engine. Testing your app with WebKit is representative of how
-your app would run in Safari. To opt-in to `experimentalWebKitSupport`, follow
-these steps:
+Safari's browser engine. Because Apple does not ship Safari's automation on every
+platform, testing against WebKit is the practical way to validate how your app
+behaves in Safari from Windows, Linux, or CI — without needing a Mac. To opt-in to
+`experimentalWebKitSupport`, follow these steps:
 
 1. Add `experimentalWebKitSupport: true` to your
    [configuration](/app/references/configuration) to enable the experiment.
@@ -346,7 +371,8 @@ npx playwright install-deps webkit
 
 ### Launching by a path
 
-You can launch any supported browser by specifying a path to the binary:
+If a browser isn't auto-detected — for example a portable install or a custom
+build — you can launch any supported browser by specifying a path to the binary:
 
 ```shell
 cypress run --browser /usr/bin/chromium
@@ -366,7 +392,9 @@ you.
 ### Customize available browsers
 
 Sometimes you might want to modify the list of browsers found before running
-tests.
+tests. This is useful when your application only targets certain browsers, or
+when you want to test in a Chromium-based browser that Cypress doesn't detect on
+its own.
 
 For example, your web application might _only_ be designed to work in a Chrome
 browser, and not inside the Electron browser.
@@ -467,21 +495,129 @@ in the **Settings** tab.
 
 Some browsers such as Internet Explorer are not currently supported.
 
-## Headless Mode
+## Browser environment
+
+Cypress launches the browser in a way that's different from a regular browser
+environment. These differences are deliberate: each one removes a source of
+noise or unpredictability so that your tests are _more reliable_, _more
+reproducible_, and _easier to debug_.
+
+### Cypress Profile
+
+Cypress generates its own isolated profile apart from your normal browser
+profile. This means things like `history` entries, `cookies`, and
+`3rd party extensions` from your regular browsing session will not affect your
+tests in Cypress.
+
+The value here is isolation: tests start from a predictable, clean slate and
+can't be influenced (or broken) by the state of your personal browser, which is a
+common source of "passes locally, fails in CI" surprises.
+
+:::caution
+
+<strong>Wait, I need my developer extensions!</strong>
+
+That's no problem - you have to reinstall them **once** in the Cypress launched
+browser. We'll continue to use this Cypress testing profile on subsequent
+launches so all of your configuration will be preserved.
+
+:::
+
+### Disabled Barriers
+
+Cypress automatically disables certain functionality in the Cypress launched
+browser that tend to get in the way of automated testing. This includes various
+features and prompts that are commonly disabled in automation — for example,
+ignoring certificate errors, allowing blocked pop-ups, and disabling things like
+password saving, autofill, session restoring, background throttling, and device
+permission prompts.
+
+The goal is to keep these native browser behaviors from interrupting an
+unattended run — a "Save password?" dialog or a throttled background tab can
+stall or destabilize a test, so Cypress turns them off up front.
+
+### Extra Tabs
+
+Any extra tabs (i.e. tabs other than the one opened by Cypress) will be closed between tests. We recommend using your own browser instead of the one launched by Cypress for general-purpose browsing.
+
+### Customize the browser launch
+
+When Cypress goes to launch your browser, it gives you an opportunity to modify
+the arguments, preferences, environment, and extensions used to launch it. This
+is the main extension point for tailoring the browser to your application's
+needs.
+
+This enables you to do things like:
+
+- Load your own extension
+- Enable or disable experimental features
+- Change command-line arguments, preferences, and environment variables
+
+[This part of the API is documented here.](/api/node-events/browser-launch-api)
+
+:::caution
+
+<strong>Loading extensions in Chrome 137 and above</strong>
+
+Chrome-branded browsers (e.g., standard Chrome) version 137 and above no longer
+support loading extensions via the [Browser Launch API](/api/node-events/browser-launch-api#Add-browser-extensions),
+because Chrome removed support for the `--load-extension` flag. If you attempt to
+load an extension in an affected Chrome version, Cypress will display a warning and
+the extension will not be loaded.
+
+To continue loading extensions, use
+[Chrome for Testing](#Chrome-Browsers) or [Chromium](#Chrome-Browsers) instead.
+See the Cypress Docker image examples for
+[Chrome for Testing](https://github.com/cypress-io/cypress-docker-images/tree/master/examples/chrome-for-testing)
+and [Chromium](https://github.com/cypress-io/cypress-docker-images/tree/master/examples/chromium).
+
+:::
+
+### Distinguishing the Cypress browser
+
+You might notice that if you already have the browser open you will see two of
+the same browser icons in your dock.
+
+<DocsImage
+  src="/img/app/launching-browsers/multiple-chrome-icons.png"
+  alt="Cypress icon with 2 Google Chrome icons"
+/>
+
+Because Cypress runs in its own profile, it can be difficult to tell its browser
+apart from your normal one — and accidentally treating the Cypress browser like a
+regular one (or vice versa) leads to confusion.
+
+To make them easier to tell apart, you may find downloading and using a browser's
+release channel versions (Dev, Canary, etc.) useful. These browsers have
+different icons from the standard stable browser, making them more
+distinguishable. You can also use the bundled
+[Electron browser](#Electron-Browser), which does not have a dock icon.
+
+Additionally, in Chrome-based browsers, we've made the browser spawned by
+Cypress look different than regular sessions. You'll see a darker theme around
+the chrome of the browser, so you'll always be able to visually distinguish them.
+
+<DocsImage
+  src="/img/app/launching-browsers/cypress-browser-chrome.png"
+  alt="Cypress Browser with darker chrome"
+/>
+
+## Headless mode
 
 When running [cypress run](/app/references/command-line#cypress-run) from the
 CLI, Cypress launches browsers **headlessly** by default — the browser runs
-without a visible UI, which is well suited to Continuous Integration. When
-running [cypress open](/app/references/command-line#cypress-open), the browser
-is **always headed**.
+without a visible UI. This is what makes Cypress well suited to Continuous
+Integration, where there is no display to render to and headless runs are faster
+and lighter. When running [cypress open](/app/references/command-line#cypress-open),
+the browser is **always headed** so you can watch and debug interactively.
 
 How each browser is launched headlessly differs slightly:
 
-| Browser                | Default during `cypress run`                       | How it runs headless                |
-| ---------------------- | -------------------------------------------------- | ----------------------------------- |
-| Electron               | Headless (the default browser, typically used in CI) | Internal Electron headless mode   |
-| Chrome / Chromium / Edge | Headless                                          | Launched with `--headless=new`      |
-| Firefox                | Headless                                            | Launched with `-headless`           |
+| Browser                  | Default during `cypress run`                         | How it runs headless            |
+| ------------------------ | ---------------------------------------------------- | ------------------------------- |
+| Electron                 | Headless (the default browser, typically used in CI) | Internal Electron headless mode |
+| Chrome / Chromium / Edge | Headless                                             | Launched with `--headless=new`  |
+| Firefox                  | Headless                                             | Launched with `-headless`       |
 
 To show the browser while running `cypress run`, pass the
 [`--headed`](/app/references/command-line#cypress-run-headed) flag:
@@ -501,8 +637,8 @@ the following defaults for rendering:
 - A default screen size of **1280x720**.
 - A device pixel ratio (DPR) forced to **1**.
 
-These defaults affect the size and resolution of screenshots and videos captured
-during the run. You can override them in the
+Knowing these defaults matters because they determine the size and resolution of
+the screenshots and videos captured during the run. You can override them in the
 [`before:browser:launch`](/api/node-events/browser-launch-api#Set-screen-size-when-running-headless)
 event — for example, to change the window size or force a retina-like DPR for
 higher-resolution output.
@@ -525,87 +661,22 @@ recorded screenshots and videos — usually surfaces the difference, which is
 often related to the headless rendering defaults above (viewport/screen size or
 device pixel ratio).
 
-## Browser Environment
-
-Cypress launches the browser in a way that's different from a regular browser
-environment. But it launches in a way that we believe makes testing _more
-reliable_ and _accessible_.
-
-### Launching Browsers
-
-When Cypress goes to launch your browser it will give you an opportunity to
-modify the arguments used to launch the browser.
-
-This enables you to do things like:
-
-- Load your own extension
-- Enable or disable experimental features
-
-[This part of the API is documented here.](/api/node-events/browser-launch-api)
-
-:::caution
-
-<strong>Loading extensions in Chrome 137 and above</strong>
-
-Chrome-branded browsers (e.g., standard Chrome) version 137 and above no longer
-support loading extensions via the [Browser Launch API](/api/node-events/browser-launch-api#Add-browser-extensions),
-because Chrome removed support for the `--load-extension` flag. If you attempt to
-load an extension in an affected Chrome version, Cypress will display a warning and
-the extension will not be loaded.
-
-To continue loading extensions, use
-[Chrome for Testing](#Chrome-Browsers) or [Chromium](#Chrome-Browsers) instead.
-See the Cypress Docker image examples for
-[Chrome for Testing](https://github.com/cypress-io/cypress-docker-images/tree/master/examples/chrome-for-testing)
-and [Chromium](https://github.com/cypress-io/cypress-docker-images/tree/master/examples/chromium).
-
-:::
-
-### Cypress Profile
-
-Cypress generates its own isolated profile apart from your normal browser
-profile. This means things like `history` entries, `cookies`, and
-`3rd party extensions` from your regular browsing session will not affect your
-tests in Cypress.
-
-:::caution
-
-<strong>Wait, I need my developer extensions!</strong>
-
-That's no problem - you have to reinstall them **once** in the Cypress launched
-browser. We'll continue to use this Cypress testing profile on subsequent
-launches so all of your configuration will be preserved.
-
-:::
-
-### Extra Tabs
-
-Any extra tabs (i.e. tabs other than the one opened by Cypress) will be closed between tests. We recommend using your own browser instead of the one launched by Cypress for general-purpose browsing.
-
-### Disabled Barriers
-
-Cypress automatically disables certain functionality in the Cypress launched
-browser that tend to get in the way of automated testing. This includes various
-features and prompts that are commonly disabled in automation — for example,
-ignoring certificate errors, allowing blocked pop-ups, and disabling things like
-password saving, autofill, session restoring, background throttling, and device
-permission prompts.
-
-## Downloading Files
+## Downloading files
 
 When your application downloads a file, Cypress automatically saves it to the
 [`downloadsFolder`](/app/references/configuration#Downloads) (by default
 `cypress/downloads`) without showing the browser's native "Save As" prompt or
-download shelf. This lets you download a file during a test and then assert on
-its contents directly from disk.
+download shelf. This is what makes downloads testable end-to-end: a native
+file-picker dialog would block an unattended run, so Cypress routes downloads to a
+known folder where you can assert on them directly from disk.
 
 How Cypress configures automatic downloads depends on the browser family:
 
-| Browser family            | Mechanism                                                                                                                                  |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| Chrome / Edge / Electron  | The [Chrome DevTools Protocol](https://chromedevtools.github.io/devtools-protocol/) `Page.setDownloadBehavior` command, pointed at the `downloadsFolder`. |
-| Firefox                   | The `browser.download.*` preferences (e.g. `browser.download.dir` and `browser.download.folderList`) set on the browser profile.            |
-| WebKit (Experimental)     | [Playwright](https://playwright.dev/) download events, which save the downloaded file to the `downloadsFolder`.                             |
+| Browser family           | Mechanism                                                                                                                                                 |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Chrome / Edge / Electron | The [Chrome DevTools Protocol](https://chromedevtools.github.io/devtools-protocol/) `Page.setDownloadBehavior` command, pointed at the `downloadsFolder`. |
+| Firefox                  | The `browser.download.*` preferences (e.g. `browser.download.dir` and `browser.download.folderList`) set on the browser profile.                          |
+| WebKit (Experimental)    | [Playwright](https://playwright.dev/) download events, which save the downloaded file to the `downloadsFolder`.                                           |
 
 ### Asserting on a downloaded file
 
@@ -633,33 +704,6 @@ If you need Cypress to recognize a download with an uncommon mime type, see
 [Support unique file download mime types](/api/node-events/browser-launch-api#Support-unique-file-download-mime-types).
 
 :::
-
-## Browser Icon
-
-You might notice that if you already have the browser open you will see two of
-the same browser icons in your dock.
-
-<DocsImage
-  src="/img/app/launching-browsers/multiple-chrome-icons.png"
-  alt="Cypress icon with 2 Google Chrome icons"
-/>
-
-We understand that when Cypress is running in its own profile it can be
-difficult to tell the difference between your normal browser and Cypress.
-
-For this reason you may find downloading and using a browser's release channel
-versions (Dev, Canary, etc) useful. These browsers have different icons from the
-standard stable browser, making them more distinguishable. You can also use the
-bundled [Electron browser](#Electron-Browser), which does not have a dock icon.
-
-Additionally, in Chrome-based browsers, we've made the browser spawned by
-Cypress look different than regular sessions. You'll see a darker theme around
-the chrome of the browser. You'll always be able to visually distinguish these.
-
-<DocsImage
-  src="/img/app/launching-browsers/cypress-browser-chrome.png"
-  alt="Cypress Browser with darker chrome"
-/>
 
 ## Troubleshooting
 

--- a/docs/app/references/launching-browsers.mdx
+++ b/docs/app/references/launching-browsers.mdx
@@ -643,14 +643,6 @@ download shelf. This is what makes downloads testable end-to-end: a native
 file-picker dialog would block an unattended run, so Cypress routes downloads to a
 known folder where you can assert on them directly from disk.
 
-How Cypress configures automatic downloads depends on the browser family:
-
-| Browser family           | Mechanism                                                                                                                                                 |
-| ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Chrome / Edge / Electron | The [Chrome DevTools Protocol](https://chromedevtools.github.io/devtools-protocol/) `Page.setDownloadBehavior` command, pointed at the `downloadsFolder`. |
-| Firefox                  | The `browser.download.*` preferences (e.g. `browser.download.dir` and `browser.download.folderList`) set on the browser profile.                          |
-| WebKit (Experimental)    | [Playwright](https://playwright.dev/) download events, which save the downloaded file to the `downloadsFolder`.                                           |
-
 ### Asserting on a downloaded file
 
 Because downloads are saved to a known folder, you can read a file back and

--- a/docs/app/references/launching-browsers.mdx
+++ b/docs/app/references/launching-browsers.mdx
@@ -401,9 +401,6 @@ tests. This is useful when your application only targets certain browsers, or
 when you want to test in a Chromium-based browser that Cypress doesn't detect on
 its own.
 
-For example, your web application might _only_ be designed to work in a Chrome
-browser, and not inside the Electron browser.
-
 In the [setupNodeEvents](/api/node-events/configuration-api) function, you can
 filter the list of browsers passed inside the `config` object and return the
 list of browsers you want available for selection during `cypress open`.

--- a/docs/app/references/launching-browsers.mdx
+++ b/docs/app/references/launching-browsers.mdx
@@ -336,7 +336,7 @@ behaves in Safari from Windows, Linux, or CI, without needing a Mac. To opt-in t
 4. Now, you should be able to use WebKit like any other browser. For example, to
    record with WebKit in CI:
    ```shell
-   cypress run --browser webkit --record # ...
+   cypress run --browser webkit --record
    ```
 
 We built this experiment on top of the Playwright WebKit browser as a

--- a/docs/app/references/launching-browsers.mdx
+++ b/docs/app/references/launching-browsers.mdx
@@ -493,25 +493,11 @@ Any extra tabs (i.e. tabs other than the one opened by Cypress) will be closed b
 ### Disabled Barriers
 
 Cypress automatically disables certain functionality in the Cypress launched
-browser that tend to get in the way of automated testing.
-
-#### The Cypress launched browser automatically:
-
-- Ignores certificate errors.
-- Allows blocked pop-ups.
-- Disables 'Saving passwords'.
-- Disables 'Autofill forms and passwords'.
-- Disables asking to become your primary browser.
-- Disables device discovery notifications.
-- Disables language translations.
-- Disables restoring sessions.
-- Disables background network traffic.
-- Disables background and renderer throttling.
-- Disables prompts requesting permission to use devices like cameras or mics
-- Disables user gesture requirements for autoplaying videos.
-
-You can see all of the default chrome command line switches we send
-[here](https://github.com/cypress-io/cypress/blob/develop/packages/server/lib/util/chromium_flags.ts#L36).
+browser that tend to get in the way of automated testing. This includes various
+features and prompts that are commonly disabled in automation — for example,
+ignoring certificate errors, allowing blocked pop-ups, and disabling things like
+password saving, autofill, session restoring, background throttling, and device
+permission prompts.
 
 ## Browser Icon
 

--- a/docs/app/references/launching-browsers.mdx
+++ b/docs/app/references/launching-browsers.mdx
@@ -775,6 +775,10 @@ not affect the bundled [Electron browser](#Electron-Browser), so switching to
 cypress run --browser electron
 ```
 
+This policy is also generally not applied to Chromium or
+[Chrome for Testing](#Chrome-Browsers), so running your tests in Chrome for
+Testing is another way to avoid policy-related connection failures.
+
 See [Chrome policy](#Chrome-policy) and [Edge policy](#Edge-policy) for more.
 
 #### Other things to check

--- a/docs/app/references/launching-browsers.mdx
+++ b/docs/app/references/launching-browsers.mdx
@@ -665,6 +665,65 @@ the chrome of the browser. You'll always be able to visually distinguish these.
 
 [Having issues launching installed browsers? Read more about troubleshooting browser launching](/app/references/troubleshooting#Launching-browsers)
 
+### Cypress failed to make a connection to the Chrome DevTools Protocol
+
+Cypress controls Chrome, Chromium, and Edge through the
+[Chrome DevTools Protocol](https://chromedevtools.github.io/devtools-protocol/)
+(CDP) over a remote debugging port. After launching the browser, Cypress retries
+the CDP connection for up to 50 seconds; if it never connects, the run fails with
+an error like:
+
+```
+Cypress failed to make a connection to the Chrome DevTools Protocol
+after retrying for 50 seconds.
+```
+
+This means the browser launched but Cypress could not reach it on the remote
+debugging port.
+
+#### Check for a remote debugging policy
+
+The most common cause in managed/enterprise environments is remote debugging
+being disabled by an enterprise or group policy. Cypress cannot drive the browser
+without it. To check:
+
+1. Open **chrome://policy** (or **edge://policy** for Edge) in the affected
+   browser.
+2. Look for the
+   [`RemoteDebuggingAllowed`](https://chromeenterprise.google/policies/#RemoteDebuggingAllowed)
+   policy.
+3. Ensure it is either undefined or set to enabled/`true`. If it is set to
+   disabled, Cypress will not be able to connect (this typically surfaces as an
+   `ECONNREFUSED` error).
+
+This policy applies only to the standalone Chrome and Edge browsers — it does not
+affect the bundled [Electron browser](#Electron-Browser), so switching to
+`--browser electron` is a useful way to confirm whether a policy is the cause:
+
+```shell
+cypress run --browser electron
+```
+
+See [Chrome policy](#Chrome-policy) and [Edge policy](#Edge-policy) for more.
+
+#### Other things to check
+
+If the policy is not the issue:
+
+- **Network/firewall rules blocking `127.0.0.1` connections** on the remote
+  debugging port. A proxy or VPN that intercepts `localhost`/`127.0.0.1` traffic
+  will also prevent Cypress from connecting — allow local connections, or exclude
+  `localhost` and `127.0.0.1` from any proxy.
+- **Security software that closes or sandboxes the browser process** immediately
+  after launch. Antivirus or endpoint protection may terminate the browser before
+  Cypress can connect.
+- **A custom `before:browser:launch` argument** preventing the browser from
+  starting. If you modify launch arguments, temporarily remove your
+  customizations to rule them out.
+
+See [Troubleshooting](/app/references/troubleshooting#Launching-browsers) for more
+browser launch problems.
+
 ## See also
 
 - [Browser Launch API](/api/node-events/browser-launch-api)

--- a/docs/app/references/troubleshooting.mdx
+++ b/docs/app/references/troubleshooting.mdx
@@ -534,6 +534,70 @@ the end of the path:
 cypress open --browser C:/User/Application/browser.exe:chrome
 ```
 
+#### Cypress failed to make a connection to the Chrome DevTools Protocol
+
+Cypress controls Chrome, Chromium, and Edge through the
+[Chrome DevTools Protocol](https://chromedevtools.github.io/devtools-protocol/)
+(CDP) over a remote debugging port. After launching the browser, Cypress retries
+the CDP connection for up to 50 seconds; if it never connects, the run fails with
+an error like:
+
+```
+Cypress failed to make a connection to the Chrome DevTools Protocol
+after retrying for 50 seconds.
+```
+
+This means the browser launched but Cypress could not reach it on the remote
+debugging port.
+
+##### Check for a remote debugging policy
+
+The most common cause in managed/enterprise environments is remote debugging
+being disabled by an enterprise or group policy. Cypress cannot drive the browser
+without it. To check:
+
+1. Open **chrome://policy** (or **edge://policy** for Edge) in the affected
+   browser.
+2. Look for the
+   [`RemoteDebuggingAllowed`](https://chromeenterprise.google/policies/#RemoteDebuggingAllowed)
+   policy.
+3. Ensure it is either undefined or set to enabled/`true`. If it is set to
+   disabled, Cypress will not be able to connect (this typically surfaces as an
+   `ECONNREFUSED` error).
+
+This policy applies only to the standalone Chrome and Edge browsers, and it does
+not affect the bundled
+[Electron browser](/app/references/launching-browsers#Electron-Browser), so
+switching to `--browser electron` is a useful way to confirm whether a policy is
+the cause:
+
+```shell
+cypress run --browser electron
+```
+
+This policy is also generally not applied to Chromium or
+[Chrome for Testing](/app/references/launching-browsers#Chrome-Browsers), so
+running your tests in Chrome for Testing is another way to avoid policy-related
+connection failures.
+
+See [Chrome policy](/app/references/launching-browsers#Chrome-policy) and
+[Edge policy](/app/references/launching-browsers#Edge-policy) for more.
+
+##### Other things to check
+
+If the policy is not the issue:
+
+- **Network/firewall rules blocking `127.0.0.1` connections** on the remote
+  debugging port. A proxy or VPN that intercepts `localhost`/`127.0.0.1` traffic
+  will also prevent Cypress from connecting. Allow local connections, or exclude
+  `localhost` and `127.0.0.1` from any proxy.
+- **Security software that closes or sandboxes the browser process** immediately
+  after launch. Antivirus or endpoint protection may terminate the browser before
+  Cypress can connect.
+- **A custom `before:browser:launch` argument** preventing the browser from
+  starting. If you modify launch arguments, temporarily remove your
+  customizations to rule them out.
+
 ### Error: read ECONNRESET
 
 If Cypress and/or the browser closes unexpectedly with an error like:

--- a/docs/app/references/troubleshooting.mdx
+++ b/docs/app/references/troubleshooting.mdx
@@ -571,9 +571,7 @@ not affect the bundled
 testing with `--browser electron` is a useful way to confirm whether a policy is
 the cause:
 
-```shell
-cypress run --browser electron
-```
+<CypressCommandTabs command="run --browser electron" />
 
 This policy is also generally not applied to Chromium or
 [Chrome for Testing](/app/references/launching-browsers#Chrome-Browsers), so

--- a/docs/app/references/troubleshooting.mdx
+++ b/docs/app/references/troubleshooting.mdx
@@ -534,7 +534,7 @@ the end of the path:
 cypress open --browser C:/User/Application/browser.exe:chrome
 ```
 
-#### Cypress failed to make a connection to the Chrome DevTools Protocol
+### Cypress failed to make a connection to the Chrome DevTools Protocol
 
 Cypress controls Chrome, Chromium, and Edge through the
 [Chrome DevTools Protocol](https://chromedevtools.github.io/devtools-protocol/)
@@ -550,7 +550,7 @@ after retrying for 50 seconds.
 This means the browser launched but Cypress could not reach it on the remote
 debugging port.
 
-##### Check for a remote debugging policy
+#### Check for a remote debugging policy
 
 The most common cause in managed/enterprise environments is remote debugging
 being disabled by an enterprise or group policy. Cypress cannot drive the browser
@@ -583,7 +583,7 @@ connection failures.
 See [Chrome policy](/app/references/launching-browsers#Chrome-policy) and
 [Edge policy](/app/references/launching-browsers#Edge-policy) for more.
 
-##### Other things to check
+#### Other things to check
 
 If the policy is not the issue:
 

--- a/docs/app/references/troubleshooting.mdx
+++ b/docs/app/references/troubleshooting.mdx
@@ -91,6 +91,16 @@ caljajdfkjjjdehjdoimjkkakekklcck
 
 You can check the current company policies for your Chrome installation by typing `chrome://policy` into the address bar and pressing Enter.
 
+:::tip
+
+Enterprise or group policies are generally applied to standard, Chrome-branded
+browsers, not to Chromium or Chrome for Testing. If company policies are getting
+in the way of running Cypress, consider running your tests in
+[Chrome for Testing](/app/references/launching-browsers#Chrome-Browsers), which is
+built for automation and is not subject to these policies.
+
+:::
+
 ### Allow Cypress URLs on VPNs
 
 To send the data and results of your tests to

--- a/docs/app/references/troubleshooting.mdx
+++ b/docs/app/references/troubleshooting.mdx
@@ -568,7 +568,7 @@ without it. To check:
 This policy applies only to the standalone Chrome and Edge browsers, and it does
 not affect the bundled
 [Electron browser](/app/references/launching-browsers#Electron-Browser), so
-switching to `--browser electron` is a useful way to confirm whether a policy is
+testing with `--browser electron` is a useful way to confirm whether a policy is
 the cause:
 
 ```shell

--- a/src/components/cypress-command-tabs/index.tsx
+++ b/src/components/cypress-command-tabs/index.tsx
@@ -1,0 +1,55 @@
+import React from 'react'
+import Tabs from '@theme/Tabs'
+import TabItem from '@theme/TabItem'
+import CodeBlock from '@theme/CodeBlock'
+
+interface CypressCommandTabsProps {
+  /**
+   * The Cypress subcommand and any arguments, i.e. everything that comes after
+   * `cypress`. For example `run --headed`. Multiple alternative commands can be
+   * provided on separate lines.
+   */
+  command: string
+  /**
+   * Optional environment variable assignment(s) to prepend before the command,
+   * e.g. `IGNORE_CHROME_PREFERENCES=1`.
+   */
+  env?: string
+}
+
+const runners = [
+  { value: 'npm', label: 'npm', runner: 'npx cypress' },
+  { value: 'yarn', label: 'Yarn', runner: 'yarn cypress' },
+  { value: 'pnpm', label: 'pnpm', runner: 'pnpm cypress' },
+  { value: 'bun', label: 'Bun', runner: 'bunx cypress' },
+]
+
+/**
+ * Renders a Cypress command across the supported package managers (npm, Yarn,
+ * pnpm, and Bun) as a synced tab group, so a single source command stays DRY.
+ */
+const CypressCommandTabs: React.FC<CypressCommandTabsProps> = ({
+  command,
+  env,
+}) => {
+  const lines = command
+    .trim()
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+  const envPrefix = env ? `${env} ` : ''
+
+  return (
+    <Tabs groupId="package-manager">
+      {runners.map(({ value, label, runner }) => (
+        <TabItem key={value} value={value} label={label}>
+          <CodeBlock language="shell">
+            {lines.map((line) => `${envPrefix}${runner} ${line}`).join('\n')}
+          </CodeBlock>
+        </TabItem>
+      ))}
+    </Tabs>
+  )
+}
+
+export default CypressCommandTabs

--- a/src/theme/MDXComponents.js
+++ b/src/theme/MDXComponents.js
@@ -1,55 +1,56 @@
 // Import the original mapper
-import MDXComponents from "@theme-original/MDXComponents";
-import AnatomyOfAnError from "@site/docs/partials/_anatomy-of-an-error.mdx";
-import AccessibilityPremiumNote from "@site/docs/partials/_accessibility-premium-note.mdx";
-import AttributeFilters from "@site/docs/partials/_attributefilters.mdx";
-import AutoCancellationBenefits from "@site/docs/partials/_auto-cancellation-benefits.mdx";
-import Badge from "@site/src/components/badge";
-import Btn from "@site/src/components/button";
-import ComponentOnlyBadge from "@site/src/components/component-only-badge";
-import TestReplayInfo from "@site/docs/partials/_test-replay-info.mdx";
-import CypressConfigFileTabs from "@site/src/components/cypress-config-file-tabs";
-import CypressInstallCommands from "@site/docs/partials/_cypress-install-commands.mdx";
-import CypressCacheClearCommands from "@site/docs/partials/_cypress-cache-clear-commands.mdx";
-import CypressInstallBinaryCommands from "@site/docs/partials/_cypress-install-binary-commands.mdx";
-import CypressEnvVsCypressExpose from "@site/docs/partials/_cy-env-vs-cypress-expose.mdx";
-import CypressOpenCommands from "@site/docs/partials/_cypress-open-commands.mdx";
-import CypressRunCommands from "@site/docs/partials/_cypress-run-commands.mdx";
-import DefaultSelectorPriority from "@site/docs/partials/_default-selector-priority.mdx";
-import DocsImage from "@site/src/components/docs-image";
-import DocsVideo from "@site/src/components/docs-video";
-import DocumentDomainWorkaround from "@site/docs/partials/_document-domain-workaround.mdx";
-import E2EOnlyBadge from "@site/src/components/e2e-only-badge";
-import E2EOrCtTabs from "@site/src/components/e2e-or-ct-tabs";
-import ElementFilters from "@site/docs/partials/_elementfilters.mdx";
-import VueSyntaxTabs from "@site/src/components/vue-syntax-tabs";
-import HeaderAssertions from "@site/docs/partials/_header-assertions.mdx";
-import InterceptAliasIndex from "@site/docs/partials/_intercept-alias-index.mdx";
-import HeaderRequirements from "@site/docs/partials/_header-requirements.mdx";
-import HeaderTimeouts from "@site/docs/partials/_header-timeouts.mdx";
-import HeaderYields from "@site/docs/partials/_header-yields.mdx";
-import Icon from "@site/src/components/icon";
-import ImportMountFunctions from "@site/docs/partials/_import-mount-functions.mdx";
-import IntellisenseCodeCompletion from "@site/docs/partials/_intellisense-code-completion.mdx";
-import ProductHeading from "@site/src/components/product-heading";
-import Profiles from "@site/docs/partials/_profiles.mdx";
-import SignificantAttributes from "@site/docs/partials/_significantattributes.mdx";
-import SourceMaps from "@site/docs/partials/_source-maps.mdx";
-import SupportFileConfiguration from "@site/docs/partials/_support-file-configuration.mdx";
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
-import ThenShouldAndDifference from "@site/docs/partials/_then-should-and-difference.mdx";
-import WarningSetupNodeEvents from "@site/docs/partials/_warning-setup-node-events.mdx";
-import ViewFilters from "@site/docs/partials/_viewfilters.mdx";
-import Views from "@site/docs/partials/_views.mdx";
-import LineBreak from "@site/src/components/line-break";
-import Logo from "@site/src/components/logo";
-import AccordionBlock from "@site/src/components/accordion-block";
-import CloudFreePlan from "@site/docs/partials/_cloud_free_plan.mdx";
-import CiProviderCloudSteps from "@site/docs/partials/_ci_provider_cloud_steps.mdx";
-import UrlAllowList from "@site/docs/partials/_url_allowlist.mdx";
-import UICovPremiumNote from "@site/docs/partials/_ui-coverage-premium-note.mdx";
-import ResultsApiEnvVars from "@site/docs/partials/_results-api-env-vars.mdx";
+import MDXComponents from '@theme-original/MDXComponents'
+import AnatomyOfAnError from '@site/docs/partials/_anatomy-of-an-error.mdx'
+import AccessibilityPremiumNote from '@site/docs/partials/_accessibility-premium-note.mdx'
+import AttributeFilters from '@site/docs/partials/_attributefilters.mdx'
+import AutoCancellationBenefits from '@site/docs/partials/_auto-cancellation-benefits.mdx'
+import Badge from '@site/src/components/badge'
+import Btn from '@site/src/components/button'
+import ComponentOnlyBadge from '@site/src/components/component-only-badge'
+import TestReplayInfo from '@site/docs/partials/_test-replay-info.mdx'
+import CypressConfigFileTabs from '@site/src/components/cypress-config-file-tabs'
+import CypressInstallCommands from '@site/docs/partials/_cypress-install-commands.mdx'
+import CypressCacheClearCommands from '@site/docs/partials/_cypress-cache-clear-commands.mdx'
+import CypressInstallBinaryCommands from '@site/docs/partials/_cypress-install-binary-commands.mdx'
+import CypressEnvVsCypressExpose from '@site/docs/partials/_cy-env-vs-cypress-expose.mdx'
+import CypressOpenCommands from '@site/docs/partials/_cypress-open-commands.mdx'
+import CypressRunCommands from '@site/docs/partials/_cypress-run-commands.mdx'
+import CypressCommandTabs from '@site/src/components/cypress-command-tabs'
+import DefaultSelectorPriority from '@site/docs/partials/_default-selector-priority.mdx'
+import DocsImage from '@site/src/components/docs-image'
+import DocsVideo from '@site/src/components/docs-video'
+import DocumentDomainWorkaround from '@site/docs/partials/_document-domain-workaround.mdx'
+import E2EOnlyBadge from '@site/src/components/e2e-only-badge'
+import E2EOrCtTabs from '@site/src/components/e2e-or-ct-tabs'
+import ElementFilters from '@site/docs/partials/_elementfilters.mdx'
+import VueSyntaxTabs from '@site/src/components/vue-syntax-tabs'
+import HeaderAssertions from '@site/docs/partials/_header-assertions.mdx'
+import InterceptAliasIndex from '@site/docs/partials/_intercept-alias-index.mdx'
+import HeaderRequirements from '@site/docs/partials/_header-requirements.mdx'
+import HeaderTimeouts from '@site/docs/partials/_header-timeouts.mdx'
+import HeaderYields from '@site/docs/partials/_header-yields.mdx'
+import Icon from '@site/src/components/icon'
+import ImportMountFunctions from '@site/docs/partials/_import-mount-functions.mdx'
+import IntellisenseCodeCompletion from '@site/docs/partials/_intellisense-code-completion.mdx'
+import ProductHeading from '@site/src/components/product-heading'
+import Profiles from '@site/docs/partials/_profiles.mdx'
+import SignificantAttributes from '@site/docs/partials/_significantattributes.mdx'
+import SourceMaps from '@site/docs/partials/_source-maps.mdx'
+import SupportFileConfiguration from '@site/docs/partials/_support-file-configuration.mdx'
+import Tabs from '@theme/Tabs'
+import TabItem from '@theme/TabItem'
+import ThenShouldAndDifference from '@site/docs/partials/_then-should-and-difference.mdx'
+import WarningSetupNodeEvents from '@site/docs/partials/_warning-setup-node-events.mdx'
+import ViewFilters from '@site/docs/partials/_viewfilters.mdx'
+import Views from '@site/docs/partials/_views.mdx'
+import LineBreak from '@site/src/components/line-break'
+import Logo from '@site/src/components/logo'
+import AccordionBlock from '@site/src/components/accordion-block'
+import CloudFreePlan from '@site/docs/partials/_cloud_free_plan.mdx'
+import CiProviderCloudSteps from '@site/docs/partials/_ci_provider_cloud_steps.mdx'
+import UrlAllowList from '@site/docs/partials/_url_allowlist.mdx'
+import UICovPremiumNote from '@site/docs/partials/_ui-coverage-premium-note.mdx'
+import ResultsApiEnvVars from '@site/docs/partials/_results-api-env-vars.mdx'
 
 // Font Awesome
 import { library } from '@fortawesome/fontawesome-svg-core'
@@ -164,7 +165,7 @@ library.add(
   faLinkSlash,
   faListCheck,
   faClipboardCheck,
-  faFilter,
+  faFilter
 )
 
 export default {
@@ -184,6 +185,7 @@ export default {
   CypressEnvVsCypressExpose,
   CypressOpenCommands,
   CypressRunCommands,
+  CypressCommandTabs,
   DefaultSelectorPriority,
   DocsImage,
   DocsVideo,


### PR DESCRIPTION
## Summary

Overhauls the **Launching Browsers** reference page and aligns related browser-launch documentation across the site. Documentation-only — no runtime or test impact.

## Launching Browsers page

- **Value-driven rewrite & reorganization.** Clearer intro on why Cypress launches and controls its own browser (clean isolated state + automation access), with sections regrouped into a logical flow: Supported browsers → Browser environment → Headless mode → Downloading files → Troubleshooting. All externally-referenced anchors preserved.
- **Chrome for Testing recommended.** Promoted to first in the supported-browsers list, with a tip explaining why it's preferable for automation: no auto-update (deterministic runs), versioned reproducible binaries, not subject to enterprise policies, and extension loading still works.
- **Browser version support.** Documented the hard **Firefox 135** minimum (WebDriver BiDi), distinct from the latest-3-versions support window; refreshed the example to Chrome 150.
- **New Headless mode section.** Per-browser headless mechanics (Electron, Chrome/Chromium/Edge `--headless=new`, Firefox `-headless`, WebKit via Playwright), `--headed`, rendering defaults (1280×720, forced DPR 1), and how to debug headless-only failures.
- **New Downloading files section.** Cypress auto-saves downloads to `downloadsFolder` (default `cypress/downloads`) with no native prompt.
- **`IGNORE_CHROME_PREFERENCES`.** Documented what Cypress writes to the Chrome profile and the escape hatch for environments that encrypt the user-data directory.
- Leaned out of recommending Electron as a general choice.
- Improved SEO title/meta description; removed em dashes.

## Chrome 137 extension + policy cross-links

- **`browser-launch-api.mdx`, `faq.mdx`, `node-events/overview.mdx`:** documented that standard Chrome 137+ can no longer load extensions via `before:browser:launch` (Chrome removed `--load-extension`) and cross-linked the Chrome for Testing / Chromium recommendation.

## Troubleshooting guide

- **New "Cypress failed to make a connection to the Chrome DevTools Protocol" section** (moved here from the Launching Browsers page): how Cypress drives Chromium browsers over CDP, the `RemoteDebuggingAllowed` policy check, the `--browser electron` diagnostic, and firewall/proxy/security causes.
- Noted that Chrome for Testing avoids the enterprise policies applied to branded Chrome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MpJ8kfXkDh9hAiYV3kXgXq

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and a small Docusaurus MDX component only; no product code, auth, or data paths change.
> 
> **Overview**
> This PR is **documentation-only** (no Cypress runtime changes). It rewrites the **Launching Browsers** reference and threads the same guidance through API, FAQ, and troubleshooting pages.
> 
> The **Launching Browsers** page gets a clearer narrative (why Cypress starts its own browser, supported browsers, environment, headless, downloads), promotes **Chrome for Testing**, documents the **Firefox 135** floor (WebDriver BiDi), and adds sections on **headless** behavior (per-browser mechanics, 1280×720 / DPR 1 defaults, debugging headed vs headless), **downloads** to `cypress/downloads`, and **`IGNORE_CHROME_PREFERENCES`** for encrypted user-data dirs. Inline shell examples are replaced with a new **`CypressCommandTabs`** MDX component (npm/Yarn/pnpm/Bun) registered in `MDXComponents.js`.
> 
> **Chrome 137+** can no longer load extensions via `before:browser:launch` (`--load-extension` removed); that limitation is called out in `browser-launch-api`, node-events overview, FAQ (with anchor fix), and the Chrome for Testing tip.
> 
> **Troubleshooting** gains a dedicated **Chrome DevTools Protocol** connection failure section (policy, Electron as diagnostic, Chrome for Testing), plus a tip that enterprise policies usually do not apply to Chrome for Testing. Policy sections link back to that guide.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c97ff1b4162ae84aea990dab492e1b0c61674639. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->