### PR TITLE
docs(app): add FAQ entry for Kerberos auth in Chrome

### DIFF
--- a/docs/app/faq.mdx
+++ b/docs/app/faq.mdx
@@ -645,7 +645,7 @@ event.
 
 Kerberos (integrated/SPNEGO authentication) works in Chrome via the browser
 launch args. Chromium-based browsers do not negotiate Kerberos against an
-arbitrary server by default — you have to tell the browser which origins are
+arbitrary server by default, so you have to tell the browser which origins are
 allowed to use integrated authentication.
 
 In your
@@ -689,7 +689,7 @@ against. Some notes:
 - The machine running Cypress must already have a valid Kerberos ticket (for
   example, the user is logged into the domain, or a ticket has been obtained via
   `kinit`). The browser flags only authorize Chrome to _use_ that ticket for the
-  listed origins — they do not obtain one for you.
+  listed origins. They do not obtain one for you.
 - On older versions of Chromium these flags were named
   `--auth-server-whitelist` and `--auth-negotiate-delegate-whitelist`. Use the
   `-allowlist` spelling on current versions.

--- a/docs/app/faq.mdx
+++ b/docs/app/faq.mdx
@@ -641,6 +641,62 @@ Check out our
 You use the [`before:browser:launch`](/api/node-events/browser-launch-api) plugin
 event.
 
+### <Icon name="angle-right" /> How do I get Kerberos authentication working in Chrome?
+
+Kerberos (integrated/SPNEGO authentication) works in Chrome via the browser
+launch args. Chromium-based browsers do not negotiate Kerberos against an
+arbitrary server by default — you have to tell the browser which origins are
+allowed to use integrated authentication.
+
+In your
+[`setupNodeEvents`](/app/plugins/plugins-guide#Using-a-plugin) function (the
+"plugins file"), listen for the
+[`before:browser:launch`](/api/node-events/browser-launch-api) event and add the
+relevant Chromium auth flags, such as `--auth-server-allowlist` and
+`--auth-negotiate-delegate-allowlist`:
+
+:::cypress-config-example
+
+```ts
+{
+  e2e: {
+    setupNodeEvents(on, config) {
+      on('before:browser:launch', (browser, launchOptions) => {
+        // Kerberos auth is only relevant for Chromium-based browsers,
+        // which excludes Electron
+        if (browser.family === 'chromium' && browser.name !== 'electron') {
+          launchOptions.args.push('--auth-server-allowlist=*.example.com')
+          launchOptions.args.push(
+            '--auth-negotiate-delegate-allowlist=*.example.com'
+          )
+        }
+
+        return launchOptions
+      })
+    },
+  },
+}
+```
+
+:::
+
+Replace `*.example.com` with the domain(s) you want the browser to authenticate
+against. Some notes:
+
+- These flags only apply to **Chromium-based** browsers (Chrome, Chromium, Edge).
+  They have no effect in Electron or Firefox, so guard the code with a
+  `browser.family` / `browser.name` check as shown above.
+- The machine running Cypress must already have a valid Kerberos ticket (for
+  example, the user is logged into the domain, or a ticket has been obtained via
+  `kinit`). The browser flags only authorize Chrome to _use_ that ticket for the
+  listed origins — they do not obtain one for you.
+- On older versions of Chromium these flags were named
+  `--auth-server-whitelist` and `--auth-negotiate-delegate-whitelist`. Use the
+  `-allowlist` spelling on current versions.
+
+See the [Browser Launch API](/api/node-events/browser-launch-api) for more on
+modifying browser launch arguments.
+
 ### <Icon name="angle-right" /> Can I make cy.request() poll until a condition is met?
 
 Yes. You do it the

--- a/docs/app/faq.mdx
+++ b/docs/app/faq.mdx
@@ -649,8 +649,8 @@ arbitrary server by default, so you have to tell the browser which origins are
 allowed to use integrated authentication.
 
 In your
-[`setupNodeEvents`](/app/plugins/plugins-guide#Using-a-plugin) function (the
-"plugins file"), listen for the
+[`setupNodeEvents`](/app/plugins/plugins-guide#Using-a-plugin) function, listen
+for the
 [`before:browser:launch`](/api/node-events/browser-launch-api) event and add the
 relevant Chromium auth flags, such as `--auth-server-allowlist` and
 `--auth-negotiate-delegate-allowlist`:
@@ -662,8 +662,6 @@ relevant Chromium auth flags, such as `--auth-server-allowlist` and
   e2e: {
     setupNodeEvents(on, config) {
       on('before:browser:launch', (browser, launchOptions) => {
-        // Kerberos auth is only relevant for Chromium-based browsers,
-        // which excludes Electron
         if (browser.family === 'chromium' && browser.name !== 'electron') {
           launchOptions.args.push('--auth-server-allowlist=*.example.com')
           launchOptions.args.push(
@@ -681,18 +679,12 @@ relevant Chromium auth flags, such as `--auth-server-allowlist` and
 :::
 
 Replace `*.example.com` with the domain(s) you want the browser to authenticate
-against. Some notes:
+against.
 
-- These flags only apply to **Chromium-based** browsers (Chrome, Chromium, Edge).
-  They have no effect in Electron or Firefox, so guard the code with a
-  `browser.family` / `browser.name` check as shown above.
-- The machine running Cypress must already have a valid Kerberos ticket (for
-  example, the user is logged into the domain, or a ticket has been obtained via
-  `kinit`). The browser flags only authorize Chrome to _use_ that ticket for the
-  listed origins. They do not obtain one for you.
-- On older versions of Chromium these flags were named
-  `--auth-server-whitelist` and `--auth-negotiate-delegate-whitelist`. Use the
-  `-allowlist` spelling on current versions.
+Note that the machine running Cypress must already have a valid Kerberos ticket
+(for example, the user is logged into the domain, or a ticket has been obtained
+via `kinit`). The browser flags only authorize Chrome to _use_ that ticket for
+the listed origins. They do not obtain one for you.
 
 See the [Browser Launch API](/api/node-events/browser-launch-api) for more on
 modifying browser launch arguments.


### PR DESCRIPTION
Document how to enable Kerberos / SPNEGO integrated authentication in
Chromium-based browsers using the before:browser:launch event and the
--auth-server-allowlist / --auth-negotiate-delegate-allowlist flags.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KHPDfryFYcm6iYqy9jk544

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to `faq.mdx` with no runtime or test code impact.
> 
> **Overview**
> Adds a new **How-to** FAQ entry explaining how to enable **Kerberos / SPNEGO** integrated authentication when testing in Chromium-based browsers (excluding Electron).
> 
> The doc walks through using `before:browser:launch` in `setupNodeEvents` to push `--auth-server-allowlist` and `--auth-negotiate-delegate-allowlist`, with a full `cypress.config` example gated on `browser.family === 'chromium'`. It also clarifies that Cypress does not obtain Kerberos tickets—the host must already have a valid ticket (domain login or `kinit`)—and links to the Browser Launch API for further customization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7a498703ce6caab455dfbdc7ec755acfb0bfc4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->