### PR TITLE
chore(deps): update cypress to ^15.18.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "@docusaurus/tsconfig": "3.9.2",
         "@prettier/sync": "^0.6.1",
         "@types/turndown": "^5.0.6",
-        "cypress": "^15.16.0",
+        "cypress": "^15.18.0",
         "got": "^14.6.6",
         "gray-matter": "^4.0.3",
         "husky": "^9.1.7",
@@ -9676,9 +9676,9 @@
       "license": "MIT"
     },
     "node_modules/cypress": {
-      "version": "15.16.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.16.0.tgz",
-      "integrity": "sha512-fy0M0c9xDLEp4v9y7LLKFeAQhIdDsobxDSKpD3JcZpqQefjy9TSzEyVV3HA0zu7hUi0bGHlSYlI7ASub8wgR9A==",
+      "version": "15.18.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.18.0.tgz",
+      "integrity": "sha512-aLfOYSLlVt1b6QSoVUjbCY27taZlYAT8ST47xQbwd9pvQrY/g5gXi12yItZTB+kxkkj+ZcvUYmRLUC95SlCJsw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@docusaurus/tsconfig": "3.9.2",
     "@prettier/sync": "^0.6.1",
     "@types/turndown": "^5.0.6",
-    "cypress": "^15.16.0",
+    "cypress": "^15.18.0",
     "got": "^14.6.6",
     "gray-matter": "^4.0.3",
     "husky": "^9.1.7",


### PR DESCRIPTION
Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016batKAHuNchjeQAWbyVEWm

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only dependency patch bump with no production or application code changes; main risk is possible E2E test behavior differences in the new Cypress release.
> 
> **Overview**
> Bumps the **Cypress** dev dependency from `^15.16.0` to `^15.18.0` in `package.json`, with the matching lockfile entry for `node_modules/cypress`.
> 
> No application or docs source changes—only the test runner version used by `npm test` / `cypress run`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7adff1b6400ad1169ef5da2d1da474e8f18e7bb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->