### PR TITLE
docs: fix custom dev server client script for onSpecWindow

### DIFF
--- a/docs/app/component-testing/component-framework-configuration.mdx
+++ b/docs/app/component-testing/component-framework-configuration.mdx
@@ -410,7 +410,10 @@ const devServerPublicPathRoute = CypressInstance.config(
   'devServerPublicPathRoute'
 )
 
-let importPromise = Promise.resolve()
+// `onSpecWindow` expects an array of functions that each return a dynamic
+// `import()`. Cypress invokes them in order, so the support file (if any)
+// must be added before the spec.
+const importsToLoad = []
 
 // If you do not bundle your support file along with the tests,
 // you need to add a separate import statement for the support file.
@@ -420,19 +423,15 @@ if (supportFilePath) {
     CypressInstance.config('projectRoot'),
     ''
   )
-  importPromise = importPromise.then(
-    () => import(`${devServerPublicPathRoute}${relative}`)
-  )
+  importsToLoad.push(() => import(`${devServerPublicPathRoute}${relative}`))
 }
 
 // load the spec - you can extend the load function to also load css
 const { relative } = CypressInstance.spec
-importPromise = importPromise.then(
-  () => import(`${devServerPublicPathRoute}/${relative}`)
-)
+importsToLoad.push(() => import(`${devServerPublicPathRoute}/${relative}`))
 
 // trigger loading the imports
-CypressInstance.onSpecWindow(window, importPromise)
+CypressInstance.onSpecWindow(window, importsToLoad)
 
 // then start the test process
 CypressInstance.action('app:window:before:load', window)

--- a/docs/app/component-testing/styling-components.mdx
+++ b/docs/app/component-testing/styling-components.mdx
@@ -323,6 +323,40 @@ Or via an `@import` statement
 }
 ```
 
+When fonts are loaded from local files like this, the files must be served by
+your component testing dev server so the browser can fetch them. Where you place
+the files and how you reference them depends on your bundler:
+
+- **Vite**: Put the font files in your project's
+  [`public` directory](https://vite.dev/guide/assets#the-public-directory)
+  (`public/` by default) and reference them with root-relative paths, for
+  example `url('/fonts/fira/woff2/FiraSans-Regular.woff2')`. Cypress sets Vite's
+  `base` to match its
+  [`devServerPublicPathRoute`](/app/component-testing/component-framework-configuration#devServerPublicPathRoute),
+  and Vite rewrites these paths and serves the files accordingly.
+
+- **Webpack**: `webpack-dev-server` does not serve a static directory by
+  default. Either `import` the font from a module so the bundler emits it, or add
+  a [`static`](https://webpack.js.org/configuration/dev-server/#devserverstatic)
+  entry to the `devServer` section of your webpack config so the files are
+  served:
+
+  ```js
+  // webpack.config.js
+  const path = require('path')
+
+  module.exports = {
+    devServer: {
+      static: {
+        directory: path.join(__dirname, 'public'),
+      },
+    },
+  }
+  ```
+
+If your fonts are not loading, open the browser's network tab and confirm the
+request for the font file resolves rather than returning a 404.
+
 ### Icon Fonts: None of my icons are rendering
 
 ### Theme Providers: My components don't look right/compile because they can't access providers


### PR DESCRIPTION
The "Fully Custom Dev Server" client-script example passed a chained
Promise to CypressInstance.onSpecWindow(). The runtime (script_utils
runScripts) expects scripts to be an array and inspects scripts[0];
a Promise has no length/index, so the support file and spec are never
loaded and tests hang at "Your tests are loading...".

Pass an array of import thunks instead, matching the actual vite-dev-server
and webpack-dev-server client implementations.

Refs cypress-io/cypress#32495

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019M5ySKeMFGTKnoMza4ip9S

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or configuration behavior changes in the product.
> 
> **Overview**
> Fixes the **Fully Custom Dev Server** client-script example so it matches how Cypress actually loads specs: `onSpecWindow` takes an **array of import thunks**, not a chained `Promise`, so support and spec modules load in order instead of hanging at “Your tests are loading…”.
> 
> Adds troubleshooting for **local `@font-face` fonts** in component tests—where to put files and how to serve them with **Vite** (`public/` + root-relative URLs) and **Webpack** (`devServer.static` or module imports)—plus a note to check the network tab for 404s.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13670cbf089528bdb9a18bfae6c630b2a0fe526d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->