### PR TITLE
Add sidebar_label to Writing and Organizing Tests page

### DIFF
--- a/docs/app/core-concepts/writing-and-organizing-tests.mdx
+++ b/docs/app/core-concepts/writing-and-organizing-tests.mdx
@@ -1,5 +1,6 @@
 ---
 title: Writing and Organizing Cypress Tests
+sidebar_label: Writing and Organizing Tests
 description: Learn how to structure a Cypress project and write reliable tests, covering supported spec files, folder structure, hooks, test isolation, configuration, assertions, and test statuses.
 sidebar_position: 30
 ---


### PR DESCRIPTION
Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DDiVajboYXXwsGqTgp1b1X

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation frontmatter only; no runtime or product behavior changes.
> 
> **Overview**
> Adds **`sidebar_label: Writing and Organizing Tests`** to the frontmatter of `writing-and-organizing-tests.mdx` so the docs sidebar shows a shorter label than the page **`title`** (`Writing and Organizing Cypress Tests`), matching the on-page H1 and the pattern used on other core-concepts pages (e.g. `sidebar_label` on Introduction).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9aa9df9e5056761fb16a0aef08d02c40c88f598. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->