### PR TITLE
docs: clarify .type() into contenteditable must target the editable element

### DIFF
--- a/docs/api/commands/type.mdx
+++ b/docs/api/commands/type.mdx
@@ -438,6 +438,29 @@ cy.get('input[type=text]').type('Test all the things', { force: true })
   - `url`
   - `tel`
 
+### Contenteditable Elements
+
+`.type()` supports `contenteditable` elements, but you must target the element
+that actually has the `contenteditable` attribute, not one of its child nodes,
+and that element must be focusable. Targeting a child node causes `.type()` to
+fail because the child is not itself editable.
+
+A common fix is to [`.click()`](/api/commands/click) the editable element first
+to place the cursor, then chain `.type()`:
+
+```javascript
+// ✗ Targets a child node, which is not contenteditable
+cy.get('.editor p').type('Hello, World')
+
+// ✓ Targets the element with the contenteditable attribute
+cy.get('[contenteditable]').click().type('Hello, World')
+```
+
+Rich text editors such as CKEditor, Quill, Draft.js, and ProseMirror often
+manage their own selection and DOM. For these editors, clicking to place the
+cursor first (as shown above) or dispatching input through the editor's own API
+may be necessary.
+
 ### Actionability
 
 `.type()` is an "action command" that follows all the rules of

--- a/docs/api/commands/type.mdx
+++ b/docs/api/commands/type.mdx
@@ -446,14 +446,24 @@ and that element must be focusable. Targeting a child node causes `.type()` to
 fail because the child is not itself editable.
 
 A common fix is to [`.click()`](/api/commands/click) the editable element first
-to place the cursor, then chain `.type()`:
+to place the cursor, then [`.type()`](/api/commands/type) into it. Because
+`.click()` is an action command and not a
+[query](/app/core-concepts/retry-ability#Only-queries-are-retried), query the
+element again for `.type()` rather than chaining off `.click()`, so you act on a
+fresh, non-stale subject (the editor may re-render when it gains focus):
 
 ```javascript
 // ✗ Targets a child node, which is not contenteditable
 cy.get('.editor p').type('Hello, World')
 
-// ✓ Targets the element with the contenteditable attribute
+// ✗ Chains `.type()` off the `.click()` action command, acting on a
+// potentially stale subject
 cy.get('[contenteditable]').click().type('Hello, World')
+
+// ✓ Targets the element with the contenteditable attribute and requeries
+// it for `.type()`
+cy.get('[contenteditable]').click()
+cy.get('[contenteditable]').type('Hello, World')
 ```
 
 Rich text editors such as CKEditor, Quill, Draft.js, and ProseMirror often

--- a/docs/api/commands/type.mdx
+++ b/docs/api/commands/type.mdx
@@ -446,22 +446,13 @@ and that element must be focusable. Targeting a child node causes `.type()` to
 fail because the child is not itself editable.
 
 A common fix is to [`.click()`](/api/commands/click) the editable element first
-to place the cursor, then [`.type()`](/api/commands/type) into it. Because
-`.click()` is an action command and not a
-[query](/app/core-concepts/retry-ability#Only-queries-are-retried), query the
-element again for `.type()` rather than chaining off `.click()`, so you act on a
-fresh, non-stale subject (the editor may re-render when it gains focus):
+to place the cursor, then [`.type()`](/api/commands/type) into it:
 
 ```javascript
 // ✗ Targets a child node, which is not contenteditable
 cy.get('.editor p').type('Hello, World')
 
-// ✗ Chains `.type()` off the `.click()` action command, acting on a
-// potentially stale subject
-cy.get('[contenteditable]').click().type('Hello, World')
-
-// ✓ Targets the element with the contenteditable attribute and requeries
-// it for `.type()`
+// ✓ Targets the element with the contenteditable attribute
 cy.get('[contenteditable]').click()
 cy.get('[contenteditable]').type('Hello, World')
 ```


### PR DESCRIPTION
Document the behavior discussed in cypress-io/cypress#26525: .type()
supports contenteditable elements, but you must target the element that
actually has the contenteditable attribute (not a child node), and it
must be focusable. Add the common .click().type() fix and a note that
rich text editors (CKEditor, Quill, Draft.js, ProseMirror) manage their
own selection and may require clicking first or using the editor's API.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VeHfgbXnV2bCjaU9GN72KR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to `type.mdx`; no runtime or test behavior is modified.
> 
> **Overview**
> Adds a **Contenteditable Elements** section to the `cy.type()` docs (under **Notes**), clarifying behavior that was previously only implied by the supported-elements bullet and a minimal `[contenteditable]` example.
> 
> The new text states that `.type()` must target the node that carries `contenteditable` (not a child), that the element must be focusable, and why typing into a child fails. It documents the usual **click then type** pattern with wrong vs. right examples, and notes that rich text stacks (CKEditor, Quill, Draft.js, ProseMirror) may need focus via click or the editor’s own API because they manage selection/DOM themselves.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d99af89bd6cc8bdc8692aa39c2aab8228a387df5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->