### PR TITLE
docs: remove CoffeeScript and .coffee references

### DIFF
--- a/docs/api/commands/fixture.mdx
+++ b/docs/api/commands/fixture.mdx
@@ -106,17 +106,16 @@ The example above would resolve in the following order:
 
 1. `cypress/fixtures/admin.json`
 2. `cypress/fixtures/admin.js`
-3. `cypress/fixtures/admin.coffee`
-4. `cypress/fixtures/admin.html`
-5. `cypress/fixtures/admin.txt`
-6. `cypress/fixtures/admin.csv`
-7. `cypress/fixtures/admin.png`
-8. `cypress/fixtures/admin.jpg`
-9. `cypress/fixtures/admin.jpeg`
-10. `cypress/fixtures/admin.gif`
-11. `cypress/fixtures/admin.tif`
-12. `cypress/fixtures/admin.tiff`
-13. `cypress/fixtures/admin.zip`
+3. `cypress/fixtures/admin.html`
+4. `cypress/fixtures/admin.txt`
+5. `cypress/fixtures/admin.csv`
+6. `cypress/fixtures/admin.png`
+7. `cypress/fixtures/admin.jpg`
+8. `cypress/fixtures/admin.jpeg`
+9. `cypress/fixtures/admin.gif`
+10. `cypress/fixtures/admin.tif`
+11. `cypress/fixtures/admin.tiff`
+12. `cypress/fixtures/admin.zip`
 
 #### Use import statement
 
@@ -224,8 +223,8 @@ cy.intercept('GET', '/users/**', { fixture: 'users' })
 
 #### Automated File Validation
 
-Cypress automatically validates your fixtures. If your `.json`, `.js`, or
-`.coffee` files contain syntax errors, they will be shown in the Command Log.
+Cypress automatically validates your fixtures. If your `.json` or `.js` files
+contain syntax errors, they will be shown in the Command Log.
 
 ### Encoding
 
@@ -235,7 +234,6 @@ Cypress automatically determines the encoding for the following file types:
 
 - `.json`
 - `.js`
-- `.coffee`
 - `.html`
 - `.txt`
 - `.csv`

--- a/docs/api/cypress-api/require.mdx
+++ b/docs/api/cypress-api/require.mdx
@@ -114,7 +114,6 @@ cy.origin('cypress.io', async () => {
   - `.tsx`
   - `.mjs`
   - `.json`
-  - `.coffee`
 - `Cypress.require('dependency-name')` must be on one line as a continuous string, and the dependency cannot be dynamically defined:
 
 {/* prettier-ignore-start */}

--- a/docs/api/node-events/overview.mdx
+++ b/docs/api/node-events/overview.mdx
@@ -132,8 +132,8 @@ describe how to use this event.
 ### Preprocessors
 
 The event `file:preprocessor` is used to customize how your test code is
-transpiled and sent to the browser. By default, Cypress handles ES2015+,
-TypeScript, and CoffeeScript, using webpack to package it for the browser.
+transpiled and sent to the browser. By default, Cypress handles ES2015+ and
+TypeScript, using webpack to package it for the browser.
 
 You can use the `file:preprocessor` event to do things like:
 

--- a/docs/api/node-events/preprocessors-api.mdx
+++ b/docs/api/node-events/preprocessors-api.mdx
@@ -13,8 +13,8 @@ A preprocessor is the plugin responsible for preparing a
 or a [spec file](/app/core-concepts/writing-and-organizing-tests#Spec-files)
 for the browser.
 
-A preprocessor could transpile your file from another language (CoffeeScript or
-ClojureScript) or from a newer version of JavaScript (ES2017).
+A preprocessor could transpile your file from another language (ClojureScript)
+or from a newer version of JavaScript (ES2017).
 
 A preprocessor also typically watches the source files for changes, processes
 them again, and then notifies Cypress to re-run the tests.
@@ -38,7 +38,6 @@ The webpack preprocessor handles:
 
 - ES2015 and JSX via Babel
 - TypeScript
-- CoffeeScript `1.x.x`
 - Watching and caching files
 
 :::info
@@ -58,7 +57,6 @@ Editing the options allows you to do things like:
 
 - Add your own Babel plugins
 - Modify options for TypeScript compilation
-- Add support for CoffeeScript `2.x.x`
 
 ## Excluding files from being watched
 
@@ -166,11 +164,11 @@ eventually be served to the browser.
 
 :::note
 
-If, for example, the source file is `spec.coffee`, the preprocessor should:
+If, for example, the source file is `spec.cljs`, the preprocessor should:
 
 :::
 
-1. Compile the CoffeeScript into JavaScript `spec.js`
+1. Compile the ClojureScript into JavaScript `spec.js`
 2. Write that JavaScript file to disk (example: `/Users/foo/tmp/spec.js`)
 3. Resolve with the absolute path to that file: `/Users/foo/tmp/spec.js`
 

--- a/docs/app/core-concepts/best-practices.mdx
+++ b/docs/app/core-concepts/best-practices.mdx
@@ -1239,7 +1239,7 @@ port.
 
 <DocsImage
   src="/img/app/references/cypress-loads-in-localhost-and-random-port.png"
-  alt="Url address shows localhost:53927/__/#tests/integration/organizations/list_spec.coffee"
+  alt="Url address shows localhost:53927/__/#tests/integration/organizations/list_spec.cy.js"
 />
 
 As soon as it encounters a [cy.visit()](/api/commands/visit), Cypress then
@@ -1267,7 +1267,7 @@ load the main window in the `baseUrl` you specified as soon as your tests start.
 
 <DocsImage
   src="/img/app/references/cypress-loads-window-in-base-url-localhost.png"
-  alt="Url address bar shows localhost:8484/__tests/integration/organizations/list_spec.coffee"
+  alt="Url address bar shows localhost:8484/__tests/integration/organizations/list_spec.cy.js"
 />
 
 Having a `baseUrl` set gives you the added bonus of seeing an error if your

--- a/docs/app/core-concepts/writing-and-organizing-tests.mdx
+++ b/docs/app/core-concepts/writing-and-organizing-tests.mdx
@@ -116,8 +116,6 @@ directory. Test files may be written as:
 - `.jsx`
 - `.ts`
 - `.tsx`
-- `.coffee`
-- `.cjsx`
 
 Cypress also supports `ES2015` out of the box. You can use either
 `ES2015 modules` or `CommonJS modules`. This means you can `import` or `require`

--- a/docs/app/references/error-messages.mdx
+++ b/docs/app/references/error-messages.mdx
@@ -27,7 +27,7 @@ written any tests.
 
 This message means that Cypress encountered an error when compiling and/or
 bundling your test file. Cypress automatically compiles and bundles your test
-code so you can use ES2015, CoffeeScript, modules, etc.
+code so you can use ES2015, modules, etc.
 
 #### You'll typically receive this message due to:
 
@@ -92,8 +92,8 @@ in an error when Cypress loads.
 
 Just like with your test files, the
 [`supportFile`](/app/references/configuration#Testing-Type-Specific-Options)
-can use ES2015+, [TypeScript](/app/tooling/typescript-support) or
-CoffeeScript and modules, so you can import/require other files as needed.
+can use ES2015+, [TypeScript](/app/tooling/typescript-support) and modules, so
+you can import/require other files as needed.
 
 ## Command Errors
 

--- a/docs/app/references/migration-guide.mdx
+++ b/docs/app/references/migration-guide.mdx
@@ -2629,6 +2629,7 @@ The `testFiles` option is no longer used, and has been replaced with the
 
 Default values:
 
+- No longer matches with `.coffee` or `.cjsx`.
 - `e2e.specPattern` default value is `cypress/e2e/**/*.cy.{js,jsx,ts,tsx}`.
 - `component.specPattern` default value is `**/*.cy.{js,jsx,ts,tsx}`.
 

--- a/docs/app/references/migration-guide.mdx
+++ b/docs/app/references/migration-guide.mdx
@@ -2629,7 +2629,6 @@ The `testFiles` option is no longer used, and has been replaced with the
 
 Default values:
 
-- No longer matches with `.coffee` or `.cjsx`.
 - `e2e.specPattern` default value is `cypress/e2e/**/*.cy.{js,jsx,ts,tsx}`.
 - `component.specPattern` default value is `**/*.cy.{js,jsx,ts,tsx}`.
 


### PR DESCRIPTION
## Summary

Removes CoffeeScript and `.coffee` references from the documentation, since CoffeeScript is no longer a supported language for specs, fixtures, and preprocessors.

## Changes (8 files)

- **`preprocessors-api.mdx`** — dropped CoffeeScript from the transpile intro and the webpack default/modifiable-options lists; changed the `spec.coffee` → `spec.js` compile example to ClojureScript.
- **`overview.mdx`** — removed CoffeeScript from "Cypress handles ES2015+, TypeScript, and CoffeeScript".
- **`fixture.mdx`** — removed `.coffee` from the fixture resolution order (renumbered), the syntax-validation note, and the supported-encodings list.
- **`require.mdx`** — removed `.coffee` from supported dependency extensions.
- **`writing-and-organizing-tests.mdx`** — removed `.coffee` and `.cjsx` from the spec-file extensions list.
- **`best-practices.mdx`** — updated two screenshot `alt` strings from `list_spec.coffee` to `list_spec.cy.js`.
- **`error-messages.mdx`** — removed CoffeeScript from two "you can use ES2015 / TypeScript / CoffeeScript" sentences.
- **`migration-guide.mdx`** — removed the "No longer matches with `.coffee` or `.cjsx`" bullet (the new default spec patterns remain listed).

## Intentionally left unchanged

- **`changelog.mdx`** — dated historical release notes; rewriting them would falsify the record of what past versions shipped.
- **`package-lock.json`** — its only "coffee" match is an unrelated "Buy me a coffee" funding URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01K5zjka4rupKSTYtgG7hhwQ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits with no runtime, auth, or product behavior changes; risk is limited to readers missing historical CoffeeScript mentions outside updated pages.
> 
> **Overview**
> Documentation is updated to reflect that **CoffeeScript is no longer supported** for specs, fixtures, preprocessors, and `Cypress.require` dependencies.
> 
> Across the API and guides, **`.coffee` / `.cjsx`** are dropped from supported file-extension lists (fixtures resolution order, spec formats, encoding/validation notes). **Preprocessor docs** no longer list CoffeeScript in default webpack behavior or modifiable options; the compile example now uses **ClojureScript** (`spec.cljs`) instead of CoffeeScript. **Error messages** and **organizing tests** copy no longer mention CoffeeScript alongside ES2015/TypeScript. **Best practices** screenshot alt text switches example paths from `list_spec.coffee` to `list_spec.cy.js`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a320ad2a49200009b52d727cca234b89d39c4053. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->