### PR TITLE
docs: document Next.js CSS injection requirement for component testing

### DIFF
--- a/docs/app/component-testing/styling-components.mdx
+++ b/docs/app/component-testing/styling-components.mdx
@@ -302,9 +302,9 @@ contains it inside the `<head>`:
 </html>
 ```
 
-This is the most common cause of "my Tailwind classes appear in the DOM but
-aren't styled" (or a mount error) in a Next.js component testing setup. With the
-element in place, import your global stylesheet as usual from
+A missing marker element is a common cause of "my Tailwind classes appear in the
+DOM but aren't styled" (or a mount error) in a Next.js component testing setup.
+With the element in place, import your global stylesheet as usual from
 `cypress/support/component.js`:
 
 ```js title="cypress/support/component.js"

--- a/docs/app/component-testing/styling-components.mdx
+++ b/docs/app/component-testing/styling-components.mdx
@@ -302,8 +302,6 @@ contains it inside the `<head>`:
 </html>
 ```
 
-A missing marker element is a common cause of "my Tailwind classes appear in the
-DOM but aren't styled" (or a mount error) in a Next.js component testing setup.
 With the element in place, import your global stylesheet as usual from
 `cypress/support/component.js`:
 

--- a/docs/app/component-testing/styling-components.mdx
+++ b/docs/app/component-testing/styling-components.mdx
@@ -274,6 +274,43 @@ import './main.css'
 You're usually providing public paths to these stylesheets. You can import the
 same paths within your `cypress/support/component-index.html` file.
 
+### Next.js: styles aren't applied or mounting throws
+
+Next.js injects CSS at runtime using `style-loader`, which expects a specific
+marker element to exist in the page. If that element is missing, importing a
+global stylesheet (such as a compiled Tailwind file) can leave your component
+unstyled or cause mounting to fail outright.
+
+Cypress adds this element for you when you scaffold component testing with the
+Next.js framework, so make sure your `cypress/support/component-index.html` still
+contains it inside the `<head>`:
+
+```html title="cypress/support/component-index.html"
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width,initial-scale=1.0" />
+    <title>Components App</title>
+    <!-- Used by Next.js to inject CSS. -->
+    <div id="__next_css__DO_NOT_USE__"></div>
+  </head>
+  <body>
+    <div data-cy-root></div>
+  </body>
+</html>
+```
+
+This is the most common cause of "my Tailwind classes appear in the DOM but
+aren't styled" (or a mount error) in a Next.js component testing setup. With the
+element in place, import your global stylesheet as usual from
+`cypress/support/component.js`:
+
+```js title="cypress/support/component.js"
+import '../../src/index.css'
+```
+
 ### CSS Reset or Normalize isn't applied
 
 Are you importing your normalize file within


### PR DESCRIPTION
Next.js injects CSS via style-loader and requires a
__next_css__DO_NOT_USE__ marker element in component-index.html.
This was only present in the scaffold and undocumented, leaving users
with unstyled components or mount errors (e.g. with Tailwind) and no
guidance. Add a Next.js subsection to the styling components guide.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YPhhBb5RimQnjMvrUKJFGM

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or test behavior impact.
> 
> **Overview**
> Adds a **Next.js** troubleshooting subsection to the component styling guide for when global CSS (e.g. Tailwind) leaves components unstyled or breaks mounting.
> 
> The new section explains that Next.js **`style-loader`** needs a **`#__next_css__DO_NOT_USE__`** marker in **`cypress/support/component-index.html`** (included in the Next.js scaffold), shows the expected HTML, and points readers to import global CSS from **`cypress/support/component.js`** as usual.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81ae07a9e664cc9579e01236f61fa38f6f5e3e7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->