### PR TITLE
fix missing sidebar_label

### DIFF
--- a/docs/accessibility/block-pull-requests.mdx
+++ b/docs/accessibility/block-pull-requests.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_label: Block pull requests and set policies
+sidebar_label: Block pull requests
 title: Block pull requests and set policies in Cypress Accessibility
 description: "Set policies and block pull requests automatically with Cypress Accessibility's Results API, enabling custom CI workflows to enforce accessibility standards and prevent regressions."
 sidebar_position: 55

--- a/docs/accessibility/guides/introduction.mdx
+++ b/docs/accessibility/guides/introduction.mdx
@@ -1,6 +1,7 @@
 ---
 title: Cypress Accessibility guides
 description: Learn how to set goals and make progress using Cypress Accessibility, generate reports during local development cycles, and monitor a production website.
+sidebar_label: Introduction
 sidebar_position: 10
 ---
 

--- a/docs/accessibility/guides/production-monitoring.mdx
+++ b/docs/accessibility/guides/production-monitoring.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_label: Production monitoring and website crawling
-title: 'Production monitoring'
+sidebar_label: Production monitoring
+title: 'Monitor accessibility issues in production'
 description: 'Monitor accessibility issues in production by running scheduled Cypress tests against live environments, capturing dynamic content changes, and generating automated reports for a comprehensive accessibility overview.'
 sidebar_position: 60
 ---

--- a/docs/api/cypress-api/catalog-of-events.mdx
+++ b/docs/api/cypress-api/catalog-of-events.mdx
@@ -2,6 +2,7 @@
 title: Catalog of Events
 sidebar_position: 10
 description: 'Events that Cypress emits as it runs in your browser.'
+sidebar_label: Catalog of Events
 ---
 
 Cypress emits a series of events as it runs in your browser.

--- a/docs/app/component-testing/custom-frameworks.mdx
+++ b/docs/app/component-testing/custom-frameworks.mdx
@@ -2,6 +2,7 @@
 title: 'Custom frameworks'
 description: Learn how to create a custom Framework Definition and Mount Adapter for your favorite library or framework.
 sidebar_position: 100
+sidebar_label: Custom Frameworks
 ---
 
 <ProductHeading product="app" />

--- a/docs/app/core-concepts/best-practices.mdx
+++ b/docs/app/core-concepts/best-practices.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Cypress best practices'
 description: Best practices for organizing tests, selecting elements, and controlling state in Cypress.
+sidebar_label: Best Practices
 sidebar_position: 80
 ---
 

--- a/docs/app/core-concepts/interacting-with-elements.mdx
+++ b/docs/app/core-concepts/interacting-with-elements.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Interacting with elements in Cypress'
 description: Learn how Cypress determines if an element is actionable, how to debug when elements are not actionable, and how to ignore Cypress' actionability checks.
+sidebar_label: Interacting with Elements
 sidebar_position: 35
 ---
 

--- a/docs/app/core-concepts/open-mode.mdx
+++ b/docs/app/core-concepts/open-mode.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Open mode in the Cypress app'
 description: Learn how Cypress open mode works, including the Test Runner, Command Log, Cypress Studio for recording interactions and inline edits, and tools for debugging tests in the Cypress app.
+sidebar_label: Open Mode
 sidebar_position: 60
 ---
 

--- a/docs/app/core-concepts/retry-ability.mdx
+++ b/docs/app/core-concepts/retry-ability.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Retry-ability in Cypress'
 description: Understand how Cypress retries commands, queries, and assertions to help you write faster tests with fewer run-time surprises.
+sidebar_label: Retry-ability
 sidebar_position: 50
 ---
 

--- a/docs/app/core-concepts/test-isolation.mdx
+++ b/docs/app/core-concepts/test-isolation.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Test isolation in Cypress'
 description: Learn how Cypress ensures test isolation and how to configure test isolation in end-to-end and component testing.
+sidebar_label: Test Isolation
 sidebar_position: 45
 ---
 

--- a/docs/app/core-concepts/testing-types.mdx
+++ b/docs/app/core-concepts/testing-types.mdx
@@ -2,6 +2,7 @@
 title: 'End-to-end and component testing in Cypress'
 description: 'Learn the differences between Cypress end-to-end and component tests, the benefits and considerations for each type of test, and common scenarios for each type of test.'
 sidebar_position: 20
+sidebar_label: Testing Types
 ---
 
 <ProductHeading product="app" />

--- a/docs/app/core-concepts/variables-and-aliases.mdx
+++ b/docs/app/core-concepts/variables-and-aliases.mdx
@@ -2,6 +2,7 @@
 title: 'Variables and aliases in Cypress'
 description: Learn how to handle asynchronous code in Cypress, when to assign variables, how to use aliases to share objects between hooks and tests, and how to alias DOM elements, intercepts, and requests.
 sidebar_position: 40
+sidebar_label: Variables and Aliases
 ---
 
 <ProductHeading product="app" />

--- a/docs/app/guides/accessibility-testing.mdx
+++ b/docs/app/guides/accessibility-testing.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Accessibility testing in Cypress'
 description: Learn how to ensure your application works for users with disabilities, and how to write accessibility-specific tests in Cypress.
+sidebar_label: Accessibility Testing
 ---
 
 <ProductHeading product="app" />

--- a/docs/cloud/features/analytics/enterprise-reporting.mdx
+++ b/docs/cloud/features/analytics/enterprise-reporting.mdx
@@ -2,6 +2,7 @@
 title: Enterprise reporting in Cypress Cloud
 sidebar_position: 30
 description: Enterprise Reporting in Cypress Cloud provides insights and data access to help you spot trends and anomalies, track usage, and govern your overall test program across all projects in your organization.
+sidebar_label: Enterprise Reporting
 ---
 
 <ProductHeading product="cloud" plan="enterprise" />

--- a/docs/cloud/features/analytics/overview.mdx
+++ b/docs/cloud/features/analytics/overview.mdx
@@ -2,6 +2,7 @@
 title: Types of analytics in Cypress Cloud
 sidebar_position: 10
 description: 'Compare the analytics available in Cypress Cloud — run trends, test suite size, flake rates, and enterprise reporting.'
+sidebar_label: Overview
 ---
 
 <ProductHeading product="cloud" />

--- a/docs/cloud/features/analytics/project-analytics.mdx
+++ b/docs/cloud/features/analytics/project-analytics.mdx
@@ -2,6 +2,7 @@
 title: Project analytics & insights in Cypress Cloud
 description: Cypress Cloud provides Analytics to offer insight into metrics like runs over time, run duration and visibility into tests suite size over time.
 sidebar_position: 20
+sidebar_label: Project Analytics & Insights
 ---
 
 <ProductHeading product="cloud" />

--- a/docs/cloud/features/branch-review.mdx
+++ b/docs/cloud/features/branch-review.mdx
@@ -2,6 +2,7 @@
 title: Compare branches and runs in Cypress Cloud
 description: Branch Review in Cypress Cloud surfaces the impact of Pull Requests on your test suite so you can catch regressions before they merge. Compare test results between branches and learn best practices for grouping test runs.
 sidebar_position: 50
+sidebar_label: Branch Review
 ---
 
 <ProductHeading product="cloud" />

--- a/docs/cloud/features/recorded-runs.mdx
+++ b/docs/cloud/features/recorded-runs.mdx
@@ -2,6 +2,7 @@
 title: Recorded runs in Cypress Cloud
 description: View and analyze recorded test runs in Cypress Cloud.
 sidebar_position: 30
+sidebar_label: Recorded Runs
 ---
 
 <ProductHeading product="cloud" />

--- a/docs/cloud/features/smart-orchestration/load-balancing.mdx
+++ b/docs/cloud/features/smart-orchestration/load-balancing.mdx
@@ -2,6 +2,7 @@
 title: Load balancing specs in Cypress Cloud
 description: Cypress Cloud automatically balances your spec files across the machines in your CI provider to minimize run time, cut CI costs, and eliminate manual tuning.
 sidebar_position: 30
+sidebar_label: Load Balancing
 ---
 
 <ProductHeading product="cloud" />

--- a/docs/cloud/features/smart-orchestration/overview.mdx
+++ b/docs/cloud/features/smart-orchestration/overview.mdx
@@ -2,6 +2,7 @@
 title: Overview of smart orchestration in Cypress Cloud
 description: Cypress Cloud provides four distinct Smart Orchestration features for use in CI to speed up test runs, accelerate debugging workflows, and reduce costs.
 sidebar_position: 10
+sidebar_label: Overview
 ---
 
 <ProductHeading product="cloud" />

--- a/docs/cloud/features/smart-orchestration/parallelization.mdx
+++ b/docs/cloud/features/smart-orchestration/parallelization.mdx
@@ -2,6 +2,7 @@
 title: Parallelize tests in Cypress Cloud
 description: Run tests in parallel across multiple machines to save time and money in Continuous Integration.
 sidebar_position: 20
+sidebar_label: Parallelization
 ---
 
 <ProductHeading product="cloud" />

--- a/docs/cloud/features/test-replay.mdx
+++ b/docs/cloud/features/test-replay.mdx
@@ -2,6 +2,7 @@
 title: Debug failed and flaky tests with test replay in Cypress Cloud
 description: Test Replay in Cypress Cloud allows developers to accurately and efficiently debug failed and flaky continuous integration test runs. It captures every test run detail, enabling developers to replay it and inspect the DOM, network requests, console logs, JavaScript errors, and element rendering as they happened in CI.
 sidebar_position: 40
+sidebar_label: Test Replay
 ---
 
 <ProductHeading product="cloud" />

--- a/docs/cloud/get-started/setup.mdx
+++ b/docs/cloud/get-started/setup.mdx
@@ -2,6 +2,7 @@
 title: Set up your project to record in Cypress Cloud
 description: 'Connect your project to Cypress Cloud and record your first run to unlock Test Replay, parallelization, and analytics.'
 sidebar_position: 20
+sidebar_label: Setup
 ---
 
 <ProductHeading product="cloud" />


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation navigation metadata only; no runtime, API, or security impact.
> 
> **Overview**
> Adds explicit **`sidebar_label`** values to many docs pages that were missing them, so the site sidebar shows consistent, shorter labels instead of falling back to titles.
> 
> A few pages get **label tweaks** only (e.g. **Block pull requests**, **Production monitoring**). **Production monitoring** also updates the frontmatter **`title`** to *Monitor accessibility issues in production* while the on-page H1 stays unchanged.
> 
> Touches accessibility, app core concepts, API, cloud features, and related guides—**frontmatter only**, no body content changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7811c646d40ac6ed988770084bed3be3e46ce9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->