### PR TITLE
chore: update docusaurus-plugin-image-zoom to v3.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@mdx-js/react": "^3.0.0",
         "autoprefixer": "^10.5.2",
         "clsx": "^2.1.0",
-        "docusaurus-plugin-image-zoom": "^2.0.0",
+        "docusaurus-plugin-image-zoom": "^3.0.1",
         "docusaurus-plugin-sass": "0.2.6",
         "postcss": "^8.5.16",
         "prism-react-renderer": "^2.4.1",
@@ -10229,12 +10229,12 @@
       }
     },
     "node_modules/docusaurus-plugin-image-zoom": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/docusaurus-plugin-image-zoom/-/docusaurus-plugin-image-zoom-2.0.0.tgz",
-      "integrity": "sha512-TWHQZeoiged+95CESlZk++lihzl3pqw34n0/fbexx2AocmFhbo9K2scYDgYB8amki4/X6mUCLTPZE1pQvT+00Q==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/docusaurus-plugin-image-zoom/-/docusaurus-plugin-image-zoom-3.0.1.tgz",
+      "integrity": "sha512-mQrqA99VpoMQJNbi02qkWAMVNC4+kwc6zLLMNzraHAJlwn+HrlUmZSEDcTwgn+H4herYNxHKxveE2WsYy73eGw==",
       "license": "MIT",
       "dependencies": {
-        "medium-zoom": "^1.0.8",
+        "medium-zoom": "^1.1.0",
         "validate-peer-dependencies": "^2.2.0"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@mdx-js/react": "^3.0.0",
     "autoprefixer": "^10.5.2",
     "clsx": "^2.1.0",
-    "docusaurus-plugin-image-zoom": "^2.0.0",
+    "docusaurus-plugin-image-zoom": "^3.0.1",
     "docusaurus-plugin-sass": "0.2.6",
     "postcss": "^8.5.16",
     "prism-react-renderer": "^2.4.1",


### PR DESCRIPTION
## Summary

Updates `docusaurus-plugin-image-zoom` from `^2.0.0` to `^3.0.1` in `package.json` and `package-lock.json`.

## Why

Routine dependency update to the latest major version. The only breaking change in v3.0.0 is the plugin's conversion from CommonJS to ESM, which doesn't affect this site: `docusaurus.config.js` references the plugin via `require.resolve()` (path resolution only) and Docusaurus 3.x loads ESM plugins natively. v3.0.1 is used rather than 3.0.0 because 3.0.0 was published without its compiled output.

## Notes for reviewers

- Peer dependency requirements are unchanged between v2 and v3 (`@docusaurus/theme-classic >= 3.0.0`), and the `zoom` themeConfig options this site uses are untouched, so no config changes were needed.
- Verified with a full production build (`npm run build`) on Docusaurus 3.10.1 — it completed successfully with only pre-existing broken-anchor warnings unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C6nSHxtCBCyE5qjbUXP9iV

---
_Generated by [Claude Code](https://claude.ai/code/session_01C6nSHxtCBCyE5qjbUXP9iV)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile and version pin only for a docs image-zoom plugin; no auth, data, or site config changes in the diff.
> 
> **Overview**
> Bumps **`docusaurus-plugin-image-zoom`** from `^2.0.0` to `^3.0.1` in `package.json` and `package-lock.json`. The lockfile also picks up **`medium-zoom`** `^1.1.0` (was `^1.0.8`) as a dependency of the plugin.
> 
> No application or Docusaurus config edits are in this diff—the site still registers the plugin via `require.resolve('docusaurus-plugin-image-zoom')` in `docusaurus.config.js`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6b88fa379b34f3f749868278947fcbb7ff15c81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->