### PR TITLE
chore: update prettier to 3.9.4

### DIFF
--- a/docs/api/commands/intercept.mdx
+++ b/docs/api/commands/intercept.mdx
@@ -477,9 +477,7 @@ A [`StaticResponse`][staticresponse] object represents a response to an HTTP
 request, and can be used to stub routes:
 
 ```js
-const staticResponse = {
-  /* some StaticResponse properties here... */
-}
+const staticResponse = {/* some StaticResponse properties here... */}
 
 cy.intercept('/projects', staticResponse)
 ```

--- a/docs/app/continuous-integration/bitbucket-pipelines.mdx
+++ b/docs/app/continuous-integration/bitbucket-pipelines.mdx
@@ -208,13 +208,13 @@ pipelines:
         script:
           - npm ci
     - parallel:
-      # run N steps in parallel
-      - step:
-          <<: *e2e
-      - step:
-          <<: *e2e
-      - step:
-          <<: *e2e
+        # run N steps in parallel
+        - step:
+            <<: *e2e
+        - step:
+            <<: *e2e
+        - step:
+            <<: *e2e
 definitions:
   caches:
     npm: $HOME/.npm

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "node-fetch": "^3.3.2",
         "p-map": "^7.0.5",
         "patch-package": "^8.0.0",
-        "prettier": "^3.2.5",
+        "prettier": "^3.9.4",
         "sanitize-html": "^2.17.3",
         "turndown": "^7.2.4",
         "turndown-plugin-gfm": "1.0.2",
@@ -18980,9 +18980,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
-      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.4.tgz",
+      "integrity": "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "node-fetch": "^3.3.2",
     "p-map": "^7.0.5",
     "patch-package": "^8.0.0",
-    "prettier": "^3.2.5",
+    "prettier": "^3.9.4",
     "sanitize-html": "^2.17.3",
     "turndown": "^7.2.4",
     "turndown-plugin-gfm": "1.0.2",


### PR DESCRIPTION
## Summary

Updates the `prettier` devDependency from `^3.2.5` to `3.9.4` (latest) and reformats the two markdown files flagged by the new version's formatting rules.

## Why

Routine dependency update to pick up the latest Prettier release. The new version's `--check` flagged formatting drift in two files, so they were reformatted in the same commit to keep `npm run lint:markdown` green:

- `docs/api/commands/intercept.mdx` — a comment-only object literal is now collapsed onto one line
- `docs/app/continuous-integration/bitbucket-pipelines.mdx` — YAML sequence indentation standardized (semantically identical YAML)

## Notes for reviewers

Both markdown changes are cosmetic-only output changes from Prettier itself, not manual edits. `npm run lint:markdown` passes cleanly with 3.9.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P9GKv8BSkNLk3omJYocKhe

---
_Generated by [Claude Code](https://claude.ai/code/session_01P9GKv8BSkNLk3omJYocKhe)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-tooling and cosmetic markdown formatting only; no runtime or application logic changes.
> 
> **Overview**
> Bumps the **prettier** devDependency from `^3.2.5` to `^3.9.4` in `package.json` and refreshes `package-lock.json` (resolved **3.9.4**).
> 
> Prettier 3.9.4’s formatting rules required two doc-only touch-ups so `npm run lint:markdown` stays green: **`docs/api/commands/intercept.mdx`** collapses a placeholder `staticResponse` object in a code sample onto one line, and **`docs/app/continuous-integration/bitbucket-pipelines.mdx`** adjusts indentation of the `parallel:` YAML steps in an example (behavior unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7dee8b7cee92515b0c932254ab432f17bb44f5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->