### PR TITLE
docs: add data-driven testing from external data sources

### DIFF
--- a/docs/app/core-concepts/writing-and-organizing-tests.mdx
+++ b/docs/app/core-concepts/writing-and-organizing-tests.mdx
@@ -810,6 +810,94 @@ The code above will produce a suite with 4 tests:
   > triggers event: 'mouseleave'
 ```
 
+#### Driving tests from external data
+
+A common use of dynamic tests is **data-driven testing**: keeping your test
+cases (and often their titles) in an external data source, then generating one
+test per row. The important constraint is that the `describe()`/`it()` structure
+is built **synchronously when the spec loads**. Cypress commands like
+[`cy.fixture()`](/api/commands/fixture) and [`cy.task()`](/api/commands/task)
+run _inside_ a test and resolve asynchronously, so they can supply data
+**within** a test but cannot be used to create the `it()` blocks themselves. The
+data has to be available at load time.
+
+For **JSON** data, a static `import`/`require` is all you need, since the bundler
+inlines it at build time:
+
+```javascript
+import scenarios from '../fixtures/scenarios.json'
+
+describe('Login scenarios', () => {
+  scenarios.forEach((scenario) => {
+    it(scenario.title, () => {
+      cy.visit('/login')
+      cy.get('[data-testid="username"]').type(scenario.username)
+      cy.get('[data-testid="password"]').type(scenario.password)
+      cy.get('[data-testid="submit"]').click()
+      cy.contains(scenario.expectedMessage).should('be.visible')
+    })
+  })
+})
+```
+
+Each `it()` title comes straight from the data, so the row's `title` is what
+shows up in your test output.
+
+For formats that need parsing in Node.js first — such as **CSV or Excel** — read
+and parse the file inside
+[`setupNodeEvents`](/app/references/configuration#setupNodeEvents) and hand the
+parsed rows to the browser with the `expose` configuration, then read them in
+your spec with [`Cypress.expose()`](/api/cypress-api/expose). Use `expose` only
+for non-sensitive data, since exposed values are accessible in the browser
+context.
+
+:::cypress-config-example
+
+```ts
+// parse the file with any Node.js library, e.g. `xlsx` for Excel or
+// `csv-parse` for CSV, then expose the rows to the browser
+import { readFileSync } from 'fs'
+import { parse } from 'csv-parse/sync'
+```
+
+```ts
+{
+  e2e: {
+    setupNodeEvents(on, config) {
+      const csv = readFileSync('cypress/fixtures/scenarios.csv', 'utf8')
+
+      config.expose = {
+        ...config.expose,
+        scenarios: parse(csv, { columns: true }),
+      }
+
+      return config
+    },
+  },
+}
+```
+
+:::
+
+```javascript
+describe('Login scenarios', () => {
+  Cypress.expose('scenarios').forEach((scenario) => {
+    it(scenario.title, () => {
+      // scenario.<column> holds the data for this row
+    })
+  })
+})
+```
+
+:::info
+
+Generating tests from external data works because the file is read in Node.js
+and the rows are available synchronously when the spec loads. Reaching for
+`cy.fixture()` or `cy.task()` to build the `it()` blocks won't work, since those
+run asynchronously inside a test, after the suite has already been defined.
+
+:::
+
 ## Running and watching tests
 
 You can run a test by clicking on the spec filename. For example the

--- a/docs/app/core-concepts/writing-and-organizing-tests.mdx
+++ b/docs/app/core-concepts/writing-and-organizing-tests.mdx
@@ -843,7 +843,7 @@ describe('Login scenarios', () => {
 Each `it()` title comes straight from the data, so the row's `title` is what
 shows up in your test output.
 
-For formats that need parsing in Node.js first — such as **CSV or Excel** — read
+For formats that need parsing in Node.js first, such as **CSV or Excel**, read
 and parse the file inside
 [`setupNodeEvents`](/app/references/configuration#setupNodeEvents) and hand the
 parsed rows to the browser with the `expose` configuration, then read them in
@@ -879,7 +879,7 @@ import { parse } from 'csv-parse/sync'
 
 :::
 
-```javascript
+```javascript title="cypress/e2e/login.cy.js"
 describe('Login scenarios', () => {
   Cypress.expose('scenarios').forEach((scenario) => {
     it(scenario.title, () => {
@@ -888,15 +888,6 @@ describe('Login scenarios', () => {
   })
 })
 ```
-
-:::info
-
-Generating tests from external data works because the file is read in Node.js
-and the rows are available synchronously when the spec loads. Reaching for
-`cy.fixture()` or `cy.task()` to build the `it()` blocks won't work, since those
-run asynchronously inside a test, after the suite has already been defined.
-
-:::
 
 ## Running and watching tests
 


### PR DESCRIPTION
## Motivation

[Discussion #30885](https://github.com/cypress-io/cypress/discussions/30885) ("Drive Cypress tests from excel") asks how to generate tests from an external data file, with each `it()` title coming from the data. It went unanswered, and the docs don't currently cover **data-driven testing** end to end.

The constituent pieces exist in the docs — the `forEach` → `it()` pattern (shown with inline arrays) and the [`Cypress.expose()`](https://docs.cypress.io/api/cypress-api/expose) API — but nothing connects them for the common "read a file → generate tests" case, and nothing calls out the load-time-vs-runtime constraint that trips people up (you can't use `cy.fixture()`/`cy.task()` to build `it()` blocks, because the suite is defined synchronously at load time).

## Changes

Adds a **"Driving tests from external data"** subsection to the existing *Dynamically generating tests* section in `docs/app/core-concepts/writing-and-organizing-tests.mdx`:

- The synchronous-load-time constraint, stated up front and reinforced in an `:::info` callout.
- The **JSON** case via a static `import` (no Node parsing needed).
- The **CSV/Excel** case: parse the file in `setupNodeEvents`, hand the rows to the browser via the `expose` config, and read them with `Cypress.expose()` — which doubles as a real non-secret use case for that API.

Excel is intentionally not the headline: it needs a third-party parser, so the prose frames this generically as "external data sources" and names parser libraries (`xlsx`, `csv-parse`) only in a code comment rather than blessing a dependency. The runnable example uses CSV; the pattern is identical for Excel.

I verified against the `@packages/config` source that assigning `config.expose` in `setupNodeEvents` and returning it propagates to `Cypress.expose()` in the browser (it resolves through `updateWithPluginValues` / `parseExposed` the same way `env` does).

## Test type

Documentation only — no code changes.

## How to test

- Build the docs site and confirm the new subsection renders under **Writing and Organizing Tests → Dynamically generating tests**, with the `:::cypress-config-example` and `:::info` components rendering correctly and the internal links resolving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01U7BZnUTwJVbjUgpWGJbDYY)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no runtime or product code changes.
> 
> **Overview**
> Adds a **"Driving tests from external data"** subsection under *Dynamically generating tests* in `writing-and-organizing-tests.mdx`, documenting how to generate one `it()` per row from external data.
> 
> The section states the **load-time constraint**: `describe()`/`it()` must be built synchronously when the spec loads, so **`cy.fixture()` and `cy.task()` cannot create `it()` blocks**—only supply data inside a test.
> 
> It walks through the **JSON** path with a static `import`/`require` and a full login `forEach` → `it(scenario.title)` example, then the **CSV/Excel** path: parse in **`setupNodeEvents`**, assign rows on **`config.expose`**, and iterate **`Cypress.expose('scenarios')`** in the spec (with a `:::cypress-config-example` block using `csv-parse`). It notes **`expose` is for non-sensitive data** only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c02c08ccf95b22fb031d9d0b5875b131e4546660. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->