### PR TITLE
docs: document how to end a Cypress test early

### DIFF
--- a/docs/app/faq.mdx
+++ b/docs/app/faq.mdx
@@ -427,7 +427,7 @@ There is no API to abort a test midway and have it count as **passed** with
 partial results. A test is always passed, failed, or skipped. To "stop here"
 without failing, conditionally avoid enqueuing the remaining commands; to abort
 as a failure, throw an error. See
-[Ending a test early](/app/guides/conditional-testing#ending-a-test-early) in the
+[Ending a test early](/app/guides/conditional-testing#Ending-a-test-early) in the
 Conditional Testing guide.
 
 ### <Icon name="angle-right" /> How can I make Cypress wait until something is visible in the DOM?

--- a/docs/app/faq.mdx
+++ b/docs/app/faq.mdx
@@ -421,6 +421,15 @@ Please read our extensive
 [Conditional Testing Guide](/app/guides/conditional-testing) which
 explains this in detail.
 
+### <Icon name="angle-right" /> Can I stop a test partway through and keep the steps that already ran?
+
+There is no API to abort a test midway and have it count as **passed** with
+partial results - a test is always passed, failed, or skipped. To "stop here"
+without failing, conditionally avoid enqueuing the remaining commands; to abort
+as a failure, throw an error. See
+[Ending a test early](/app/guides/conditional-testing#ending-a-test-early) in the
+Conditional Testing guide.
+
 ### <Icon name="angle-right" /> How can I make Cypress wait until something is visible in the DOM?
 
 :::info

--- a/docs/app/faq.mdx
+++ b/docs/app/faq.mdx
@@ -424,7 +424,7 @@ explains this in detail.
 ### <Icon name="angle-right" /> Can I stop a test partway through and keep the steps that already ran?
 
 There is no API to abort a test midway and have it count as **passed** with
-partial results - a test is always passed, failed, or skipped. To "stop here"
+partial results. A test is always passed, failed, or skipped. To "stop here"
 without failing, conditionally avoid enqueuing the remaining commands; to abort
 as a failure, throw an error. See
 [Ending a test early](/app/guides/conditional-testing#ending-a-test-early) in the

--- a/docs/app/guides/conditional-testing.mdx
+++ b/docs/app/guides/conditional-testing.mdx
@@ -517,9 +517,6 @@ it('skips itself when the feature is off', function () {
 })
 ```
 
-Prefer `this.skip()` over reaching into Cypress internals such as
-`cy.state('test')`, which are undocumented and may change between versions.
-
 ## Error Recovery
 
 Many of our users ask how they can recover from failed commands.

--- a/docs/app/guides/conditional-testing.mdx
+++ b/docs/app/guides/conditional-testing.mdx
@@ -446,7 +446,7 @@ cy.get('body').then(($body) => {
 ## Ending a test early
 
 A related question is how to **stop a test partway through** once some condition
-is met - for example, after iterating over a set of links - while keeping the
+is met (for example, after iterating over a set of links) while keeping the
 steps that already ran visible in the Command Log.
 
 Cypress does not have an API to abort a single test midway and have it count as
@@ -454,8 +454,8 @@ Cypress does not have an API to abort a single test midway and have it count as
 states: **passed**, **failed**, or **pending** (skipped). There is no "passed,
 but stopped early" status.
 
-The reliable way to "stop here" is the same idea as everywhere else on this page:
-don't try to abort a queue that is already running - instead, conditionally
+The reliable way to "stop here" is the same idea as everywhere else on this page.
+Rather than abort a queue that is already running, conditionally
 **avoid enqueuing** the remaining commands. Make the decision inside a
 [.then()](/api/commands/then) so it happens at the right point in the command
 queue:
@@ -490,7 +490,7 @@ are only added from within the conditional.
 
 :::
 
-If you instead want the early exit to be treated as a **failure** - a true abort -
+If you instead want the early exit to be treated as a **failure** (a true abort),
 throw an error. The steps already in the Command Log remain visible, and Cypress
 skips the remaining commands, just like any other failed test:
 

--- a/docs/app/guides/conditional-testing.mdx
+++ b/docs/app/guides/conditional-testing.mdx
@@ -443,6 +443,83 @@ cy.get('body').then(($body) => {
   })
 ```
 
+## Ending a test early
+
+A related question is how to **stop a test partway through** once some condition
+is met - for example, after iterating over a set of links - while keeping the
+steps that already ran visible in the Command Log.
+
+Cypress does not have an API to abort a single test midway and have it count as
+**passed** with partial results. A test's outcome is always one of Mocha's three
+states: **passed**, **failed**, or **pending** (skipped). There is no "passed,
+but stopped early" status.
+
+The reliable way to "stop here" is the same idea as everywhere else on this page:
+don't try to abort a queue that is already running - instead, conditionally
+**avoid enqueuing** the remaining commands. Make the decision inside a
+[.then()](/api/commands/then) so it happens at the right point in the command
+queue:
+
+```js
+it('stops once it finds the Dashboard link', () => {
+  cy.get('a').then(($links) => {
+    cy.log('completed initial steps')
+
+    const hasDashboard = [...$links].some(
+      (el) => el.innerText.trim() === 'Dashboard'
+    )
+
+    if (hasDashboard) {
+      // nothing else is enqueued from this block, so the test
+      // ends here as passed with the prior steps still logged
+      return
+    }
+
+    cy.log('continuing remaining steps')
+    // cy.get(...).click() ...
+  })
+})
+```
+
+:::caution
+
+Returning out of a `.then()` callback only prevents commands inside that callback
+from being queued. It does **not** cancel commands that were already enqueued at
+the top level of the test. Structure the test so the steps you may want to skip
+are only added from within the conditional.
+
+:::
+
+If you instead want the early exit to be treated as a **failure** - a true abort -
+throw an error. The steps already in the Command Log remain visible, and Cypress
+skips the remaining commands, just like any other failed test:
+
+```js
+cy.get('a').then(($links) => {
+  if (someCondition) {
+    throw new Error('Stopping the test early on purpose')
+  }
+})
+```
+
+Finally, if you genuinely want the test marked **skipped** rather than passed or
+failed, call Mocha's [this.skip()](https://mochajs.org/#inclusive-tests) at
+runtime (use a `function () {}` callback, not an arrow function, so `this` is
+bound):
+
+```js
+it('skips itself when the feature is off', function () {
+  cy.getCookie('featureEnabled').then((cookie) => {
+    if (!cookie) {
+      this.skip()
+    }
+  })
+})
+```
+
+Prefer `this.skip()` over reaching into Cypress internals such as
+`cy.state('test')`, which are undocumented and may change between versions.
+
 ## Error Recovery
 
 Many of our users ask how they can recover from failed commands.


### PR DESCRIPTION
Adds an "Ending a test early" section to the Conditional Testing guide
covering how to stop a test partway through (conditionally avoid enqueuing
remaining commands), how to abort as a failure (throw), and the runtime
this.skip() option, while clarifying there is no "passed with partial
results" status. Adds a matching FAQ entry that links to the new section.

Addresses the question raised in cypress-io/cypress discussion #30634.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SEEbg26jfE1wKdPEbHKoLn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, security, or test behavior impact.
> 
> **Overview**
> Documents how to **stop a Cypress test partway through** while keeping prior steps in the Command Log, clarifying there is no API for a **passed** outcome with partial results.
> 
> The Conditional Testing guide gains an **Ending a test early** section: pass by conditionally **not enqueuing** further commands inside `.then()`, fail by **throwing**, or mark **skipped** with Mocha's `this.skip()` (with a caution that early `return` only affects commands queued inside that callback). The FAQ adds a matching Q&A that links to that section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6af3e28e6c3f4daa98143983166c8d40d8487e3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->