### PR TITLE
docs: clarify resolving import path aliases in tests

### DIFF
--- a/docs/api/node-events/preprocessors-api.mdx
+++ b/docs/api/node-events/preprocessors-api.mdx
@@ -60,6 +60,72 @@ Editing the options allows you to do things like:
 - Modify options for TypeScript compilation
 - Add support for CoffeeScript `2.x.x`
 
+## Resolving import path aliases
+
+If your spec or support files import modules through path aliases (for example
+`import { user } from '@/fixtures/user'`), the preprocessor that bundles those
+files must know how to resolve the alias, otherwise the spec fails to compile
+with a "module not found" error.
+
+The default webpack preprocessor does **not** read aliases from your
+`package.json` `_moduleAliases` field, and it does **not** automatically apply
+the `compilerOptions.paths` from your `tsconfig.json` (those are a TypeScript
+type-checking feature, not a bundler feature). You need to tell the bundler about
+the aliases explicitly.
+
+The most direct option is to add a `resolve.alias` entry to the webpack config
+you pass to the preprocessor:
+
+:::cypress-config-plugin-example
+
+```javascript
+const webpackPreprocessor = require('@cypress/webpack-preprocessor')
+const path = require('path')
+
+const options = webpackPreprocessor.defaultOptions
+options.webpackOptions.resolve = {
+  ...options.webpackOptions.resolve,
+  alias: {
+    '@': path.resolve(__dirname, '../../src'),
+  },
+}
+
+on('file:preprocessor', webpackPreprocessor(options))
+```
+
+:::
+
+To reuse the aliases already declared under `compilerOptions.paths` in your
+`tsconfig.json` instead of restating them, add
+[`tsconfig-paths-webpack-plugin`](https://www.npmjs.com/package/tsconfig-paths-webpack-plugin)
+to `resolve.plugins`:
+
+:::cypress-config-plugin-example
+
+```javascript
+const webpackPreprocessor = require('@cypress/webpack-preprocessor')
+const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin')
+
+const options = webpackPreprocessor.defaultOptions
+options.webpackOptions.resolve = {
+  ...options.webpackOptions.resolve,
+  plugins: [new TsconfigPathsPlugin()],
+}
+
+on('file:preprocessor', webpackPreprocessor(options))
+```
+
+:::
+
+:::info
+
+This page covers aliases in **end-to-end** spec and support files, which are
+bundled by the preprocessor. For **component testing**, aliases are resolved by
+the dev server's Vite or Webpack config instead. See
+[Resolving import path aliases](/app/component-testing/component-framework-configuration#Resolving-import-path-aliases).
+
+:::
+
 ## Excluding files from being watched
 
 Certain tools generate files as a side effect of a build (for example,

--- a/docs/app/component-testing/component-framework-configuration.mdx
+++ b/docs/app/component-testing/component-framework-configuration.mdx
@@ -195,6 +195,85 @@ import webpackConfig from './webpack.config'
 
 :::
 
+### Resolving import path aliases
+
+If your components import modules through path aliases (for example
+`import Button from '@/components/Button'` or `import { api } from '~/lib/api'`),
+those aliases must be resolvable by the bundler Cypress uses, otherwise the spec
+fails to compile with a "module not found" (or "failed to resolve import")
+error.
+
+Cypress does **not** define any aliases of its own. It resolves them exactly the
+way your dev server does, using the bundler config it detects or the one you pass
+in:
+
+- **Vite**: aliases come from the `resolve.alias` of the `vite.config` Cypress
+  detects, or the `viteConfig` you pass to `devServer`.
+- **Webpack**: aliases come from the `resolve.alias` of the `webpack.config`
+  Cypress detects, or the `webpackConfig` you pass to `devServer`.
+
+So if your aliases are declared in a standalone `vite.config` or `webpack.config`
+at (or above) your project root, Cypress picks them up automatically and no extra
+configuration is needed.
+
+#### Meta-frameworks that own the bundler config
+
+Some meta-frameworks (such as **Nuxt**) configure Vite internally rather than
+through a standalone `vite.config` file. Cypress only reads a discoverable
+`vite.config`/`webpack.config`. It does **not** execute `nuxt.config` (or
+similar) to extract the bundler settings those frameworks generate at runtime.
+As a result, framework-provided aliases like Nuxt's `@/` and `~/` are not visible
+to Cypress and must be declared explicitly via `viteConfig`:
+
+:::cypress-config-example
+
+```ts
+import { fileURLToPath } from 'url'
+```
+
+```ts
+{
+  component: {
+    devServer: {
+      framework: 'vue',
+      bundler: 'vite',
+      viteConfig: {
+        resolve: {
+          alias: {
+            '@': fileURLToPath(new URL('./', import.meta.url)),
+            '~': fileURLToPath(new URL('./', import.meta.url)),
+          },
+        },
+      },
+    },
+  },
+}
+```
+
+:::
+
+The aliases you pass are merged with Cypress's own Vite settings, so you only need
+to declare the ones your components rely on. The same applies to Webpack
+meta-frameworks: declare the aliases under `webpackConfig.resolve.alias`.
+
+#### Aliases defined in `tsconfig.json`
+
+Aliases declared only under `compilerOptions.paths` in `tsconfig.json` are a
+TypeScript type-checking feature. Neither Vite nor Webpack reads them when
+bundling, so Cypress does not resolve them either. To make `tsconfig` paths work
+at bundle time, add the matching plugin to the config you give Cypress:
+
+- **Vite**: use
+  [`vite-tsconfig-paths`](https://www.npmjs.com/package/vite-tsconfig-paths) in
+  your `vite.config` (or in the `viteConfig` you pass to `devServer`).
+- **Webpack**: use
+  [`tsconfig-paths-webpack-plugin`](https://www.npmjs.com/package/tsconfig-paths-webpack-plugin)
+  under `resolve.plugins` in your `webpack.config` (or the `webpackConfig` you
+  pass to `devServer`).
+
+This is the same plugin your app already needs to resolve `tsconfig` paths at
+build time, so reusing your existing bundler config is usually enough.
+
 ### Function syntax (advanced)
 
 If you need direct access to the dev server API — for example, to pass options


### PR DESCRIPTION
## Motivation

Two recurring discussions surfaced the same gap: there was no documentation explaining how Cypress resolves **import path aliases** (`@/`, `~/`, `package.json` `_moduleAliases`, `tsconfig` `compilerOptions.paths`) when it bundles test code.

- [#25309](https://github.com/cypress-io/cypress/discussions/25309) — `_moduleAliases` / `tsconfig` paths not working in a Cypress test directory (E2E side).
- [#31029](https://github.com/cypress-io/cypress/discussions/31029) — Nuxt's `@/` and `~/` aliases not recognized in component tests (component testing side).

## What I verified in the implementation

The docs reflect the actual resolution logic:

- **Vite** (`npm/vite-dev-server/src/resolveConfig.ts`): uses `viteConfig` if passed (setting `configFile: false`), otherwise `findUp` locates a standalone `vite.config.*`. It merges that config's `resolve.alias` and never executes a meta-framework's internal config (e.g. `nuxt.config`).
- **Webpack** (`npm/webpack-dev-server/src/makeWebpackConfig.ts`): same pattern via `webpackConfig` or a discovered `webpack.config.*`.
- Neither path reads `package.json` `_moduleAliases` nor `tsconfig` `compilerOptions.paths` (type-checking only) at bundle time.

## Changes

- **`docs/app/component-testing/component-framework-configuration.mdx`** — new "Resolving import path aliases" section covering where aliases come from, the meta-framework caveat (Nuxt owns its Vite config, so aliases must be declared via `viteConfig.resolve.alias`), and `tsconfig` paths plugins (`vite-tsconfig-paths` / `tsconfig-paths-webpack-plugin`).
- **`docs/api/node-events/preprocessors-api.mdx`** — matching section for end-to-end spec/support files, with webpack `resolve.alias` and `tsconfig-paths-webpack-plugin` examples, cross-linked to the component testing guide.

## Verification

- `npx prettier --check` passes on both files.
- `npm run build` succeeds. Since `onBrokenLinks` / `onBrokenMarkdownLinks` are set to `throw`, this confirms the new cross-link anchors resolve.
- No em dashes (per repo authoring rules).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RJPy2DKhWA5ub6A41Q6EjD)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with example config snippets; no runtime or test code modified.
> 
> **Overview**
> Adds documentation for how Cypress resolves **import path aliases** when bundling test code, addressing gaps that drove recurring support discussions (E2E `_moduleAliases` / `tsconfig` paths and Nuxt `@/` / `~/` in component tests).
> 
> **Component testing** (`component-framework-configuration.mdx`): new **Resolving import path aliases** section explains that aliases follow detected or passed Vite/Webpack `resolve.alias`, calls out meta-frameworks like Nuxt that hide bundler config (explicit `viteConfig` / `webpackConfig` aliases), and documents `vite-tsconfig-paths` / `tsconfig-paths-webpack-plugin` when paths live only in `tsconfig.json`.
> 
> **End-to-end** (`preprocessors-api.mdx`): parallel section for spec/support preprocessing via webpack `resolve.alias` and `tsconfig-paths-webpack-plugin`, with notes that `_moduleAliases` and `compilerOptions.paths` are not applied automatically, plus a cross-link to the component testing guide.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9449b77ef0ea4ad80a4f1a43b23b41516a507738. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->