### PR TITLE
docs: clarify .within() always yields its original (parent) subject

### DIFF
--- a/docs/api/commands/within.mdx
+++ b/docs/api/commands/within.mdx
@@ -215,6 +215,7 @@ cy.get('.ag-header-cell')
 // ✓ Query the inner element directly so it becomes the yielded subject.
 cy.get('.ag-header-cell')
   .first()
+  // the input is now the yielded subject, so `.type()` operates on it
   .find('.ag-text-field-input')
   .type('hello')
 ```

--- a/docs/api/commands/within.mdx
+++ b/docs/api/commands/within.mdx
@@ -55,42 +55,9 @@ Pass in an options object to change the default behavior of `.within()`.
 
 <HeaderYields />
 
-- `.within()` yields the **same subject it was given** — the parent element the
-  callback is scoped to.
+- `.within()` yields the same subject it was given.
 - It is [unsafe](/app/core-concepts/retry-ability#Only-queries-are-retried)
   to chain further commands that rely on the subject after `.within()`.
-
-:::caution
-
-**`.within()` cannot be used to return an inner element.**
-
-The subject yielded by `.within()` is _always_ the original parent element. Any
-command you run, value you return, or [`cy.wrap()`](/api/commands/wrap) you call
-**inside** the callback has no effect on what `.within()` yields. This is true
-even when `.within()` is used inside a
-[custom command](/api/cypress-api/custom-commands) or when `.within()` blocks are
-nested.
-
-If you need to yield an element found inside the scope, query it _after_ the
-`.within()` block instead. For example, scope to the parent with
-[`.find()`](/api/commands/find) (or chain queries off the parent directly)
-rather than relying on `.within()` to hand back the inner element:
-
-```javascript
-// ✗ The inner `cy.get()` is NOT yielded — `.within()` yields the parent,
-// so chaining `.type()` operates on the wrong (parent) subject.
-cy.get('.ag-header-cell')
-  .first()
-  .within(() => {
-    cy.get('.ag-text-field-input')
-  })
-  .type('hello') // operates on `.ag-header-cell`, not the input
-
-// ✓ Query the inner element directly so it becomes the yielded subject.
-cy.get('.ag-header-cell').first().find('.ag-text-field-input').type('hello')
-```
-
-:::
 
 Trying to return a different element the `.within` callback have no effect:
 
@@ -215,6 +182,38 @@ cy.get('form').within(($form) => {
   cy.get('input[name="password"]').type('password')
   cy.root().submit()
 })
+```
+
+## Notes
+
+### Yielded Subject
+
+#### `.within()` cannot be used to return an inner element
+
+The subject yielded by `.within()` is _always_ the original parent element. Any
+command you run, value you return, or [`cy.wrap()`](/api/commands/wrap) you call
+**inside** the callback has no effect on what `.within()` yields. This is true
+even when `.within()` is used inside a
+[custom command](/api/cypress-api/custom-commands) or when `.within()` blocks are
+nested.
+
+If you need to yield an element found inside the scope, query it _after_ the
+`.within()` block instead. For example, scope to the parent with
+[`.find()`](/api/commands/find) (or chain queries off the parent directly)
+rather than relying on `.within()` to hand back the inner element:
+
+```javascript
+// ✗ The inner `cy.get()` is NOT yielded — `.within()` yields the parent,
+// so chaining `.type()` operates on the wrong (parent) subject.
+cy.get('.ag-header-cell')
+  .first()
+  .within(() => {
+    cy.get('.ag-text-field-input')
+  })
+  .type('hello') // operates on `.ag-header-cell`, not the input
+
+// ✓ Query the inner element directly so it becomes the yielded subject.
+cy.get('.ag-header-cell').first().find('.ag-text-field-input').type('hello')
 ```
 
 ## Rules

--- a/docs/api/commands/within.mdx
+++ b/docs/api/commands/within.mdx
@@ -55,9 +55,42 @@ Pass in an options object to change the default behavior of `.within()`.
 
 <HeaderYields />
 
-- `.within()` yields the same subject it was given.
+- `.within()` yields the **same subject it was given** — the parent element the
+  callback is scoped to.
 - It is [unsafe](/app/core-concepts/retry-ability#Only-queries-are-retried)
   to chain further commands that rely on the subject after `.within()`.
+
+:::caution
+
+**`.within()` cannot be used to return an inner element.**
+
+The subject yielded by `.within()` is _always_ the original parent element. Any
+command you run, value you return, or [`cy.wrap()`](/api/commands/wrap) you call
+**inside** the callback has no effect on what `.within()` yields. This is true
+even when `.within()` is used inside a
+[custom command](/api/cypress-api/custom-commands) or when `.within()` blocks are
+nested.
+
+If you need to yield an element found inside the scope, query it _after_ the
+`.within()` block instead. For example, scope to the parent with
+[`.find()`](/api/commands/find) (or chain queries off the parent directly)
+rather than relying on `.within()` to hand back the inner element:
+
+```javascript
+// ✗ The inner `cy.get()` is NOT yielded — `.within()` yields the parent,
+// so chaining `.type()` operates on the wrong (parent) subject.
+cy.get('.ag-header-cell')
+  .first()
+  .within(() => {
+    cy.get('.ag-text-field-input')
+  })
+  .type('hello') // operates on `.ag-header-cell`, not the input
+
+// ✓ Query the inner element directly so it becomes the yielded subject.
+cy.get('.ag-header-cell').first().find('.ag-text-field-input').type('hello')
+```
+
+:::
 
 Trying to return a different element the `.within` callback have no effect:
 

--- a/docs/api/commands/within.mdx
+++ b/docs/api/commands/within.mdx
@@ -213,7 +213,10 @@ cy.get('.ag-header-cell')
   .type('hello') // operates on `.ag-header-cell`, not the input
 
 // ✓ Query the inner element directly so it becomes the yielded subject.
-cy.get('.ag-header-cell').first().find('.ag-text-field-input').type('hello')
+cy.get('.ag-header-cell')
+  .first()
+  .find('.ag-text-field-input')
+  .type('hello')
 ```
 
 ## Rules


### PR DESCRIPTION
Document the behavior reported in cypress-io/cypress#8873: .within()
always yields the parent element it was scoped to, never an element
queried or returned inside the callback (including inside custom commands
or nested .within() blocks). Add a recommended pattern for yielding an
inner element by querying it after/outside the .within() block.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Rv4kraPuRaSHdWEWZWopX2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or API behavior changes.
> 
> **Overview**
> Adds a **Notes → Yielded Subject** section to the `cy.within()` docs explaining that the command **always yields the original parent element**, regardless of what runs inside the callback (including returns, `cy.wrap()`, custom commands, or nested `.within()` blocks).
> 
> Documents the **recommended workaround**: query the inner element **after** the `.within()` block (e.g. chain `.find()` on the parent) instead of expecting an inner `cy.get()` to become the yielded subject. Includes a concrete ✗/✓ example (AG Grid header cell vs text field input) showing why chaining `.type()` after `.within()` can target the wrong element.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9874a1792354aa399067b16a736a3a9f0ff2c89b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->