### PR TITLE
docs: document inverted selection of cy.contains()

### DIFF
--- a/docs/api/commands/contains.mdx
+++ b/docs/api/commands/contains.mdx
@@ -225,6 +225,31 @@ cy.get('div').contains('capital sentence', { matchCase: false }) // pass
 
 ## Notes
 
+### Inverting `cy.contains()`
+
+`cy.contains()` has no built-in negation, so there is no way to ask it directly
+for the elements that do _not_ contain a piece of text. Instead, select the full
+set of elements and remove the matching ones with
+[`.not()`](/api/commands/not) and the
+[jQuery :contains](https://api.jquery.com/contains-selector/) selector.
+
+```html
+<ul>
+  <li>Test: Name</li>
+  <li>Test: Name (1)</li>
+  <li>Test: Name (2)</li>
+  <li>Test: Name (3)</li>
+</ul>
+```
+
+```javascript
+// yields only <li>Test: Name</li>, the item without a numeric suffix
+cy.get('li').not(':contains("(")')
+```
+
+See [`.not()`](/api/commands/not) and [`.filter()`](/api/commands/filter) for
+more inverted-selection examples.
+
 ### Scopes
 
 `.contains()` acts differently whether it's starting a series of commands or
@@ -508,6 +533,8 @@ outputs the following:
 ## See also
 
 - [`cy.get()`](/api/commands/get)
+- [`.filter()`](/api/commands/filter)
 - [`.invoke()`](/api/commands/invoke)
+- [`.not()`](/api/commands/not)
 - [`.within()`](/api/commands/within)
 - [Retry-ability](/app/core-concepts/retry-ability)

--- a/docs/api/commands/contains.mdx
+++ b/docs/api/commands/contains.mdx
@@ -227,28 +227,7 @@ cy.get('div').contains('capital sentence', { matchCase: false }) // pass
 
 ### Inverting `cy.contains()`
 
-`cy.contains()` has no built-in negation, so there is no way to ask it directly
-for the elements that do _not_ contain a piece of text. Instead, select the full
-set of elements and remove the matching ones with
-[`.not()`](/api/commands/not) and the
-[jQuery :contains](https://api.jquery.com/contains-selector/) selector.
-
-```html
-<ul>
-  <li>Test: Name</li>
-  <li>Test: Name (1)</li>
-  <li>Test: Name (2)</li>
-  <li>Test: Name (3)</li>
-</ul>
-```
-
-```javascript
-// yields only <li>Test: Name</li>, the item without a numeric suffix
-cy.get('li').not(':contains("(")')
-```
-
-See [`.not()`](/api/commands/not) and [`.filter()`](/api/commands/filter) for
-more inverted-selection examples.
+<InvertedContainsSelection />
 
 ### Scopes
 

--- a/docs/api/commands/intercept.mdx
+++ b/docs/api/commands/intercept.mdx
@@ -283,8 +283,7 @@ cy.intercept({ url: '/temporary-error', times: 1 }, { forceNetworkError: true })
 
 The `query` matcher compares each query parameter against a single string value,
 so it cannot match repeated, array-style parameters such as
-`?ids[]=1&ids[]=2` (commonly produced by libraries like axios). The following
-will _not_ match that request:
+`?ids[]=1&ids[]=2`. The following will _not_ match that request:
 
 ```js
 // 🚫 does not work - the array parameter is ignored

--- a/docs/api/commands/intercept.mdx
+++ b/docs/api/commands/intercept.mdx
@@ -279,6 +279,43 @@ cy.intercept(
 cy.intercept({ url: '/temporary-error', times: 1 }, { forceNetworkError: true })
 ```
 
+### Matching array query parameters
+
+The `query` matcher compares each query parameter against a single string value,
+so it cannot match repeated, array-style parameters such as
+`?ids[]=1&ids[]=2` (commonly produced by libraries like axios). The following
+will _not_ match that request:
+
+```js
+// 🚫 does not work - the array parameter is ignored
+cy.intercept({
+  pathname: '/items',
+  query: {
+    ids: '1',
+  },
+})
+```
+
+Instead, match the request with a `RegExp` `url`, or use a
+[`routeHandler`](#routeHandler-Function) function and read the repeated values
+with [`URLSearchParams.getAll()`](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/getAll):
+
+```js
+// match any request to `/items` that includes an `ids` parameter
+cy.intercept({ method: 'GET', url: /\/items\?.*ids/ }).as('items')
+```
+
+```js
+// inspect every `ids` value and only stub when `1` is present
+cy.intercept('/items*', (req) => {
+  const ids = new URL(req.url).searchParams.getAll('ids[]')
+
+  if (ids.includes('1')) {
+    req.reply({ fixture: 'items.json' })
+  }
+}).as('items')
+```
+
 ### Pattern Matching
 
 ```js

--- a/docs/api/commands/not.mdx
+++ b/docs/api/commands/not.mdx
@@ -86,6 +86,39 @@ Pass in an options object to change the default behavior of `.not()`.
 cy.get('ul>li').not('.active').should('have.length', 4) // true
 ```
 
+### Contains
+
+#### Yield the elements that do not contain some text
+
+There is no built-in negation for [`cy.contains()`](/api/commands/contains). To
+select the elements that do _not_ contain a piece of text, select the full set
+of elements and then remove the matching ones with the
+[jQuery :contains](https://api.jquery.com/contains-selector/) selector. The
+match is a case-sensitive substring match.
+
+```html
+<ul>
+  <li>Test: Name</li>
+  <li>Test: Name (1)</li>
+  <li>Test: Name (2)</li>
+  <li>Test: Name (3)</li>
+</ul>
+```
+
+```javascript
+// yields only <li>Test: Name</li>, the item without a numeric suffix
+cy.get('li').not(':contains("(")').should('have.length', 1)
+```
+
+The same approach works with [`.filter()`](/api/commands/filter) and the
+[:not()](https://api.jquery.com/not-selector/) selector when you would rather
+keep a positive filter:
+
+```javascript
+// yields the rows that are not disabled
+cy.get('tr').filter(':not(.disabled)')
+```
+
 ## Rules
 
 <HeaderRequirements />
@@ -131,4 +164,5 @@ following:
 
 ## See also
 
+- [`cy.contains()`](/api/commands/contains)
 - [`.filter()`](/api/commands/filter)

--- a/docs/api/commands/not.mdx
+++ b/docs/api/commands/not.mdx
@@ -90,34 +90,7 @@ cy.get('ul>li').not('.active').should('have.length', 4) // true
 
 #### Yield the elements that do not contain some text
 
-There is no built-in negation for [`cy.contains()`](/api/commands/contains). To
-select the elements that do _not_ contain a piece of text, select the full set
-of elements and then remove the matching ones with the
-[jQuery :contains](https://api.jquery.com/contains-selector/) selector. The
-match is a case-sensitive substring match.
-
-```html
-<ul>
-  <li>Test: Name</li>
-  <li>Test: Name (1)</li>
-  <li>Test: Name (2)</li>
-  <li>Test: Name (3)</li>
-</ul>
-```
-
-```javascript
-// yields only <li>Test: Name</li>, the item without a numeric suffix
-cy.get('li').not(':contains("(")').should('have.length', 1)
-```
-
-The same approach works with [`.filter()`](/api/commands/filter) and the
-[:not()](https://api.jquery.com/not-selector/) selector when you would rather
-keep a positive filter:
-
-```javascript
-// yields the rows that are not disabled
-cy.get('tr').filter(':not(.disabled)')
-```
+<InvertedContainsSelection />
 
 ## Rules
 

--- a/docs/api/commands/origin.mdx
+++ b/docs/api/commands/origin.mdx
@@ -645,7 +645,10 @@ closure, so it has no access to variables defined or imported outside it (see
 arrives without its methods.
 
 Instead, import the page object _inside_ the callback with `Cypress.require()`
-and instantiate it there:
+and instantiate it there. As with any use of `Cypress.require()` in a callback,
+this requires enabling the
+[`experimentalOriginDependencies`](/app/references/experiments) option in your
+Cypress configuration (see [Dependencies / Sharing Code](#Dependencies--Sharing-Code)).
 
 <Tabs>
 <TabItem value="cypress/support/LoginPage.js">

--- a/docs/api/commands/origin.mdx
+++ b/docs/api/commands/origin.mdx
@@ -638,18 +638,17 @@ it('also uses cy.origin() + custom command', () => {
 
 #### Page objects
 
-A common question is how to use [Page Object](https://martinfowler.com/bliki/PageObject.html)
-class methods inside `cy.origin()`. You cannot pass a class instance into the
-callback: closures from the outer scope are not available (see
-[Serialization](#Serialization)), and the
-[structured clone algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm)
-used for the `args` option cannot transfer functions or class methods, so a page
-object passed through `args` arrives stripped of its methods.
+A common question is how to use Page Object class methods inside `cy.origin()`.
+You cannot pass a class instance into the callback: the callback is not a
+closure, so it has no access to variables defined or imported outside it (see
+[Serialization](#Serialization)), and a class passed through the `args` option
+arrives without its methods.
 
 Instead, import the page object _inside_ the callback with `Cypress.require()`
 and instantiate it there:
 
-`cypress/support/LoginPage.js`:
+<Tabs>
+<TabItem value="cypress/support/LoginPage.js">
 
 ```js
 export class LoginPage {
@@ -663,7 +662,26 @@ export class LoginPage {
 }
 ```
 
-`cypress/e2e/spec.cy.js`:
+</TabItem>
+<TabItem value="cypress/support/LoginPage.ts">
+
+```ts
+export class LoginPage {
+  fillUsername(username: string) {
+    cy.get('[data-test-id="username"]').type(username)
+  }
+
+  fillPassword(password: string) {
+    cy.get('[data-test-id="password"]').type(password)
+  }
+}
+```
+
+</TabItem>
+</Tabs>
+
+<Tabs>
+<TabItem value="cypress/e2e/spec.cy.js">
 
 ```js
 it('logs in on a secondary origin', () => {
@@ -681,6 +699,29 @@ it('logs in on a secondary origin', () => {
   )
 })
 ```
+
+</TabItem>
+<TabItem value="cypress/e2e/spec.cy.ts">
+
+```ts
+it('logs in on a secondary origin', () => {
+  cy.origin(
+    'cypress.io',
+    { args: { username, password } },
+    ({ username, password }) => {
+      const { LoginPage } = Cypress.require('../support/LoginPage')
+      const loginPage = new LoginPage()
+
+      cy.visit('/login')
+      loginPage.fillUsername(username)
+      loginPage.fillPassword(password)
+    }
+  )
+})
+```
+
+</TabItem>
+</Tabs>
 
 Any data the methods need, such as the credentials above, is still passed in
 through the `args` option as serializable values.

--- a/docs/api/commands/origin.mdx
+++ b/docs/api/commands/origin.mdx
@@ -636,6 +636,72 @@ it('also uses cy.origin() + custom command', () => {
 })
 ```
 
+#### Page objects
+
+A common question is how to use [Page Object](https://martinfowler.com/bliki/PageObject.html)
+class methods inside `cy.origin()`. You cannot pass a class instance into the
+callback: closures from the outer scope are not available (see
+[Serialization](#Serialization)), and the
+[structured clone algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm)
+used for the `args` option cannot transfer functions or class methods, so a page
+object passed through `args` arrives stripped of its methods.
+
+Instead, import the page object _inside_ the callback with `Cypress.require()`
+and instantiate it there:
+
+`cypress/support/LoginPage.js`:
+
+```js
+export class LoginPage {
+  fillUsername(username) {
+    cy.get('[data-test-id="username"]').type(username)
+  }
+
+  fillPassword(password) {
+    cy.get('[data-test-id="password"]').type(password)
+  }
+}
+```
+
+`cypress/e2e/spec.cy.js`:
+
+```js
+it('logs in on a secondary origin', () => {
+  cy.origin(
+    'cypress.io',
+    { args: { username, password } },
+    ({ username, password }) => {
+      const { LoginPage } = Cypress.require('../support/LoginPage')
+      const loginPage = new LoginPage()
+
+      cy.visit('/login')
+      loginPage.fillUsername(username)
+      loginPage.fillPassword(password)
+    }
+  )
+})
+```
+
+Any data the methods need, such as the credentials above, is still passed in
+through the `args` option as serializable values.
+
+If you would rather not import the class, pass only the serializable data the
+page object holds, such as a map of selectors, through `args` and call the
+Cypress commands directly inside the callback:
+
+```js
+import selectors from '../support/selectors.json'
+
+cy.origin(
+  'cypress.io',
+  { args: { selectors, username } },
+  ({ selectors, username }) => {
+    cy.visit('/login')
+    cy.get(selectors.username).type(username)
+  }
+)
+```
+
 ### Callback restrictions
 
 Because of the way in which the callback is transmitted and executed, there are

--- a/docs/api/commands/session.mdx
+++ b/docs/api/commands/session.mdx
@@ -458,6 +458,28 @@ it('can create a blog post', () => {
 })
 ```
 
+:::caution
+
+When a session is cached across specs, every spec that uses it must call
+`cy.session()` with the **same** `id`, `setup`, `validate`, and
+`cacheAcrossSpecs` value. If any of these differ between specs, Cypress throws an
+error rather than reusing the session. For this reason, define the session once
+in a shared custom command or helper function (as in the example above) and call
+that everywhere, rather than copying the `cy.session()` call into each spec.
+
+:::
+
+:::info
+
+The cross-spec cache lives in memory for a single `cypress run` on a single
+machine. It is not written to disk and is not shared between machines, so:
+
+- A new `cypress run` starts with an empty cache and runs `setup` again.
+- When specs are split across machines in parallel CI, `setup` runs at least
+  once per machine.
+
+:::
+
 ### Multiple login commands
 
 A more complex app may require multiple login commands, which may require

--- a/docs/api/commands/session.mdx
+++ b/docs/api/commands/session.mdx
@@ -469,16 +469,12 @@ that everywhere, rather than copying the `cy.session()` call into each spec.
 
 :::
 
-:::info
-
 The cross-spec cache lives in memory for a single `cypress run` on a single
 machine. It is not written to disk and is not shared between machines, so:
 
 - A new `cypress run` starts with an empty cache and runs `setup` again.
 - When specs are split across machines in parallel CI, `setup` runs at least
   once per machine.
-
-:::
 
 ### Multiple login commands
 

--- a/docs/app/component-testing/angular/overview.mdx
+++ b/docs/app/component-testing/angular/overview.mdx
@@ -146,7 +146,7 @@ Cypress builds your component specs with the Angular build pipeline. When you do
 (including `assets`, `styles`, and `stylePreprocessorOptions`) from the default
 application project in your `angular.json`. When you **do** provide your own
 [`projectConfig`](#Options-API), it _replaces_ the configuration Cypress detects
-from `angular.json` — so any build options your styles rely on must be repeated
+from `angular.json`, so any build options your styles rely on must be repeated
 in your `buildOptions`. The two issues below are usually a result of this.
 
 ### Sass `@use` / `@import` can't find a stylesheet
@@ -194,12 +194,12 @@ resolve the imports:
 
 ### Tailwind CSS v4 utility classes aren't applied
 
-With [Tailwind CSS v4](https://tailwindcss.com/blog/tailwindcss-v4), you may find
-that your own styles load correctly but Tailwind utility classes such as
-`bg-red-500` have no effect — the class is present on the element in the DevTools
-inspector, but no rule is generated for it. This is because Tailwind v4 generates
-utilities through its own build plugin, which is not part of the Angular build
-pipeline Cypress uses to compile your `styles`.
+With Tailwind CSS v4, you may find that your own styles load correctly but
+Tailwind utility classes such as `bg-red-500` have no effect. The class is
+present on the element in the DevTools inspector, but no rule is generated for
+it. This is because Tailwind v4 generates utilities through its own build
+plugin, which is not part of the Angular build pipeline Cypress uses to compile
+your `styles`.
 
 A reliable workaround is to precompile your Tailwind stylesheet into a plain CSS
 file with the [Tailwind CLI](https://tailwindcss.com/docs/installation/tailwind-cli)
@@ -207,9 +207,39 @@ and load that compiled file through `buildOptions.styles`.
 
 Install the CLI:
 
+<Tabs>
+  <TabItem value="npm">
+
 ```shell
 npm install -D @tailwindcss/cli
 ```
+
+  </TabItem>
+
+  <TabItem value="yarn">
+
+```shell
+yarn add -D @tailwindcss/cli
+```
+
+  </TabItem>
+
+  <TabItem value="pnpm">
+
+```shell
+pnpm add -D @tailwindcss/cli
+```
+
+  </TabItem>
+
+  <TabItem value="bun">
+
+```shell
+bun add -d @tailwindcss/cli
+```
+
+  </TabItem>
+</Tabs>
 
 Compile your stylesheet before opening or running Cypress, then point
 `buildOptions.styles` at the compiled output:

--- a/docs/app/component-testing/angular/overview.mdx
+++ b/docs/app/component-testing/angular/overview.mdx
@@ -156,7 +156,7 @@ If your Sass resolves imports through paths configured in `angular.json` under
 testing like:
 
 ```
-Can't find stylesheet to import.
+❌ Can't find stylesheet to import.
 @use 'mixins'
 ```
 
@@ -164,20 +164,33 @@ This happens when a custom `projectConfig` omits those include paths. Add the
 same `stylePreprocessorOptions` to your `buildOptions` so the Sass compiler can
 resolve the imports:
 
-```ts title=cypress.config.ts
-options: {
-  projectConfig: {
-    root: '',
-    sourceRoot: 'src',
-    buildOptions: {
-      styles: ['src/styles.scss'],
-      stylePreprocessorOptions: {
-        includePaths: ['src/styles'],
+:::cypress-config-example
+
+```ts
+{
+  component: {
+    devServer: {
+      framework: 'angular',
+      bundler: 'webpack',
+      options: {
+        projectConfig: {
+          root: '',
+          sourceRoot: 'src',
+          buildOptions: {
+            styles: ['src/styles.scss'],
+            stylePreprocessorOptions: {
+              includePaths: ['src/styles'],
+            },
+          },
+        },
       },
     },
+    specPattern: '**/*.cy.ts',
   },
-},
+}
 ```
+
+:::
 
 ### Tailwind CSS v4 utility classes aren't applied
 
@@ -211,15 +224,28 @@ Compile your stylesheet before opening or running Cypress, then point
 }
 ```
 
-```ts title=cypress.config.ts
-options: {
-  projectConfig: {
-    buildOptions: {
-      styles: ['cypress/support/compiled-styles.css'],
+:::cypress-config-example
+
+```ts
+{
+  component: {
+    devServer: {
+      framework: 'angular',
+      bundler: 'webpack',
+      options: {
+        projectConfig: {
+          buildOptions: {
+            styles: ['cypress/support/compiled-styles.css'],
+          },
+        },
+      },
     },
+    specPattern: '**/*.cy.ts',
   },
-},
+}
 ```
+
+:::
 
 ## See also
 

--- a/docs/app/component-testing/angular/overview.mdx
+++ b/docs/app/component-testing/angular/overview.mdx
@@ -139,6 +139,88 @@ export default {
 - [Angular 20 Standalone](https://github.com/cypress-io/cypress-component-testing-apps/tree/main/angular-standalone)
 - [Angular 21 Zoneless](https://github.com/cypress-io/cypress-component-testing-apps/tree/main/angular-zoneless)
 
+## Styling
+
+Cypress builds your component specs with the Angular build pipeline. When you do
+**not** provide an `options.projectConfig`, Cypress reads the build options
+(including `assets`, `styles`, and `stylePreprocessorOptions`) from the default
+application project in your `angular.json`. When you **do** provide your own
+[`projectConfig`](#Options-API), it _replaces_ the configuration Cypress detects
+from `angular.json` — so any build options your styles rely on must be repeated
+in your `buildOptions`. The two issues below are usually a result of this.
+
+### Sass `@use` / `@import` can't find a stylesheet
+
+If your Sass resolves imports through paths configured in `angular.json` under
+`stylePreprocessorOptions.includePaths`, you may see an error during component
+testing like:
+
+```
+Can't find stylesheet to import.
+@use 'mixins'
+```
+
+This happens when a custom `projectConfig` omits those include paths. Add the
+same `stylePreprocessorOptions` to your `buildOptions` so the Sass compiler can
+resolve the imports:
+
+```ts title=cypress.config.ts
+options: {
+  projectConfig: {
+    root: '',
+    sourceRoot: 'src',
+    buildOptions: {
+      styles: ['src/styles.scss'],
+      stylePreprocessorOptions: {
+        includePaths: ['src/styles'],
+      },
+    },
+  },
+},
+```
+
+### Tailwind CSS v4 utility classes aren't applied
+
+With [Tailwind CSS v4](https://tailwindcss.com/blog/tailwindcss-v4), you may find
+that your own styles load correctly but Tailwind utility classes such as
+`bg-red-500` have no effect — the class is present on the element in the DevTools
+inspector, but no rule is generated for it. This is because Tailwind v4 generates
+utilities through its own build plugin, which is not part of the Angular build
+pipeline Cypress uses to compile your `styles`.
+
+A reliable workaround is to precompile your Tailwind stylesheet into a plain CSS
+file with the [Tailwind CLI](https://tailwindcss.com/docs/installation/tailwind-cli)
+and load that compiled file through `buildOptions.styles`.
+
+Install the CLI:
+
+```shell
+npm install -D @tailwindcss/cli
+```
+
+Compile your stylesheet before opening or running Cypress, then point
+`buildOptions.styles` at the compiled output:
+
+```json title=package.json
+{
+  "scripts": {
+    "build:ct-styles": "npx @tailwindcss/cli -i ./src/styles.scss -o ./cypress/support/compiled-styles.css",
+    "cypress:open": "npm run build:ct-styles && cypress open --component",
+    "cypress:run": "npm run build:ct-styles && cypress run --component"
+  }
+}
+```
+
+```ts title=cypress.config.ts
+options: {
+  projectConfig: {
+    buildOptions: {
+      styles: ['cypress/support/compiled-styles.css'],
+    },
+  },
+},
+```
+
 ## See also
 
 - [Component Testing code coverage](/app/tooling/code-coverage#component-testing-code-coverage)

--- a/docs/app/tooling/reporters.mdx
+++ b/docs/app/tooling/reporters.mdx
@@ -150,6 +150,16 @@ npx cypress run --reporter junit \
   --reporter-options "mochaFile=results/my-test-output.xml,toConsole=true"
 ```
 
+:::caution
+
+When running multiple spec files, a static `mochaFile` name like
+`results/my-test-output.xml` is **overwritten by each spec**, so the final
+report only contains the results from the last spec that ran. Use the `[hash]`
+token to write one file per spec, then merge them. See
+[Merging reports across spec files](#Merging-reports-across-spec-files) below.
+
+:::
+
 ## Merging reports across spec files
 
 Each spec file is processed completely separately during each `cypress run`
@@ -158,9 +168,11 @@ unique reports for each specfile, use the `[hash]` in the `mochaFile` filename.
 
 The following configuration will create separate XML files in the `results`
 folder. You can then merge the reported output in a separate step using a 3rd
-party tool. For example, for the
-[Mochawesome](https://github.com/adamgruber/mochawesome) reporter, you can use
-the [mochawesome-merge](https://github.com/antontelesh/mochawesome-merge) tool.
+party tool. For JUnit XML reports, you can use
+[junit-report-merger](https://www.npmjs.com/package/junit-report-merger), and
+for the [Mochawesome](https://github.com/adamgruber/mochawesome) reporter, you
+can use the
+[mochawesome-merge](https://github.com/antontelesh/mochawesome-merge) tool.
 
 #### Cypress configuration
 

--- a/docs/partials/_inverted-contains-selection.mdx
+++ b/docs/partials/_inverted-contains-selection.mdx
@@ -1,0 +1,29 @@
+There is no built-in negation for [`cy.contains()`](/api/commands/contains), so
+there is no way to ask it directly for the elements that do _not_ contain a
+piece of text. Instead, select the full set of elements and remove the matching
+ones with [`.not()`](/api/commands/not) and the
+[jQuery :contains](https://api.jquery.com/contains-selector/) selector. The
+match is a case-sensitive substring match.
+
+```html
+<ul>
+  <li>Test: Name</li>
+  <li>Test: Name (1)</li>
+  <li>Test: Name (2)</li>
+  <li>Test: Name (3)</li>
+</ul>
+```
+
+```javascript
+// yields only <li>Test: Name</li>, the item without a numeric suffix
+cy.get('li').not(':contains("(")')
+```
+
+The same approach works with [`.filter()`](/api/commands/filter) and the
+[:not()](https://api.jquery.com/not-selector/) selector when you would rather
+keep a positive filter:
+
+```javascript
+// yields the rows that are not disabled
+cy.get('tr').filter(':not(.disabled)')
+```

--- a/src/theme/MDXComponents.js
+++ b/src/theme/MDXComponents.js
@@ -32,6 +32,7 @@ import HeaderYields from '@site/docs/partials/_header-yields.mdx'
 import Icon from '@site/src/components/icon'
 import ImportMountFunctions from '@site/docs/partials/_import-mount-functions.mdx'
 import IntellisenseCodeCompletion from '@site/docs/partials/_intellisense-code-completion.mdx'
+import InvertedContainsSelection from '@site/docs/partials/_inverted-contains-selection.mdx'
 import ProductHeading from '@site/src/components/product-heading'
 import Profiles from '@site/docs/partials/_profiles.mdx'
 import SignificantAttributes from '@site/docs/partials/_significantattributes.mdx'
@@ -203,6 +204,7 @@ export default {
   Icon,
   ImportMountFunctions,
   IntellisenseCodeCompletion,
+  InvertedContainsSelection,
   ProductHeading,
   Profiles,
   SignificantAttributes,


### PR DESCRIPTION
Add examples for selecting elements that do not contain text using
.not(':contains(...)') and .filter(':not(...)'), addressing
cypress-io/cypress discussion #15659.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TesW5DnynAHPoBwXpCeBwH

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and MDX partial registration only; no Cypress runtime or test behavior changes.
> 
> **Overview**
> **Docs expand beyond inverted `cy.contains()`** with a shared partial (`InvertedContainsSelection`) on **`contains`** and **`not`**, plus cross-links between those commands and **`.filter()`**.
> 
> **`cy.intercept`** gains a section on **array-style query params** (`?ids[]=1&ids[]=2`): why the `query` matcher fails and how to match with a **`RegExp` `url`** or a **`routeHandler`** using **`URLSearchParams.getAll()`**.
> 
> **`cy.origin`** documents **page objects** inside the callback via **`Cypress.require()`** (and a selectors-via-`args` alternative), with **`experimentalOriginDependencies`** called out.
> 
> **`cy.session`** adds cautions for **`cacheAcrossSpecs`**: identical session definitions across specs and in-memory / per-machine cache behavior in CI.
> 
> **Angular component testing** adds a **Styling** section: custom **`projectConfig`** replacing `angular.json` options, **Sass `includePaths`**, and **Tailwind v4** precompile-via-CLI workaround.
> 
> **Reporters** warns that a static **`mochaFile`** is overwritten per spec and points to **`[hash]`** plus **`junit-report-merger`** for JUnit merges.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6555ce2fc1bad363d42bce7cd8c03c77416a7dd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->