### PR TITLE
docs: clarify Cypress.$ runs synchronously and does not wait for cy commands

### DIFF
--- a/docs/api/utilities/$.mdx
+++ b/docs/api/utilities/$.mdx
@@ -58,6 +58,36 @@ cy.wrap($li)
 
 ## Notes
 
+### Cypress.$ runs immediately and does not wait for `cy` commands
+
+`Cypress.$` queries the application under test's DOM _synchronously_, at the
+moment the line of code runs. Unlike [`cy.get()`](/api/commands/get), it is not
+a queued command and does not wait for previous `cy` commands to finish.
+
+```javascript
+cy.visit('/page-with-list')
+// runs immediately, before cy.visit() has navigated, so it queries the
+// previous (blank) page and returns an empty jQuery object: [jQuery{0}]
+const $items = Cypress.$('li')
+```
+
+To query the DOM _after_ prior commands have run, move the query into a
+[`.then()`](/api/commands/then) callback, which Cypress defers until the
+preceding commands finish, or query off an element yielded by `cy`:
+
+```javascript
+cy.visit('/page-with-list')
+cy.get('body').then(($body) => {
+  // runs after cy.visit() has finished and the page has rendered
+  const $items = $body.find('li')
+})
+```
+
+If you reached for `Cypress.$` to conditionally do something based on whether an
+element exists, read the
+[Conditional Testing](/app/guides/conditional-testing) guide first. The DOM
+must be in a known, stable state for this to be reliable.
+
 ### Cypress.$ vs. cy.$$
 
 You can also query DOM elements with `cy.$$`. But `Cypress.$` and `cy.$$` are


### PR DESCRIPTION
Adds a note to the Cypress.$ utility page's Notes section explaining that it
queries the AUT DOM synchronously at call time and, unlike cy.get(), is not a
queued command. Calling it directly after cy.visit() queries the page before
navigation completes and returns an empty jQuery object, which is a common
point of confusion (see discussion #31027). Shows the correct .then()-deferred
pattern and links to the Conditional Testing guide.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Bewu1LyWXToKunjSSSrN2P

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to `docs/api/utilities/$.mdx` with no runtime or test impact.
> 
> **Overview**
> Adds a **Notes** subsection on the `Cypress.$` utility page explaining that it queries the AUT DOM **synchronously** when the line runs and is **not** queued like `cy.get()`, so calling it right after `cy.visit()` can hit the wrong page and return an empty jQuery set.
> 
> Documents the recommended fix: defer the query with **`.then()`** (or query from a `cy`-yielded element) and points readers who use `Cypress.$` for existence checks to the **Conditional Testing** guide.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c201cb678f0fb41ef591944c711f1812efba60b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->