### PR TITLE
Rewrite 'Open the App' doc to emphasize feature value and improve clarity

### DIFF
--- a/docs/app/get-started/install-cypress.mdx
+++ b/docs/app/get-started/install-cypress.mdx
@@ -9,6 +9,11 @@ sidebar_position: 30
 
 # Installation
 
+Cypress installs into your project as a single dev dependency with everything
+included: the app, the test runner, and a bundled browser. There are no
+separate browser drivers to manage or servers to run, so you can go from an
+empty project to watching your first test run in a real browser in minutes.
+
 :::info
 
 <WhatYoullLearn />

--- a/docs/app/get-started/install-cypress.mdx
+++ b/docs/app/get-started/install-cypress.mdx
@@ -9,11 +9,6 @@ sidebar_position: 30
 
 # Installation
 
-Cypress installs into your project as a single dev dependency with everything
-included: the app, the test runner, and a bundled browser. There are no
-separate browser drivers to manage or servers to run, so you can go from an
-empty project to watching your first test run in a real browser in minutes.
-
 :::info
 
 <WhatYoullLearn />

--- a/docs/app/get-started/open-the-app.mdx
+++ b/docs/app/get-started/open-the-app.mdx
@@ -56,9 +56,36 @@ invoked, only that `npm run cy:open` starts it.
 
 Now you can open Cypress from your project root with:
 
+<Tabs>
+  <TabItem value="npm">
+
 ```shell
 npm run cy:open
 ```
+
+  </TabItem>
+  <TabItem value="yarn">
+
+```shell
+yarn cy:open
+```
+
+  </TabItem>
+  <TabItem value="pnpm">
+
+```shell
+pnpm cy:open
+```
+
+  </TabItem>
+  <TabItem value="bun">
+
+```shell
+bun run cy:open
+```
+
+  </TabItem>
+</Tabs>
 
 :::caution
 

--- a/docs/app/get-started/open-the-app.mdx
+++ b/docs/app/get-started/open-the-app.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Open the Cypress app: step-by-step guide'
-description: 'Open the Cypress app to run tests interactively, watch them execute in a real browser, and debug failures visually — with guided setup that configures your project for you.'
+description: 'Open the Cypress app to run tests interactively, watch them execute in a real browser, and debug failures visually, with guided setup that configures your project for you.'
 sidebar_label: Open the App
 sidebar_position: 40
 ---
@@ -25,7 +25,7 @@ The Cypress app is where you'll spend most of your time while writing tests:
 it runs your tests in a real browser as you work, re-runs them automatically
 when you save a file, and lets you travel back through each step of a test to
 see exactly what happened. Opening the app for the first time also sets up
-your project for you — the Launchpad generates the configuration and folder
+your project for you: the Launchpad generates the configuration and folder
 structure Cypress needs, so you can go from installation to a running test
 without writing any config by hand.
 
@@ -42,7 +42,7 @@ After a moment, the Cypress Launchpad will open.
 
 Typing the full command works fine, but adding Cypress to the `scripts` field
 in your `package.json` gives you a shorter command that's consistent for
-everyone working in the project — teammates don't need to know how Cypress is
+everyone working in the project. Teammates don't need to know how Cypress is
 invoked, only that `npm run cy:open` starts it.
 
 ```json title="package.json"
@@ -74,7 +74,7 @@ Use a descriptive, non-ambiguous name such as `cy:open` or `cy:run`.
 ### CLI tools
 
 Installing Cypress through npm also gives you access to many other CLI
-commands — for running tests headlessly in CI, checking your installation,
+commands for running tests headlessly in CI, checking your installation,
 managing the binary cache, and more. Cypress is also a fully baked JavaScript
 library you can import into your Node scripts.
 
@@ -88,8 +88,8 @@ Read more in the [command line reference](/app/references/command-line).
 />
 
 When Cypress opens, the Launchpad is the first thing you'll see. It walks you
-through the decisions and configuration a new project needs — choosing a
-testing type, generating configuration files, and picking a browser — so you
+through the decisions and configuration a new project needs (choosing a
+testing type, generating configuration files, and picking a browser) so you
 don't have to set any of this up manually. If your project is already
 configured, the Launchpad gets you back to your tests in a couple of clicks.
 
@@ -108,8 +108,8 @@ you want to do?
 
 - **[E2E Testing](/app/core-concepts/testing-types#What-is-E2E-Testing)** runs
   your whole application in the browser and visits pages the way a user would.
-  It's the best way to verify complete user journeys — logging in, filling out
-  forms, checking out — across your entire stack.
+  It's the best way to verify complete user journeys across your entire
+  stack, like logging in, filling out forms, and checking out.
 - **[Component Testing](/app/core-concepts/testing-types#What-is-Component-Testing)**
   mounts individual components of your app in isolation. It's a fast, focused
   way to test a component's behavior across many states and props without
@@ -117,7 +117,7 @@ you want to do?
 
 For more background on this decision, read
 [Testing Types](/app/core-concepts/testing-types). If you're not sure which to
-pick, choose **E2E Testing** for now — this isn't a permanent choice, and you
+pick, choose **E2E Testing** for now. This isn't a permanent choice, and you
 can set up the other testing type at any time later.
 
 ### Step 2: Review the generated configuration
@@ -135,7 +135,7 @@ configuration format up front.
 
 You can read about what each file does in the
 [Cypress configuration reference](/app/references/configuration), or simply
-scroll down and click **Continue** — the defaults work well for most projects,
+scroll down and click **Continue**. The defaults work well for most projects,
 and you can adjust the configuration whenever you need to.
 
 ### Step 3: Launch a browser
@@ -148,7 +148,7 @@ and you can adjust the configuration whenever you need to.
 Finally, the Launchpad shows the compatible browsers it found on your system,
 including the Electron browser that ships with Cypress. Running your tests in
 the same browsers your users rely on gives you confidence that your app works
-where it matters — and you can switch browsers at any time, even in the middle
+where it matters, and you can switch browsers at any time, even in the middle
 of a testing session.
 
 To learn more about your options here, see the
@@ -183,6 +183,6 @@ You're set up and ready to write your first test:
 - Chose Component Testing?
   [Get started with Component Testing](/app/component-testing/get-started).
 
-To get the most out of the app itself — the Command Log, time-travel
-debugging, and Cypress Studio — read about
+To get the most out of the app itself, including the Command Log, time-travel
+debugging, and Cypress Studio, read about
 [Open Mode](/app/core-concepts/open-mode).

--- a/docs/app/get-started/open-the-app.mdx
+++ b/docs/app/get-started/open-the-app.mdx
@@ -61,8 +61,6 @@ npm run cy:open
 
 :::caution
 
-<strong>Best Practice</strong>
-
 Don't name a script `cypress`, especially if you use Yarn as your package
 manager. When running commands on the Cypress binary (e.g. `yarn cypress verify`),
 Yarn will reference the script of the same name instead, and
@@ -73,16 +71,16 @@ Use a descriptive, non-ambiguous name such as `cy:open` or `cy:run`.
 
 ## The Launchpad
 
-<DocsImage
-  src="/img/app/core-concepts/open-mode/the-launchpad.png"
-  alt="The Launchpad window"
-/>
-
 When Cypress opens, the Launchpad is the first thing you'll see. It walks you
 through the decisions and configuration a new project needs (choosing a
 testing type, generating configuration files, and picking a browser) so you
 don't have to set any of this up manually. If your project is already
 configured, the Launchpad gets you back to your tests in a couple of clicks.
+
+<DocsImage
+  src="/img/app/core-concepts/open-mode/the-launchpad.png"
+  alt="The Launchpad window"
+/>
 
 The first time you open Cypress in a project, the Launchpad takes you through
 the following steps in order.

--- a/docs/app/get-started/open-the-app.mdx
+++ b/docs/app/get-started/open-the-app.mdx
@@ -151,9 +151,36 @@ every time. Pass the testing type and browser directly to
 [`cypress open`](/app/references/command-line#cypress-open) to land straight
 on your specs:
 
+<Tabs>
+  <TabItem value="npm">
+
 ```shell
 npx cypress open --e2e --browser chrome
 ```
+
+  </TabItem>
+  <TabItem value="yarn">
+
+```shell
+yarn cypress open --e2e --browser chrome
+```
+
+  </TabItem>
+  <TabItem value="pnpm">
+
+```shell
+pnpm cypress open --e2e --browser chrome
+```
+
+  </TabItem>
+  <TabItem value="bun">
+
+```shell
+bunx cypress open --e2e --browser chrome
+```
+
+  </TabItem>
+</Tabs>
 
 This is a handy addition to your npm scripts for the testing type you use most.
 

--- a/docs/app/get-started/open-the-app.mdx
+++ b/docs/app/get-started/open-the-app.mdx
@@ -84,14 +84,11 @@ configured, the Launchpad gets you back to your tests in a couple of clicks.
 />
 
 The first time you open Cypress in a project, the Launchpad takes you through
-the following steps in order.
+the following steps in order. You'll only see this full setup once: on later
+opens, the Launchpad remembers your configuration, and you can
+[skip the prompts entirely](#Skip-the-setup-prompts) from the command line.
 
 ### Step 1: Choose a testing type
-
-<DocsImage
-  src="/img/app/get-started/open-the-app/choose-testing-type.png"
-  alt="The Launchpad test type selector"
-/>
 
 The Launchpad presents your biggest decision first: what type of testing do
 you want to do?
@@ -110,12 +107,12 @@ For more background on this decision, read
 pick, choose **E2E Testing** for now. This isn't a permanent choice, and you
 can set up the other testing type at any time later.
 
-### Step 2: Review the generated configuration
-
 <DocsImage
-  src="/img/app/get-started/open-the-app/scaffolded-files.png"
-  alt="The Launchpad scaffolded files list"
+  src="/img/app/get-started/open-the-app/choose-testing-type.png"
+  alt="The Launchpad test type selector"
 />
+
+### Step 2: Review the generated configuration
 
 Next, the Launchpad generates a set of configuration files tailored to your
 chosen testing type and lists each change for you to review. This scaffolding
@@ -128,12 +125,22 @@ You can read about what each file does in
 scroll down and click **Continue**. The defaults work well for most projects,
 and you can adjust the configuration whenever you need to.
 
-### Step 3: Launch a browser
-
 <DocsImage
-  src="/img/app/get-started/open-the-app/select-browser.png"
-  alt="The Launchpad browser selector"
+  src="/img/app/get-started/open-the-app/scaffolded-files.png"
+  alt="The Launchpad scaffolded files list"
 />
+
+:::info
+
+If you chose Component Testing, the Launchpad shows two extra screens before
+generating configuration files: it auto-detects your front-end framework and
+bundler, then verifies that the required dependencies are installed. See the
+[Component Testing setup guide](/app/component-testing/get-started) for a
+full walkthrough.
+
+:::
+
+### Step 3: Launch a browser
 
 Finally, the Launchpad shows the compatible browsers it found on your system,
 including the Electron browser that ships with Cypress. Running your tests in
@@ -144,6 +151,11 @@ of a testing session.
 To learn more about your options here, see the
 [guide on launching browsers](/app/references/launching-browsers). Pick a
 browser and click **Start** to begin testing.
+
+<DocsImage
+  src="/img/app/get-started/open-the-app/select-browser.png"
+  alt="The Launchpad browser selector"
+/>
 
 ## Skip the setup prompts
 
@@ -215,8 +227,7 @@ top right unlocks insights from your recorded runs, right inside the app:
 The run insights require your project to
 [record runs to Cypress Cloud](/cloud/get-started/setup), and the AI features
 require a linked project. Setup takes a few minutes, and Cypress Cloud has a
-free plan to get you started. Learn more about these features in
-[Open Mode](/app/core-concepts/open-mode).
+free plan to get you started.
 
 ## Troubleshooting
 

--- a/docs/app/get-started/open-the-app.mdx
+++ b/docs/app/get-started/open-the-app.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Open the Cypress app: step-by-step guide'
-description: 'Open the app in Cypress to visually see, review, and debug end-to-end and component tests.'
+description: 'Open the Cypress app to run tests interactively, watch them execute in a real browser, and debug failures visually — with guided setup that configures your project for you.'
 sidebar_label: Open the App
 sidebar_position: 40
 ---
@@ -13,27 +13,39 @@ sidebar_position: 40
 
 <WhatYoullLearn />
 
-- How to open the Cypress app
-- How to add npm scripts for opening Cypress
-- How to choose a testing type, set up configuration, and launch a browser in Cypress
-  :::
+- How to open the Cypress app with `cypress open`
+- How to add an npm script so anyone on your team can open Cypress the same way
+- How the Launchpad guides you through choosing a testing type, generating
+  configuration, and launching a browser
+- How to skip the setup prompts once your project is configured
+
+:::
+
+The Cypress app is where you'll spend most of your time while writing tests:
+it runs your tests in a real browser as you work, re-runs them automatically
+when you save a file, and lets you travel back through each step of a test to
+see exactly what happened. Opening the app for the first time also sets up
+your project for you — the Launchpad generates the configuration and folder
+structure Cypress needs, so you can go from installation to a running test
+without writing any config by hand.
 
 ## `cypress open`
 
-You can open Cypress from your **project root** using one of the following commands,
-depending on the package manager (npm, Yarn or pnpm) you are using:
+Open Cypress from your **project root** using the command for your package
+manager (npm, Yarn, or pnpm):
 
 <CypressOpenCommands />
 
 After a moment, the Cypress Launchpad will open.
 
-### Adding npm Scripts
+### Add an npm script
 
-While there's nothing wrong with writing out the full path to the Cypress
-executable each time, it's much easier and clearer to add Cypress commands to
-the `scripts` field in your `package.json` file.
+Typing the full command works fine, but adding Cypress to the `scripts` field
+in your `package.json` gives you a shorter command that's consistent for
+everyone working in the project — teammates don't need to know how Cypress is
+invoked, only that `npm run cy:open` starts it.
 
-```javascript
+```json title="package.json"
 {
   "scripts": {
     "cy:open": "cypress open"
@@ -41,32 +53,32 @@ the `scripts` field in your `package.json` file.
 }
 ```
 
-Now you can invoke the command from your project root like so:
+Now you can open Cypress from your project root with:
 
 ```shell
 npm run cy:open
 ```
 
-...and Cypress will open right up for you.
-
 :::caution
 
 <strong>Best Practice</strong>
 
-Don't use `cypress` as the exact name of a script, especially if you use Yarn as package manager.
-When running commands on the Cypress binary (e.g. `yarn cypress verify`), Yarn will reference the
-script of the same name instead and [Cypress CLI commands](/app/references/command-line) may not work as expected.
-Use instead a descriptive and non-ambiguous script name such as `cy:open` or `cy:run`.
+Don't name a script `cypress`, especially if you use Yarn as your package
+manager. When running commands on the Cypress binary (e.g. `yarn cypress verify`),
+Yarn will reference the script of the same name instead, and
+[Cypress CLI commands](/app/references/command-line) may not work as expected.
+Use a descriptive, non-ambiguous name such as `cy:open` or `cy:run`.
 
 :::
 
 ### CLI tools
 
-By installing Cypress through `npm` you also get access to many other CLI
-commands. On top of that, Cypress is also a fully baked JavaScript library you
-can import into your Node scripts.
+Installing Cypress through npm also gives you access to many other CLI
+commands — for running tests headlessly in CI, checking your installation,
+managing the binary cache, and more. Cypress is also a fully baked JavaScript
+library you can import into your Node scripts.
 
-You can [read more about the CLI here](/app/references/command-line).
+Read more in the [command line reference](/app/references/command-line).
 
 ## The Launchpad
 
@@ -75,61 +87,102 @@ You can [read more about the CLI here](/app/references/command-line).
   alt="The Launchpad window"
 />
 
-On opening Cypress, your testing journey begins with the Launchpad. Its job is
-to guide you through the decisions and configuration tasks you need to complete
-before you start writing your first test.
+When Cypress opens, the Launchpad is the first thing you'll see. It walks you
+through the decisions and configuration a new project needs — choosing a
+testing type, generating configuration files, and picking a browser — so you
+don't have to set any of this up manually. If your project is already
+configured, the Launchpad gets you back to your tests in a couple of clicks.
 
-If this is your first time using Cypress it will take you through the following
-steps in order.
+The first time you open Cypress in a project, the Launchpad takes you through
+the following steps in order.
 
-### Choosing a Testing Type
+### Step 1: Choose a testing type
 
 <DocsImage
   src="/img/app/get-started/open-the-app/choose-testing-type.png"
   alt="The Launchpad test type selector"
 />
 
-The Launchpad presents you with your biggest decision first: What type of
-testing shall I do?
-[E2E Testing](/app/core-concepts/testing-types#What-is-E2E-Testing), where I
-run my whole application and visit pages to test them? Or
-[Component Testing](/app/core-concepts/testing-types#What-is-Component-Testing),
-where I mount individual components of my app and test them in isolation?
+The Launchpad presents your biggest decision first: what type of testing do
+you want to do?
 
-For more background on this critical decision, read
-[Testing Types](/app/core-concepts/testing-types). Alternatively, if you're
-not sure which type you want and just want to get on with your testing journey,
-just choose **E2E** for now - you can always change this later!
+- **[E2E Testing](/app/core-concepts/testing-types#What-is-E2E-Testing)** runs
+  your whole application in the browser and visits pages the way a user would.
+  It's the best way to verify complete user journeys — logging in, filling out
+  forms, checking out — across your entire stack.
+- **[Component Testing](/app/core-concepts/testing-types#What-is-Component-Testing)**
+  mounts individual components of your app in isolation. It's a fast, focused
+  way to test a component's behavior across many states and props without
+  running your whole application.
 
-### Quick Configuration
+For more background on this decision, read
+[Testing Types](/app/core-concepts/testing-types). If you're not sure which to
+pick, choose **E2E Testing** for now — this isn't a permanent choice, and you
+can set up the other testing type at any time later.
+
+### Step 2: Review the generated configuration
 
 <DocsImage
   src="/img/app/get-started/open-the-app/scaffolded-files.png"
   alt="The Launchpad scaffolded files list"
 />
 
-On the next step, the Launchpad will scaffold out a set of configuration files
-appropriate to your chosen testing type, and the changes will be listed for you
-to review. For more information about the generated config check out the
-[Cypress configuration reference](/app/references/configuration), or you can
-just scroll down and hit "Continue".
+Next, the Launchpad generates a set of configuration files tailored to your
+chosen testing type and lists each change for you to review. This scaffolding
+saves you from writing boilerplate: you get a working `cypress.config.js`,
+support files, and example fixtures without needing to know Cypress's
+configuration format up front.
 
-### Launching a Browser
+You can read about what each file does in the
+[Cypress configuration reference](/app/references/configuration), or simply
+scroll down and click **Continue** — the defaults work well for most projects,
+and you can adjust the configuration whenever you need to.
+
+### Step 3: Launch a browser
 
 <DocsImage
   src="/img/app/get-started/open-the-app/select-browser.png"
   alt="The Launchpad browser selector"
 />
 
-Lastly, you're presented with the list of compatible browsers Cypress found on
-your system. To understand more about your options here, see
-[our guide on launching browsers](/app/references/launching-browsers). Again,
-don't sweat it, you can switch browsers whenever you want. Now **MASH THAT
-START BUTTON!**
+Finally, the Launchpad shows the compatible browsers it found on your system,
+including the Electron browser that ships with Cypress. Running your tests in
+the same browsers your users rely on gives you confidence that your app works
+where it matters — and you can switch browsers at any time, even in the middle
+of a testing session.
+
+To learn more about your options here, see the
+[guide on launching browsers](/app/references/launching-browsers). Pick a
+browser and click **Start** to begin testing.
+
+## Skip the setup prompts
+
+Once your project is configured, you don't need to click through the Launchpad
+every time. Pass the testing type and browser directly to
+[`cypress open`](/app/references/command-line#cypress-open) to land straight
+on your specs:
+
+```shell
+npx cypress open --e2e --browser chrome
+```
+
+This is a handy addition to your npm scripts for the testing type you use most.
+
+## Troubleshooting
+
+If the Cypress app doesn't open, or a browser you expect to see isn't listed,
+see the [troubleshooting guide](/app/references/troubleshooting) and
+[launching browsers](/app/references/launching-browsers) for common fixes.
 
 ## Next Steps
 
-Time to get testing! If you chose
-[to start with E2E Testing, go here](/app/end-to-end-testing/writing-your-first-end-to-end-test).
-Alternatively, if you decided
-[to try Component Testing, go here](/app/component-testing/get-started).
+You're set up and ready to write your first test:
+
+- Chose E2E Testing?
+  [Write your first E2E test](/app/end-to-end-testing/writing-your-first-end-to-end-test).
+- Chose Component Testing?
+  [Get started with Component Testing](/app/component-testing/get-started).
+
+To get the most out of the app itself — the Command Log, time-travel
+debugging, and Cypress Studio — read about
+[Open Mode](/app/core-concepts/open-mode).

--- a/docs/app/get-started/open-the-app.mdx
+++ b/docs/app/get-started/open-the-app.mdx
@@ -120,6 +120,11 @@ opens, the Launchpad remembers your configuration, and you can
 The Launchpad presents your biggest decision first: what type of testing do
 you want to do?
 
+<DocsImage
+  src="/img/app/get-started/open-the-app/choose-testing-type.png"
+  alt="The Launchpad test type selector"
+/>
+
 - **[E2E Testing](/app/core-concepts/testing-types#What-is-E2E-Testing)** runs
   your whole application in the browser and visits pages the way a user would.
   It's the best way to verify complete user journeys across your entire
@@ -133,11 +138,6 @@ For more background on this decision, read
 [Testing Types](/app/core-concepts/testing-types). If you're not sure which to
 pick, choose **E2E Testing** for now. This isn't a permanent choice, and you
 can set up the other testing type at any time later.
-
-<DocsImage
-  src="/img/app/get-started/open-the-app/choose-testing-type.png"
-  alt="The Launchpad test type selector"
-/>
 
 ### Step 2: Review the generated configuration
 

--- a/docs/app/get-started/open-the-app.mdx
+++ b/docs/app/get-started/open-the-app.mdx
@@ -202,3 +202,12 @@ You're set up and ready to write your first test:
 To get the most out of the app itself, including the Command Log, time-travel
 debugging, and Cypress Studio, read about
 [Open Mode](/app/core-concepts/open-mode).
+
+## See also
+
+- [Command Line](/app/references/command-line)
+- [Cypress configuration](/app/references/configuration)
+- [Launching Browsers](/app/references/launching-browsers)
+- [Open Mode](/app/core-concepts/open-mode)
+- [Testing Types](/app/core-concepts/testing-types)
+- [Troubleshooting](/app/references/troubleshooting)

--- a/docs/app/get-started/open-the-app.mdx
+++ b/docs/app/get-started/open-the-app.mdx
@@ -147,15 +147,15 @@ saves you from writing boilerplate: you get a working `cypress.config.js`,
 support files, and example fixtures without needing to know Cypress's
 configuration format up front.
 
-You can read about what each file does in
-[Project structure](/app/core-concepts/writing-and-organizing-tests#Project-structure), or simply
-scroll down and click **Continue**. The defaults work well for most projects,
-and you can adjust the configuration whenever you need to.
-
 <DocsImage
   src="/img/app/get-started/open-the-app/scaffolded-files.png"
   alt="The Launchpad scaffolded files list"
 />
+
+You can read about what each file does in
+[Project structure](/app/core-concepts/writing-and-organizing-tests#Project-structure), or simply
+scroll down and click **Continue**. The defaults work well for most projects,
+and you can adjust the configuration whenever you need to.
 
 :::info
 
@@ -175,14 +175,14 @@ the same browsers your users rely on gives you confidence that your app works
 where it matters, and you can switch browsers at any time, even in the middle
 of a testing session.
 
-To learn more about your options here, see the
-[guide on launching browsers](/app/references/launching-browsers). Pick a
-browser and click **Start** to begin testing.
-
 <DocsImage
   src="/img/app/get-started/open-the-app/select-browser.png"
   alt="The Launchpad browser selector"
 />
+
+To learn more about your options here, see the
+[guide on launching browsers](/app/references/launching-browsers). Pick a
+browser and click **Start** to begin testing.
 
 ## Skip the setup prompts
 

--- a/docs/app/get-started/open-the-app.mdx
+++ b/docs/app/get-started/open-the-app.mdx
@@ -239,8 +239,11 @@ debugging, and Cypress Studio, read about
 
 ## See also
 
+- [AI Test Generation](/app/guides/ai-test-generation)
 - [Command Line](/app/references/command-line)
+- [`cy.prompt()`](/api/commands/prompt)
 - [Cypress configuration](/app/references/configuration)
+- [Cypress Studio](/app/guides/cypress-studio)
 - [Launching Browsers](/app/references/launching-browsers)
 - [Open Mode](/app/core-concepts/open-mode)
 - [Testing Types](/app/core-concepts/testing-types)

--- a/docs/app/get-started/open-the-app.mdx
+++ b/docs/app/get-started/open-the-app.mdx
@@ -9,6 +9,14 @@ sidebar_position: 40
 
 # Open the App
 
+The Cypress app is where you'll spend most of your time while writing tests:
+it runs your tests in a real browser as you work, re-runs them automatically
+when you save a file, and lets you travel back through each step of a test to
+see exactly what happened. Opening the app for the first time also sets up
+your project for you: the Launchpad generates the configuration and folder
+structure Cypress needs, so you can go from installation to a running test
+without writing any config by hand.
+
 :::info
 
 <WhatYoullLearn />
@@ -20,14 +28,6 @@ sidebar_position: 40
 - How to skip the setup prompts once your project is configured
 
 :::
-
-The Cypress app is where you'll spend most of your time while writing tests:
-it runs your tests in a real browser as you work, re-runs them automatically
-when you save a file, and lets you travel back through each step of a test to
-see exactly what happened. Opening the app for the first time also sets up
-your project for you: the Launchpad generates the configuration and folder
-structure Cypress needs, so you can go from installation to a running test
-without writing any config by hand.
 
 ## `cypress open`
 

--- a/docs/app/get-started/open-the-app.mdx
+++ b/docs/app/get-started/open-the-app.mdx
@@ -26,6 +26,7 @@ without writing any config by hand.
 - How the Launchpad guides you through choosing a testing type, generating
   configuration, and launching a browser
 - How to skip the setup prompts once your project is configured
+- The benefits of logging in to Cypress Cloud from the app
 
 :::
 
@@ -183,6 +184,29 @@ bunx cypress open --e2e --browser chrome
 </Tabs>
 
 This is a handy addition to your npm scripts for the testing type you use most.
+
+## Log in to the app
+
+You can use the Cypress app without an account, but logging in to
+[Cypress Cloud](/cloud/get-started/introduction) from the profile menu in the
+top right unlocks insights from your recorded runs, right inside the app:
+
+- **See run history alongside your specs.** The Specs page shows each spec's
+  latest run statuses, average duration, and flaky-test annotations, so you
+  can spot slow or unreliable tests before you even run them.
+- **Review recorded runs without leaving the app.** The Runs page shows your
+  project's recorded runs, scoped to your current git branch.
+- **Debug CI failures locally.** The Debug page surfaces failed tests from
+  your latest recorded run, lets you re-run just those failures, and opens
+  [Test Replay](/cloud/features/test-replay) so you can see exactly what
+  happened in CI.
+- **Get notified when runs finish.** Cloud run notifications appear in the
+  app, and clicking one takes you straight to the run.
+
+To populate this data, your project needs to record runs to Cypress Cloud.
+[Setting up a project to record](/cloud/get-started/setup) takes a few
+minutes, and Cypress Cloud has a free plan to get you started. Learn more
+about these features in [Open Mode](/app/core-concepts/open-mode).
 
 ## Troubleshooting
 

--- a/docs/app/get-started/open-the-app.mdx
+++ b/docs/app/get-started/open-the-app.mdx
@@ -202,11 +202,21 @@ top right unlocks insights from your recorded runs, right inside the app:
   happened in CI.
 - **Get notified when runs finish.** Cloud run notifications appear in the
   app, and clicking one takes you straight to the run.
+- **Get AI assertion recommendations in Cypress Studio.** As you record
+  interactions with [Cypress Studio](/app/guides/cypress-studio), Studio AI
+  watches what changes in your UI and recommends assertions for you to review
+  and keep, so you don't have to guess what to assert after every click.
+- **Generate tests from natural language with `cy.prompt`.** Logging in lets
+  you use [`cy.prompt`](/api/commands/prompt) to turn plain-language steps
+  like `'click the login button'` into real, executable Cypress commands,
+  with self-healing when your UI changes. Learn more in
+  [AI Test Generation](/app/guides/ai-test-generation).
 
-To populate this data, your project needs to record runs to Cypress Cloud.
-[Setting up a project to record](/cloud/get-started/setup) takes a few
-minutes, and Cypress Cloud has a free plan to get you started. Learn more
-about these features in [Open Mode](/app/core-concepts/open-mode).
+The run insights require your project to
+[record runs to Cypress Cloud](/cloud/get-started/setup), and the AI features
+require a linked project. Setup takes a few minutes, and Cypress Cloud has a
+free plan to get you started. Learn more about these features in
+[Open Mode](/app/core-concepts/open-mode).
 
 ## Troubleshooting
 

--- a/docs/app/get-started/open-the-app.mdx
+++ b/docs/app/get-started/open-the-app.mdx
@@ -71,15 +71,6 @@ Use a descriptive, non-ambiguous name such as `cy:open` or `cy:run`.
 
 :::
 
-### CLI tools
-
-Installing Cypress through npm also gives you access to many other CLI
-commands for running tests headlessly in CI, checking your installation,
-managing the binary cache, and more. Cypress is also a fully baked JavaScript
-library you can import into your Node scripts.
-
-Read more in the [command line reference](/app/references/command-line).
-
 ## The Launchpad
 
 <DocsImage

--- a/docs/app/get-started/open-the-app.mdx
+++ b/docs/app/get-started/open-the-app.mdx
@@ -122,8 +122,8 @@ saves you from writing boilerplate: you get a working `cypress.config.js`,
 support files, and example fixtures without needing to know Cypress's
 configuration format up front.
 
-You can read about what each file does in the
-[Cypress configuration reference](/app/references/configuration), or simply
+You can read about what each file does in
+[Project structure](/app/core-concepts/writing-and-organizing-tests#Project-structure), or simply
 scroll down and click **Continue**. The defaults work well for most projects,
 and you can adjust the configuration whenever you need to.
 

--- a/docs/app/get-started/open-the-app.mdx
+++ b/docs/app/get-started/open-the-app.mdx
@@ -32,7 +32,7 @@ without writing any config by hand.
 ## `cypress open`
 
 Open Cypress from your **project root** using the command for your package
-manager (npm, Yarn, or pnpm):
+manager (npm, Yarn, pnpm, or Bun):
 
 <CypressOpenCommands />
 


### PR DESCRIPTION
## Summary

Rewrites the "Open the App" get-started page to lead with the value of each feature (interactive runs, guided Launchpad setup, Cloud login benefits) instead of just the mechanics, and restructures it for clarity.

## Why

The previous version described *how* to open the app but not *why* each step mattered: the intro jumped straight to the command, the Launchpad steps didn't explain the benefit of scaffolded config or browser choice, and features gated behind Cloud login (run insights, Debug page, Studio AI, `cy.prompt`) weren't mentioned at all. The tone also had some dated phrasing ("MASH THAT START BUTTON!").

Changes to `docs/app/get-started/open-the-app.mdx`:

- New value-focused intro placed above the "What You'll Learn" callout
- Launchpad steps numbered (1–3), each led by the benefit it provides, with screenshots placed directly after each section's first paragraph
- Info callout in Step 2 covering Component Testing's extra Launchpad screens (framework/bundler detection, dependency check)
- Note that full setup only appears on first open
- New "Skip the setup prompts" section with `--e2e`/`--browser` flags in package-manager tabs (npm, Yarn, pnpm, Bun); the npm script example uses the same tabs
- New "Log in to the app" section listing the benefits of logging in to Cypress Cloud: Specs page run insights, Runs page, Debug page with Test Replay, run notifications, Studio AI assertion recommendations, and `cy.prompt`
- New Troubleshooting pointer and "See also" section
- Fixes: package manager list now includes Bun; scaffolded-files link now points to Project structure instead of the configuration reference; removed the "CLI tools" section and the "Best Practice" callout title

## Notes for reviewers

- All feature claims in the login section were verified against the Open Mode, Cypress Studio, and `cy.prompt` docs (Studio AI and `cy.prompt` require a Cloud account/linked project; run insights require recorded runs).
- Heading renames don't break inbound links: the only cross-reference to this page targets `#cypress-open`, which is unchanged. The removed "CLI tools" anchor had no inbound links.
- Intentionally left out (discussed but deferred): renaming the page to "First-Time Setup", a screenshot of the profile/login menu (needs a new asset), and a first-run walkthrough video.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CoEb1HyN3prCivAziL3QSM