### PR TITLE
add cy.prompt FAQ docs

### DIFF
--- a/docs/api/commands/prompt.mdx
+++ b/docs/api/commands/prompt.mdx
@@ -571,7 +571,7 @@ These apply to all `cy.prompt` usage unless noted otherwise.
 | API Testing      | API requests (e.g., `cy.request()`) is not supported [See issue](https://github.com/cypress-io/cypress/issues/32792)                                                                                                                                                                                                                                                    |
 | DOM Support      | Canvas and iframe elements are not supported. See [canvas issue](https://github.com/cypress-io/cypress/issues/32830) and [iframe issue](https://github.com/cypress-io/cypress/issues/32800)                                                                                                                                                                             |
 
-For pricing, org-level execution limits, and billing details, see the
+For pricing, organization-level execution limits, and billing details, see the
 [cy.prompt FAQ](/cloud/faq#cyprompt). For workflows and per-hour limits on
 non-recording runs, see
 [Pricing and usage limits](/app/guides/ai-test-generation#Pricing-and-usage-limits)

--- a/docs/api/commands/prompt.mdx
+++ b/docs/api/commands/prompt.mdx
@@ -571,12 +571,8 @@ These apply to all `cy.prompt` usage unless noted otherwise.
 | API Testing      | API requests (e.g., `cy.request()`) is not supported [See issue](https://github.com/cypress-io/cypress/issues/32792)                                                                                                                                                                                                                                                    |
 | DOM Support      | Canvas and iframe elements are not supported. See [canvas issue](https://github.com/cypress-io/cypress/issues/32830) and [iframe issue](https://github.com/cypress-io/cypress/issues/32800)                                                                                                                                                                             |
 
-For pricing, organization-level execution limits, and billing details, see the
-[cy.prompt FAQ](/cloud/faq#cyprompt). For workflows and per-hour limits on
-non-recording runs, see
-[Pricing and usage limits](/app/guides/ai-test-generation#Pricing-and-usage-limits)
-in the guide. For migrating from `cy.prompt` to regular Cypress code, see the
-[App FAQ](/app/faq#cyprompt).
+For pricing, usage limits, and billing, see the
+[cy.prompt FAQ](/cloud/faq#cyprompt).
 
 ## History
 

--- a/docs/api/commands/prompt.mdx
+++ b/docs/api/commands/prompt.mdx
@@ -571,7 +571,12 @@ These apply to all `cy.prompt` usage unless noted otherwise.
 | API Testing      | API requests (e.g., `cy.request()`) is not supported [See issue](https://github.com/cypress-io/cypress/issues/32792)                                                                                                                                                                                                                                                    |
 | DOM Support      | Canvas and iframe elements are not supported. See [canvas issue](https://github.com/cypress-io/cypress/issues/32830) and [iframe issue](https://github.com/cypress-io/cypress/issues/32800)                                                                                                                                                                             |
 
-For pricing and per-hour usage limits, see [Pricing and usage limits](/app/guides/ai-test-generation#Pricing-and-usage-limits) in the guide.
+For pricing, org-level execution limits, and billing details, see the
+[cy.prompt FAQ](/cloud/faq#cyprompt). For workflows and per-hour limits on
+non-recording runs, see
+[Pricing and usage limits](/app/guides/ai-test-generation#Pricing-and-usage-limits)
+in the guide. For migrating from `cy.prompt` to regular Cypress code, see the
+[App FAQ](/app/faq#cyprompt).
 
 ## History
 

--- a/docs/app/faq.mdx
+++ b/docs/app/faq.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Frequently asked questions: Cypress App'
-description: 'Get answers to common questions about Cypress, including general questions, how-to questions, and more.'
+description: 'Get answers to common questions about Cypress, including cy.prompt, how-to questions, and more.'
 sidebar_label: FAQ
 sidebar_position: 200
 ---
@@ -1868,3 +1868,38 @@ files inside that folder should use.
 Don't forget to update your
 [`specPattern`](/app/references/configuration#component)
 to include the new file location.
+
+## cy.prompt
+
+The `cy.prompt` command supports natural language testing directly within the Cypress App. It requires a free or paid Cypress Cloud account. For Cloud-related `cy.prompt` execution limits, billing, and usage information, see the [Cloud FAQ](/cloud/faq#cyprompt).
+
+### <Icon name="angle-right" /> What happens when AI is disabled for my organization and the `cy.prompt` is called in the app?
+
+Any **pre-existing** prompt commands and steps that are called in the app will function based on previously cached generated code, but operations that
+require AI to function will fail. This includes most self-healing behavior and
+the creation of new prompt commands. This minimizes disruption if you have chosen to disable AI after creating some natural language tests.
+
+Organization admins and owners can enable or disable AI capabilities from
+[organization settings](/cloud/account-management/organizations#Manage-Cloud-AI).
+
+### <Icon name="angle-right" /> How do I migrate from cy.prompt code to regular Cypress code?
+
+If you plan to do this as you write tests, use the **Code** button in the
+Cypress App's command log. It gives you the code for any prompt and allows you to
+save it. This represents an author-only use of `cy.prompt`.
+
+If you plan to do this after tests have been recorded, download a full report of
+all the test code and related `cy.prompt` steps, and where they are located in
+your test suite. This is available in the **Properties** tab in the cy.prompt
+area for a specific run. See
+[View and export generated code](/app/guides/ai-test-generation#View-and-export-generated-code)
+for step-by-step instructions.
+
+### <Icon name="angle-right" /> What limitations does cy.prompt have?
+
+See the [Limitations](/api/commands/prompt#Limitations) section in the
+[`cy.prompt` API reference](/api/commands/prompt) to learn what commands and
+other techniques are not supported.
+
+Review the steps of your generated tests to confirm they are behaving as
+intended, especially if attempting steps that are documented as not supported.

--- a/docs/app/faq.mdx
+++ b/docs/app/faq.mdx
@@ -1875,12 +1875,8 @@ The `cy.prompt` command supports natural language testing directly within the Cy
 
 ### <Icon name="angle-right" /> What happens when AI is disabled for my organization and the `cy.prompt` is called in the app?
 
-Any **pre-existing** prompt commands and steps that are called in the app will function based on previously cached generated code, but operations that
-require AI to function will fail. This includes most self-healing behavior and
-the creation of new prompt commands. This minimizes disruption if you have chosen to disable AI after creating some natural language tests.
-
-Organization admins and owners can enable or disable AI capabilities from
-[organization settings](/cloud/account-management/organizations#Manage-Cloud-AI).
+Any **pre-existing** prompt commands and steps that are called in the app will attempt to run based on previously cached generated code. AI-dependent functionality will no longer work. This includes most self-healing behavior and
+the creation of new prompt commands.
 
 ### <Icon name="angle-right" /> How do I migrate from cy.prompt code to regular Cypress code?
 

--- a/docs/app/guides/ai-test-generation.mdx
+++ b/docs/app/guides/ai-test-generation.mdx
@@ -527,7 +527,7 @@ in the Cloud FAQ.
 :::
 
 The limits below apply to **runs that are not recording to Cypress Cloud** and
-supplement org-level execution metering for local authoring workflows.
+supplement organization-level execution metering for local authoring workflows.
 
 There are two sets of limits: per-user hourly limits and per-prompt limits.
 

--- a/docs/app/guides/ai-test-generation.mdx
+++ b/docs/app/guides/ai-test-generation.mdx
@@ -510,11 +510,10 @@ cy.get('#tab-all').should('have.class', 'text-indigo-500')
 ## Pricing and usage limits
 
 Cypress Cloud meters [`cy.prompt`](/api/commands/prompt) usage at the organization
-level as **cy.prompt executions**. Each time a `cy.prompt` command runs in open
-mode or run mode counts as one execution. Plan limits apply per billing period
-and are pro-rated to your contract term. See the
-[cy.prompt FAQ](/cloud/faq#cyprompt) for execution counting, the grace period,
-limit behavior, and billing details.
+level as **cy.prompt executions**, with separate per-user hourly limits on runs
+that are not recording to Cypress Cloud. The
+[cy.prompt FAQ](/cloud/faq#cyprompt) is the full reference for execution counting,
+usage limits, the grace period, billing, and usage notifications.
 
 :::note
 
@@ -525,35 +524,6 @@ prior to the cutoff. See
 in the Cloud FAQ.
 
 :::
-
-The limits below apply to **runs that are not recording to Cypress Cloud** and
-supplement organization-level execution metering for local authoring workflows.
-
-There are two sets of limits: per-user hourly limits and per-prompt limits.
-
-### Per-user hourly limits
-
-_Usage limits only apply to runs that are not recording to Cypress Cloud._
-
-**User limits on projects with free accounts:**
-
-- 100 prompts per hour per user
-- 500 prompt steps per hour per user
-
-**User limits on projects with paid accounts (or on free trial):**
-
-- 600 prompts per hour per user
-- 3,000 prompt steps per hour per user
-
-### Per-prompt limits
-
-- Up to 50 steps per `cy.prompt` call to maintain context fidelity and produce reliable, executable commands.
-- System-wide limits apply to the total input length processed by `cy.prompt`. Very long prompts may be rejected or require splitting.
-
-To improve reliability and performance, consider the following:
-
-- Keep one action or assertion per step.
-- Split long flows into multiple `cy.prompt` calls.
 
 ## Privacy and security
 

--- a/docs/app/guides/ai-test-generation.mdx
+++ b/docs/app/guides/ai-test-generation.mdx
@@ -509,13 +509,25 @@ cy.get('#tab-all').should('have.class', 'text-indigo-500')
 
 ## Pricing and usage limits
 
-`cy.prompt` is free to use during the beta period. Users are limited by the number of `cy.prompt` definitions and steps they can run per hour. This limit is higher for paid accounts and lower for free accounts. Our intention is to not limit normal usage of the feature.
+Cypress Cloud meters [`cy.prompt`](/api/commands/prompt) usage at the organization
+level as **cy.prompt executions**. Each time a `cy.prompt` command runs in open
+mode or run mode counts as one execution. Plan limits apply per billing period
+and are pro-rated to your contract term. See the
+[cy.prompt FAQ](/cloud/faq#cyprompt) for execution counting, the grace period,
+limit behavior, and billing details.
 
 :::note
 
-Please note that pricing and usage limitations are subject to future adjustments. We commit to keeping you informed of any such changes.
+Through August 1, 2026, accumulated usage before that date is ignored for
+billing purposes. There are no charges or limiting behavior related to usage
+prior to the cutoff. See
+[What happens at the end of the grace period?](/cloud/faq#What-happens-at-the-end-of-the-cyprompt-grace-period)
+in the Cloud FAQ.
 
 :::
+
+The limits below apply to **runs that are not recording to Cypress Cloud** and
+supplement org-level execution metering for local authoring workflows.
 
 There are two sets of limits: per-user hourly limits and per-prompt limits.
 
@@ -536,7 +548,7 @@ _Usage limits only apply to runs that are not recording to Cypress Cloud._
 ### Per-prompt limits
 
 - Up to 50 steps per `cy.prompt` call to maintain context fidelity and produce reliable, executable commands.
-- During the beta period, system-wide limits apply to the total input length processed by `cy.prompt`. Very long prompts may be rejected or require splitting.
+- System-wide limits apply to the total input length processed by `cy.prompt`. Very long prompts may be rejected or require splitting.
 
 To improve reliability and performance, consider the following:
 

--- a/docs/cloud/account-management/billing-and-usage.mdx
+++ b/docs/cloud/account-management/billing-and-usage.mdx
@@ -93,6 +93,8 @@ The **AI Prompts** card tracks [cy.prompt](/api/commands/prompt) usage in your o
 
 The "Prompt execution" information conveys how many times the [cy.prompt](/api/commands/prompt) command has been executed in your organization, either on developer machines or in CI. Each [cy.prompt](/api/commands/prompt) command can define more than one step to be executed. We also break down the number of commands that took place in "Open mode" or in "Run mode". Together this tells you not just how much AI is being used, but _where_: whether developers are authoring tests interactively, or whether self-healing is running in CI, so you can see how your team is putting AI to work.
 
+For limit behavior, the grace period, and what happens when you exceed your allowance, see [cy.prompt](/cloud/faq#cyprompt) in the Cloud FAQ.
+
 ### Usage over time
 
 Click the **Usage details** button in order to view graphs of your cy.prompt AI usage.
@@ -115,7 +117,7 @@ The **By project** tab shows your prompt usage per project during the selected b
 
 ## Usage notification
 
-A **usage notification** emails your organization's owner and admins when your recorded test results reach a number you choose in the current billing cycle. Instead of remembering to check this page, you get told when you are approaching your limit, so you can upgrade or adjust before [parallelization is disabled and new results are hidden](/cloud/faq#What-happens-once-I-reach-the-test-results-limit). That early warning is the difference between a planned upgrade and a surprise interruption to your CI feedback, and it keeps owners and admins aware of usage trends without anyone having to monitor the dashboard manually.
+A **usage notification** emails your organization's owner and admins when your recorded test results reach a number you choose in the current billing cycle. You can also set thresholds for [`cy.prompt`](/api/commands/prompt) execution usage on this page. See [Can I be notified of usage approaching limits?](/cloud/faq#Can-I-be-notified-of-usage-approaching-limits) in the Cloud FAQ. Instead of remembering to check this page, you get told when you are approaching your limit, so you can upgrade or adjust before [parallelization is disabled and new results are hidden](/cloud/faq#What-happens-once-I-reach-the-test-results-limit). That early warning is the difference between a planned upgrade and a surprise interruption to your CI feedback, and it keeps owners and admins aware of usage trends without anyone having to monitor the dashboard manually.
 
 From the **Usage notification** card, click **Create notification**
 
@@ -210,6 +212,7 @@ If you have any questions regarding the OSS plan, please feel free
 - [What counts as a test result?](/cloud/faq#What-counts-as-a-test-result)
 - [What happens once I reach the test results limit?](/cloud/faq#What-happens-once-I-reach-the-test-results-limit)
 - [When does my billing period reset?](/cloud/faq#When-does-my-billing-period-reset)
+- [cy.prompt usage and limits](/cloud/faq#cyprompt)
 - [How do I reduce my Cypress Cloud usage or lower my bill?](/cloud/faq#How-do-I-reduce-my-Cypress-Cloud-usage-or-lower-my-bill)
 - [What happens if I downgrade my account?](/cloud/faq#What-happens-if-I-downgrade-my-account)
 - [How much does it cost?](/cloud/faq#How-much-does-it-cost)

--- a/docs/cloud/account-management/billing-and-usage.mdx
+++ b/docs/cloud/account-management/billing-and-usage.mdx
@@ -117,7 +117,7 @@ The **By project** tab shows your prompt usage per project during the selected b
 
 ## Usage notification
 
-A **usage notification** emails your organization's owner and admins when your recorded test results reach a number you choose in the current billing cycle. You can also set thresholds for [`cy.prompt`](/api/commands/prompt) execution usage on this page. See [Can I be notified of usage approaching limits?](/cloud/faq#Can-I-be-notified-of-usage-approaching-limits) in the Cloud FAQ. Instead of remembering to check this page, you get told when you are approaching your limit, so you can upgrade or adjust before [parallelization is disabled and new results are hidden](/cloud/faq#What-happens-once-I-reach-the-test-results-limit). That early warning is the difference between a planned upgrade and a surprise interruption to your CI feedback, and it keeps owners and admins aware of usage trends without anyone having to monitor the dashboard manually.
+A **usage notification** emails your organization's owner and admins when your recorded test results reach a number you choose in the current billing cycle. Instead of remembering to check this page, you get told when you are approaching your limit, so you can upgrade or adjust before [parallelization is disabled and new results are hidden](/cloud/faq#What-happens-once-I-reach-the-test-results-limit). That early warning is the difference between a planned upgrade and a surprise interruption to your CI feedback, and it keeps owners and admins aware of usage trends without anyone having to monitor the dashboard manually.
 
 From the **Usage notification** card, click **Create notification**
 

--- a/docs/cloud/faq.mdx
+++ b/docs/cloud/faq.mdx
@@ -768,7 +768,7 @@ Cloud:
   rejected or require splitting. To stay within these limits, keep one action or
   assertion per step and split long flows into multiple `cy.prompt` calls.
 
-### <Icon name="angle-right" /> My organization shows that is over limit during the `cy.prompt` grace period, will I be charged anything for this?
+### <Icon name="angle-right" /> My organization shows that it is over the limit during the `cy.prompt` grace period, will I be charged anything for this?
 
 No. There are no charges or limiting behavior related to any usage prior to the
 August 1, 2026 cutoff.

--- a/docs/cloud/faq.mdx
+++ b/docs/cloud/faq.mdx
@@ -747,6 +747,27 @@ has changed since the step last ran, so tests keep passing as the UI evolves. Wh
 [Self-healing](/app/guides/ai-test-generation#Self-healing) in the AI Test
 Generation guide.
 
+### <Icon name="angle-right" /> What are the cy.prompt usage limits?
+
+Beyond your plan's execution allowance, `cy.prompt` has two additional sets of
+limits.
+
+**Per-user hourly limits** apply only to runs that are not recording to Cypress
+Cloud:
+
+- Free accounts: 100 prompts per hour per user, and 500 prompt steps per hour per
+  user.
+- Paid accounts (or on a free trial): 600 prompts per hour per user, and 3,000
+  prompt steps per hour per user.
+
+**Per-prompt limits** apply to every `cy.prompt` call:
+
+- Up to 50 steps per call, to maintain context fidelity and produce reliable,
+  executable commands.
+- System-wide limits apply to the total input length. Very long prompts may be
+  rejected or require splitting. To stay within these limits, keep one action or
+  assertion per step and split long flows into multiple `cy.prompt` calls.
+
 ### <Icon name="angle-right" />My organization show as over limit during the `cy.prompt` grace period, will I be charged anything for this?
 
 No. There are no charges or limiting behavior related to any usage prior to the

--- a/docs/cloud/faq.mdx
+++ b/docs/cloud/faq.mdx
@@ -155,9 +155,11 @@ retention to 30 days and test results to 500 per billing period.
 
 Your usage cycle resets at the start of each billing period, at which point
 your recorded [test result](#What-counts-as-a-test-result) and AI usage counters
-return to zero for the new period. Most plans bill monthly, though some annual
-plans use an annual test results allowance. You can confirm the dates of your
-current period on your organization's
+return to zero for the new period. Org-level
+[`cy.prompt`](/api/commands/prompt) execution counts reset on the same schedule.
+See [cy.prompt](/cloud/faq#cyprompt) for details. Most plans bill monthly,
+though some annual plans use an annual test results allowance. You can confirm
+the dates of your current period on your organization's
 [Billing & Usage](/cloud/account-management/billing-and-usage) page.
 
 ### <Icon name="angle-right" /> How do I reduce my Cypress Cloud usage or lower my bill?
@@ -716,8 +718,109 @@ Yes. This displays console logs from within the application under test or your s
 
 ## Cloud AI :sparkles:
 
-### What is Cloud AI?
+### <Icon name="angle-right" /> What is Cloud AI?
 
 Cloud AI is part of Cypress AI: capabilities in Cypress Cloud (such as Test Intent Summaries, Error Summaries, and UI Coverage Test Generation) plus AI in the Cypress App ([Studio AI](/app/guides/cypress-studio) and [cy.prompt()](/api/commands/prompt)) when you're connected to Cloud. These capabilities are continuously being added to improve insights and make it easier to accomplish tasks.
 
-See [AI at Cypress](/cloud/features/cypress-ai-features) for the full picture.
+See [AI at Cypress](/cloud/features/cypress-ai-features) for the full picture. For [`cy.prompt`](/api/commands/prompt) execution limits, billing, and the grace period, see [cy.prompt](#cyprompt) below.
+
+## cy.prompt
+
+### <Icon name="angle-right" /> What is a cy.prompt execution?
+
+Every time a [`cy.prompt`](/api/commands/prompt) command runs, in open mode or run
+mode, that counts as a single cy.prompt execution. Usage is treated consistently
+whether you are authoring and running tests locally or in CI runs.
+
+As an example: if a test suite includes 3 `cy.prompt` commands in the test code and they are each invoked exactly once,
+each full run of that suite consumes 3 `cy.prompt` executions.
+
+Track usage on your organization's
+[Billing & Usage](/cloud/account-management/billing-and-usage#Prompt-executions)
+page. For migrating from `cy.prompt` to regular Cypress code, see the
+[App FAQ](/app/faq#cyprompt).
+
+### <Icon name="angle-right" /> What is AI self-healing?
+
+[`cy.prompt`](/api/commands/prompt) self-heals a step when the element it needs
+has changed since the step last ran, so tests keep passing as the UI evolves. When possible, the step may self-heal from a cache of previously-successful selectors for the element referenced that spec. If no good selector exists, `cy.prompt` will create a new one using AI to find the appropriate element. See
+[Self-healing](/app/guides/ai-test-generation#Self-healing) in the AI Test
+Generation guide.
+
+### <Icon name="angle-right" />My organization show as over limit during the `cy.prompt` grace period, will I be charged anything for this?
+
+No. There are no charges or limiting behavior related to any usage prior to the
+August 1, 2026 cutoff.
+
+### <Icon name="angle-right" /> What happens at the end of the `cy.prompt` grace period?
+
+Your accumulated usage from before August 1, 2026 will be fully ignored for
+billing purposes. On August 1, 2026, your organization will start with a count
+of zero `cy.prompt` executions consumed. You will see a limit that matches your
+plan and is pro-rated to your contract term.
+
+For example, if you have 6 months remaining on your plan on August 1, 2026, and
+the plan has 2,000 built-in cy.prompt executions for the year, you would have
+1,000 executions available.
+
+### <Icon name="angle-right" /> What happens when I exceed my allowed limit of cy.prompt executions?
+
+You will see warnings in the Cypress Cloud UI in the lead-up to exceeding your
+limit, and after it is crossed.
+
+On a paid plan:
+
+- There is no functional disruption and no automatic charges for moderate
+  executions over your limit.
+- We ask you to proactively right-size your plan to match your usage.
+- Outside of cases where this process is abused, you will not experience
+  unexpected changes in behavior or costs from running in excess of the defined
+  limit.
+
+On a free plan:
+
+- AI self-healing and new prompt creation will be disabled for the remainder of
+  the monthly renewal cycle.
+- When your plan renews, these functions will work normally again.
+
+### <Icon name="angle-right" /> What happens when AI is disabled for my organization?
+
+Existing prompt commands and steps will continue to execute, but operations that
+require AI to function will fail. This includes most self-healing behavior and
+the creation of new prompt commands.
+
+Organization admins and owners can enable or disable AI capabilities from
+[organization settings](/cloud/account-management/organizations#Manage-Cloud-AI).
+
+### <Icon name="angle-right" /> When does my usage reset?
+
+Usage is tracked similar to test results and resets on the same schedule with the
+start of the billing period for your existing plan. See
+[When does my billing period reset?](#When-does-my-billing-period-reset) and your
+organization's
+[Billing & Usage](/cloud/account-management/billing-and-usage) page for dates.
+
+### <Icon name="angle-right" /> Can I buy increased limits?
+
+You can upgrade your plan to gain increased execution limits, along with the
+other benefits of higher-level plans. See
+[Cypress Cloud plans](https://www.cypress.io/pricing?utm_source=docs.cypress.io&utm_medium=cloud-faq)
+for details.
+
+Reach out to your Cypress representative if you have questions about this, or
+if you are on a plan where a self-serve upgrade is not an option for you.
+
+### <Icon name="angle-right" /> Can I be notified of usage approaching limits?
+
+Yes. On the [Billing & Usage](/cloud/account-management/billing-and-usage#Usage-notification)
+page, you can set thresholds for email alerts based on usage, similar to the
+ones you already get for test management.
+
+### <Icon name="angle-right" /> What limitations does cy.prompt have?
+
+See the [Limitations](/api/commands/prompt#Limitations) section in the
+[`cy.prompt` API reference](/api/commands/prompt) to learn what commands and
+other techniques are not supported.
+
+Review the steps of your generated tests to confirm they are behaving as
+intended, especially if attempting steps that are documented as not supported.

--- a/docs/cloud/faq.mdx
+++ b/docs/cloud/faq.mdx
@@ -743,7 +743,7 @@ page. For migrating from `cy.prompt` to regular Cypress code, see the
 ### <Icon name="angle-right" /> What is AI self-healing?
 
 [`cy.prompt`](/api/commands/prompt) self-heals a step when the element it needs
-has changed since the step last ran, so tests keep passing as the UI evolves. When possible, the step may self-heal from a cache of previously-successful selectors for the element referenced that spec. If no good selector exists, `cy.prompt` will create a new one using AI to find the appropriate element. See
+has changed since the step last ran, so tests keep passing as the UI evolves. When possible, the step may self-heal from a cache of previously-successful selectors for the element referenced in that spec. If no good selector exists, `cy.prompt` will create a new one using AI to find the appropriate element. See
 [Self-healing](/app/guides/ai-test-generation#Self-healing) in the AI Test
 Generation guide.
 

--- a/docs/cloud/faq.mdx
+++ b/docs/cloud/faq.mdx
@@ -786,23 +786,21 @@ the plan has 2,000 built-in cy.prompt executions for the year, you would have
 
 ### <Icon name="angle-right" /> What happens when I exceed my allowed limit of cy.prompt executions?
 
-You will see warnings in the Cypress Cloud UI in the lead-up to exceeding your
-limit, and after it is crossed.
+You will see warnings in the Cypress Cloud UI as you approach your limit, and
+after you cross it.
 
 On a paid plan:
 
-- There is no functional disruption and no automatic charges for moderate
-  executions over your limit.
-- We ask you to proactively right-size your plan to match your usage.
-- Outside of cases where this process is abused, you will not experience
-  unexpected changes in behavior or costs from running in excess of the defined
-  limit.
+- Your tests and `cy.prompt` will run normally. You will not be charged for
+  prompt executions over your plan's limit.
+- If you regularly go over your limit, we ask that you update your plan to
+  match your usage.
 
 On a free plan:
 
-- AI self-healing and new prompt creation will be disabled for the remainder of
-  the monthly renewal cycle.
-- When your plan renews, these functions will work normally again.
+- AI self-healing and new prompt creation will be turned off for the rest of
+  your monthly billing cycle.
+- When your plan renews, these features will work again.
 
 ### <Icon name="angle-right" /> What happens when AI is disabled for my organization?
 

--- a/docs/cloud/faq.mdx
+++ b/docs/cloud/faq.mdx
@@ -768,7 +768,7 @@ Cloud:
   rejected or require splitting. To stay within these limits, keep one action or
   assertion per step and split long flows into multiple `cy.prompt` calls.
 
-### <Icon name="angle-right" />My organization show as over limit during the `cy.prompt` grace period, will I be charged anything for this?
+### <Icon name="angle-right" /> My organization show as over limit during the `cy.prompt` grace period, will I be charged anything for this?
 
 No. There are no charges or limiting behavior related to any usage prior to the
 August 1, 2026 cutoff.

--- a/docs/cloud/faq.mdx
+++ b/docs/cloud/faq.mdx
@@ -791,8 +791,7 @@ after you cross it.
 
 On a paid plan:
 
-- Your tests and `cy.prompt` will run normally. You will not be charged for
-  prompt executions over your plan's limit.
+- Your tests and `cy.prompt` will run normally. You will not be automatically charged for prompt executions over your plan's limit.
 - If you regularly go over your limit, we ask that you update your plan to
   match your usage.
 

--- a/docs/cloud/faq.mdx
+++ b/docs/cloud/faq.mdx
@@ -768,7 +768,7 @@ Cloud:
   rejected or require splitting. To stay within these limits, keep one action or
   assertion per step and split long flows into multiple `cy.prompt` calls.
 
-### <Icon name="angle-right" /> My organization show as over limit during the `cy.prompt` grace period, will I be charged anything for this?
+### <Icon name="angle-right" /> My organization shows that is over limit during the `cy.prompt` grace period, will I be charged anything for this?
 
 No. There are no charges or limiting behavior related to any usage prior to the
 August 1, 2026 cutoff.

--- a/docs/cloud/features/cypress-ai-features.mdx
+++ b/docs/cloud/features/cypress-ai-features.mdx
@@ -261,9 +261,12 @@ Cloud MCP, Test Intent Summaries and Error Summaries are available for free to a
 
 UI Coverage Test Generation is included with UI Coverage premium solutions subscriptions.
 
-For organization-level [`cy.prompt`](/api/commands/prompt) execution limits and billing,
-see the [cy.prompt FAQ](/cloud/faq#cyprompt). Studio AI recommendations are provided at no additional charge during the beta period. Pricing
-is subject to change. We will communicate any changes before they take effect.
+Studio AI recommendations are provided at no additional charge during the beta period.
+
+For [`cy.prompt`](/api/commands/prompt) execution limits and billing,
+see the [cy.prompt FAQ](/cloud/faq#cyprompt)
+
+Pricing is subject to change. We will communicate any changes before they take effect.
 
 See [Cypress Cloud plans](https://www.cypress.io/pricing) for full plan details.
 

--- a/docs/cloud/features/cypress-ai-features.mdx
+++ b/docs/cloud/features/cypress-ai-features.mdx
@@ -235,7 +235,10 @@ Free accounts include a two-week trial of all paid features, including higher AI
 
 ### Usage limits
 
-Usage limits vary by feature and plan. During beta periods, limits are subject to change.
+Usage limits vary by feature and plan. For org-level [`cy.prompt`](/api/commands/prompt)
+execution limits and billing, see the [cy.prompt FAQ](/cloud/faq#cyprompt).
+
+Some hourly limits apply to all plans, those are as follows:
 
 | Capability / Tool           | Free plan              | Paid plan                 |
 | --------------------------- | ---------------------- | ------------------------- |
@@ -258,7 +261,9 @@ Cloud MCP, Test Intent Summaries and Error Summaries are available for free to a
 
 UI Coverage Test Generation is included with UI Coverage premium solutions subscriptions.
 
-Studio AI recommendations and `cy.prompt()`, during beta periods, are provided at no additional charge. Pricing is subject to change. We will communicate any changes before they take effect.
+For org-level [`cy.prompt`](/api/commands/prompt) execution limits and billing,
+see the [cy.prompt FAQ](/cloud/faq#cyprompt). Studio AI recommendations are provided at no additional charge during the beta period. Pricing
+is subject to change. We will communicate any changes before they take effect.
 
 See [Cypress Cloud plans](https://www.cypress.io/pricing) for full plan details.
 
@@ -266,7 +271,7 @@ See [Cypress Cloud plans](https://www.cypress.io/pricing) for full plan details.
 
 | Capability / Tool           | Release Status      |
 | --------------------------- | ------------------- |
-| cy.prompt()                 | Beta                |
+| cy.prompt                   | Generally Available |
 | Studio AI recommendations   | Beta                |
 | Test Intent Summaries       | Generally Available |
 | Error Summaries             | Generally Available |

--- a/docs/cloud/features/cypress-ai-features.mdx
+++ b/docs/cloud/features/cypress-ai-features.mdx
@@ -235,7 +235,7 @@ Free accounts include a two-week trial of all paid features, including higher AI
 
 ### Usage limits
 
-Usage limits vary by feature and plan. For org-level [`cy.prompt`](/api/commands/prompt)
+Usage limits vary by feature and plan. For organization-level [`cy.prompt`](/api/commands/prompt)
 execution limits and billing, see the [cy.prompt FAQ](/cloud/faq#cyprompt).
 
 Some hourly limits apply to all plans, those are as follows:
@@ -261,7 +261,7 @@ Cloud MCP, Test Intent Summaries and Error Summaries are available for free to a
 
 UI Coverage Test Generation is included with UI Coverage premium solutions subscriptions.
 
-For org-level [`cy.prompt`](/api/commands/prompt) execution limits and billing,
+For organization-level [`cy.prompt`](/api/commands/prompt) execution limits and billing,
 see the [cy.prompt FAQ](/cloud/faq#cyprompt). Studio AI recommendations are provided at no additional charge during the beta period. Pricing
 is subject to change. We will communicate any changes before they take effect.
 

--- a/docs/cloud/features/cypress-ai-features.mdx
+++ b/docs/cloud/features/cypress-ai-features.mdx
@@ -238,7 +238,7 @@ Free accounts include a two-week trial of all paid features, including higher AI
 Usage limits vary by feature and plan. For organization-level [`cy.prompt`](/api/commands/prompt)
 execution limits and billing, see the [cy.prompt FAQ](/cloud/faq#cyprompt).
 
-Some hourly limits apply to all plans, those are as follows:
+Some hourly limits apply to all plans. Those are as follows:
 
 | Capability / Tool           | Free plan              | Paid plan                 |
 | --------------------------- | ---------------------- | ------------------------- |

--- a/docs/cloud/features/cypress-ai-features.mdx
+++ b/docs/cloud/features/cypress-ai-features.mdx
@@ -264,7 +264,7 @@ UI Coverage Test Generation is included with UI Coverage premium solutions subsc
 Studio AI recommendations are provided at no additional charge during the beta period.
 
 For [`cy.prompt`](/api/commands/prompt) execution limits and billing,
-see the [cy.prompt FAQ](/cloud/faq#cyprompt)
+see the [cy.prompt FAQ](/cloud/faq#cyprompt).
 
 Pricing is subject to change. We will communicate any changes before they take effect.
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes with no application or billing logic modifications.
> 
> **Overview**
> **Centralizes `cy.prompt` billing, limits, and grace-period policy** in a new [Cloud FAQ](/cloud/faq#cyprompt) section and **replaces duplicated detail** in the AI Test Generation guide and API reference with links to that FAQ.
> 
> Adds an **App FAQ** `cy.prompt` section (AI disabled behavior, migrating to plain Cypress code, limitations) and **cross-links** from Billing & Usage and Cypress AI features. Updates **release status** for `cy.prompt` from Beta to **Generally Available** on the Cypress AI page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd08728cb4f1cf0e890b039a83c6a724bfbdc450. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->