### PR TITLE
docs: expand FAQ guidance on querying elements inside an iframe

### DIFF
--- a/docs/api/cypress-api/custom-commands.mdx
+++ b/docs/api/cypress-api/custom-commands.mdx
@@ -624,6 +624,59 @@ cy.createUser({
 })
 ```
 
+#### Query inside an iframe
+
+Cypress has no dedicated command for switching into an iframe, so a custom command
+is a convenient way to reuse the same-origin pattern of reading the frame's
+`contentDocument.body` and re-wrapping it with [`cy.wrap()`](/api/commands/wrap).
+The `.should('not.be.empty')` assertion waits for the frame's document to load
+before proceeding.
+
+<Tabs>
+<TabItem value="cypress/support/commands.js">
+
+```js
+Cypress.Commands.add('getIframeBody', (selector) => {
+  return cy
+    .get(selector)
+    .its('0.contentDocument.body')
+    .should('not.be.empty')
+    .then(cy.wrap)
+})
+```
+
+</TabItem>
+<TabItem value="cypress/support/commands.ts">
+
+```typescript
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      getIframeBody(selector: string): Chainable<JQuery<HTMLElement>>
+    }
+  }
+}
+
+Cypress.Commands.add('getIframeBody', (selector) => {
+  return cy
+    .get(selector)
+    .its('0.contentDocument.body')
+    .should('not.be.empty')
+    .then(cy.wrap)
+})
+```
+
+</TabItem>
+</Tabs>
+
+```js title="spec.cy.js"
+cy.getIframeBody('#my-iframe').find('[data-testid="submit"]').click()
+```
+
+This works for same-origin iframes only. For the cross-origin restrictions, see
+[How do I test elements inside an iframe?](/app/faq#How-do-I-test-elements-inside-an-iframe)
+in the FAQ.
+
 :::info
 
 <strong>Command Log</strong>

--- a/docs/app/faq.mdx
+++ b/docs/app/faq.mdx
@@ -885,7 +885,7 @@ cy.get('iframe')
   // iframe to exist.
   .its('0.contentDocument.body')
   // Wait for the iframe document to finish rendering its content before
-  // continuing — otherwise you may query an empty body.
+  // continuing, otherwise you may query an empty body.
   .should('not.be.empty')
   // Re-wrap the raw DOM body so the rest of the chain is a Cypress subject
   // with built-in retry-ability.
@@ -937,7 +937,7 @@ cy.iframe('#my-iframe').find('[data-testid="submit"]').click()
 
 The community [`cypress-iframe`](https://www.npmjs.com/package/cypress-iframe)
 plugin (`cy.iframe()` / `cy.frameLoaded()` / `.iframe()`) essentially packages the
-patterns above — grabbing the frame's body and adding retries until it loads. For
+patterns above by grabbing the frame's body and adding retries until it loads. For
 most same-origin iframes on modern Cypress versions it is optional, but it can
 still be a convenient shorthand if you interact with many iframes.
 
@@ -951,7 +951,7 @@ still be a convenient shorthand if you interact with many iframes.
   [Cross-origin iframes](/app/guides/cross-origin-testing#Cross-origin-iframes) in
   the Cross Origin Testing guide.
 - **[`cy.origin()`](/api/commands/origin) does not help here.** `cy.origin()`
-  handles top-level navigation to another origin — it cannot reach into an
+  handles top-level navigation to another origin. It cannot reach into an
   embedded cross-origin `<iframe>`.
 - **Workaround for cross-origin iframes:** setting
   [`chromeWebSecurity`](/app/references/configuration#Browser) to `false` lets

--- a/docs/app/faq.mdx
+++ b/docs/app/faq.mdx
@@ -866,8 +866,98 @@ fuss with your database.
 
 ### <Icon name="angle-right" /> How do I test elements inside an iframe?
 
-We have an [open proposal](https://github.com/cypress-io/cypress/issues/136) to
-expand the APIs to support "switching into" an iframe and then back out of them.
+Cypress can interact with elements inside a **same-origin** `<iframe>` today, so a
+third-party plugin is usually not required. There is no dedicated "switch into an
+iframe" command yet (see the [open proposal](https://github.com/cypress-io/cypress/issues/136)),
+but you can reach into the iframe's document with existing commands and then chain
+the usual `cy.*` queries and actions off of it.
+
+#### Query into a same-origin iframe
+
+The most common approach is to grab the iframe element, read its
+`contentDocument.body`, and re-wrap it with [`cy.wrap()`](/api/commands/wrap) so
+you can continue chaining commands into the iframe:
+
+```javascript
+cy.get('iframe')
+  // '0' indexes into the jQuery object to get the raw <iframe> DOM element,
+  // then reads its document body. `.its()` retries, so this waits for the
+  // iframe to exist.
+  .its('0.contentDocument.body')
+  // Wait for the iframe document to finish rendering its content before
+  // continuing — otherwise you may query an empty body.
+  .should('not.be.empty')
+  // Re-wrap the raw DOM body so the rest of the chain is a Cypress subject
+  // with built-in retry-ability.
+  .then(cy.wrap)
+  .find('[data-testid="submit"]')
+  .click()
+```
+
+An equivalent pattern uses jQuery's `.contents()` to reach the iframe document:
+
+```javascript
+cy.get('iframe')
+  .its('0.contentDocument')
+  .should('exist')
+  .its('body')
+  .should('not.be.empty')
+  .then(cy.wrap)
+  .find('h1')
+  .should('have.text', 'Hello, iframe')
+```
+
+To keep specs readable, wrap either pattern in a custom command:
+
+```javascript title="cypress/support/commands.js"
+Cypress.Commands.add('iframe', (iframeSelector) => {
+  return cy
+    .get(iframeSelector)
+    .its('0.contentDocument.body')
+    .should('not.be.empty')
+    .then(cy.wrap)
+})
+```
+
+```javascript
+cy.iframe('#my-iframe').find('[data-testid="submit"]').click()
+```
+
+#### Why the extra steps?
+
+- `.its('0.contentDocument.body')` yields a **raw DOM element**. Passing it through
+  [`cy.wrap()`](/api/commands/wrap) turns it back into a Cypress subject, which
+  restores [retry-ability](/app/core-concepts/retry-ability) for the `.find()`,
+  `.click()`, assertions, and everything else that follows.
+- The `.should('not.be.empty')` assertion is important: an `<iframe>` loads its
+  document asynchronously, so without waiting you may query the body before its
+  content has rendered.
+
+#### The `cypress-iframe` plugin
+
+The community [`cypress-iframe`](https://www.npmjs.com/package/cypress-iframe)
+plugin (`cy.iframe()` / `cy.frameLoaded()` / `.iframe()`) essentially packages the
+patterns above — grabbing the frame's body and adding retries until it loads. For
+most same-origin iframes on modern Cypress versions it is optional, but it can
+still be a convenient shorthand if you interact with many iframes.
+
+#### Restrictions
+
+- **Cross-origin iframes are not supported.** Because of the browser's
+  [same-origin policy](https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy),
+  reading `contentDocument` on an iframe served from a different origin (a Stripe
+  payment form, an embedded YouTube/Vimeo video, an Auth0 login, a Disqus comment
+  widget, etc.) returns `null`, so none of the patterns above will work. See
+  [Cross-origin iframes](/app/guides/cross-origin-testing#Cross-origin-iframes) in
+  the Cross Origin Testing guide.
+- **[`cy.origin()`](/api/commands/origin) does not help here.** `cy.origin()`
+  handles top-level navigation to another origin — it cannot reach into an
+  embedded cross-origin `<iframe>`.
+- **Workaround for cross-origin iframes:** setting
+  [`chromeWebSecurity`](/app/references/configuration#Browser) to `false` lets
+  Chromium-family browsers access cross-origin iframes embedded in your app. This
+  is not supported in Firefox or WebKit. See
+  [Disabling Web Security](/app/guides/cross-origin-testing#Disabling-Web-Security).
 
 ### <Icon name="angle-right" /> How do I preserve cookies / localStorage in between my tests?
 

--- a/docs/app/guides/cross-origin-testing.mdx
+++ b/docs/app/guides/cross-origin-testing.mdx
@@ -218,6 +218,11 @@ If you'd like support for this
 you can
 [disable web security](/app/guides/cross-origin-testing#Disabling-Web-Security).
 
+Note that **same-origin** iframes are not affected by this restriction and can be
+queried natively. See
+[How do I test elements inside an iframe?](/app/faq#How-do-I-test-elements-inside-an-iframe)
+in the FAQ.
+
 ### Insecure Content
 
 Because of the way Cypress is designed, if you're testing an HTTPS site,

--- a/docs/app/guides/migration/playwright-to-cypress.mdx
+++ b/docs/app/guides/migration/playwright-to-cypress.mdx
@@ -1119,6 +1119,13 @@ cy.getIframeBody('#payment-frame').within(() => {
 })
 ```
 
+This works for **same-origin** iframes. Unlike Playwright's `frameLocator`,
+Cypress cannot reach into a **cross-origin** iframe unless you set
+[`chromeWebSecurity`](/app/references/configuration#Browser) to `false` in
+Chromium-family browsers. See
+[How do I test elements inside an iframe?](/app/faq#How-do-I-test-elements-inside-an-iframe)
+for the full details and restrictions.
+
 ## Shadow DOM
 
 For Shadow DOM in Cypress, you can traverse explicitly:

--- a/docs/app/references/trade-offs.mdx
+++ b/docs/app/references/trade-offs.mdx
@@ -38,7 +38,11 @@ eventually address.
 
 - [Workarounds for the lack of a `cy.hover()` command.](/api/commands/hover)
 - [There is not any native or mobile events support.](https://github.com/cypress-io/cypress/issues/311#issuecomment-339824191)
-- [iframe support is somewhat limited, but does work.](https://github.com/cypress-io/cypress/issues/136)
+- iframe support is somewhat limited, but does work. Same-origin iframes can be
+  queried natively (see
+  [How do I test elements inside an iframe?](/app/faq#How-do-I-test-elements-inside-an-iframe)),
+  while a "switch into an iframe" command is still an
+  [open proposal](https://github.com/cypress-io/cypress/issues/136).
 
 ## Permanent trade-offs
 


### PR DESCRIPTION
Replace the thin "open proposal" FAQ answer with practical guidance:
native same-origin iframe querying via .its('0.contentDocument.body')
and cy.wrap, a reusable custom command, notes on the cypress-iframe
plugin, and the cross-origin restrictions (same-origin policy,
cy.origin not applying, chromeWebSecurity workaround).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011kZVHa1Pt8k1XiEp74VyYa

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to MDX documentation with no runtime, test, or configuration impact.
> 
> **Overview**
> **Documentation-only** update that replaces the thin FAQ answer on iframe testing with actionable guidance and wires that content into several other docs.
> 
> The **FAQ** now explains how to query **same-origin** iframes using `.its('0.contentDocument.body')`, `.should('not.be.empty')`, and `cy.wrap()`, documents an alternate `.contents()`-style path, suggests a reusable `cy.iframe()` custom command, covers why `cy.wrap` restores retry-ability, notes when **`cypress-iframe`** is optional, and spells out **cross-origin** limits (`contentDocument` is `null`, `cy.origin()` does not apply, `chromeWebSecurity: false` workaround).
> 
> **Custom Commands** adds a **`getIframeBody`** parent-command example (JS + TS) that mirrors the FAQ pattern and links back to the FAQ for restrictions.
> 
> **Cross Origin Testing**, **Playwright → Cypress**, and **Trade-offs** gain short callouts that same-origin iframes work natively and point readers to the expanded FAQ instead of only referencing the open iframe API proposal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d671276e6b734db72b37acb19de3df813d3acc14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->