### PR TITLE
update some titles and descriptions

### DIFF
--- a/docs/accessibility/changelog.mdx
+++ b/docs/accessibility/changelog.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Changelog: Cypress Accessibility'
+title: 'Cypress Accessibility Release Notes'
 description: 'Stay up to date with the latest features, improvements, and bug fixes for Cypress Accessibility.'
 sidebar_label: Changelog
 sidebar_position: 200

--- a/docs/accessibility/configuration/attributefilters.mdx
+++ b/docs/accessibility/configuration/attributefilters.mdx
@@ -1,6 +1,6 @@
 ---
-title: Filter attributes used for element identification and grouping in Cypress Accessibility
-description: 'The attributeFilters configuration property allows users to specify patterns for attributes and their values that should not be used for identifying and grouping elements.'
+title: Control element identification in Cypress Accessibility
+description: 'Use attributeFilters to exclude attribute patterns from element identification and grouping in Cypress Accessibility.'
 sidebar_label: attributeFilters
 sidebar_position: 50
 ---

--- a/docs/accessibility/configuration/axe-core-configuration.mdx
+++ b/docs/accessibility/configuration/axe-core-configuration.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Axe Core® configuration'
-description: 'Configure Axe Core® rules for Cypress Accessibility.'
+title: 'Configure Axe Core® rules in Cypress Accessibility'
+description: 'Enable, disable, and tune individual Axe Core® rules to control which accessibility checks run in Cypress.'
 sidebar_label: 'Axe Core® configuration'
 ---
 

--- a/docs/accessibility/configuration/components.mdx
+++ b/docs/accessibility/configuration/components.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Components'
+title: Component attributes in Cypress Accessibility
 description: 'The accessibility components configuration controls how component-related HTML attributes appear in stable violation-target selectors.'
 sidebar_label: components
 sidebar_position: 45

--- a/docs/accessibility/configuration/elementfilters.mdx
+++ b/docs/accessibility/configuration/elementfilters.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Element Filters'
+title: 'elementFilters: exclude elements from scans'
 description: 'The `elementFilters` property allows you to specify selectors for elements that should be excluded from Cypress Accessibility.'
 sidebar_label: elementFilters
 sidebar_position: 30

--- a/docs/accessibility/configuration/ignoring-rules-per-element.mdx
+++ b/docs/accessibility/configuration/ignoring-rules-per-element.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Ignoring rules for specific elements'
-description: 'Elements can avoid failing certain rules using a data-a11y-ignore attribute'
+title: Ignore accessibility rules per element
+description: 'Use the data-a11y-ignore attribute to exclude specific accessibility rules from elements in Cypress Accessibility.'
 sidebar_label: 'Ignore rules for specific elements'
 sidebar_position: 70
 ---

--- a/docs/accessibility/configuration/overview.mdx
+++ b/docs/accessibility/configuration/overview.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Overview
-title: Configuration in Cypress Accessibility
-description: 'Configuration allows you to customize and fine-tune Cypress Accessibility.'
+title: Configure Cypress Accessibility
+description: 'Customize Cypress Accessibility element identification, filters, profiles, and Axe Core® rules'
 sidebar_position: 10
 ---
 

--- a/docs/accessibility/configuration/profiles.mdx
+++ b/docs/accessibility/configuration/profiles.mdx
@@ -1,6 +1,6 @@
 ---
-title: Use different profiles for different runs in Cypress Accessibility
-description: 'The profiles configuration property allows you to create configuration overrides that are applied based on run tags.'
+title: 'profiles: apply config overrides by run tag'
+description: 'Use the profiles property to apply Cypress Accessibility configuration overrides based on run tags.'
 sidebar_position: 100
 sidebar_label: profiles
 ---

--- a/docs/accessibility/configuration/significantattributes.mdx
+++ b/docs/accessibility/configuration/significantattributes.mdx
@@ -1,5 +1,5 @@
 ---
-title: Prioritize specific attributes for element identification and grouping in Cypress Accessibility
+title: 'significantAttributes: prioritize element attributes'
 description: 'The significantAttributes configuration property allows users to specify custom attributes that should be considered "significant" for the purpose of identification and grouping.'
 sidebar_label: significantAttributes
 sidebar_position: 40

--- a/docs/accessibility/configuration/viewfilters.mdx
+++ b/docs/accessibility/configuration/viewfilters.mdx
@@ -1,5 +1,5 @@
 ---
-title: Exclude URLs from Accessibility scans in Cypress
+title: 'viewFilters: exclude URLs from scans'
 description: 'The viewFilters property allows you to specify URL patterns for URLs that should be excluded from Accessibility.'
 sidebar_label: viewFilters
 sidebar_position: 20

--- a/docs/accessibility/configuration/views.mdx
+++ b/docs/accessibility/configuration/views.mdx
@@ -1,5 +1,5 @@
 ---
-title: Views of URLs and mounted components in Cypress Accessibility
+title: 'Views: URLs and components in Accessibility'
 description: 'Cypress Accessibility automatically groups certain URL patterns to create views. For URLs that are not automatically grouped, the views property allows you to specify your own URL patterns that represent views.'
 sidebar_label: views
 sidebar_position: 10

--- a/docs/accessibility/core-concepts/accessibility-score.mdx
+++ b/docs/accessibility/core-concepts/accessibility-score.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Accessibility score'
+title: How the accessibility score is calculated
 description: 'Cypress produces a top-line percentage score that indicates a general sense of accessibility for a project.'
 sidebar_label: Accessibility score
 sidebar_position: 40

--- a/docs/accessibility/core-concepts/compare-reports.mdx
+++ b/docs/accessibility/core-concepts/compare-reports.mdx
@@ -1,6 +1,6 @@
 ---
 title: Compare accessibility reports in Cypress Accessibility
-description: 'Review the main areas to pay attention to when first reviewing an accessibility report for a Cypress run.'
+description: 'Compare accessibility reports between two Cypress runs to spot new violations, regressions, and fixes before they merge.'
 sidebar_position: 40
 sidebar_label: Compare reports
 ---

--- a/docs/accessibility/core-concepts/cypress-rules.mdx
+++ b/docs/accessibility/core-concepts/cypress-rules.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Cypress rules'
-description: 'Review the main areas to pay attention to when first reviewing an accessibility report for a Cypress run.'
+title: 'Cypress accessibility rules'
+description: 'The custom accessibility rules Cypress layers on top of Axe Core® and how each one is evaluated.'
 sidebar_position: 70
 sidebar_label: Cypress rules
 ---

--- a/docs/accessibility/core-concepts/element-identification.mdx
+++ b/docs/accessibility/core-concepts/element-identification.mdx
@@ -1,6 +1,6 @@
 ---
-title: Uniquely identify test elements in Cypress Accessibility
-description: 'Elements are uniquely identified across views and snapshots by their HTML attributes, location, and other signals in the DOM.'
+title: How Cypress Accessibility identifies elements
+description: 'How Cypress Accessibility uniquely identifies elements across views and snapshots using HTML attributes, location, and other DOM signals.'
 sidebar_label: Element identification
 sidebar_position: 20
 ---

--- a/docs/accessibility/core-concepts/how-it-works.mdx
+++ b/docs/accessibility/core-concepts/how-it-works.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'How it works'
+title: How Cypress Accessibility works
 description: 'Accessibility checks are powered by Axe Core® from Deque Systems based on common accessibility standards.'
 sidebar_label: 'How it works'
 sidebar_position: 50

--- a/docs/accessibility/core-concepts/inspecting-violation-details.mdx
+++ b/docs/accessibility/core-concepts/inspecting-violation-details.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Inspecting accessibility violation details'
+title: Inspect accessibility violation details
 description: 'Learn how to inspect the details of an accessibility violation and its severity in Cypress.'
 sidebar_label: Inspect violation details
 sidebar_position: 20

--- a/docs/accessibility/get-started/introduction.mdx
+++ b/docs/accessibility/get-started/introduction.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_label: Introduction
-title: Automated accessibility checks in Cypress Accessibility
+title: What is Cypress Accessibility?
 description: 'Cypress Accessibility provides organized, visual, and actionable accessibility reports, based completely on the tests you record to Cypress Cloud, and powered by Axe Core® by Deque Systems.'
 sidebar_position: 10
 ---

--- a/docs/accessibility/guides/accessibility-automation.mdx
+++ b/docs/accessibility/guides/accessibility-automation.mdx
@@ -1,8 +1,7 @@
 ---
 sidebar_label: Accessibility automation principles
 title: 'Accessibility automation principles'
-description: "
-Apply these core principles to maximize the impact of Cypress Accessibility's automation: complement automation with human judgment for deeper insights, manage false positives effectively, and ensure robust assistive technology support."
+description: "Apply these core principles to maximize the impact of Cypress Accessibility's automation: complement automation with human judgment for deeper insights, manage false positives effectively, and ensure robust assistive technology support."
 sidebar_position: 80
 ---
 

--- a/docs/accessibility/guides/detect-changes.mdx
+++ b/docs/accessibility/guides/detect-changes.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Detect and manage changes
-title: 'Detect changes'
-description: 'Monitor accessibility issues in production by running scheduled Cypress tests against live environments, capturing dynamic content changes, and generating automated reports for a comprehensive accessibility overview.'
+title: Detect and manage changes in Cypress Accessibility
+description: 'Detect accessibility changes between runs in Cypress so new violations are caught the moment they are introduced.'
 sidebar_position: 70
 ---
 

--- a/docs/accessibility/guides/introduction.mdx
+++ b/docs/accessibility/guides/introduction.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Guides overview'
+title: Cypress Accessibility guides
 description: Learn how to set goals and make progress using Cypress Accessibility, generate reports during local development cycles, and monitor a production website.
 sidebar_position: 10
 ---

--- a/docs/accessibility/guides/results-api.mdx
+++ b/docs/accessibility/guides/results-api.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'API of results'
+title: 'Accessibility Results API: enforce standards in CI'
 description: 'Programmatically fetch Accessibility results in a CI environment and fail your pipeline if your standards are not met.'
 sidebar_label: Results API
 sidebar_position: 100

--- a/docs/api/cypress-api/screenshot-api.mdx
+++ b/docs/api/cypress-api/screenshot-api.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Cypress.Screenshot'
-description: Set defaults for how screenshots are captured during .screenshot(` and automatic screenshots taken during test failures in Cypress
+description: Set defaults for how screenshots are captured during .screenshot() and automatically on test failures in Cypress.
 sidebar_label: Screenshot
 ---
 

--- a/docs/api/node-events/after-run-api.mdx
+++ b/docs/api/node-events/after-run-api.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'After Run Event'
+title: 'after:run event'
 description: 'The after:run event fires after a run is finished in Cypress.'
 sidebar_label: 'after:run'
 ---

--- a/docs/api/node-events/after-screenshot-api.mdx
+++ b/docs/api/node-events/after-screenshot-api.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'After Screenshot Event'
+title: 'after:screenshot event'
 description: 'The after:screenshot event fires after a screenshot is taken in Cypress.'
 sidebar_label: 'after:screenshot'
 ---

--- a/docs/api/node-events/after-spec-api.mdx
+++ b/docs/api/node-events/after-spec-api.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'After Spec Event'
+title: 'after:spec event'
 description: 'The after:spec event fires after a spec file is run in Cypress.'
 sidebar_label: 'after:spec'
 ---

--- a/docs/api/node-events/before-run-api.mdx
+++ b/docs/api/node-events/before-run-api.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Before Run Event'
+title: 'before:run event'
 description: 'The before:run event fires before a run starts in Cypress.'
 sidebar_label: 'before:run'
 ---

--- a/docs/api/node-events/before-spec-api.mdx
+++ b/docs/api/node-events/before-spec-api.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Before Spec Event'
+title: 'before:spec event'
 description: 'The before:spec event fires before a spec file is run in Cypress.'
 sidebar_label: 'before:spec'
 ---

--- a/docs/api/node-events/browser-launch-api.mdx
+++ b/docs/api/node-events/browser-launch-api.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Browser Launch Event'
+title: 'before:browser:launch event'
 description: 'The before:browser:launch event gives you the opportunity to modify the browser preferences, install extensions, add and remove command-line arguments, and modify other options before Cypress launches a browser.'
 sidebar_label: 'before:browser:launch'
 ---

--- a/docs/app/end-to-end-testing/testing-your-app.mdx
+++ b/docs/app/end-to-end-testing/testing-your-app.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Effective E2E testing in Cypress'
 sidebar_label: 'Testing Your App'
-description: 'Discover effective end-to-end testing strategies in Cypress App Testing Guide. Elevate your testing proficiency'
+description: 'Strategies for end-to-end testing your own app in Cypress: seeding state, handling logins, and choosing reliable selectors.'
 sidebar_position: 20
 slug: /app/end-to-end-testing/testing-your-app
 ---

--- a/docs/app/end-to-end-testing/writing-your-first-end-to-end-test.mdx
+++ b/docs/app/end-to-end-testing/writing-your-first-end-to-end-test.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'End-to-end testing: your first test with Cypress'
 sidebar_label: 'Your First Test'
-description: 'Dive into Cypress end-to-end testing with a guide on writing your first test. Learn step-by-step, best practices, and tips for efficient test creation'
+description: 'Write your first Cypress end-to-end test step by step: visit a page, query elements, make assertions, and debug failures.'
 sidebar_position: 10
 slug: /app/end-to-end-testing/writing-your-first-end-to-end-test
 ---

--- a/docs/app/get-started/why-cypress.mdx
+++ b/docs/app/get-started/why-cypress.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Cypress testing solutions'
-description: 'Explore Cypress documentation for a comprehensive guide on end-to-end, component, and accessibility testing. Discover features, commands, best practices, and get started with Cypress today'
+title: 'Why Cypress? End-to-end, component & accessibility testing'
+description: 'Why teams choose Cypress for end-to-end, component, and accessibility testing — its architecture, features, and trade-offs.'
 sidebar_label: Why Cypress?
 sidebar_position: 10
 ---

--- a/docs/app/guides/authentication-testing/amazon-cognito-authentication.mdx
+++ b/docs/app/guides/authentication-testing/amazon-cognito-authentication.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Testing Amazon Cognito authentication in Cypress'
 sidebar_label: 'Amazon Cognito Authentication'
-description: 'Implement Amazon Cognito authentication in Cypress. Securely manage authentication processes for Cypress end-to-end testing scenarios'
+description: 'Test Amazon Cognito login in Cypress using the Amplify SDK and cy.session() to reuse authenticated state.'
 ---
 
 <ProductHeading product="app" />

--- a/docs/app/guides/authentication-testing/auth0-authentication.mdx
+++ b/docs/app/guides/authentication-testing/auth0-authentication.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Testing Auth0 authentication in Cypress'
 sidebar_label: 'Auth0 Authentication'
-description: 'Seamlessly implement Auth0 authentication with Cypress. Integrate Auth0 authentication for secure testing'
+description: 'Test Auth0 login flows in Cypress with cy.origin(), and reuse authenticated sessions across tests with cy.session().'
 ---
 
 <ProductHeading product="app" />

--- a/docs/app/guides/authentication-testing/google-authentication.mdx
+++ b/docs/app/guides/authentication-testing/google-authentication.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Testing Google authentication in Cypress'
 sidebar_label: 'Google Authentication'
-description: 'Secure testing with seamless integration of Google Authentication, ensuring reliable and protected test scenarios'
+description: 'Test Google (OAuth) login in Cypress using cy.origin(), and cache authenticated sessions with cy.session().'
 ---
 
 <ProductHeading product="app" />

--- a/docs/app/guides/authentication-testing/okta-authentication.mdx
+++ b/docs/app/guides/authentication-testing/okta-authentication.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Testing Okta authentication in Cypress'
 sidebar_label: 'Okta Authentication'
-description: 'Implement Okta authentication in Cypress end-to-end testing. Ensure secure and reliable authentication processes for Cypress testing scenarios'
+description: 'Test Okta login in Cypress end-to-end tests using cy.origin(), and cache sessions with cy.session().'
 ---
 
 <ProductHeading product="app" />

--- a/docs/app/references/migration-guide.mdx
+++ b/docs/app/references/migration-guide.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Migration guide in Cypress'
-description: 'A guide to help you migrate to the latest version of Cypress.'
+description: 'A guide to help you upgrade to the latest version of Cypress.'
 sidebar_label: 'Migration Guide'
 ---
 

--- a/docs/cloud/features/analytics/overview.mdx
+++ b/docs/cloud/features/analytics/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: Types of analytics in Cypress Cloud
 sidebar_position: 10
-description: 'Types of Analytics in Cypress Cloud.'
+description: 'Compare the analytics available in Cypress Cloud — run trends, test suite size, flake rates, and enterprise reporting.'
 ---
 
 <ProductHeading product="cloud" />

--- a/docs/cloud/features/smart-orchestration/load-balancing.mdx
+++ b/docs/cloud/features/smart-orchestration/load-balancing.mdx
@@ -1,5 +1,5 @@
 ---
-title: Load balancing specsin Cypress Cloud
+title: Load balancing specs in Cypress Cloud
 description: Cypress Cloud automatically balances your spec files across the machines in your CI provider to minimize run time, cut CI costs, and eliminate manual tuning.
 sidebar_position: 30
 ---

--- a/docs/cloud/get-started/introduction.mdx
+++ b/docs/cloud/get-started/introduction.mdx
@@ -2,7 +2,7 @@
 title: Introduction to Cypress Cloud
 sidebar_position: 10
 sidebar_label: Introduction
-description: Scale your testing with confidence on every release.
+description: 'Cypress Cloud records your test runs to give you Test Replay, flake detection, parallelization, and analytics across CI.'
 ---
 
 <ProductHeading product="cloud" />

--- a/docs/cloud/get-started/setup.mdx
+++ b/docs/cloud/get-started/setup.mdx
@@ -1,6 +1,6 @@
 ---
 title: Set up your project to record in Cypress Cloud
-description: Learn how to set up your project to record tests in Cypress Cloud.
+description: 'Connect your project to Cypress Cloud and record your first run to unlock Test Replay, parallelization, and analytics.'
 sidebar_position: 20
 ---
 

--- a/docs/ui-coverage/configuration/additionalinteractioncommands.mdx
+++ b/docs/ui-coverage/configuration/additionalinteractioncommands.mdx
@@ -1,6 +1,6 @@
 ---
-title: Extend the interaction command types recognized by UI Coverage in Cypress
-description: 'The `additionalInteractionCommands` configuration property allows users to extend the default set of interaction command types recognized by UI Coverage.'
+title: 'additionalInteractionCommands'
+description: 'Use additionalInteractionCommands to extend the default set of interaction command types recognized by UI Coverage.'
 sidebar_label: additionalInteractionCommands
 sidebar_position: 90
 ---

--- a/docs/ui-coverage/configuration/allowedinteractioncommands.mdx
+++ b/docs/ui-coverage/configuration/allowedinteractioncommands.mdx
@@ -1,6 +1,6 @@
 ---
-title: Limit the interaction commands tracked for specific elements in UI Coverage in Cypress
-description: 'The `allowedInteractionCommands` configuration property allows users to limit the interaction commands that are tracked for specific elements in UI Coverage.'
+title: 'allowedInteractionCommands'
+description: 'Use allowedInteractionCommands to limit the interaction commands that are tracked for specific elements in UI Coverage.'
 sidebar_label: allowedInteractionCommands
 sidebar_position: 100
 ---

--- a/docs/ui-coverage/configuration/attributefilters.mdx
+++ b/docs/ui-coverage/configuration/attributefilters.mdx
@@ -1,6 +1,6 @@
 ---
-title: Filter attributes used for element identification and grouping in UI Coverage in Cypress
-description: 'The attributeFilters configuration property allows users to specify patterns for attributes and their values that should not be used for identifying and grouping elements.'
+title: 'attributeFilters: control element identification'
+description: 'Use attributeFilters to exclude attribute patterns from element identification and grouping in UI Coverage.'
 sidebar_label: attributeFilters
 sidebar_position: 60
 ---

--- a/docs/ui-coverage/configuration/elementfilters.mdx
+++ b/docs/ui-coverage/configuration/elementfilters.mdx
@@ -1,5 +1,5 @@
 ---
-title: Exclude elements from UI Coverage in Cypress
+title: 'elementFilters: exclude elements from UI Coverage'
 description: 'The elementFilters property allows you to specify selectors for elements that should be excluded from UI Coverage.'
 sidebar_label: elementFilters
 sidebar_position: 40

--- a/docs/ui-coverage/configuration/elementgroups.mdx
+++ b/docs/ui-coverage/configuration/elementgroups.mdx
@@ -1,5 +1,5 @@
 ---
-title: Group elements in UI Coverage in Cypress
+title: 'elementGroups: group elements with custom logic'
 description: 'The `elementGroups` configuration allows you to group elements in UI Coverage using custom logic.'
 sidebar_label: elementGroups
 sidebar_position: 80

--- a/docs/ui-coverage/configuration/elements.mdx
+++ b/docs/ui-coverage/configuration/elements.mdx
@@ -1,5 +1,5 @@
 ---
-title: Identify elements in UI Coverage in Cypress
+title: 'elements: identify elements with custom logic'
 description: 'The elements configuration allows you to uniquely identify elements in UI Coverage using custom logic.'
 sidebar_label: elements
 sidebar_position: 70

--- a/docs/ui-coverage/configuration/overview.mdx
+++ b/docs/ui-coverage/configuration/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: Configuration in UI Coverage in Cypress
+title: Configure UI Coverage in Cypress
 description: 'Configuration allows you to customize and fine-tune UI Coverage in Cypress to suit specific needs and scenarios.'
 sidebar_label: Overview
 sidebar_position: 10

--- a/docs/ui-coverage/configuration/profiles.mdx
+++ b/docs/ui-coverage/configuration/profiles.mdx
@@ -1,6 +1,6 @@
 ---
-title: Use different profiles for different runs in UI Coverage in Cypress
-description: 'The profiles configuration property allows you to create configuration overrides that are applied based on run tags.'
+title: 'profiles: apply config overrides by run tag'
+description: 'Use the profiles property to apply UI Coverage configuration overrides based on run tags.'
 sidebar_label: profiles
 sidebar_position: 100
 ---

--- a/docs/ui-coverage/configuration/significantattributes.mdx
+++ b/docs/ui-coverage/configuration/significantattributes.mdx
@@ -1,5 +1,5 @@
 ---
-title: Prioritize specific attributes for element identification and grouping in UI Coverage in Cypress
+title: 'significantAttributes: prioritize element attributes'
 description: 'The significantAttributes configuration property allows users to specify custom attributes that should be considered "significant" for the purpose of identification and grouping in UI Coverage.'
 sidebar_label: significantAttributes
 sidebar_position: 50

--- a/docs/ui-coverage/configuration/viewfilters.mdx
+++ b/docs/ui-coverage/configuration/viewfilters.mdx
@@ -1,5 +1,5 @@
 ---
-title: Exclude URLs from UI Coverage in Cypress
+title: 'viewFilters: exclude URLs from UI Coverage'
 description: 'The viewFilters property allows you to specify URL patterns for URLs that should be excluded from UI Coverage.'
 sidebar_label: viewFilters
 sidebar_position: 30

--- a/docs/ui-coverage/configuration/views.mdx
+++ b/docs/ui-coverage/configuration/views.mdx
@@ -1,5 +1,5 @@
 ---
-title: Group URLs in UI Coverage in Cypress
+title: 'views: group URLs into UI Coverage views'
 description: 'The `views` configuration allows you to group URLs in UI Coverage using custom logic.'
 sidebar_label: views
 sidebar_position: 20

--- a/docs/ui-coverage/core-concepts/element-grouping.mdx
+++ b/docs/ui-coverage/core-concepts/element-grouping.mdx
@@ -1,5 +1,5 @@
 ---
-title: Group related elements in UI Coverage in Cypress
+title: How UI Coverage groups related elements
 description: 'UI Coverage groups elements that are related to one another through structural or behavioral hints, but this is configurable.'
 sidebar_label: Element Grouping
 sidebar_position: 20

--- a/docs/ui-coverage/core-concepts/element-identification.mdx
+++ b/docs/ui-coverage/core-concepts/element-identification.mdx
@@ -1,6 +1,6 @@
 ---
-title: Uniquely identify test elements in UI Coverage in Cypress
-description: 'Elements are uniquely identified across views and snapshots by their HTML attributes, location, and other signals in the DOM.'
+title: How UI Coverage identifies elements
+description: 'How UI Coverage uniquely identifies elements across views and snapshots using HTML attributes, location, and other DOM signals.'
 sidebar_label: Element Identification
 sidebar_position: 20
 ---

--- a/docs/ui-coverage/core-concepts/interactivity.mdx
+++ b/docs/ui-coverage/core-concepts/interactivity.mdx
@@ -1,5 +1,5 @@
 ---
-title: Testing interactive elements in UI Coverage in Cypress
+title: How UI Coverage detects interactive elements
 description: 'UI Coverage uses a set of rules, based on HTML semantics, WHATWG standards, as well as some additional rules defined by Cypress, to determine which elements are interactive.'
 sidebar_label: Interactivity
 sidebar_position: 10

--- a/docs/ui-coverage/core-concepts/views.mdx
+++ b/docs/ui-coverage/core-concepts/views.mdx
@@ -1,5 +1,5 @@
 ---
-title: Views of URLs and mounted components in UI Coverage in Cypress
+title: 'Views: URLs and mounted components in UI Coverage'
 description: 'UI Coverage is organized into views, which are the unique URLs across all snapshots from end-to-end tests and the unique mounted components from component tests.'
 sidebar_label: Views
 sidebar_position: 100

--- a/docs/ui-coverage/get-started/introduction.mdx
+++ b/docs/ui-coverage/get-started/introduction.mdx
@@ -1,5 +1,5 @@
 ---
-title: Test coverage with UI Coverage in Cypress
+title: What is UI Coverage?
 description: 'Increase your test coverage with UI Coverage, a visual test coverage report based on the interactive elements that make up your application.'
 sidebar_label: Introduction
 sidebar_position: 10

--- a/docs/ui-coverage/get-started/setup.mdx
+++ b/docs/ui-coverage/get-started/setup.mdx
@@ -1,5 +1,5 @@
 ---
-title: Set up UI Coverage by recording a run in Cypress
+title: Set up UI Coverage with no instrumentation required
 description: 'Set up UI Coverage by recording a run. No setup or instrumentation is required.'
 sidebar_label: Get Started
 sidebar_position: 20

--- a/docs/ui-coverage/guides/address-coverage-gaps.mdx
+++ b/docs/ui-coverage/guides/address-coverage-gaps.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Address coverage gaps
-title: Address coverage gaps in UI Coverage in Cypress
-description: 'Learn how to address test coverage gaps with Cypress UI Coverage to ensure quality of your application.'
+title: Address coverage gaps with UI Coverage
+description: 'Close UI Coverage gaps by adding tests for the untested elements UI Coverage surfaces after each run.'
 sidebar_position: 20
 ---
 

--- a/docs/ui-coverage/guides/block-pull-requests.mdx
+++ b/docs/ui-coverage/guides/block-pull-requests.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_label: Block pull requests and set policies
-title: Block pull requests and set policies in UI Coverage in Cypress
+title: Block pull requests with UI Coverage policies
 description: "Set policies and block pull requests automatically with Cypress UI Coverage's Results API, enabling custom CI workflows to enforce test coverage standards and prevent regressions."
 sidebar_position: 40
 ---

--- a/docs/ui-coverage/guides/compare-reports.mdx
+++ b/docs/ui-coverage/guides/compare-reports.mdx
@@ -1,5 +1,5 @@
 ---
-title: Compare UI coverage reports in UI Coverage in Cypress
+title: Compare UI Coverage reports across runs
 description: 'Review where coverage has changed in the application between two runs.'
 sidebar_position: 40
 sidebar_label: Compare reports

--- a/docs/ui-coverage/guides/identify-coverage-gaps.mdx
+++ b/docs/ui-coverage/guides/identify-coverage-gaps.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Identify coverage gaps
-title: Identify coverage gaps in UI Coverage in Cypress
-description: 'Learn how to identify coverage gaps with Cypress UI Coverage to ensure quality of your application.'
+title: Identify coverage gaps with UI Coverage
+description: 'Find untested interactive elements in your app using UI Coverage reports from recorded Cypress runs.'
 sidebar_position: 10
 ---
 

--- a/docs/ui-coverage/guides/ignore-elements.mdx
+++ b/docs/ui-coverage/guides/ignore-elements.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Ignore elements
-title: Ignore elements in UI Coverage in Cypress
-description: 'Learn how to exclude irrelevant elements from your UI Coverage reports to focus on meaningful insights.'
+title: Ignore elements in UI Coverage reports
+description: 'Exclude specific elements from UI Coverage with elementFilters so reports focus on what you actually test.'
 sidebar_position: 50
 ---
 

--- a/docs/ui-coverage/guides/ignore-views-and-links.mdx
+++ b/docs/ui-coverage/guides/ignore-views-and-links.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Ignore views and links
-title: Ignore views and links in UI Coverage in Cypress
-description: 'Learn how to exclude irrelevant views and links from your UI Coverage reports to focus on meaningful insights.'
+title: Ignore views and links in UI Coverage
+description: 'Exclude irrelevant views and links from UI Coverage reports so scores reflect the parts of your app you test.'
 sidebar_position: 40
 ---
 

--- a/docs/ui-coverage/guides/monitor-changes.mdx
+++ b/docs/ui-coverage/guides/monitor-changes.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_label: Monitor changes
-title: Monitor changes in UI Coverage in Cypress
+title: Monitor UI Coverage changes over time
 description: 'Learn how to monitor changes to your UI Coverage scores over time to ensure proactive quality assurance.'
 sidebar_position: 70
 ---

--- a/docs/ui-coverage/guides/reduce-noise.mdx
+++ b/docs/ui-coverage/guides/reduce-noise.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Reduce noise
-title: Reduce noise in UI Coverage in Cypress
-description: 'Learn how to exclude irrelevant elements from your UI Coverage reports to focus on meaningful insights.'
+title: Reduce noise in UI Coverage reports
+description: 'Cut noise from UI Coverage reports by filtering out elements that do not represent real coverage gaps.'
 sidebar_position: 60
 ---
 

--- a/docs/ui-coverage/guides/reduce-test-duplication.mdx
+++ b/docs/ui-coverage/guides/reduce-test-duplication.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_label: Reduce test duplication
-title: Reduce test duplication in UI Coverage in Cypress
+title: Reduce test duplication with UI Coverage
 description: 'Optimize your test suite by identifying and consolidating duplicate tests with Cypress UI Coverage.'
 sidebar_position: 30
 ---

--- a/docs/ui-coverage/results-api.mdx
+++ b/docs/ui-coverage/results-api.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'API for test results'
+title: 'UI Coverage Results API: enforce coverage in CI'
 description: 'Programmatically fetch UI Coverage results in a CI environment and fail the build if the test coverage is not acceptable.'
 sidebar_label: Results API
 sidebar_position: 100

--- a/docs/ui-coverage/work-with-ai-agents.mdx
+++ b/docs/ui-coverage/work-with-ai-agents.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_label: Work with AI agents
-title: Work with AI agents in UI Coverage in Cypress
+title: Use AI agents with UI Coverage
 description: 'Use AI assistants with UI Coverage and Cypress Cloud MCP: pull coverage scores and untested elements from recorded runs, tune reports for clearer signal, and review coverage deltas alongside passing tests.'
 sidebar_position: 110
 ---


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation metadata only; no runtime, config schema, or page body changes.
> 
> **Overview**
> Updates **frontmatter only** (`title` and `description`) across a large set of Cypress docs MDX files—no body content changes.
> 
> **Cypress Accessibility & UI Coverage** pages get clearer, action-oriented titles (often including config property names like `viewFilters`, `profiles`, `elementFilters`) and descriptions that spell out what each page covers (compare reports, Results API, element identification, guides).
> 
> **App, API, and Cloud** pages receive similar SEO-oriented tweaks: e.g. auth guides describe `cy.session()` / `cy.origin()` patterns, node event pages use lowercase event names (`after:run`, `before:browser:launch`), **load balancing** fixes a typo in the title, and **Screenshot API** fixes a broken `.screenshot(` reference in the description.
> 
> **Changelog** is renamed in metadata to **Cypress Accessibility Release Notes**; one guide’s multi-line `description` is collapsed to a single line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23e935271b7656e082f61c7da851672b49c79284. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->