### PR TITLE
Correct npm allowScripts example

### DIFF
--- a/docs/app/get-started/install-cypress.mdx
+++ b/docs/app/get-started/install-cypress.mdx
@@ -91,7 +91,9 @@ Or add `cypress` to `allowScripts` in `package.json` manually:
 
 ```json title="package.json"
 {
-  "allowScripts": ["cypress"]
+  "allowScripts": {
+    "cypress": true
+  }
 }
 ```
 


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress-documentation/issues/6586

## Situation

- Cypress documentation [npm configuration](https://docs.cypress.io/app/get-started/install-cypress#npm-configuration) advises that the following can be added to `package.json`:

```json
{
"allowScripts": ["cypress"]
}
```

This configuration however does not work.

## Change

Correct the example in the [npm configuration](https://docs.cypress.io/app/get-started/install-cypress#npm-configuration) documentation section:

**BEFORE**

```json
{
"allowScripts": ["cypress"]
}
```

**AFTER**

```json
{
  "allowScripts": {
    "cypress": true
  }
}
```


## Verification

Ubuntu 24.04.4 LTS, Node.js 24.18.0 LTS (packaged with npm 11.16.0)

```shell
cd $(mktemp -d)
cat > package.json <<EOT
{
  "allowScripts": {
    "cypress": true
  }
}
EOT
npm install cypress
```

Confirm no errors or warnings from npm.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or security impact.
> 
> **Overview**
> Fixes the **npm configuration** example on the Install Cypress page so the manual `allowScripts` snippet matches npm’s expected shape.
> 
> The doc previously showed `"allowScripts": ["cypress"]`, which does not work with npm’s allowlist. It now shows `"allowScripts": { "cypress": true }`, aligned with `npm approve-scripts cypress` and verified install behavior on current npm.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8eacfbd7554e3db5a5d749d9c2be87f374fb17cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->