### PR TITLE
docs: add cy.getCookies() example building a Cookie header for cy.request()

### DIFF
--- a/docs/api/commands/getcookies.mdx
+++ b/docs/api/commands/getcookies.mdx
@@ -74,6 +74,28 @@ cy.getCookies()
   })
 ```
 
+#### Build a `Cookie` header for `cy.request()`
+
+You can combine the cookies for the current domain into a single `Cookie`
+header string and pass it to [`cy.request()`](/api/commands/request).
+
+```javascript
+cy.getCookies().then((cookies) => {
+  const cookieHeader = cookies.map((c) => `${c.name}=${c.value}`).join('; ')
+
+  cy.request({
+    url: '/api/protected',
+    headers: {
+      Cookie: cookieHeader,
+    },
+  })
+})
+```
+
+Note that `cy.request()` automatically sends the browser's cookies for the
+request URL, so setting the `Cookie` header manually is only necessary for
+custom scenarios.
+
 ## Rules
 
 <HeaderRequirements />

--- a/docs/api/commands/getcookies.mdx
+++ b/docs/api/commands/getcookies.mdx
@@ -74,27 +74,33 @@ cy.getCookies()
   })
 ```
 
-#### Build a `Cookie` header for `cy.request()`
+#### Forward the session to another destination
 
-You can combine the cookies for the current domain into a single `Cookie`
-header string and pass it to [`cy.request()`](/api/commands/request).
+[`cy.request()`](/api/commands/request) already sends the browser's cookies for
+the request URL automatically, so you don't need to build a `Cookie` header to
+call your own logged-in API. Reach for this pattern only when you need to
+forward the current session somewhere Cypress won't attach cookies on its own,
+such as:
+
+- a **different domain** (`cy.request()` only sends cookies that match the
+  request URL)
+- something **outside the browser**, like a [`cy.task()`](/api/commands/task),
+  [`cy.exec()`](/api/commands/exec), or an external HTTP client
+
+In those cases, combine the cookies into a single `Cookie` header string:
 
 ```javascript
 cy.getCookies().then((cookies) => {
   const cookieHeader = cookies.map((c) => `${c.name}=${c.value}`).join('; ')
 
   cy.request({
-    url: '/api/protected',
+    url: 'https://api.other-service.com/protected',
     headers: {
       Cookie: cookieHeader,
     },
   })
 })
 ```
-
-Note that `cy.request()` automatically sends the browser's cookies for the
-request URL, so setting the `Cookie` header manually is only necessary for
-custom scenarios.
 
 ## Rules
 


### PR DESCRIPTION
Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LnakErZnvTqF4PzmjPpCA5

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the Cypress API reference; no runtime or test behavior is affected.
> 
> **Overview**
> Adds a **“Forward the session to another destination”** example under `cy.getCookies()` in `getcookies.mdx`.
> 
> The new section clarifies that **`cy.request()` already sends matching cookies** for the request URL, so a manual `Cookie` header is unnecessary for same-origin logged-in API calls. It documents when to build a header from `getCookies()` instead—**cross-domain** requests and **non-browser** paths (`cy.task`, `cy.exec`, external clients)—with a short sample that maps cookies to `name=value` pairs joined by `; ` and passes them in `cy.request` headers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9abd57b78b070e9789479f80654fe082e1d69eff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->