### PR TITLE
Remove references to expired Cypress Migrator tool

### DIFF
--- a/docs/app/guides/migration/protractor-to-cypress.mdx
+++ b/docs/app/guides/migration/protractor-to-cypress.mdx
@@ -29,15 +29,6 @@ To start, let's look at a quick code sample to see how approachable Cypress is
 coming from Protractor. In this scenario, we have a test to validate that a user
 can sign up for a new account.
 
-:::tip
-
-To see how this conversion would work with some of your own test code, you can
-paste it into the interactive
-[Cypress Migrator tool](https://migrator.cypress.io/), which will generate the
-equivalent Cypress code.
-
-:::
-
 <Badge type="danger">Before: Protractor</Badge>
 
 ```js


### PR DESCRIPTION
## Summary

The Cypress Migrator tool (https://migrator.cypress.io/) is being expired and its URL will become a dead link. This PR removes all references to it from the documentation.

The tool was referenced in exactly one place — a `:::tip` callout in the Protractor-to-Cypress migration guide that suggested pasting test code into the interactive Migrator tool. Since the tool was the sole subject of that callout, the entire block was removed.

## Changes

- Removed the Migrator tool `:::tip` block from `docs/app/guides/migration/protractor-to-cypress.mdx`

Verified there are no remaining references to `migrator` / `Migrator` anywhere in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YEvtVM2NQvehrPnQtg3KW3)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only removal of a dead link; no product or test behavior changes.
> 
> **Overview**
> Removes the **`:::tip`** callout in the Protractor-to-Cypress migration guide that pointed readers to the interactive [Cypress Migrator](https://migrator.cypress.io/) tool. The migrator URL is being retired, so the whole tip block was dropped rather than rewritten—the surrounding before/after code sample is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae3306e104cc14c2ec8ae418885093759e3f13d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->