### PR TITLE
docs: add cy.task() example for running Node code before each test

### DIFF
--- a/docs/api/commands/task.mdx
+++ b/docs/api/commands/task.mdx
@@ -216,6 +216,55 @@ on('task', {
 
 :::
 
+### Run Node code before each test
+
+There is no `setupNodeEvents` event that fires before each individual test — the
+most granular lifecycle events available in Node are
+[`before:spec`](/api/node-events/before-spec-api) and
+[`after:spec`](/api/node-events/after-spec-api), which run once per spec file.
+Individual tests only exist inside the browser, so to run Node code before
+_every_ test, register a global `beforeEach` hook in your
+[support file](/app/core-concepts/writing-and-organizing-tests#Support-file) that
+calls `cy.task()`. Because it lives in the support file, it applies to every test
+in every spec without duplicating code.
+
+A common use case is tagging your application's server logs with the name of the
+test that is currently running, so that when a test fails you can correlate it
+with the exact backend requests it made.
+
+```javascript
+// cypress/support/e2e.js
+beforeEach(function () {
+  cy.task('logTestStart', {
+    title: this.currentTest.fullTitle(),
+    spec: Cypress.spec.relative,
+  })
+})
+```
+
+:::cypress-config-plugin-example
+
+```ts
+import fs from 'fs'
+```
+
+```ts
+on('task', {
+  logTestStart({ title, spec }) {
+    // write a marker to a log that your app server also writes to,
+    // so server-side logs can be tied back to the test that triggered them
+    fs.appendFileSync(
+      'logs/test-run.log',
+      `[${spec}] ▶ starting: ${title}\n`
+    )
+
+    return null
+  },
+})
+```
+
+:::
+
 ### Return a Promise from an asynchronous task
 
 ```javascript

--- a/docs/api/commands/task.mdx
+++ b/docs/api/commands/task.mdx
@@ -218,45 +218,23 @@ on('task', {
 
 ### Run Node code before each test
 
-There is no `setupNodeEvents` event that fires before each individual test. The
-most granular lifecycle events available in Node are
-[`before:spec`](/api/node-events/before-spec-api) and
-[`after:spec`](/api/node-events/after-spec-api), which run once per spec file.
-Individual tests only exist inside the browser, so to run Node code before
-_every_ test, register a global `beforeEach` hook in your
-[support file](/app/core-concepts/writing-and-organizing-tests#Support-file) that
-calls `cy.task()`. Because it lives in the support file, it applies to every test
-in every spec without duplicating code.
-
-A common use case is tagging your application's server logs with the name of the
-test that is currently running, so that when a test fails you can correlate it
-with the exact backend requests it made.
+There is no `setupNodeEvents` event for each test. To run Node code before every
+test, call `cy.task()` from a global `beforeEach` in your
+[support file](/app/core-concepts/writing-and-organizing-tests#Support-file).
 
 ```javascript
 // cypress/support/e2e.js
 beforeEach(function () {
-  cy.task('logTestStart', {
-    title: this.currentTest.fullTitle(),
-    spec: Cypress.spec.relative,
-  })
+  cy.task('logTestStart', this.currentTest.fullTitle())
 })
 ```
 
 :::cypress-config-plugin-example
 
 ```ts
-import fs from 'fs'
-```
-
-```ts
 on('task', {
-  logTestStart({ title, spec }) {
-    // write a marker to a log that your app server also writes to,
-    // so server-side logs can be tied back to the test that triggered them
-    fs.appendFileSync(
-      'logs/test-run.log',
-      `[${spec}] ▶ starting: ${title}\n`
-    )
+  logTestStart(title) {
+    console.log(`Starting: ${title}`)
 
     return null
   },

--- a/docs/api/commands/task.mdx
+++ b/docs/api/commands/task.mdx
@@ -218,7 +218,7 @@ on('task', {
 
 ### Run Node code before each test
 
-There is no `setupNodeEvents` event that fires before each individual test — the
+There is no `setupNodeEvents` event that fires before each individual test. The
 most granular lifecycle events available in Node are
 [`before:spec`](/api/node-events/before-spec-api) and
 [`after:spec`](/api/node-events/after-spec-api), which run once per spec file.


### PR DESCRIPTION
## What

Adds a new example — **"Run Node code before each test"** — to the `cy.task()` documentation (`docs/api/commands/task.mdx`).

## Why

[Discussion #31332](https://github.com/cypress-io/cypress/discussions/31332) asks whether `setupNodeEvents` has a `before:test` hook to run Node code before each individual test. It does not — the most granular Node-side lifecycle events are `before:spec` / `after:spec`, which run once per spec file. This question comes up periodically, and the supported pattern (a global `beforeEach` in the support file calling `cy.task()`) wasn't documented in an obvious place.

## Details

The new example:
- Explains that no per-test Node event exists and why (individual tests only run in the browser).
- Shows the supported workaround: a global `beforeEach` in the support file that calls `cy.task()`, so it applies to every test in every spec with no per-spec duplication.
- Uses a believable real-world use case — tagging the application's server logs with the currently-running test so backend requests can be correlated with the test that failed.
- Passes the test title (`this.currentTest.fullTitle()`) and spec path (`Cypress.spec.relative`) to Node and returns `null` as required.

Placed directly after the existing "Seed a database" example, which follows the same `beforeEach` + `cy.task()` shape, and uses the repo's existing `:::cypress-config-plugin-example` conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015BcQfjZVzYTNwqQ1VkpCUL)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to `task.mdx` with no runtime, config, or test behavior impact.
> 
> **Overview**
> Adds a **"Run Node code before each test"** section to the `cy.task()` docs, placed after the database seeding example.
> 
> It clarifies that **`setupNodeEvents` has no per-test hook** (only spec-level lifecycle on the Node side) and documents the supported pattern: a **global `beforeEach` in the support file** that calls `cy.task()` so Node code runs before every test without repeating hooks in each spec. The example wires `this.currentTest.fullTitle()` into a `logTestStart` task that logs on the Node side and returns `null`, using the existing `:::cypress-config-plugin-example` block style.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 486411808a9e57329d02754c05bcd7fb71b57cb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->