### PR TITLE
Switch URLs config var from Cypress.env to Cypress.expose

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -48,7 +48,8 @@ export default defineConfig({
 
       const URLs = walk(path).filter((file) => file !== undefined).map((file) => file.slice(5))
 
-      config.env.URLs = URLs
+      config.expose = config.expose || {}
+      config.expose.URLs = URLs
 
       return config
     },

--- a/cypress/e2e/all_accessibility_pages.cy.ts
+++ b/cypress/e2e/all_accessibility_pages.cy.ts
@@ -1,4 +1,4 @@
-const URLs: Array<string> = Cypress.env('URLs')
+const URLs: Array<string> = Cypress.expose('URLs')
 
 // Mostly this is to get a UI Coverage and Accessibility report
 describe('Visit all Accessibility pages', () => {

--- a/cypress/e2e/all_api_pages.cy.ts
+++ b/cypress/e2e/all_api_pages.cy.ts
@@ -1,4 +1,4 @@
-const URLs: Array<string> = Cypress.env('URLs')
+const URLs: Array<string> = Cypress.expose('URLs')
 
 // Mostly this is to get a UI Coverage and Accessibility report
 describe('Visit all API pages', () => {

--- a/cypress/e2e/all_app_pages.cy.ts
+++ b/cypress/e2e/all_app_pages.cy.ts
@@ -1,4 +1,4 @@
-const URLs: Array<string> = Cypress.env('URLs')
+const URLs: Array<string> = Cypress.expose('URLs')
 
 // Mostly this is to get a UI Coverage and Accessibility report
 describe('Visit all App pages', () => {

--- a/cypress/e2e/all_cloud_pages.cy.ts
+++ b/cypress/e2e/all_cloud_pages.cy.ts
@@ -1,4 +1,4 @@
-const URLs: Array<string> = Cypress.env('URLs')
+const URLs: Array<string> = Cypress.expose('URLs')
 
 // Mostly this is to get a UI Coverage and Accessibility report
 describe('Visit all Cloud pages', () => {

--- a/cypress/e2e/all_ui_cov_pages.cy.ts
+++ b/cypress/e2e/all_ui_cov_pages.cy.ts
@@ -1,4 +1,4 @@
-const URLs: Array<string> = Cypress.env('URLs')
+const URLs: Array<string> = Cypress.expose('URLs')
 
 // Mostly this is to get a UI Coverage and Accessibility report
 describe('Visit all UI Coverage pages', () => {


### PR DESCRIPTION
The dynamically-computed list of doc page URLs is public, non-sensitive
data, so use the newer Cypress.expose() API in setupNodeEvents and the
page-sweeping e2e specs instead of the deprecated Cypress.env().

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UcUqLvwPgHRJAb2McG8i73

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only Cypress API swap with no production or sensitive config changes; behavior should be equivalent if expose is supported on the project's Cypress version.
> 
> **Overview**
> Moves the dynamically built docs page URL list from the deprecated **`Cypress.env`** / **`config.env`** path to **`Cypress.expose`** / **`config.expose`**, since that list is public test data, not secrets.
> 
> In **`cypress.config.ts`**, `setupNodeEvents` now assigns `URLs` to `config.expose.URLs` (with `config.expose` initialized if missing). The five page-sweep e2e specs (`all_*_pages.cy.ts`) read the list via **`Cypress.expose('URLs')`** at module load, with the same filtering and visit behavior as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3affadfceb7495010f1bdaee453ec15e27e811be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->