### PR TITLE
docs: document --tag workaround for differentiating runs by Node.js version

### DIFF
--- a/docs/app/references/command-line.mdx
+++ b/docs/app/references/command-line.mdx
@@ -661,6 +661,20 @@ Cypress Cloud will display any tags sent with the appropriate run.
   alt="Cypress run in Cypress Cloud displaying flags"
 />
 
+Tags are also useful for surfacing environment details that Cypress Cloud
+does not record on its own, such as the Node.js version or the browser a run
+used. By tagging runs with these values you can easily differentiate runs that
+were executed against different versions in the same matrix. For example, when
+running across multiple browsers and Node.js versions you can include both in
+the tags:
+
+```shell
+cypress run --record --browser "${browser}" --tag "${browser},${nodeVersion}"
+```
+
+This makes runs that use the same spec set but a different browser or Node.js
+version easy to tell apart in Cypress Cloud.
+
 :::info
 
 **App Quality Profiles**: If you use Cypress Cloud's [accessibility](/accessibility/get-started/introduction) and [UI Coverage reporting](/accessibility/get-started/introduction), a run tag can be mapped to [App Quality Profiles](/accessibility/configuration/profiles) to automatically apply different configuration settings for different types of runs.

--- a/docs/app/references/command-line.mdx
+++ b/docs/app/references/command-line.mdx
@@ -662,18 +662,18 @@ Cypress Cloud will display any tags sent with the appropriate run.
 />
 
 Tags are also useful for surfacing environment details that Cypress Cloud
-does not record on its own, such as the Node.js version or the browser a run
-used. By tagging runs with these values you can easily differentiate runs that
-were executed against different versions in the same matrix. For example, when
-running across multiple browsers and Node.js versions you can include both in
-the tags:
+does not record on its own, such as the Node.js version a run used. By tagging
+runs with these values you can easily differentiate runs that were executed
+against different versions in the same matrix. For example, when testing across
+multiple Node.js versions in CI you can include the version in the tags:
 
 ```shell
-cypress run --record --browser "${browser}" --tag "${browser},${nodeVersion}"
+cypress run --record --tag "node-${nodeVersion}"
 ```
 
-This makes runs that use the same spec set but a different browser or Node.js
-version easy to tell apart in Cypress Cloud.
+This makes runs that use the same spec set but a different Node.js version (or
+any other build/environment detail Cypress Cloud does not capture) easy to tell
+apart in Cypress Cloud.
 
 :::info
 

--- a/docs/cloud/features/recorded-runs.mdx
+++ b/docs/cloud/features/recorded-runs.mdx
@@ -87,6 +87,13 @@ status.
   alt="Run details header"
 />
 
+:::tip
+The run header surfaces the browsers, operating systems, and Cypress version
+used, but not every environment detail (for example, the Node.js version). To
+make those details visible and filterable in Cypress Cloud, add them as
+[run tags](/app/references/command-line#cypress-run-tag-lt-tag-gt).
+:::
+
 ### Run in progress panel
 
 If the selected run is currently in progress, an additional panel will be shown


### PR DESCRIPTION
Adds a use case to the cypress run --tag section showing how tags can
encode environment details that Cypress Cloud does not record on its own,
such as the Node.js version or browser, so matrix runs are easy to tell
apart.

Refs cypress-io/cypress#25581

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016JjT589dGSMpJ9MzLNe5xX

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no product or runtime behavior impact.
> 
> **Overview**
> Documents a **workaround for telling apart matrix runs** when Cypress Cloud does not store every CI detail (e.g. Node.js version).
> 
> The **`cypress run --tag`** section now explains tagging runs with values like `node-${nodeVersion}` so same-spec runs on different Node versions stay distinguishable in Cloud. The **Recorded Runs** run-header section adds a tip that browsers/OS/Cypress are shown in the header but other env details are not, and points readers to run tags to make them visible and filterable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4648ab77a104a8d26d668f8a5df05b247eeb1f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->