### PR TITLE
chore: update docusaurus-plugin-sass to 0.2.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "autoprefixer": "^10.5.2",
         "clsx": "^2.1.0",
         "docusaurus-plugin-image-zoom": "^2.0.0",
-        "docusaurus-plugin-sass": "0.2.5",
+        "docusaurus-plugin-sass": "0.2.6",
         "postcss": "^8.4.34",
         "prism-react-renderer": "^2.4.1",
         "react": "^18.2.0",
@@ -10248,12 +10248,12 @@
       }
     },
     "node_modules/docusaurus-plugin-sass": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/docusaurus-plugin-sass/-/docusaurus-plugin-sass-0.2.5.tgz",
-      "integrity": "sha512-Z+D0fLFUKcFpM+bqSUmqKIU+vO+YF1xoEQh5hoFreg2eMf722+siwXDD+sqtwU8E4MvVpuvsQfaHwODNlxJAEg==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/docusaurus-plugin-sass/-/docusaurus-plugin-sass-0.2.6.tgz",
+      "integrity": "sha512-2hKQQDkrufMong9upKoG/kSHJhuwd+FA3iAe/qzS/BmWpbIpe7XKmq5wlz4J5CJaOPu4x+iDJbgAxZqcoQf0kg==",
       "license": "MIT",
       "dependencies": {
-        "sass-loader": "^10.1.1"
+        "sass-loader": "^16.0.2"
       },
       "peerDependencies": {
         "@docusaurus/core": "^2.0.0-beta || ^3.0.0-alpha",
@@ -13172,15 +13172,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/klona": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.6.tgz",
-      "integrity": "sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/latest-version": {
@@ -20352,32 +20343,29 @@
       }
     },
     "node_modules/sass-loader": {
-      "version": "10.5.2",
-      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-10.5.2.tgz",
-      "integrity": "sha512-vMUoSNOUKJILHpcNCCyD23X34gve1TS7Rjd9uXHeKqhvBG39x6XbswFDtpbTElj6XdMFezoWhkh5vtKudf2cgQ==",
+      "version": "16.0.8",
+      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-16.0.8.tgz",
+      "integrity": "sha512-hcov4ZwZJIGbEuyNr9EmiTmZueyrxSToE6GOzoZnq5JM7ecRO7ttyvilPn+VmRsqiP16+VYZzVnGZj/hzZgKBA==",
       "license": "MIT",
       "dependencies": {
-        "klona": "^2.0.4",
-        "loader-utils": "^2.0.0",
-        "neo-async": "^2.6.2",
-        "schema-utils": "^3.0.0",
-        "semver": "^7.3.2"
+        "neo-async": "^2.6.2"
       },
       "engines": {
-        "node": ">= 10.13.0"
+        "node": ">= 18.12.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       },
       "peerDependencies": {
-        "fibers": ">= 3.1.0",
+        "@rspack/core": "0.x || ^1.0.0 || ^2.0.0-0",
         "node-sass": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
         "sass": "^1.3.0",
-        "webpack": "^4.36.0 || ^5.0.0"
+        "sass-embedded": "*",
+        "webpack": "^5.0.0"
       },
       "peerDependenciesMeta": {
-        "fibers": {
+        "@rspack/core": {
           "optional": true
         },
         "node-sass": {
@@ -20385,56 +20373,13 @@
         },
         "sass": {
           "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
         }
-      }
-    },
-    "node_modules/sass-loader/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/sass-loader/node_modules/ajv-keywords": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "ajv": "^6.9.1"
-      }
-    },
-    "node_modules/sass-loader/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "license": "MIT"
-    },
-    "node_modules/sass-loader/node_modules/schema-utils": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
-      "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/json-schema": "^7.0.8",
-        "ajv": "^6.12.5",
-        "ajv-keywords": "^3.5.2"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/sass/node_modules/chokidar": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "autoprefixer": "^10.5.2",
     "clsx": "^2.1.0",
     "docusaurus-plugin-image-zoom": "^2.0.0",
-    "docusaurus-plugin-sass": "0.2.5",
+    "docusaurus-plugin-sass": "0.2.6",
     "postcss": "^8.4.34",
     "prism-react-renderer": "^2.4.1",
     "react": "^18.2.0",


### PR DESCRIPTION
## Summary

Upgrades `docusaurus-plugin-sass` from 0.2.5 to 0.2.6 (the latest version) in `package.json` and `package-lock.json`.

## Why

Routine dependency update to stay current. The notable change in 0.2.6 is that the plugin's internal `sass-loader` dependency was bumped from v10 to v16, which also prunes ~75 lines of stale transitive dependencies from the lockfile. No issue associated.

## Notes for reviewers

- The plugin's peer dependency requirements (`@docusaurus/core ^3`, `sass ^1.30.0`) are unchanged and already satisfied by this repo's `@docusaurus/core ^3.10.1` and `sass ^1.70.0`.
- Verified with a full `npm run build`: it completed successfully and the SCSS compiled to `dist/assets/css/styles.*.css`. The broken-anchor warnings in the build log are pre-existing and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017cQLvFkMGkTSSTYAh3SuYf

---
_Generated by [Claude Code](https://claude.ai/code/session_017cQLvFkMGkTSSTYAh3SuYf)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only change for the docs build toolchain with no application logic changes; peer deps remain satisfied.
> 
> **Overview**
> Bumps **`docusaurus-plugin-sass`** from **0.2.5** to **0.2.6** in `package.json` and refreshes `package-lock.json`.
> 
> The upgrade pulls in **`sass-loader` v16** (replacing v10) and drops several older transitive packages (`klona`, nested `schema-utils`/`ajv` trees). Docusaurus config for the plugin is unchanged; this only affects how SCSS is compiled during the docs build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04c450d863278a33d0c05606f7d66b2b998a708e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->