### PR TITLE
docs: clarify CYPRESS_RECORD_KEY must be an OS-level environment variable

### DIFF
--- a/docs/app/guides/environment-variables.mdx
+++ b/docs/app/guides/environment-variables.mdx
@@ -125,6 +125,19 @@ The environment variable `CYPRESS_INTERNAL_ENV` is reserved and should not be se
 
 :::
 
+:::note
+
+Some `CYPRESS_`-prefixed variables are consumed by the Cypress CLI and Cypress
+Cloud rather than being treated as test environment variables. Most notably,
+[`CYPRESS_RECORD_KEY`](/app/references/command-line#cypress-run-record-key-lt-record-key-gt)
+and [`CYPRESS_PROJECT_ID`](/cloud/account-management/projects#Identification) are
+read directly from your operating system environment when recording to Cypress
+Cloud. They must be set as OS-level environment variables (as shown above) and
+**cannot** be supplied through `cypress.env.json` or the `env` block of your
+Cypress configuration.
+
+:::
+
 ### 4. `--env` CLI flag
 
 Pass environment variables via the command line. Multiple values must be separated by a comma, not a space. In some shells, like Windows PowerShell, you may need to surround the key/value pair with quotes.

--- a/docs/app/references/command-line.mdx
+++ b/docs/app/references/command-line.mdx
@@ -553,6 +553,18 @@ Now you can omit the `--key` flag.
 cypress run --record
 ```
 
+:::caution
+
+`CYPRESS_RECORD_KEY` must be set as an actual operating system environment
+variable (as shown above with `export`) — Cypress reads it directly from your
+shell or CI environment. Adding it to your
+[`cypress.env.json`](/app/guides/environment-variables#2-cypressenvjson)
+file or the `env` block of your Cypress configuration does **not** enable
+recording, since those only populate test environment variables. If you don't
+want to set an environment variable, pass the key inline with `--key` instead.
+
+:::
+
 For more information on recording runs, see the
 [Cypress Cloud setup instructions](/cloud/get-started/setup#Setup). For an
 in-depth explanation of how Cypress uses your record key and `projectId` to save

--- a/docs/app/references/command-line.mdx
+++ b/docs/app/references/command-line.mdx
@@ -553,17 +553,7 @@ Now you can omit the `--key` flag.
 cypress run --record
 ```
 
-:::caution
-
-`CYPRESS_RECORD_KEY` must be set as an actual operating system environment
-variable (as shown above with `export`) — Cypress reads it directly from your
-shell or CI environment. Adding it to your
-[`cypress.env.json`](/app/guides/environment-variables#2-cypressenvjson)
-file or the `env` block of your Cypress configuration does **not** enable
-recording, since those only populate test environment variables. If you don't
-want to set an environment variable, pass the key inline with `--key` instead.
-
-:::
+<RecordKeyEnvVar />
 
 For more information on recording runs, see the
 [Cypress Cloud setup instructions](/cloud/get-started/setup#Setup). For an

--- a/docs/app/references/error-messages.mdx
+++ b/docs/app/references/error-messages.mdx
@@ -623,16 +623,7 @@ Cypress app or in [Cypress Cloud](https://on.cypress.io/cloud).
 You will want to then
 [add the key to your config file or as an environment variable](/app/continuous-integration/overview#Record-tests).
 
-:::caution
-
-`CYPRESS_RECORD_KEY` must be set as an actual operating system environment
-variable (for example via `export CYPRESS_RECORD_KEY=...` or your CI provider's
-secrets). It is **not** read from `cypress.env.json` or the `env` block of your
-Cypress configuration — those only populate test environment variables. If you
-placed your record key there, move it to an OS-level environment variable or
-pass it inline with [`--key`](/app/references/command-line#cypress-run-record-key-lt-record-key-gt).
-
-:::
+<RecordKeyEnvVar />
 
 ### <Icon name="exclamation-triangle" color="red" /> The `cypress ci` command has been deprecated
 

--- a/docs/app/references/error-messages.mdx
+++ b/docs/app/references/error-messages.mdx
@@ -623,6 +623,17 @@ Cypress app or in [Cypress Cloud](https://on.cypress.io/cloud).
 You will want to then
 [add the key to your config file or as an environment variable](/app/continuous-integration/overview#Record-tests).
 
+:::caution
+
+`CYPRESS_RECORD_KEY` must be set as an actual operating system environment
+variable (for example via `export CYPRESS_RECORD_KEY=...` or your CI provider's
+secrets). It is **not** read from `cypress.env.json` or the `env` block of your
+Cypress configuration — those only populate test environment variables. If you
+placed your record key there, move it to an OS-level environment variable or
+pass it inline with [`--key`](/app/references/command-line#cypress-run-record-key-lt-record-key-gt).
+
+:::
+
 ### <Icon name="exclamation-triangle" color="red" /> The `cypress ci` command has been deprecated
 
 As of version [`0.19.0`](/app/references/changelog#0-19-0) and CLI versions

--- a/docs/partials/_record-key-env-var.mdx
+++ b/docs/partials/_record-key-env-var.mdx
@@ -1,0 +1,11 @@
+:::caution
+
+`CYPRESS_RECORD_KEY` must be set as an actual operating system environment
+variable (for example via `export CYPRESS_RECORD_KEY=...` or your CI provider's
+secrets). Cypress reads it directly from your shell or CI environment — it is
+**not** read from `cypress.env.json` or the `env` block of your Cypress
+configuration, since those only populate test environment variables. If you
+don't want to set an environment variable, pass the key inline with the `--key`
+flag instead.
+
+:::

--- a/src/theme/MDXComponents.js
+++ b/src/theme/MDXComponents.js
@@ -35,6 +35,7 @@ import IntellisenseCodeCompletion from '@site/docs/partials/_intellisense-code-c
 import InvertedContainsSelection from '@site/docs/partials/_inverted-contains-selection.mdx'
 import ProductHeading from '@site/src/components/product-heading'
 import Profiles from '@site/docs/partials/_profiles.mdx'
+import RecordKeyEnvVar from '@site/docs/partials/_record-key-env-var.mdx'
 import SignificantAttributes from '@site/docs/partials/_significantattributes.mdx'
 import SourceMaps from '@site/docs/partials/_source-maps.mdx'
 import SupportFileConfiguration from '@site/docs/partials/_support-file-configuration.mdx'
@@ -207,6 +208,7 @@ export default {
   InvertedContainsSelection,
   ProductHeading,
   Profiles,
+  RecordKeyEnvVar,
   SignificantAttributes,
   SourceMaps,
   SupportFileConfiguration,


### PR DESCRIPTION
## Motivation

In [discussion #27735](https://github.com/cypress-io/cypress/discussions/27735), a user set `CYPRESS_RECORD_KEY` inside their `cypress.env.json` file and ran `cypress run --record`, but still hit:

> You passed the `--record` flag but did not provide us your Record Key.

This is expected behavior, but it isn't documented. The record key is read directly from the **operating system environment** by the CLI and server:

- `cli/lib/exec/run.ts` → `util.getEnv('CYPRESS_RECORD_KEY')` (only reads `process.env` / npm config)
- `packages/server/lib/modes/record.ts` → `env.get('CYPRESS_RECORD_KEY')`

`cypress.env.json` and the config `env` block only populate **test** environment variables (`Cypress.env()`) — they never feed the recorder. Several docs pages show the correct `export CYPRESS_RECORD_KEY=...` form, but none warned that placing it in `cypress.env.json` won't work, which is the exact gotcha users keep hitting.

## Changes

Three small, targeted clarifications:

- **`docs/app/guides/environment-variables.mdx`** — note alongside the `CYPRESS_*` reserved-variable callout explaining that `CYPRESS_RECORD_KEY` / `CYPRESS_PROJECT_ID` are consumed by the CLI/Cloud and cannot be supplied via `cypress.env.json` or the `env` block.
- **`docs/app/references/command-line.mdx`** — caution in the `cypress run --record --key` section that the key must be an OS-level env var, with `--key` as the inline alternative.
- **`docs/app/references/error-messages.mdx`** — caution on the exact "did not provide us your Record Key" error pointing users to move the key out of `cypress.env.json`.

Phrasing focuses on "doesn't feed the recorder / must be OS-level" rather than "filtered out of your tests," because at the OS level the key does also surface as `Cypress.env('RECORD_KEY')` — the only thing that fails is the `cypress.env.json` path.

## Notes

- Docs-only change; no code or behavior changes.
- All cross-links verified against existing anchors (`#2-cypressenvjson`, `#cypress-run-record-key-lt-record-key-gt`, `#Identification`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LCrmHzqzuWKgxxKVx1GBy2)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no runtime or test behavior changes.
> 
> **Overview**
> Documents that **`CYPRESS_RECORD_KEY`** (and **`CYPRESS_PROJECT_ID`**) are read from the OS/CI environment by the CLI and Cloud for recording—not from `cypress.env.json` or the config `env` block.
> 
> Adds a reusable **`RecordKeyEnvVar`** caution partial and wires it into the **`cypress run --record`** CLI section and the “did not provide your Record Key” error page. The environment-variables guide gets a new note under **`CYPRESS_*`** explaining the same split and linking to record-key and project identification docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37e558dbb6f79bd8fff0e4d3c49bb7a45add5367. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->