### PR TITLE
docs: remove unmaintained plugins (not updated in 2–3+ years)

### DIFF
--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -160,13 +160,6 @@
           "badge": "community"
         },
         {
-          "name": "cly",
-          "description": "A prototype of generating quicker project scaffolding for Cypress.",
-          "link": "https://github.com/bahmutov/cly",
-          "keywords": ["cypress cli", "prototype", "CLI", "scaffolding"],
-          "badge": "community"
-        },
-        {
           "name": "cypress-watch-and-reload",
           "description": "Reloads Cypress when one of the watched files changes.",
           "link": "https://github.com/bahmutov/cypress-watch-and-reload",
@@ -195,13 +188,6 @@
           "badge": "community"
         },
         {
-          "name": "cypress-hmr-restarter",
-          "description": "Restarts tests when receiving webpack-dev-server HMR updates.",
-          "link": "https://github.com/Svish/cypress-hmr-restarter",
-          "keywords": ["webpack", "webpack-dev-server", "hmr"],
-          "badge": "community"
-        },
-        {
           "name": "cypress-repeat",
           "description": "Run Cypress multiple times in a row, great at finding test flake.",
           "link": "https://github.com/bahmutov/cypress-repeat",
@@ -212,13 +198,6 @@
           "name": "cypress-expect",
           "description": "Cypress CLI wrapper where you can specify the total number of expected tests.",
           "link": "https://github.com/bahmutov/cypress-expect",
-          "keywords": ["cli"],
-          "badge": "community"
-        },
-        {
-          "name": "cy-search",
-          "description": "Search Cypress documentation from the terminal.",
-          "link": "https://github.com/bahmutov/cy-search",
           "keywords": ["cli"],
           "badge": "community"
         },
@@ -277,13 +256,6 @@
           "description": "A Cypress plugin which automatically adds and enables IntelliSense for custom commands",
           "link": "https://github.com/ExpediaGroup/cypress-codegen",
           "keywords": ["commands", "development", "codegen"],
-          "badge": "community"
-        },
-        {
-          "name": "cypress-backoff",
-          "description": "A Cypress plugin to apply different timeout strategies to retried tests",
-          "link": "https://github.com/joostvanwollingen/cypress-backoff",
-          "keywords": ["retries", "backoff"],
           "badge": "community"
         },
         {
@@ -604,13 +576,6 @@
           "description": "A Cypress plugin to add a tab command.",
           "link": "https://github.com/Bkucera/cypress-plugin-tab",
           "keywords": ["commands"],
-          "badge": "community"
-        },
-        {
-          "name": "cypress-plugin-multiple-click",
-          "description": "Click multiple times in Cypress.",
-          "link": "https://github.com/MohamadKh75/cypress-plugin-multiple-click",
-          "keywords": ["testing", "commands", "click"],
           "badge": "community"
         },
         {

--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -1000,13 +1000,6 @@
           "badge": "community"
         },
         {
-          "name": "Cypress Visual Regression with Resemble.JS",
-          "description": "A module for adding visual regression testing to Cypress, based on Cypress Visual Regression plugin and Resemble.JS library. The main difference between 'Cypress Visual Regression' plugin and this one is that the present plugin mitigates the anti-aliasing problem. The problem appears when comparing the base and actual screenshots generated on different environments (e.g. Windows vs Linux).",
-          "link": "https://github.com/Andremoniy/cypress-visual-regression-resemble-js",
-          "keywords": ["image-diff", "snapshot"],
-          "badge": "community"
-        },
-        {
           "name": "Visual Regression Tracker",
           "description": "Integration with open source service for visual testing and managing its results.",
           "link": "https://github.com/Visual-Regression-Tracker/agent-cypress",

--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -620,13 +620,6 @@
           "badge": "community"
         },
         {
-          "name": "cypress-react-selector",
-          "description": "cypress custom commands to locate react elements by component, props and state.",
-          "link": "https://github.com/abhinaba-ghosh/cypress-react-selector",
-          "keywords": ["react", "commands", "locator"],
-          "badge": "community"
-        },
-        {
           "name": "cypress-layout-inspector",
           "description": "A simple utility to provide layout testing functionality to Cypress via custom assertions.",
           "link": "https://github.com/msmps/cypress-layout-inspector",

--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -431,13 +431,6 @@
           "badge": "community"
         },
         {
-          "name": "cy-view",
-          "description": "Run tests on multiple URLs at various viewport sizes.",
-          "link": "https://github.com/andrewmcoupe/cy-view",
-          "keywords": ["viewports"],
-          "badge": "community"
-        },
-        {
           "name": "cypress-axe",
           "description": "Helps test your applications for accessibility issues using axe-core.",
           "link": "https://github.com/avanslaars/cypress-axe",
@@ -485,13 +478,6 @@
             "cdp",
             "commands"
           ],
-          "badge": "community"
-        },
-        {
-          "name": "cypress-fill-command",
-          "description": "A Cypress command for fill inputs.",
-          "link": "https://github.com/DanielFerrariR/cypress-fill-command",
-          "keywords": ["commands"],
           "badge": "community"
         },
         {
@@ -832,13 +818,6 @@
           "badge": "official"
         },
         {
-          "name": "cypress-angular-unit-test",
-          "description": "Test Angular component using Cypress Test Runner.",
-          "link": "https://github.com/bahmutov/cypress-angular-unit-test",
-          "keywords": ["component", "angular"],
-          "badge": "community"
-        },
-        {
           "name": "cypress-ct-custom-devserver",
           "description": "Simplified API for creating custom dev servers for Cypress.",
           "link": "https://github.com/fochlac/cypress-ct-custom-devserver",
@@ -1012,13 +991,6 @@
           "description": "Logs to terminal and files mimicking cypress UI. Logs all cypress commands, request/response data and browser console logs.",
           "link": "https://github.com/archfz/cypress-terminal-report",
           "keywords": ["reporter", "logs", "terminal", "CI", "CLI"],
-          "badge": "community"
-        },
-        {
-          "name": "autoset-status-cypress-testrail-reporter",
-          "description": "TestRail Reporter which auto-set status for specific TestRun for Cypress.",
-          "link": "https://github.com/dkuznetsov21/autoset-status-cypress-testrail-reporter",
-          "keywords": ["testrail", "reporter", "autoset", "status"],
           "badge": "community"
         },
         {

--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -230,13 +230,6 @@
           "badge": "community"
         },
         {
-          "name": "cypress-log-filter",
-          "description": "Easily filter Cypress command logs based on different log levels",
-          "link": "https://github.com/Brugui7/cypress-log-filter",
-          "keywords": ["log", "command", "filter"],
-          "badge": "community"
-        },
-        {
           "name": "cy-search",
           "description": "Search Cypress documentation from the terminal.",
           "link": "https://github.com/bahmutov/cy-search",

--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -216,19 +216,6 @@
           "badge": "community"
         },
         {
-          "name": "cypress-browser-permissions",
-          "description": "Controls permissions for desktop notifications, geolocation, and other browser APIs",
-          "link": "https://github.com/kamranayub/cypress-browser-permissions",
-          "keywords": [
-            "permissions",
-            "notifications",
-            "geolocation",
-            "camera",
-            "microphone"
-          ],
-          "badge": "community"
-        },
-        {
           "name": "cypress-repeat",
           "description": "Run Cypress multiple times in a row, great at finding test flake.",
           "link": "https://github.com/bahmutov/cypress-repeat",

--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -1165,13 +1165,6 @@
           "badge": "community"
         },
         {
-          "name": "cymap",
-          "description": "Access email from any email server by leveraging IMAP capabilities inside Cypress.",
-          "link": "https://github.com/FC122/cymap",
-          "keywords": ["imap", "email", "test", "commands"],
-          "badge": "community"
-        },
-        {
           "name": "cypress-mailpit",
           "description": "A collection of useful Cypress commands for testing Emails utilizing the Mailpit RestAPI. Comes with TypeScript support",
           "link": "https://github.com/pushpak1300/cypress-mailpit",

--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -45,13 +45,6 @@
           "link": "https://github.com/mammadataei/cypress-vite",
           "keywords": ["vite"],
           "badge": "community"
-        },
-        {
-          "name": "cypress-laravel",
-          "description": "Add commands and hooks to test Laravel applications.",
-          "link": "https://github.com/noeldemartin/cypress-laravel",
-          "keywords": ["php", "laravel"],
-          "badge": "community"
         }
       ]
     },

--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -26,13 +26,6 @@
           "badge": "community"
         },
         {
-          "name": "cypress-rollup-preprocessor",
-          "description": "Cypress preprocessor for bundling JavaScript via rollup.",
-          "link": "https://github.com/lmarqs/cypress-rollup-preprocessor",
-          "keywords": ["rollup"],
-          "badge": "community"
-        },
-        {
           "name": "@bahmutov/cypress-esbuild-preprocessor",
           "description": "Bundle Cypress specs using esbuild.",
           "link": "https://github.com/bahmutov/cypress-esbuild-preprocessor",
@@ -516,13 +509,6 @@
           "badge": "community"
         },
         {
-          "name": "cypress-commands",
-          "description": "A collection of Cypress commands to extend and complement the defaults.",
-          "link": "https://github.com/Lakitna/cypress-commands",
-          "keywords": ["commands"],
-          "badge": "community"
-        },
-        {
           "name": "cypress-recurse",
           "description": "A way to re-run Cypress commands until a predicate function returns true.",
           "link": "https://github.com/bahmutov/cypress-recurse",
@@ -941,18 +927,6 @@
             "image-diff",
             "image comparison",
             "image snapshot"
-          ],
-          "badge": "community"
-        },
-        {
-          "name": "Micoo",
-          "description": "Cypress plugin for doing visual regression testing with Micoo services",
-          "link": "https://github.com/Mikuu/Micoo/tree/master/clients/micoocypress",
-          "keywords": [
-            "visual regression testing",
-            "visual testing",
-            "screenshots comparison",
-            "testing service"
           ],
           "badge": "community"
         }

--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -237,13 +237,6 @@
           "badge": "community"
         },
         {
-          "name": "cypress-tags",
-          "description": "Use custom tags to slice up Cypress test runs.",
-          "link": "https://github.com/infosum/cypress-tags",
-          "keywords": ["test", "tag", "browserify"],
-          "badge": "community"
-        },
-        {
           "name": "@swimlane/cy-mockapi",
           "description": "Easily mock your REST API in Cypress by putting responses in the fixtures directory tree.",
           "link": "https://github.com/swimlane/cy-mockapi",

--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -690,13 +690,6 @@
           "badge": "community"
         },
         {
-          "name": "@datashard/snapshot",
-          "description": "Adds Snapshot command. Adds value / object / DOM element snapshot testing support to Cypress test runner",
-          "link": "https://github.com/datashard/snapshot",
-          "keywords": ["snapshot", "comparison", "commands"],
-          "badge": "community"
-        },
-        {
           "name": "cypress-plugin-dotenv",
           "description": "Load .env variables in Cypress.",
           "link": "https://github.com/MohamadKh75/cypress-plugin-dotenv",

--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -453,13 +453,6 @@
           "badge": "community"
         },
         {
-          "name": "cypress-graphql-mock-network",
-          "description": "Custom commands to mock your GraphQL API at the network level. Using service-workers for complete isolation of the mock server.",
-          "link": "https://github.com/warrenday/cypress-graphql-mock-network",
-          "keywords": ["graphql", "mocking", "networking", "commands"],
-          "badge": "community"
-        },
-        {
           "name": "cy-mobile-commands",
           "description": "Mobile testing helper for Cypress.",
           "link": "https://gitlab.com/nTopus/cy-mobile-commands#readme",
@@ -527,13 +520,6 @@
           "description": "Fire native system events from Cypress like hover, swipe, etc.",
           "link": "https://github.com/dmtrKovalenko/cypress-real-events",
           "keywords": ["commands"],
-          "badge": "community"
-        },
-        {
-          "name": "cypress-azure-keyvault",
-          "description": "Cypress custom command to get keys from Azure Key Vaults.",
-          "link": "https://github.com/prma85/cypress-azure-keyvault",
-          "keywords": ["testing", "azure", "keyvault", "secret"],
           "badge": "community"
         },
         {
@@ -909,13 +895,6 @@
           "description": "Logs to terminal and files mimicking cypress UI. Logs all cypress commands, request/response data and browser console logs.",
           "link": "https://github.com/archfz/cypress-terminal-report",
           "keywords": ["reporter", "logs", "terminal", "CI", "CLI"],
-          "badge": "community"
-        },
-        {
-          "name": "cypress-teamcity-reporter",
-          "description": "Custom reporter for Teamcity which makes it possible to display test results in real-time and add them on the Tests tab of the Build Results page.",
-          "link": "https://github.com/prma85/cypress-teamcity-reporter",
-          "keywords": ["teamcity", "reporter"],
           "badge": "community"
         },
         {

--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -663,13 +663,6 @@
           "badge": "community"
         },
         {
-          "name": "cypress-plugin-dotenv",
-          "description": "Load .env variables in Cypress.",
-          "link": "https://github.com/MohamadKh75/cypress-plugin-dotenv",
-          "keywords": ["testing", "commands", ".env", "environment variables"],
-          "badge": "community"
-        },
-        {
           "name": "cypress-intercept-formdata",
           "description": "Work with Cypress' Intercept multipart/form-data requests",
           "link": "https://github.com/yoavniran/cypress-intercept-formdata",

--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -959,13 +959,6 @@
           "badge": "community"
         },
         {
-          "name": "Visual Regression Tracker",
-          "description": "Integration with open source service for visual testing and managing its results.",
-          "link": "https://github.com/Visual-Regression-Tracker/agent-cypress",
-          "keywords": ["screenshots", "image-diff", "visual regression"],
-          "badge": "community"
-        },
-        {
           "name": "Cypress Image Diff",
           "description": "Visual regression testing plugin maintained by DIT - UK Gov.",
           "link": "https://github.com/uktrade/cypress-image-diff",

--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -679,20 +679,6 @@
           "badge": "community"
         },
         {
-          "name": "WordPress ReactJS Boilerplate",
-          "description": "Complete WordPress Plugin Boilerplate including Cypress.io E2E tests.",
-          "link": "https://github.com/matzeeable/wp-reactjs-starter",
-          "keywords": ["wp", "wordpress"],
-          "badge": "community"
-        },
-        {
-          "name": "Next Right Now - Next.js Boilerplate",
-          "description": "Next.js boilerplate with Jest/Cypress and CI/CD pipeline built-in (monorepo, multi-tenants).",
-          "link": "https://github.com/UnlyEd/next-right-now",
-          "keywords": ["next.js", "react", "monorepo", "multi-tenants"],
-          "badge": "community"
-        },
-        {
           "name": "cypress-rails",
           "description": "Ruby gem to run Cypress against Rails apps, replacing Capybara in system tests.",
           "link": "https://github.com/testdouble/cypress-rails",

--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -1159,13 +1159,6 @@
           "badge": "community"
         },
         {
-          "name": "cypress-mailhog",
-          "description": "A collection of useful Cypress commands for testing Emails utilizing the MailHog RestAPI. Comes with TypeScript support.",
-          "link": "https://github.com/SMenigat/cypress-mailhog",
-          "keywords": ["email", "mailhog", "test", "commands"],
-          "badge": "community"
-        },
-        {
           "name": "cypress-guerrillamail",
           "description": "Create and use a randomly-generated email address from Guerrilla Mail.",
           "link": "https://github.com/e23thr/cypress-guerrillamail",

--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -195,13 +195,6 @@
           "badge": "community"
         },
         {
-          "name": "cypress-expect-n-assertions",
-          "description": "Cypress helper that checks number of expected and actual assertions in the test.",
-          "link": "https://github.com/bahmutov/cypress-expect-n-assertions",
-          "keywords": ["test", "assertion"],
-          "badge": "community"
-        },
-        {
           "name": "cypress-hmr-restarter",
           "description": "Restarts tests when receiving webpack-dev-server HMR updates.",
           "link": "https://github.com/Svish/cypress-hmr-restarter",
@@ -523,13 +516,6 @@
           "badge": "community"
         },
         {
-          "name": "cypress-cy-select",
-          "description": "data-cy shorthand notation for cypress get and find functions.",
-          "link": "https://github.com/FlorianGoussin/cypress-cy-select",
-          "keywords": ["commands", "shorthand"],
-          "badge": "community"
-        },
-        {
           "name": "Cypress-SignalR-Mock",
           "description": "Easy way to publish messages from and to your SignalR hubs in Cypress E2E tests.",
           "link": "https://github.com/JasonLandbridge/Cypress-SignalR-Mock",
@@ -555,13 +541,6 @@
           "description": "Custom commands for indexedDb. Allows populating, modifying and asserting data stored in indexedDb.",
           "link": "https://github.com/thisdot/open-source/tree/main/libs/cypress-indexeddb",
           "keywords": ["commands", "indexedDb"],
-          "badge": "community"
-        },
-        {
-          "name": "cypress-layout-inspector",
-          "description": "A simple utility to provide layout testing functionality to Cypress via custom assertions.",
-          "link": "https://github.com/msmps/cypress-layout-inspector",
-          "keywords": ["testing", "ui", "dom", "assertions"],
           "badge": "community"
         },
         {
@@ -965,13 +944,6 @@
           "description": "Logs to terminal and files mimicking cypress UI. Logs all cypress commands, request/response data and browser console logs.",
           "link": "https://github.com/archfz/cypress-terminal-report",
           "keywords": ["reporter", "logs", "terminal", "CI", "CLI"],
-          "badge": "community"
-        },
-        {
-          "name": "cypress-testrail-reporter",
-          "description": "Custom reporter for publishing Cypress results to a TestRail test run.",
-          "link": "https://github.com/Vivify-Ideas/cypress-testrail-reporter",
-          "keywords": ["testrail", "reporter"],
           "badge": "community"
         },
         {


### PR DESCRIPTION
## Summary

Removes **32 unmaintained plugins** from the plugins directory (`src/data/plugins.json`). The bulk of these have had **no release in 2–3+ years** (last npm publish dates range from **April 2022 to mid‑2024**), and the remainder are archived/superseded projects or repository boilerplates that no longer belong in the directory. Removing them keeps the plugin listing pointed at actively maintained, working options.

Plugin link count: **144 → 112**.

### Removed — last npm publish 2+ years ago
_(date = npm `time.modified`, i.e. last publish)_

- autoset-status-cypress-testrail-reporter — 2022‑04‑11 — https://github.com/dkuznetsov21/autoset-status-cypress-testrail-reporter
- cy-view — 2022‑04‑28 — https://github.com/andrewmcoupe/cy-view
- cypress-angular-unit-test — 2022‑04‑28 — https://github.com/bahmutov/cypress-angular-unit-test
- cypress-fill-command — 2022‑04‑28 — https://github.com/DanielFerrariR/cypress-fill-command
- Micoo — 2022‑05‑09 — https://github.com/Mikuu/Micoo/tree/master/clients/micoocypress
- cypress-commands — 2022‑06‑14 — https://github.com/Lakitna/cypress-commands
- cypress-rollup-preprocessor — 2022‑06‑18 — https://github.com/lmarqs/cypress-rollup-preprocessor
- cypress-testrail-reporter — 2022‑07‑19 — https://github.com/Vivify-Ideas/cypress-testrail-reporter
- cypress-layout-inspector — 2022‑12‑05 — https://github.com/msmps/cypress-layout-inspector
- cypress-expect-n-assertions — 2023‑01‑04 — https://github.com/bahmutov/cypress-expect-n-assertions
- cypress-cy-select — 2023‑02‑28 — https://github.com/FlorianGoussin/cypress-cy-select
- cypress-plugin-multiple-click — 2023‑03‑11 — https://github.com/MohamadKh75/cypress-plugin-multiple-click
- cy-search — 2023‑04‑04 — https://github.com/bahmutov/cy-search
- cly — 2023‑04‑05 — https://github.com/bahmutov/cly
- cypress-hmr-restarter — 2023‑04‑19 — https://github.com/Svish/cypress-hmr-restarter
- cypress-backoff — 2023‑05‑18 — https://github.com/joostvanwollingen/cypress-backoff
- cypress-graphql-mock-network — 2023‑12‑27 — https://github.com/warrenday/cypress-graphql-mock-network
- cypress-teamcity-reporter — 2024‑05‑14 — https://github.com/prma85/cypress-teamcity-reporter
- cypress-azure-keyvault — 2024‑05‑14 — https://github.com/prma85/cypress-azure-keyvault

### Also removed — unmaintained / archived / superseded / boilerplate

- Cypress Visual Regression with Resemble.JS — https://github.com/Andremoniy/cypress-visual-regression-resemble-js
- cypress-react-selector — https://github.com/abhinaba-ghosh/cypress-react-selector
- cypress-mailhog — https://github.com/SMenigat/cypress-mailhog
- cypress-laravel — https://github.com/noeldemartin/cypress-laravel
- @datashard/snapshot — https://github.com/datashard/snapshot
- cymap — https://github.com/FC122/cymap
- cypress-browser-permissions — https://github.com/kamranayub/cypress-browser-permissions
- cypress-log-filter — https://github.com/Brugui7/cypress-log-filter
- Visual Regression Tracker — https://github.com/Visual-Regression-Tracker/agent-cypress
- cypress-tags — https://github.com/infosum/cypress-tags
- cypress-plugin-dotenv — https://github.com/MoKhajavi75/cypress-plugin-dotenv
- WordPress ReactJS Boilerplate (repo boilerplate) — https://github.com/matzeeable/wp-reactjs-starter
- Next Right Now - Next.js Boilerplate (repo boilerplate) — https://github.com/UnlyEd/next-right-now

## How this was determined

Staleness was measured via each package's **npm last-publish date** (`registry.npmjs.org` `time.modified`). npm publish dates are a proxy for repository activity — a project could have unreleased commits — so anything borderline should be double‑checked before merge.

## Changes

- `src/data/plugins.json` — removed 32 plugin entries across the Preprocessors, Custom Commands, CLI, Visual Testing, Reporting, and Email sections. JSON validity verified after each removal.

## Test / verification

- Confirmed `src/data/plugins.json` parses as valid JSON after every change.
- No other files touched; no code or config changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ldk32ehGaXaBc6tAZCBKM9)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation/catalog-only edit with no runtime behavior; users who relied on removed links may need to find alternatives elsewhere.
> 
> **Overview**
> Trims the Cypress plugins directory by **removing 32 community listings** from `src/data/plugins.json`, bringing the catalog from **144 to 112** links. The goal is to surface options that are still maintained rather than stale, archived, or superseded packages.
> 
> Removals span **Preprocessors** (e.g. rollup, Laravel helpers), **Development Tools** (CLI/scaffolding, HMR restarter, log filters, tags, browser permissions), **Custom Commands** (fill, GraphQL mock-network, generic command packs, React selectors, Azure Key Vault, dotenv, snapshots), **Framework tooling** (WordPress/Next.js boilerplates), **Component Testing** (legacy Angular unit-test helper), **Visual Testing** (Resemble.js fork, VRT service integrations, Micoo), **Reporting** (TestRail/TeamCity reporters), and **Email** (MailHog, IMAP cymap).
> 
> No application code or build config changes—only the JSON data that powers the plugins page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00588c2d6faab69ad9cdc6eb5babc924b3e25fc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->