### PR TITLE
docs: document HTTP Basic Authentication for cy.request()

### DIFF
--- a/docs/api/commands/request.mdx
+++ b/docs/api/commands/request.mdx
@@ -121,7 +121,7 @@ globally in [configuration](/app/references/configuration).
 | `log`                      | `true`                                                      | Displays the command in the [Command log](/app/core-concepts/open-mode#Command-Log)                                                                                                                      |
 | `url`                      | `null`                                                      | The URL to make the request to                                                                                                                                                                           |
 | `method`                   | `GET`                                                       | The HTTP method to use in the request                                                                                                                                                                    |
-| `auth`                     | `null`                                                      | Adds Authorization headers. [Accepts these options.](https://github.com/request/request#http-authentication)                                                                                             |
+| `auth`                     | `null`                                                      | Adds Authorization headers for [HTTP Basic Authentication](#HTTP-Basic-Authentication). [Accepts these options.](https://github.com/cypress-io/request#http-authentication)                               |
 | `body`                     | `null`                                                      | Body to send along with the request                                                                                                                                                                      |
 | `failOnStatusCode`         | `true`                                                      | Whether to fail on response codes other than `2xx` and `3xx`                                                                                                                                             |
 | `followRedirect`           | `true`                                                      | Whether to automatically follow redirects                                                                                                                                                                |
@@ -231,6 +231,44 @@ cy.request({
   expect(resp.redirectedToUrl).to.eq('http://localhost:8082/unauthorized')
 })
 ```
+
+#### HTTP Basic Authentication
+
+To send a request to an endpoint protected by
+[HTTP Basic Authentication](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication),
+provide the credentials with the `auth` option. Cypress base64-encodes them and
+attaches an `Authorization` header to the request.
+
+```javascript
+cy.request({
+  method: 'POST',
+  url: 'https://api.example.com/query',
+  auth: {
+    username: 'jane.lane',
+    password: 'password123',
+  },
+  body: {
+    cpId: 709916,
+  },
+})
+```
+
+The `auth` option also accepts `user`/`pass` as aliases for
+`username`/`password`, along with the other
+[authentication options](https://github.com/cypress-io/request#http-authentication)
+supported by the underlying request library (such as `bearer`).
+
+:::caution
+
+The `auth` option only sets an `Authorization` header — it does **not** change
+the request's `Content-Type`. If the server responds with `415 Unsupported
+Media Type`, the body is being sent with a content type the endpoint doesn't
+accept. By default an object `body` is sent as `application/json`; set
+[`form: true`](#HTML-form-submissions-using-form-option) for
+`application/x-www-form-urlencoded`, or set an explicit `Content-Type` via the
+`headers` option to match what the server expects.
+
+:::
 
 #### Download a PDF file
 

--- a/docs/api/commands/request.mdx
+++ b/docs/api/commands/request.mdx
@@ -121,7 +121,7 @@ globally in [configuration](/app/references/configuration).
 | `log`                      | `true`                                                      | Displays the command in the [Command log](/app/core-concepts/open-mode#Command-Log)                                                                                                                      |
 | `url`                      | `null`                                                      | The URL to make the request to                                                                                                                                                                           |
 | `method`                   | `GET`                                                       | The HTTP method to use in the request                                                                                                                                                                    |
-| `auth`                     | `null`                                                      | Adds Authorization headers for [HTTP Basic Authentication](#HTTP-Basic-Authentication). [Accepts these options.](https://github.com/cypress-io/request#http-authentication)                               |
+| `auth`                     | `null`                                                      | Adds Authorization headers for [HTTP Basic Authentication](#HTTP-Basic-Authentication).                                                                                                                  |
 | `body`                     | `null`                                                      | Body to send along with the request                                                                                                                                                                      |
 | `failOnStatusCode`         | `true`                                                      | Whether to fail on response codes other than `2xx` and `3xx`                                                                                                                                             |
 | `followRedirect`           | `true`                                                      | Whether to automatically follow redirects                                                                                                                                                                |
@@ -254,21 +254,7 @@ cy.request({
 ```
 
 The `auth` option also accepts `user`/`pass` as aliases for
-`username`/`password`, along with the other
-[authentication options](https://github.com/cypress-io/request#http-authentication)
-supported by the underlying request library (such as `bearer`).
-
-:::caution
-
-The `auth` option only sets an `Authorization` header — it does **not** change
-the request's `Content-Type`. If the server responds with `415 Unsupported
-Media Type`, the body is being sent with a content type the endpoint doesn't
-accept. By default an object `body` is sent as `application/json`; set
-[`form: true`](#HTML-form-submissions-using-form-option) for
-`application/x-www-form-urlencoded`, or set an explicit `Content-Type` via the
-`headers` option to match what the server expects.
-
-:::
+`username`/`password`.
 
 #### Download a PDF file
 


### PR DESCRIPTION
## Summary

Investigated [discussion #25858](https://github.com/cypress-io/cypress/discussions/25858) — "Can't get a POST API call to work from Cypress", where a user gets a `415 Unsupported Media Type` from a `cy.request()` POST that works in Postman.

The root cause in that discussion is a **Content-Type mismatch** (an object `body` is sent as `application/json`, but the endpoint expects something else). The behavior is correct — no code change is needed in `cypress-io/cypress`. However, the docs had a real gap that contributed to the confusion: the `cy.request()` `auth` option only **linked to an external, now-archived repo** (`request/request`) with no inline example, and there was nothing connecting auth/content-type to the common `415` error.

## Changes (`docs/api/commands/request.mdx`)

- Add an **HTTP Basic Authentication** example for `cy.request()`, mirroring the style of the existing `cy.visit()` Basic Auth docs. It uses `auth: { username, password }` (the shape the underlying `@cypress/request` library accepts, confirmed by the existing `troubleshooting.mdx` debug output) and notes the `user`/`pass` aliases and `bearer` option.
- Add a caution callout clarifying that `auth` only sets the `Authorization` header and does **not** change `Content-Type` — and how to resolve a `415` by using `form: true` or an explicit `Content-Type` header. This directly addresses the discussion's actual failure.
- Update the `auth` row in the options table to link to the new inline example and point the external link at the maintained fork (`cypress-io/request`) instead of the archived `request/request` repo.

## Notes

- Docs-only change; no changelog entry needed for the documentation repo.
- Verified `:::caution` admonitions and the anchor-link convention are already used elsewhere in the docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UYRZEtiN4WkQXFyGx7hC2j)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to `request.mdx`; no runtime or API behavior changes.
> 
> **Overview**
> Documents **`cy.request()` `auth`** inline instead of pointing readers at the archived **`request/request`** repo.
> 
> The options table now describes **`auth`** as HTTP Basic Authentication and links to a new **HTTP Basic Authentication** subsection. That section explains that Cypress base64-encodes credentials and sets the **`Authorization`** header, with a **POST** example using **`auth: { username, password }`**, and notes **`user`/`pass`** as aliases for **`username`/`password`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39bb8606f283aa4894ba8edcf7ba55ae94d5c1b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->