### PR TITLE
docs: clarify Nuxt component testing support

### DIFF
--- a/docs/app/component-testing/vue/overview.mdx
+++ b/docs/app/component-testing/vue/overview.mdx
@@ -160,11 +160,6 @@ same way you test any Vue 3 + Vite project, by setting the `vue` framework and t
 
 :::
 
-Nuxt 2 is not supported, as it is built on Vue 2, which has reached end-of-life.
-See
-[Nuxt 2 CT no longer supported](/app/references/migration-guide#Nuxt-2-CT-no-longer-supported)
-in the migration guide.
-
 Because Cypress does not execute `nuxt.config`, the bundler behavior Nuxt
 normally provides is not applied for you. Account for the following in the config
 you pass to Cypress:

--- a/docs/app/component-testing/vue/overview.mdx
+++ b/docs/app/component-testing/vue/overview.mdx
@@ -138,6 +138,45 @@ in manually via the `webpackConfig` option.
 
 - [Vue 3 Webpack 5 with TypeScript](https://github.com/cypress-io/cypress-component-testing-apps/tree/main/vue3-webpack-ts)
 
+## Using Cypress with Nuxt
+
+Cypress does not ship a dedicated [Nuxt](https://nuxt.com/) framework definition,
+and it does not read `nuxt.config`. Instead, you component test a Nuxt 3+ app the
+same way you test any Vue 3 + Vite project, by setting the `vue` framework and the
+`vite` bundler:
+
+:::cypress-config-example
+
+```ts
+{
+  component: {
+    devServer: {
+      framework: 'vue',
+      bundler: 'vite',
+    },
+  },
+}
+```
+
+:::
+
+Nuxt 2 is not supported, as it is built on Vue 2, which has reached end-of-life.
+See
+[Nuxt 2 CT no longer supported](/app/references/migration-guide#Nuxt-2-CT-no-longer-supported)
+in the migration guide.
+
+Because Cypress does not execute `nuxt.config`, the bundler behavior Nuxt
+normally provides is not applied for you. Account for the following in the config
+you pass to Cypress:
+
+- **Path aliases** — Nuxt's `~` and `@` aliases are not visible to Cypress.
+  Declare the ones your components use via `viteConfig`. See
+  [Meta-frameworks that own the bundler config](/app/component-testing/component-framework-configuration#Meta-frameworks-that-own-the-bundler-config).
+- **Auto-imports** — Nuxt auto-imports components and composables (such as `ref`,
+  `useRoute`, and `useRuntimeConfig`). These are not available when a component is
+  mounted in isolation, so either import what your component relies on explicitly
+  or add the equivalent Vite plugin to your `viteConfig`.
+
 ## See also
 
 - [Component Testing code coverage](/app/tooling/code-coverage#component-testing-code-coverage)

--- a/docs/app/references/migration-guide.mdx
+++ b/docs/app/references/migration-guide.mdx
@@ -760,7 +760,7 @@ import { mount } from '@cypress/vue2'
 
 ### Nuxt 2 CT no longer supported
 
-[Nuxt 2 reached end-of-life on June 30th, 2024](https://v2.nuxt.com/) and is built on Vue 2, which is also end-of-life. Cypress has never shipped a dedicated Nuxt framework definition — Nuxt apps are component tested as Vue apps — so component testing a Nuxt 2 project relied on the Vue 2 harness. With Cypress 14 no longer shipping that harness with the binary, Nuxt 2 apps can no longer be component tested out of the box.
+[Nuxt 2 reached end-of-life on June 30th, 2024](https://v2.nuxt.com/) and is built on Vue 2, which is also end-of-life. Component testing a Nuxt 2 project relied on the Vue 2 harness. With Cypress 14 no longer shipping that harness with the binary, Nuxt 2 apps can no longer be component tested out of the box.
 
 For component testing a Nuxt 3+ app (which is Vue 3 + Vite), see [Using Cypress with Nuxt](/app/component-testing/vue/overview#Using-Cypress-with-Nuxt).
 

--- a/docs/app/references/migration-guide.mdx
+++ b/docs/app/references/migration-guide.mdx
@@ -758,6 +758,16 @@ import { mount } from 'cypress/vue2'
 import { mount } from '@cypress/vue2'
 ```
 
+### Nuxt 2 CT no longer supported
+
+[Nuxt 2 reached end-of-life on June 30th, 2024](https://v2.nuxt.com/) and is built on Vue 2, which is also end-of-life. Cypress has never shipped a dedicated Nuxt framework definition — Nuxt apps are component tested as Vue apps — so component testing a Nuxt 2 project relied on the Vue 2 harness. With Cypress 14 no longer shipping that harness with the binary, Nuxt 2 apps can no longer be component tested out of the box.
+
+For component testing a Nuxt 3+ app (which is Vue 3 + Vite), see [Using Cypress with Nuxt](/app/component-testing/vue/overview#Using-Cypress-with-Nuxt).
+
+#### To continue using Nuxt 2
+
+If you haven't been able to migrate away from Nuxt 2, the underlying Vue 2 harness can still be installed independently via the [@cypress/vue2](https://www.npmjs.com/package/@cypress/vue2) package, as described in [To continue using Vue 2](#Vue-2-CT-no-longer-supported). Note that this package is deprecated and no longer supported by Cypress, and is intended only as a temporary workaround while you migrate to Nuxt 3+.
+
 ### Create React App CT no longer supported
 
 [create-react-app](https://create-react-app.dev/) is no longer actively maintained or supported (see [CRA issue #13393](https://github.com/facebook/create-react-app/issues/13393)). Your component tests will now need a bundler to run. If still using [create-react-app](https://create-react-app.dev/), you'll either need to:


### PR DESCRIPTION
Cypress has no dedicated Nuxt framework definition; Nuxt apps are tested
as Vue apps. Document the code-accurate path for Nuxt 3+ (Vue 3 + Vite)
in the Vue overview, including the alias and auto-import caveats users
must handle themselves. Add the missing "Nuxt 2 CT no longer supported"
migration section, mirroring the other frameworks dropped in Cypress 14.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LrLTjnrJXqxHPLmkWmZJQA

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or product behavior impact.
> 
> **Overview**
> Documents how **Nuxt 3+** fits into Cypress component testing: there is no Nuxt-specific framework option—apps are configured like **Vue 3 + Vite** (`framework: 'vue'`, `bundler: 'vite'`). The new Vue overview section states that **`nuxt.config` is not applied**, and calls out **path aliases** (`~`, `@`) and **auto-imports** as gaps users must handle via `viteConfig` or explicit imports, with a link to the existing meta-frameworks guidance.
> 
> The **Cypress 14 migration guide** gains a **Nuxt 2 component testing** section aligned with other dropped frameworks: Nuxt 2/EOL and reliance on the removed in-binary Vue 2 harness, a pointer to the new Nuxt 3+ overview, and the **`@cypress/vue2`** workaround for staying on Nuxt 2 temporarily.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90b441bfcb8b14a1ec46b943bb2e0cc77c837764. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->