### PR TITLE
chore: update sass to ^1.101.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "remark-directive": "^3.0.0",
-        "sass": "^1.70.0",
+        "sass": "^1.101.0",
         "sharp": "^0.35.3"
       },
       "devDependencies": {
@@ -12445,9 +12445,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.4.tgz",
-      "integrity": "sha512-p6u1bG3YSnINT5RQmx/yRZBpenIl30kVxkTLDyHLIMk0gict704Q9n+thfDI7lTRm9vXdDYutVzXhzcThxTnXA==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+      "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
       "license": "MIT"
     },
     "node_modules/import-fresh": {
@@ -20332,20 +20332,20 @@
       }
     },
     "node_modules/sass": {
-      "version": "1.97.3",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.97.3.tgz",
-      "integrity": "sha512-fDz1zJpd5GycprAbu4Q2PV/RprsRtKC/0z82z0JLgdytmcq0+ujJbJ/09bPGDxCLkKY3Np5cRAOcWiVkLXJURg==",
+      "version": "1.101.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.101.0.tgz",
+      "integrity": "sha512-OL3GoQyoUdDt843DpVmDO6y2k1sc5IhUDSpu8XucEI+35neq5QivZ1iuegnpraEVTJXlQGK1gl27zKcTLEPbQw==",
       "license": "MIT",
       "dependencies": {
-        "chokidar": "^4.0.0",
-        "immutable": "^5.0.2",
+        "chokidar": "^5.0.0",
+        "immutable": "^5.1.5",
         "source-map-js": ">=0.6.2 <2.0.0"
       },
       "bin": {
         "sass": "sass.js"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.19.0"
       },
       "optionalDependencies": {
         "@parcel/watcher": "^2.4.1"
@@ -20438,27 +20438,27 @@
       }
     },
     "node_modules/sass/node_modules/chokidar": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
       "license": "MIT",
       "dependencies": {
-        "readdirp": "^4.0.1"
+        "readdirp": "^5.0.0"
       },
       "engines": {
-        "node": ">= 14.16.0"
+        "node": ">= 20.19.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/sass/node_modules/readdirp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
       "license": "MIT",
       "engines": {
-        "node": ">= 14.18.0"
+        "node": ">= 20.19.0"
       },
       "funding": {
         "type": "individual",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "remark-directive": "^3.0.0",
-    "sass": "^1.70.0",
+    "sass": "^1.101.0",
     "sharp": "^0.35.3"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Updates the `sass` dependency from `^1.70.0` to `^1.101.0` (the latest release) in `package.json` and `package-lock.json`.

## Why

Routine dependency maintenance — bring `sass` up to the latest version to pick up ~18 months of compiler fixes and deprecation handling.

## Notes for reviewers

- Dependency-only change; no source or style files were modified.
- `npm ls sass` confirms 1.101.0 resolves and dedupes cleanly across the site itself, `docusaurus-plugin-sass`/`sass-loader@10`, and vitest/vite.
- Verified with a full clean `npm run build`: webpack client and server bundles compile successfully and the build completes with `[SUCCESS] Generated static files in "dist"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGwjFSiSFGvM2VN4HN9NP7

---
_Generated by [Claude Code](https://claude.ai/code/session_01KGwjFSiSFGvM2VN4HN9NP7)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only bump with no app code changes; main caveat is Sass’s new Node >=20.19.0 requirement and possible subtle SCSS compile differences across many minor releases.
> 
> **Overview**
> Bumps the direct **`sass`** dependency from **`^1.70.0`** to **`^1.101.0`** in `package.json` and refreshes `package-lock.json` so the resolved compiler is **1.101.0**.
> 
> The lockfile also pulls newer transitive tooling used by **`sass`**: **`chokidar`** 5.x, **`readdirp`** 5.x, and **`immutable`** 5.1.9. **`sass`** now declares **`node >= 20.19.0`** (up from 14.x), which aligns with CI’s Node **22.15.1** but is worth noting for anyone building locally on older Node.
> 
> No application source or style files change—only dependency metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94ae127a51a1caaf8ce813744dbe6e8de0902cc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->