### PR TITLE
Update remark-directive from ^3.0.0 to ^4.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "prism-react-renderer": "^2.4.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "remark-directive": "^3.0.0",
+        "remark-directive": "^4.0.0",
         "sass": "^1.101.0",
         "sharp": "^0.35.3"
       },
@@ -3815,6 +3815,97 @@
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@docusaurus/mdx-loader/node_modules/micromark-extension-directive": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-extension-directive/-/micromark-extension-directive-3.0.2.tgz",
+      "integrity": "sha512-wjcXHgk+PPdmvR58Le9d7zQYWy+vKEU9Se44p2CrCDPiLr2FMyiT4Fyb5UFKFC66wGB3kPlgD7q3TnoqPS7SZA==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "parse-entities": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@docusaurus/mdx-loader/node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/@docusaurus/mdx-loader/node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/@docusaurus/mdx-loader/node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@docusaurus/mdx-loader/node_modules/remark-directive": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/remark-directive/-/remark-directive-3.0.1.tgz",
+      "integrity": "sha512-gwglrEQEZcZYgVyG1tQuA+h58EZfq5CSULw7J90AFuCTyib1thgHPoqQ+h9iFvU6R+vnZ5oNFQR5QKgGpk741A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-directive": "^3.0.0",
+        "micromark-extension-directive": "^3.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/@docusaurus/module-type-aliases": {
@@ -14708,9 +14799,9 @@
       "license": "MIT"
     },
     "node_modules/micromark-extension-directive": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/micromark-extension-directive/-/micromark-extension-directive-3.0.2.tgz",
-      "integrity": "sha512-wjcXHgk+PPdmvR58Le9d7zQYWy+vKEU9Se44p2CrCDPiLr2FMyiT4Fyb5UFKFC66wGB3kPlgD7q3TnoqPS7SZA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-directive/-/micromark-extension-directive-4.0.0.tgz",
+      "integrity": "sha512-/C2nqVmXXmiseSSuCdItCMho7ybwwop6RrrRPk0KbOHW21JKoCldC+8rFOaundDoRBUWBnJJcxeA/Kvi34WQXg==",
       "license": "MIT",
       "dependencies": {
         "devlop": "^1.0.0",
@@ -19811,14 +19902,14 @@
       }
     },
     "node_modules/remark-directive": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/remark-directive/-/remark-directive-3.0.1.tgz",
-      "integrity": "sha512-gwglrEQEZcZYgVyG1tQuA+h58EZfq5CSULw7J90AFuCTyib1thgHPoqQ+h9iFvU6R+vnZ5oNFQR5QKgGpk741A==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/remark-directive/-/remark-directive-4.0.0.tgz",
+      "integrity": "sha512-7sxn4RfF1o3izevPV1DheyGDD6X4c9hrGpfdUpm7uC++dqrnJxIZVkk7CoKqcLm0VUMAuOol7Mno3m6g8cfMuA==",
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "mdast-util-directive": "^3.0.0",
-        "micromark-extension-directive": "^3.0.0",
+        "micromark-extension-directive": "^4.0.0",
         "unified": "^11.0.0"
       },
       "funding": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "prism-react-renderer": "^2.4.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "remark-directive": "^3.0.0",
+    "remark-directive": "^4.0.0",
     "sass": "^1.101.0",
     "sharp": "^0.35.3"
   },


### PR DESCRIPTION
## Summary

Updates the `remark-directive` dependency from `^3.0.0` to `^4.0.0` in `package.json` and regenerates `package-lock.json`. No code changes were needed.

## Why

Routine dependency update to the latest major version. `remark-directive` provides the triple-colon `:::name` directive syntax that the custom remark plugins in `plugins/cypressRemarkPlugins` (`:::visit-mount-example`, `:::cypress-config-example`, `:::cypress-config-plugin-example`) are built on.

v4.0.0 is a small major: it bumps the underlying parser (`micromark-extension-directive` 3 → 4), which now keeps trailing whitespace in directive labels (the only breaking change) and adds support for non-ASCII letters in attribute names. It stays on the same unified@11 / mdast-util-directive@3 ecosystem used by Docusaurus 3.

## Notes for reviewers

- The one breaking change only affects consumers that read directive *labels* (the `[bracketed text]` after a directive name). Our custom plugins match only on `node.type` and `node.name` (`plugins/cypressRemarkPlugins/src/utils/matchHelpers.ts`), so they are unaffected.
- Verified with a full `npm run build` — all 355 doc pages compiled through the remark pipeline with `onBrokenLinks`/`onBrokenAnchors` set to `throw`.
- `@docusaurus/mdx-loader` still pins its own nested `remark-directive@3.0.1`; that's expected and independent of the plugin configured in `docusaurus.config.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLr3L4RyAaNcPZ7DbJSkJQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01TLr3L4RyAaNcPZ7DbJSkJQ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only dependency bump on the docs MDX pipeline; custom plugins don't rely on the v4 label whitespace change.
> 
> **Overview**
> Bumps the direct **`remark-directive`** dependency from **^3.0.0** to **^4.0.0** and refreshes **`package-lock.json`**. There are **no application or plugin code changes**; `docusaurus.config.js` still loads `remark-directive` the same way for the custom Cypress remark plugins (`:::visit-mount-example`, `:::cypress-config-example`, etc.).
> 
> v4 mainly updates **`micromark-extension-directive`** (3 → 4). The notable behavior change is trailing whitespace preserved in directive *labels*; matching in `plugins/cypressRemarkPlugins` uses directive **`type`** and **`name`** only, so those plugins should behave as before. **`@docusaurus/mdx-loader`** continues to ship its own nested **`remark-directive@3.0.1`**, separate from this top-level dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65eb1604cd644f842b09e3977cc8a085b0383d4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->