### PR TITLE
docs(component-testing): add Testing Error States section for React

### DIFF
--- a/docs/app/component-testing/angular/examples.mdx
+++ b/docs/app/component-testing/angular/examples.mdx
@@ -451,14 +451,6 @@ it('routes render errors to the ErrorHandler', () => {
 })
 ```
 
-:::caution
-
-A custom `ErrorHandler` observes the error, but it does **not** stop the error
-from propagating to Cypress. The `cy.on('uncaught:exception')` handler is
-required regardless of whether you provide a custom `ErrorHandler`.
-
-:::
-
 ## Custom Mount Commands
 
 ### Customizing `cy.mount()`

--- a/docs/app/component-testing/angular/examples.mdx
+++ b/docs/app/component-testing/angular/examples.mdx
@@ -400,14 +400,6 @@ These spies can automatically be created if `autoSpyOutputs: true` is configured
 
 ## Testing Error States
 
-:::info
-
-The Angular example below is drafted from the verified React pattern but has
-**not** yet been run locally against a real project. Run it in your own setup
-before relying on it, and adjust as needed.
-
-:::
-
 <ComponentTestingErrorStates />
 
 ```ts

--- a/docs/app/component-testing/angular/examples.mdx
+++ b/docs/app/component-testing/angular/examples.mdx
@@ -408,15 +408,7 @@ before relying on it, and adjust as needed.
 
 :::
 
-`cy.mount()` is an asynchronous Cypress command: it _enqueues_ the mount and
-returns immediately, before the component ever renders. When a component throws
-during render, the error surfaces as an uncaught exception rather than as a
-synchronous throw.
-
-By default Cypress fails the test on any uncaught exception, so to assert on a
-render error you listen for it with
-[`cy.on('uncaught:exception')`](/api/cypress-api/catalog-of-events#Uncaught-Exceptions)
-and return `false` to prevent Cypress from failing the test:
+<ComponentTestingErrorStates />
 
 ```ts
 import { UserProfileComponent } from './user-profile.component'

--- a/docs/app/component-testing/angular/examples.mdx
+++ b/docs/app/component-testing/angular/examples.mdx
@@ -420,7 +420,7 @@ it('surfaces a render error', () => {
 
 ### Testing with a custom `ErrorHandler`
 
-The idiomatic way to observe render errors in Angular is a custom
+The recommended way to observe render errors in Angular is a custom
 [`ErrorHandler`](https://angular.dev/api/core/ErrorHandler) provider. Angular
 routes errors thrown during change detection to the `ErrorHandler`, so you can
 provide one backed by a [`cy.stub()`](/api/commands/stub) and assert it was

--- a/docs/app/component-testing/angular/examples.mdx
+++ b/docs/app/component-testing/angular/examples.mdx
@@ -408,24 +408,13 @@ before relying on it, and adjust as needed.
 
 :::
 
-You might expect to assert that mounting a component throws:
+`cy.mount()` is an asynchronous Cypress command: it _enqueues_ the mount and
+returns immediately, before the component ever renders. When a component throws
+during render, the error surfaces as an uncaught exception rather than as a
+synchronous throw.
 
-```ts
-// ❌ This does NOT work
-it('throws when data is missing', () => {
-  expect(() => cy.mount(UserProfileComponent)).to.throw()
-})
-```
-
-This assertion silently passes without testing anything. `cy.mount()` is an
-asynchronous Cypress command: it _enqueues_ the mount and returns immediately,
-before the component ever renders. There is no synchronous error for
-`expect().to.throw()` to catch, so the assertion is meaningless (and
-`.not.to.throw()` would "pass" for the same reason).
-
-Instead, when a component throws during render, the error surfaces as an
-uncaught exception. By default Cypress fails the test on any uncaught
-exception, so to assert on a render error you listen for it with
+By default Cypress fails the test on any uncaught exception, so to assert on a
+render error you listen for it with
 [`cy.on('uncaught:exception')`](/api/cypress-api/catalog-of-events#Uncaught-Exceptions)
 and return `false` to prevent Cypress from failing the test:
 

--- a/docs/app/component-testing/angular/examples.mdx
+++ b/docs/app/component-testing/angular/examples.mdx
@@ -398,6 +398,94 @@ cy.get('@countChange').should('have.been.called')
 
 These spies can automatically be created if `autoSpyOutputs: true` is configured. The suffix in this case will be `ChangeSpy`.
 
+## Testing Error States
+
+:::info
+
+The Angular example below is drafted from the verified React pattern but has
+**not** yet been run locally against a real project. Run it in your own setup
+before relying on it, and adjust as needed.
+
+:::
+
+You might expect to assert that mounting a component throws:
+
+```ts
+// ❌ This does NOT work
+it('throws when data is missing', () => {
+  expect(() => cy.mount(UserProfileComponent)).to.throw()
+})
+```
+
+This assertion silently passes without testing anything. `cy.mount()` is an
+asynchronous Cypress command: it _enqueues_ the mount and returns immediately,
+before the component ever renders. There is no synchronous error for
+`expect().to.throw()` to catch, so the assertion is meaningless (and
+`.not.to.throw()` would "pass" for the same reason).
+
+Instead, when a component throws during render, the error surfaces as an
+uncaught exception. By default Cypress fails the test on any uncaught
+exception, so to assert on a render error you listen for it with
+[`cy.on('uncaught:exception')`](/api/cypress-api/catalog-of-events#Uncaught-Exceptions)
+and return `false` to prevent Cypress from failing the test:
+
+```ts
+import { UserProfileComponent } from './user-profile.component'
+
+it('surfaces a render error', () => {
+  cy.on('uncaught:exception', (err) => {
+    // Assert on the error thrown during render...
+    expect(err.message).to.include('user is required')
+
+    // ...and return false so Cypress does not fail the test.
+    return false
+  })
+
+  cy.mount(UserProfileComponent)
+})
+```
+
+### Testing with a custom `ErrorHandler`
+
+The idiomatic way to observe render errors in Angular is a custom
+[`ErrorHandler`](https://angular.dev/api/core/ErrorHandler) provider. Angular
+routes errors thrown during change detection to the `ErrorHandler`, so you can
+provide one backed by a [`cy.stub()`](/api/commands/stub) and assert it was
+called:
+
+```ts
+import { ErrorHandler } from '@angular/core'
+import { ChildWithErrorComponent } from './child-with-error.component'
+
+it('routes render errors to the ErrorHandler', () => {
+  const handleError = cy.stub().as('handleError')
+
+  // A custom ErrorHandler observes the error, but it does NOT stop the error
+  // from propagating to Cypress as an uncaught exception. Cypress fails on
+  // uncaught exceptions by default, so we must still suppress that behavior.
+  cy.on('uncaught:exception', (err) => {
+    // Only suppress the specific error we expect.
+    expect(err.message).to.include('I crashed!')
+
+    return false
+  })
+
+  cy.mount(ChildWithErrorComponent, {
+    providers: [{ provide: ErrorHandler, useValue: { handleError } }],
+  })
+
+  cy.get('@handleError').should('have.been.called')
+})
+```
+
+:::caution
+
+A custom `ErrorHandler` observes the error, but it does **not** stop the error
+from propagating to Cypress. The `cy.on('uncaught:exception')` handler is
+required regardless of whether you provide a custom `ErrorHandler`.
+
+:::
+
 ## Custom Mount Commands
 
 ### Customizing `cy.mount()`

--- a/docs/app/component-testing/react/examples.mdx
+++ b/docs/app/component-testing/react/examples.mdx
@@ -165,14 +165,6 @@ export class ErrorBoundary extends React.Component {
 </TabItem>
 </Tabs>
 
-:::caution
-
-An Error Boundary renders fallback UI, but it does **not** stop the error from
-propagating to Cypress. The `cy.on('uncaught:exception')` handler is required
-regardless of whether you use an Error Boundary.
-
-:::
-
 ## Custom Mount Commands
 
 ### Customizing `cy.mount()`

--- a/docs/app/component-testing/react/examples.mdx
+++ b/docs/app/component-testing/react/examples.mdx
@@ -96,10 +96,8 @@ which renders fallback UI via `getDerivedStateFromError()`. You can mount a
 component wrapped in your Error Boundary and assert that the fallback UI is
 displayed:
 
-<Tabs>
-<TabItem value="ErrorBoundary.cy.jsx">
-
 ```jsx
+// ErrorBoundary.cy.jsx
 import { ErrorBoundary } from './ErrorBoundary'
 
 const errorMessage = 'I crashed!'
@@ -128,10 +126,10 @@ it('displays the fallback UI on error', () => {
 })
 ```
 
-</TabItem>
-<TabItem value="ErrorBoundary.jsx">
+Where `ErrorBoundary` renders fallback UI from `getDerivedStateFromError()`:
 
 ```jsx
+// ErrorBoundary.jsx
 import React from 'react'
 
 export class ErrorBoundary extends React.Component {
@@ -161,9 +159,6 @@ export class ErrorBoundary extends React.Component {
   }
 }
 ```
-
-</TabItem>
-</Tabs>
 
 ## Custom Mount Commands
 

--- a/docs/app/component-testing/react/examples.mdx
+++ b/docs/app/component-testing/react/examples.mdx
@@ -70,15 +70,7 @@ it('clicking + fires a change event with the incremented value', () => {
 
 ## Testing Error States
 
-`cy.mount()` is an asynchronous Cypress command: it _enqueues_ the mount and
-returns immediately, before the component ever renders. When a component throws
-during render, the error surfaces as an uncaught exception rather than as a
-synchronous throw.
-
-By default Cypress fails the test on any uncaught exception, so to assert on a
-render error you listen for it with
-[`cy.on('uncaught:exception')`](/api/cypress-api/catalog-of-events#Uncaught-Exceptions)
-and return `false` to prevent Cypress from failing the test:
+<ComponentTestingErrorStates />
 
 ```jsx
 import { UserProfile } from './UserProfile'

--- a/docs/app/component-testing/react/examples.mdx
+++ b/docs/app/component-testing/react/examples.mdx
@@ -68,6 +68,131 @@ it('clicking + fires a change event with the incremented value', () => {
 })
 ```
 
+## Testing Error States
+
+When migrating from React Testing Library, you might expect to assert that
+mounting a component throws:
+
+```js
+// ❌ This does NOT work
+it('throws when data is missing', () => {
+  expect(() => cy.mount(<UserProfile />)).to.throw()
+})
+```
+
+This assertion silently passes without testing anything. `cy.mount()` is an
+asynchronous Cypress command: it _enqueues_ the mount and returns immediately,
+before the component ever renders. There is no synchronous error for
+`expect().to.throw()` to catch, so the assertion is meaningless (and
+`.not.to.throw()` would "pass" for the same reason).
+
+Instead, when a component throws during render, the error surfaces as an
+uncaught exception. By default Cypress fails the test on any uncaught
+exception, so to assert on a render error you listen for it with
+[`cy.on('uncaught:exception')`](/api/cypress-api/catalog-of-events#Uncaught-Exceptions)
+and return `false` to prevent Cypress from failing the test:
+
+```jsx
+import { UserProfile } from './UserProfile'
+
+it('surfaces a render error', () => {
+  cy.on('uncaught:exception', (err) => {
+    // Assert on the error thrown during render...
+    expect(err.message).to.include('user is required')
+
+    // ...and return false so Cypress does not fail the test.
+    return false
+  })
+
+  cy.mount(<UserProfile />)
+})
+```
+
+### Testing Error Boundaries
+
+The idiomatic way to handle render errors in React is an
+[Error Boundary](https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary),
+which renders fallback UI via `getDerivedStateFromError()`. You can mount a
+component wrapped in your Error Boundary and assert that the fallback UI is
+displayed:
+
+<Tabs>
+<TabItem value="ErrorBoundary.cy.jsx">
+
+```jsx
+import { ErrorBoundary } from './ErrorBoundary'
+
+const errorMessage = 'I crashed!'
+const ChildWithError = () => {
+  throw new Error(errorMessage)
+}
+
+it('displays the fallback UI on error', () => {
+  // An Error Boundary renders fallback UI, but it does NOT stop the error
+  // from propagating to Cypress as an uncaught exception. Cypress fails on
+  // uncaught exceptions by default, so we must still suppress that behavior.
+  cy.on('uncaught:exception', (err) => {
+    // Only suppress the specific error we expect.
+    expect(err.message).to.include(errorMessage)
+
+    return false
+  })
+
+  cy.mount(
+    <ErrorBoundary name="ChildWithError">
+      <ChildWithError />
+    </ErrorBoundary>
+  )
+
+  cy.get('header h1').should('contain', 'Something went wrong.')
+})
+```
+
+</TabItem>
+<TabItem value="ErrorBoundary.jsx">
+
+```jsx
+import React from 'react'
+
+export class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = { error: null }
+  }
+
+  static getDerivedStateFromError(error) {
+    return { error }
+  }
+
+  render() {
+    const { name } = this.props
+    const { error } = this.state
+
+    if (error) {
+      return (
+        <header>
+          <h1>Something went wrong.</h1>
+          <h2>{`${name} failed to load`}</h2>
+        </header>
+      )
+    }
+
+    return this.props.children
+  }
+}
+```
+
+</TabItem>
+</Tabs>
+
+:::caution
+
+An Error Boundary renders fallback UI, but it does **not** stop the error from
+propagating to Cypress. The `cy.on('uncaught:exception')` handler is required
+regardless of whether you use an Error Boundary.
+
+:::
+
 ## Custom Mount Commands
 
 ### Customizing `cy.mount()`

--- a/docs/app/component-testing/react/examples.mdx
+++ b/docs/app/component-testing/react/examples.mdx
@@ -70,25 +70,13 @@ it('clicking + fires a change event with the incremented value', () => {
 
 ## Testing Error States
 
-When migrating from React Testing Library, you might expect to assert that
-mounting a component throws:
+`cy.mount()` is an asynchronous Cypress command: it _enqueues_ the mount and
+returns immediately, before the component ever renders. When a component throws
+during render, the error surfaces as an uncaught exception rather than as a
+synchronous throw.
 
-```js
-// ❌ This does NOT work
-it('throws when data is missing', () => {
-  expect(() => cy.mount(<UserProfile />)).to.throw()
-})
-```
-
-This assertion silently passes without testing anything. `cy.mount()` is an
-asynchronous Cypress command: it _enqueues_ the mount and returns immediately,
-before the component ever renders. There is no synchronous error for
-`expect().to.throw()` to catch, so the assertion is meaningless (and
-`.not.to.throw()` would "pass" for the same reason).
-
-Instead, when a component throws during render, the error surfaces as an
-uncaught exception. By default Cypress fails the test on any uncaught
-exception, so to assert on a render error you listen for it with
+By default Cypress fails the test on any uncaught exception, so to assert on a
+render error you listen for it with
 [`cy.on('uncaught:exception')`](/api/cypress-api/catalog-of-events#Uncaught-Exceptions)
 and return `false` to prevent Cypress from failing the test:
 

--- a/docs/app/component-testing/react/examples.mdx
+++ b/docs/app/component-testing/react/examples.mdx
@@ -90,7 +90,7 @@ it('surfaces a render error', () => {
 
 ### Testing Error Boundaries
 
-The idiomatic way to handle render errors in React is an
+The recommended way to handle render errors in React is an
 [Error Boundary](https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary),
 which renders fallback UI via `getDerivedStateFromError()`. You can mount a
 component wrapped in your Error Boundary and assert that the fallback UI is

--- a/docs/app/component-testing/svelte/examples.mdx
+++ b/docs/app/component-testing/svelte/examples.mdx
@@ -102,10 +102,8 @@ The idiomatic way to render fallback UI in Svelte 5 is
 cleanest approach is a dedicated fixture component that imports the failing
 component directly, then mount that fixture and assert the fallback is shown:
 
-<Tabs>
-<TabItem value="ErrorBoundary.cy.js">
-
 ```js
+// ErrorBoundary.cy.js
 import ErrorBoundary from './ErrorBoundary.svelte'
 
 it('displays the fallback UI on error', () => {
@@ -125,10 +123,11 @@ it('displays the fallback UI on error', () => {
 })
 ```
 
-</TabItem>
-<TabItem value="ErrorBoundary.svelte">
+Where the `ErrorBoundary` fixture wraps the failing component in a
+`<svelte:boundary>` with a `failed` snippet:
 
 ```html
+<!-- ErrorBoundary.svelte -->
 <script>
   import ChildWithError from './ChildWithError.svelte'
 </script>
@@ -141,6 +140,3 @@ it('displays the fallback UI on error', () => {
   {/snippet}
 </svelte:boundary>
 ```
-
-</TabItem>
-</Tabs>

--- a/docs/app/component-testing/svelte/examples.mdx
+++ b/docs/app/component-testing/svelte/examples.mdx
@@ -76,16 +76,6 @@ cy.mount(Stepper).then(({ component }) => {
 
 ## Testing Error States
 
-:::info
-
-The Svelte example below is drafted from the verified React pattern but has
-**not** yet been run locally against a real project. It also relies on
-[`<svelte:boundary>`](https://svelte.dev/docs/svelte/svelte-boundary), which
-requires Svelte 5. Run it in your own setup before relying on it, and adjust as
-needed.
-
-:::
-
 <ComponentTestingErrorStates />
 
 ```js

--- a/docs/app/component-testing/svelte/examples.mdx
+++ b/docs/app/component-testing/svelte/examples.mdx
@@ -136,7 +136,7 @@ Where the `ErrorBoundary` fixture wraps the failing component in a
   <ChildWithError />
 
   {#snippet failed(error)}
-    <div data-cy="fallback">Something went wrong.</div>
+  <div data-cy="fallback">Something went wrong.</div>
   {/snippet}
 </svelte:boundary>
 ```

--- a/docs/app/component-testing/svelte/examples.mdx
+++ b/docs/app/component-testing/svelte/examples.mdx
@@ -144,11 +144,3 @@ it('displays the fallback UI on error', () => {
 
 </TabItem>
 </Tabs>
-
-:::caution
-
-`<svelte:boundary>` renders fallback UI, but it does **not** stop the error from
-propagating to Cypress. The `cy.on('uncaught:exception')` handler is required
-regardless of whether you use a boundary.
-
-:::

--- a/docs/app/component-testing/svelte/examples.mdx
+++ b/docs/app/component-testing/svelte/examples.mdx
@@ -73,3 +73,111 @@ cy.mount(Stepper).then(({ component }) => {
   //component is the rendered instance of Stepper
 })
 ```
+
+## Testing Error States
+
+:::info
+
+The Svelte example below is drafted from the verified React pattern but has
+**not** yet been run locally against a real project. It also relies on
+[`<svelte:boundary>`](https://svelte.dev/docs/svelte/svelte-boundary), which
+requires Svelte 5. Run it in your own setup before relying on it, and adjust as
+needed.
+
+:::
+
+You might expect to assert that mounting a component throws:
+
+```js
+// ❌ This does NOT work
+it('throws when a prop is missing', () => {
+  expect(() => cy.mount(UserProfile)).to.throw()
+})
+```
+
+This assertion silently passes without testing anything. `cy.mount()` is an
+asynchronous Cypress command: it _enqueues_ the mount and returns immediately,
+before the component ever renders. There is no synchronous error for
+`expect().to.throw()` to catch, so the assertion is meaningless (and
+`.not.to.throw()` would "pass" for the same reason).
+
+Instead, when a component throws during render, the error surfaces as an
+uncaught exception. By default Cypress fails the test on any uncaught
+exception, so to assert on a render error you listen for it with
+[`cy.on('uncaught:exception')`](/api/cypress-api/catalog-of-events#Uncaught-Exceptions)
+and return `false` to prevent Cypress from failing the test:
+
+```js
+import UserProfile from './UserProfile.svelte'
+
+it('surfaces a render error', () => {
+  cy.on('uncaught:exception', (err) => {
+    // Assert on the error thrown during render...
+    expect(err.message).to.include('user is required')
+
+    // ...and return false so Cypress does not fail the test.
+    return false
+  })
+
+  cy.mount(UserProfile)
+})
+```
+
+### Testing with `<svelte:boundary>`
+
+The idiomatic way to render fallback UI in Svelte 5 is
+[`<svelte:boundary>`](https://svelte.dev/docs/svelte/svelte-boundary) with a
+`failed` snippet. Rather than nesting components through `cy.mount()`, the
+cleanest approach is a dedicated fixture component that imports the failing
+component directly, then mount that fixture and assert the fallback is shown:
+
+<Tabs>
+<TabItem value="ErrorBoundary.cy.js">
+
+```js
+import ErrorBoundary from './ErrorBoundary.svelte'
+
+it('displays the fallback UI on error', () => {
+  // <svelte:boundary> renders fallback UI, but it does NOT stop the error from
+  // propagating to Cypress as an uncaught exception. Cypress fails on uncaught
+  // exceptions by default, so we must still suppress that behavior.
+  cy.on('uncaught:exception', (err) => {
+    // Only suppress the specific error we expect.
+    expect(err.message).to.include('I crashed!')
+
+    return false
+  })
+
+  cy.mount(ErrorBoundary)
+
+  cy.get('[data-cy=fallback]').should('contain', 'Something went wrong.')
+})
+```
+
+</TabItem>
+<TabItem value="ErrorBoundary.svelte">
+
+```html
+<script>
+  import ChildWithError from './ChildWithError.svelte'
+</script>
+
+<svelte:boundary>
+  <ChildWithError />
+
+  {#snippet failed(error)}
+    <div data-cy="fallback">Something went wrong.</div>
+  {/snippet}
+</svelte:boundary>
+```
+
+</TabItem>
+</Tabs>
+
+:::caution
+
+`<svelte:boundary>` renders fallback UI, but it does **not** stop the error from
+propagating to Cypress. The `cy.on('uncaught:exception')` handler is required
+regardless of whether you use a boundary.
+
+:::

--- a/docs/app/component-testing/svelte/examples.mdx
+++ b/docs/app/component-testing/svelte/examples.mdx
@@ -86,24 +86,13 @@ needed.
 
 :::
 
-You might expect to assert that mounting a component throws:
+`cy.mount()` is an asynchronous Cypress command: it _enqueues_ the mount and
+returns immediately, before the component ever renders. When a component throws
+during render, the error surfaces as an uncaught exception rather than as a
+synchronous throw.
 
-```js
-// ❌ This does NOT work
-it('throws when a prop is missing', () => {
-  expect(() => cy.mount(UserProfile)).to.throw()
-})
-```
-
-This assertion silently passes without testing anything. `cy.mount()` is an
-asynchronous Cypress command: it _enqueues_ the mount and returns immediately,
-before the component ever renders. There is no synchronous error for
-`expect().to.throw()` to catch, so the assertion is meaningless (and
-`.not.to.throw()` would "pass" for the same reason).
-
-Instead, when a component throws during render, the error surfaces as an
-uncaught exception. By default Cypress fails the test on any uncaught
-exception, so to assert on a render error you listen for it with
+By default Cypress fails the test on any uncaught exception, so to assert on a
+render error you listen for it with
 [`cy.on('uncaught:exception')`](/api/cypress-api/catalog-of-events#Uncaught-Exceptions)
 and return `false` to prevent Cypress from failing the test:
 

--- a/docs/app/component-testing/svelte/examples.mdx
+++ b/docs/app/component-testing/svelte/examples.mdx
@@ -96,7 +96,7 @@ it('surfaces a render error', () => {
 
 ### Testing with `<svelte:boundary>`
 
-The idiomatic way to render fallback UI in Svelte 5 is
+The recommended way to render fallback UI in Svelte 5 is
 [`<svelte:boundary>`](https://svelte.dev/docs/svelte/svelte-boundary) with a
 `failed` snippet. Rather than nesting components through `cy.mount()`, the
 cleanest approach is a dedicated fixture component that imports the failing

--- a/docs/app/component-testing/svelte/examples.mdx
+++ b/docs/app/component-testing/svelte/examples.mdx
@@ -86,15 +86,7 @@ needed.
 
 :::
 
-`cy.mount()` is an asynchronous Cypress command: it _enqueues_ the mount and
-returns immediately, before the component ever renders. When a component throws
-during render, the error surfaces as an uncaught exception rather than as a
-synchronous throw.
-
-By default Cypress fails the test on any uncaught exception, so to assert on a
-render error you listen for it with
-[`cy.on('uncaught:exception')`](/api/cypress-api/catalog-of-events#Uncaught-Exceptions)
-and return `false` to prevent Cypress from failing the test:
+<ComponentTestingErrorStates />
 
 ```js
 import UserProfile from './UserProfile.svelte'

--- a/docs/app/component-testing/vue/examples.mdx
+++ b/docs/app/component-testing/vue/examples.mdx
@@ -101,7 +101,7 @@ it('surfaces a render error', () => {
 
 ### Testing with `onErrorCaptured`
 
-The idiomatic way to render fallback UI in Vue is a wrapper component that uses
+The recommended way to render fallback UI in Vue is a wrapper component that uses
 the [`onErrorCaptured`](https://vuejs.org/api/composition-api-lifecycle#onerrorcaptured)
 lifecycle hook to catch errors from its descendants. You can mount a component
 inside such a wrapper and assert that the fallback UI is displayed:

--- a/docs/app/component-testing/vue/examples.mdx
+++ b/docs/app/component-testing/vue/examples.mdx
@@ -79,6 +79,120 @@ it('clicking + fires a change event with the incremented value', () => {
 })
 ```
 
+## Testing Error States
+
+:::info
+
+The Vue example below is drafted from the verified React pattern but has **not**
+yet been run locally against a real project. Run it in your own setup before
+relying on it, and adjust as needed.
+
+:::
+
+You might expect to assert that mounting a component throws:
+
+```js
+// ❌ This does NOT work
+it('throws when a prop is missing', () => {
+  expect(() => cy.mount(UserProfile)).to.throw()
+})
+```
+
+This assertion silently passes without testing anything. `cy.mount()` is an
+asynchronous Cypress command: it _enqueues_ the mount and returns immediately,
+before the component ever renders. There is no synchronous error for
+`expect().to.throw()` to catch, so the assertion is meaningless (and
+`.not.to.throw()` would "pass" for the same reason).
+
+Instead, when a component throws during render, the error surfaces as an
+uncaught exception. By default Cypress fails the test on any uncaught
+exception, so to assert on a render error you listen for it with
+[`cy.on('uncaught:exception')`](/api/cypress-api/catalog-of-events#Uncaught-Exceptions)
+and return `false` to prevent Cypress from failing the test:
+
+```js
+import UserProfile from './UserProfile.vue'
+
+it('surfaces a render error', () => {
+  cy.on('uncaught:exception', (err) => {
+    // Assert on the error thrown during render...
+    expect(err.message).to.include('user is required')
+
+    // ...and return false so Cypress does not fail the test.
+    return false
+  })
+
+  cy.mount(UserProfile)
+})
+```
+
+### Testing with `onErrorCaptured`
+
+The idiomatic way to render fallback UI in Vue is a wrapper component that uses
+the [`onErrorCaptured`](https://vuejs.org/api/composition-api-lifecycle#onerrorcaptured)
+lifecycle hook to catch errors from its descendants. You can mount a component
+inside such a wrapper and assert that the fallback UI is displayed:
+
+<Tabs>
+<TabItem value="ErrorBoundary.cy.js">
+
+```js
+import { h } from 'vue'
+import ErrorBoundary from './ErrorBoundary.vue'
+import ChildWithError from './ChildWithError.vue'
+
+it('displays the fallback UI on error', () => {
+  // onErrorCaptured renders fallback UI, but it does NOT stop the error from
+  // propagating to Cypress as an uncaught exception. Cypress fails on uncaught
+  // exceptions by default, so we must still suppress that behavior.
+  cy.on('uncaught:exception', (err) => {
+    // Only suppress the specific error we expect.
+    expect(err.message).to.include('I crashed!')
+
+    return false
+  })
+
+  cy.mount(() => h(ErrorBoundary, () => h(ChildWithError)))
+
+  cy.get('[data-cy=fallback]').should('contain', 'Something went wrong.')
+})
+```
+
+</TabItem>
+<TabItem value="ErrorBoundary.vue">
+
+```html
+<template>
+  <div v-if="error" data-cy="fallback">Something went wrong.</div>
+  <slot v-else />
+</template>
+
+<script setup>
+import { ref, onErrorCaptured } from 'vue'
+
+const error = ref(null)
+
+onErrorCaptured((err) => {
+  error.value = err
+
+  // Returning false stops the error from propagating further up the Vue tree,
+  // but it still reaches Cypress as an uncaught exception.
+  return false
+})
+</script>
+```
+
+</TabItem>
+</Tabs>
+
+:::caution
+
+`onErrorCaptured` renders fallback UI, but it does **not** stop the error from
+propagating to Cypress. The `cy.on('uncaught:exception')` handler is required
+regardless of whether you use an error-capturing wrapper.
+
+:::
+
 ## Using Slots
 
 ### Default Slot

--- a/docs/app/component-testing/vue/examples.mdx
+++ b/docs/app/component-testing/vue/examples.mdx
@@ -89,24 +89,13 @@ relying on it, and adjust as needed.
 
 :::
 
-You might expect to assert that mounting a component throws:
+`cy.mount()` is an asynchronous Cypress command: it _enqueues_ the mount and
+returns immediately, before the component ever renders. When a component throws
+during render, the error surfaces as an uncaught exception rather than as a
+synchronous throw.
 
-```js
-// ❌ This does NOT work
-it('throws when a prop is missing', () => {
-  expect(() => cy.mount(UserProfile)).to.throw()
-})
-```
-
-This assertion silently passes without testing anything. `cy.mount()` is an
-asynchronous Cypress command: it _enqueues_ the mount and returns immediately,
-before the component ever renders. There is no synchronous error for
-`expect().to.throw()` to catch, so the assertion is meaningless (and
-`.not.to.throw()` would "pass" for the same reason).
-
-Instead, when a component throws during render, the error surfaces as an
-uncaught exception. By default Cypress fails the test on any uncaught
-exception, so to assert on a render error you listen for it with
+By default Cypress fails the test on any uncaught exception, so to assert on a
+render error you listen for it with
 [`cy.on('uncaught:exception')`](/api/cypress-api/catalog-of-events#Uncaught-Exceptions)
 and return `false` to prevent Cypress from failing the test:
 

--- a/docs/app/component-testing/vue/examples.mdx
+++ b/docs/app/component-testing/vue/examples.mdx
@@ -89,15 +89,7 @@ relying on it, and adjust as needed.
 
 :::
 
-`cy.mount()` is an asynchronous Cypress command: it _enqueues_ the mount and
-returns immediately, before the component ever renders. When a component throws
-during render, the error surfaces as an uncaught exception rather than as a
-synchronous throw.
-
-By default Cypress fails the test on any uncaught exception, so to assert on a
-render error you listen for it with
-[`cy.on('uncaught:exception')`](/api/cypress-api/catalog-of-events#Uncaught-Exceptions)
-and return `false` to prevent Cypress from failing the test:
+<ComponentTestingErrorStates />
 
 ```js
 import UserProfile from './UserProfile.vue'

--- a/docs/app/component-testing/vue/examples.mdx
+++ b/docs/app/component-testing/vue/examples.mdx
@@ -158,14 +158,6 @@ onErrorCaptured((err) => {
 </TabItem>
 </Tabs>
 
-:::caution
-
-`onErrorCaptured` renders fallback UI, but it does **not** stop the error from
-propagating to Cypress. The `cy.on('uncaught:exception')` handler is required
-regardless of whether you use an error-capturing wrapper.
-
-:::
-
 ## Using Slots
 
 ### Default Slot

--- a/docs/app/component-testing/vue/examples.mdx
+++ b/docs/app/component-testing/vue/examples.mdx
@@ -106,10 +106,8 @@ the [`onErrorCaptured`](https://vuejs.org/api/composition-api-lifecycle#onerrorc
 lifecycle hook to catch errors from its descendants. You can mount a component
 inside such a wrapper and assert that the fallback UI is displayed:
 
-<Tabs>
-<TabItem value="ErrorBoundary.cy.js">
-
 ```js
+// ErrorBoundary.cy.js
 import { h } from 'vue'
 import ErrorBoundary from './ErrorBoundary.vue'
 import ChildWithError from './ChildWithError.vue'
@@ -131,10 +129,11 @@ it('displays the fallback UI on error', () => {
 })
 ```
 
-</TabItem>
-<TabItem value="ErrorBoundary.vue">
+Where `ErrorBoundary` captures the error with `onErrorCaptured` and renders
+fallback UI:
 
 ```html
+<!-- ErrorBoundary.vue -->
 <template>
   <div v-if="error" data-cy="fallback">Something went wrong.</div>
   <slot v-else />
@@ -154,9 +153,6 @@ onErrorCaptured((err) => {
 })
 </script>
 ```
-
-</TabItem>
-</Tabs>
 
 ## Using Slots
 

--- a/docs/app/component-testing/vue/examples.mdx
+++ b/docs/app/component-testing/vue/examples.mdx
@@ -140,17 +140,17 @@ fallback UI:
 </template>
 
 <script setup>
-import { ref, onErrorCaptured } from 'vue'
+  import { ref, onErrorCaptured } from 'vue'
 
-const error = ref(null)
+  const error = ref(null)
 
-onErrorCaptured((err) => {
-  error.value = err
+  onErrorCaptured((err) => {
+    error.value = err
 
-  // Returning false stops the error from propagating further up the Vue tree,
-  // but it still reaches Cypress as an uncaught exception.
-  return false
-})
+    // Returning false stops the error from propagating further up the Vue tree,
+    // but it still reaches Cypress as an uncaught exception.
+    return false
+  })
 </script>
 ```
 

--- a/docs/app/component-testing/vue/examples.mdx
+++ b/docs/app/component-testing/vue/examples.mdx
@@ -81,14 +81,6 @@ it('clicking + fires a change event with the incremented value', () => {
 
 ## Testing Error States
 
-:::info
-
-The Vue example below is drafted from the verified React pattern but has **not**
-yet been run locally against a real project. Run it in your own setup before
-relying on it, and adjust as needed.
-
-:::
-
 <ComponentTestingErrorStates />
 
 ```js

--- a/docs/partials/_component-testing-error-states.mdx
+++ b/docs/partials/_component-testing-error-states.mdx
@@ -1,0 +1,9 @@
+`cy.mount()` is an asynchronous Cypress command: it _enqueues_ the mount and
+returns immediately, before the component ever renders. When a component throws
+during render, the error surfaces as an uncaught exception rather than as a
+synchronous throw.
+
+By default Cypress fails the test on any uncaught exception, so to assert on a
+render error you listen for it with
+[`cy.on('uncaught:exception')`](/api/cypress-api/catalog-of-events#Uncaught-Exceptions)
+and return `false` to prevent Cypress from failing the test:

--- a/src/theme/MDXComponents.js
+++ b/src/theme/MDXComponents.js
@@ -7,6 +7,7 @@ import AutoCancellationBenefits from '@site/docs/partials/_auto-cancellation-ben
 import Badge from '@site/src/components/badge'
 import Btn from '@site/src/components/button'
 import ComponentOnlyBadge from '@site/src/components/component-only-badge'
+import ComponentTestingErrorStates from '@site/docs/partials/_component-testing-error-states.mdx'
 import TestReplayInfo from '@site/docs/partials/_test-replay-info.mdx'
 import CypressConfigFileTabs from '@site/src/components/cypress-config-file-tabs'
 import CypressInstallCommands from '@site/docs/partials/_cypress-install-commands.mdx'
@@ -181,6 +182,7 @@ export default {
   Badge,
   Btn,
   ComponentOnlyBadge,
+  ComponentTestingErrorStates,
   CypressConfigFileTabs,
   CypressInstallCommands,
   CypressCacheClearCommands,


### PR DESCRIPTION
Explains why expect(() => cy.mount(...)).to.throw() does not work (cy.mount
is async/queued), documents the cy.on('uncaught:exception') pattern, and
shows the idiomatic Error Boundary fallback-UI approach with the caveat that
the uncaught:exception handler is still required. Cross-links to the Catalog
of Events instead of re-documenting the event.

Verified against npm/react/cypress/component/basic/error-boundary.cy.jsx.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01V1YfyJUHiEUwfQ9UBmLEam

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or test harness code; risk is limited to doc accuracy and MDX rendering.
> 
> **Overview**
> Adds **Testing Error States** guidance to the Angular, React, Svelte, and Vue component-testing example docs, using a shared partial so the async-`cy.mount()` / `uncaught:exception` explanation is not duplicated.
> 
> The new partial `_component-testing-error-states.mdx` explains that render failures show up as uncaught exceptions (not synchronous throws from `expect(() => cy.mount(...)).to.throw()`), and points readers to `cy.on('uncaught:exception')` with a link to the Catalog of Events. Each framework page includes a basic “surfaces a render error” example plus a second pattern: React **Error Boundaries**, Angular custom **`ErrorHandler`** with `cy.stub()`, Svelte 5 **`<svelte:boundary>`**, and Vue **`onErrorCaptured`** wrappers—with the repeated note that fallback UI or handlers still require suppressing the expected uncaught exception in Cypress.
> 
> `ComponentTestingErrorStates` is wired in `MDXComponents.js` so the partial renders as `<ComponentTestingErrorStates />` on those pages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32d9c8709d66e4a62c726f992fa2c43ad661e126. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->