### PR TITLE
docs: clarify response body parsing when Content-Type header is absent

### DIFF
--- a/docs/api/commands/intercept.mdx
+++ b/docs/api/commands/intercept.mdx
@@ -1287,6 +1287,29 @@ modified:
 `Content-Type: application/json` and the body contains valid JSON, this will be
 an `object`. And if the body contains binary content, this will be a buffer.
 
+Cypress relies on the `Content-Type: application/json` header to decide whether
+to parse the body as JSON. If that header is absent, the body is yielded as a
+`string` even when it contains JSON. This commonly happens with responses that
+omit a `Content-Type` header — for example, a `304 Not Modified` response, which
+[per RFC 7232](https://datatracker.ietf.org/doc/html/rfc7232#section-4.1) is not
+expected to include representation metadata such as `Content-Type`, or a `301`
+redirect. When asserting on `response.body` for these responses, either assert
+against the string value or parse it yourself with `JSON.parse()`:
+
+```js
+cy.wait('@getResource').then(({ response }) => {
+  // when no `Content-Type: application/json` header is present,
+  // `response.body` is a string and must be parsed before
+  // asserting on its properties
+  const body =
+    typeof response.body === 'string'
+      ? JSON.parse(response.body)
+      : response.body
+
+  expect(body).to.have.property('id')
+})
+```
+
 `res` also has some optional properties which can be set to control
 Cypress-specific behavior:
 

--- a/docs/api/commands/intercept.mdx
+++ b/docs/api/commands/intercept.mdx
@@ -1290,7 +1290,7 @@ an `object`. And if the body contains binary content, this will be a buffer.
 Cypress relies on the `Content-Type: application/json` header to decide whether
 to parse the body as JSON. If that header is absent, the body is yielded as a
 `string` even when it contains JSON. This commonly happens with responses that
-omit a `Content-Type` header — for example, a `304 Not Modified` response, which
+omit a `Content-Type` header. For example, a `304 Not Modified` response, which
 [per RFC 7232](https://datatracker.ietf.org/doc/html/rfc7232#section-4.1) is not
 expected to include representation metadata such as `Content-Type`, or a `301`
 redirect. When asserting on `response.body` for these responses, either assert

--- a/docs/api/commands/wait.mdx
+++ b/docs/api/commands/wait.mdx
@@ -118,6 +118,17 @@ Pass in an options object to change the default behavior of `cy.wait()`.
 - `cy.wait()` 'yields an object containing the HTTP request and response
   properties of the request.
 
+:::info
+
+`response.body` is only parsed into an `object` when the response includes a
+`Content-Type: application/json` header. Responses that omit this header — such
+as a `304 Not Modified` or `301` redirect — yield `response.body` as a `string`.
+See
+[the note about `body`](/api/commands/intercept#Response-object-properties) in
+the `cy.intercept()` documentation for details and an example.
+
+:::
+
 ## Examples
 
 ### Time

--- a/docs/api/commands/wait.mdx
+++ b/docs/api/commands/wait.mdx
@@ -121,8 +121,8 @@ Pass in an options object to change the default behavior of `cy.wait()`.
 :::info
 
 `response.body` is only parsed into an `object` when the response includes a
-`Content-Type: application/json` header. Responses that omit this header — such
-as a `304 Not Modified` or `301` redirect — yield `response.body` as a `string`.
+`Content-Type: application/json` header. Responses that omit this header, such
+as a `304 Not Modified` or `301` redirect, yield `response.body` as a `string`.
 See
 [the note about `body`](/api/commands/intercept#Response-object-properties) in
 the `cy.intercept()` documentation for details and an example.


### PR DESCRIPTION
Document that cy.intercept()/cy.wait() only parse a response body into an
object when a Content-Type: application/json header is present. Responses
that omit the header (e.g. 304 Not Modified or 301 redirects) yield the
body as a string. Adds an example showing how to handle this case.

Addresses cypress-io/cypress#25544

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TfHcsEiAFSHoVx7NgEP3zg

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only clarification of existing network stubbing behavior; no product code or test runner changes.
> 
> **Overview**
> Documents that **`response.body`** from **`cy.intercept()`** / **`cy.wait()`** is only auto-parsed to an **`object`** when the response has **`Content-Type: application/json`**. Without that header (e.g. **304 Not Modified**, **301** redirects), the body stays a **`string`** even if it is JSON.
> 
> **`intercept.mdx`** expands the existing “Note about `body`” with RFC context and a **`cy.wait('@getResource')`** example that uses **`JSON.parse()`** when needed. **`wait.mdx`** adds an info callout under alias yields that points readers to that intercept section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4eb3b7246eaefc6bb294b70898ee6a99038bdf54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->