### PR TITLE
Set allowCypressEnv: false in Cypress config

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -53,10 +53,6 @@ export default defineConfig({
       config.expose = config.expose || {}
       config.expose.URLs = URLs
 
-      // Optional: `cypress run --env limitPerSection=2` to spot-check a few
-      // pages per section instead of every page. Exposed here (rather than read
-      // via the deprecated `Cypress.env()`) because the spec needs it
-      // synchronously at load time to build the list of tests.
       config.expose.limitPerSection = Number(config.env.limitPerSection) || 0
 
       return config

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -4,6 +4,7 @@ import { join } from 'path'
 
 export default defineConfig({
   projectId: 'imown1',
+  allowCypressEnv: false,
   fixturesFolder: false,
   viewportHeight: 800,
   viewportWidth: 1200,
@@ -51,6 +52,12 @@ export default defineConfig({
 
       config.expose = config.expose || {}
       config.expose.URLs = URLs
+
+      // Optional: `cypress run --env limitPerSection=2` to spot-check a few
+      // pages per section instead of every page. Exposed here (rather than read
+      // via the deprecated `Cypress.env()`) because the spec needs it
+      // synchronously at load time to build the list of tests.
+      config.expose.limitPerSection = Number(config.env.limitPerSection) || 0
 
       return config
     },

--- a/cypress/e2e/page_titles.cy.ts
+++ b/cypress/e2e/page_titles.cy.ts
@@ -4,7 +4,6 @@ const URLs: Array<string> = Cypress.expose('URLs')
 
 // Optional: `cypress run --env limitPerSection=2` to spot-check a few pages
 // per section instead of every page (useful for fast local iteration).
-// Exposed from setupNodeEvents so it works with `allowCypressEnv: false`.
 const limitPerSection: number = Cypress.expose('limitPerSection')
 
 function selectUrls(urls: string[]): string[] {

--- a/cypress/e2e/page_titles.cy.ts
+++ b/cypress/e2e/page_titles.cy.ts
@@ -4,7 +4,8 @@ const URLs: Array<string> = Cypress.expose('URLs')
 
 // Optional: `cypress run --env limitPerSection=2` to spot-check a few pages
 // per section instead of every page (useful for fast local iteration).
-const limitPerSection = Number(Cypress.env('limitPerSection')) || 0
+// Exposed from setupNodeEvents so it works with `allowCypressEnv: false`.
+const limitPerSection: number = Cypress.expose('limitPerSection')
 
 function selectUrls(urls: string[]): string[] {
   if (!limitPerSection) return urls


### PR DESCRIPTION
## Summary

Sets `allowCypressEnv: false` in `cypress.config.ts`, disabling the deprecated `Cypress.env()` API, and migrates the one remaining usage in the `page_titles` spec off it so the tests still run.

## Why

`Cypress.env()` is deprecated as of Cypress 15.10.0 and slated for removal in Cypress 16. This repo runs Cypress ^15.16.0, where `allowCypressEnv: false` opts the project into the safer, more explicit environment-variable model ahead of that removal.

The `page_titles` spec read `Cypress.env('limitPerSection')` **synchronously at spec-load time** to build the list of `it()` blocks. Because `cy.env()` is async (test-time only), it isn't a valid replacement here. Instead, `limitPerSection` is now exposed from `setupNodeEvents` via `config.expose` (the same mechanism already used for `URLs`) and read with `Cypress.expose('limitPerSection')`.

Closes #<!-- issue number, or remove this line if none -->

## Notes for reviewers

- Verified end-to-end: with the dev server running, `cypress run --spec cypress/e2e/page_titles.cy.ts --env limitPerSection=1` passes (5 tests — one page per section), confirming both that the config loads with `allowCypressEnv: false` and that the exposed `limitPerSection` value is applied correctly.
- No other specs or support files reference `Cypress.env()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PpYJz1XMNTcqEUMghzJADZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PpYJz1XMNTcqEUMghzJADZ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only Cypress configuration and one e2e spec; no production or auth/data paths affected.
> 
> **Overview**
> Opts the Cypress project into **`allowCypressEnv: false`** so the deprecated `Cypress.env()` API is blocked ahead of Cypress 16.
> 
> The **`page_titles`** e2e spec still needs `limitPerSection` at **spec load time** (to decide which `it()` blocks to register), so it no longer reads `Cypress.env('limitPerSection')`. **`setupNodeEvents`** now copies `config.env.limitPerSection` onto **`config.expose.limitPerSection`**, and the spec reads it with **`Cypress.expose('limitPerSection')`**—the same pattern already used for **`URLs`**. The existing **`cypress run --env limitPerSection=N`** workflow is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7320a0d438d2f5b0e830e470e7da52ab6978afa8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->