### PR TITLE
Update TypeScript to v6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "@docusaurus/module-type-aliases": "^3.10.1",
         "@docusaurus/tsconfig": "3.10.1",
         "@prettier/sync": "^0.6.1",
+        "@types/node": "^25.9.4",
         "@types/turndown": "^5.0.6",
         "cypress": "^15.18.0",
         "got": "^15.1.0",
@@ -50,7 +51,7 @@
         "sanitize-html": "^2.17.5",
         "turndown": "^7.2.4",
         "turndown-plugin-gfm": "1.0.2",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "vitest": "^4.1.9",
         "wait-on": "^9.0.10"
       }
@@ -6980,12 +6981,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.0.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.10.tgz",
-      "integrity": "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg==",
+      "version": "25.9.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.4.tgz",
+      "integrity": "sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.16.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@types/prismjs": {
@@ -22121,9 +22122,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
@@ -22148,9 +22149,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "sanitize-html": "^2.17.5",
         "turndown": "^7.2.4",
         "turndown-plugin-gfm": "1.0.2",
-        "typescript": "^5.3.3",
+        "typescript": "^5.9.3",
         "vitest": "^4.1.9",
         "wait-on": "^9.0.10"
       }

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "sanitize-html": "^2.17.5",
     "turndown": "^7.2.4",
     "turndown-plugin-gfm": "1.0.2",
-    "typescript": "^5.3.3",
+    "typescript": "^5.9.3",
     "vitest": "^4.1.9",
     "wait-on": "^9.0.10"
   },

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@docusaurus/module-type-aliases": "^3.10.1",
     "@docusaurus/tsconfig": "3.10.1",
     "@prettier/sync": "^0.6.1",
+    "@types/node": "^25.9.4",
     "@types/turndown": "^5.0.6",
     "cypress": "^15.18.0",
     "got": "^15.1.0",
@@ -75,7 +76,7 @@
     "sanitize-html": "^2.17.5",
     "turndown": "^7.2.4",
     "turndown-plugin-gfm": "1.0.2",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.9",
     "wait-on": "^9.0.10"
   },

--- a/plugins/cypressRemarkPlugins/package.json
+++ b/plugins/cypressRemarkPlugins/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@types/prettier": "^2.6.3",
     "prettier": "^2.7.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "unist-util-visit": "^2.0.3"
   },
   "files": [

--- a/plugins/cypressRemarkPlugins/package.json
+++ b/plugins/cypressRemarkPlugins/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@types/prettier": "^2.6.3",
     "prettier": "^2.7.1",
-    "typescript": "^4.7.4",
+    "typescript": "^5.9.3",
     "unist-util-visit": "^2.0.3"
   },
   "files": [

--- a/plugins/cypressRemarkPlugins/src/copyTsToJs/transformTsToJs.ts
+++ b/plugins/cypressRemarkPlugins/src/copyTsToJs/transformTsToJs.ts
@@ -36,6 +36,9 @@ function makeTsCompilerOptions(
     newLine: ts.NewLineKind.LineFeed,
     removeComments: false,
     esModuleInterop: false,
+    // TypeScript 6 emits a 'use strict' prologue by default, which would
+    // show up in the transformed JS code samples
+    alwaysStrict: false,
     pretty: true,
     ...overrideOptions,
     module: ts.ModuleKind.ESNext,

--- a/plugins/cypressRemarkPlugins/tsconfig.json
+++ b/plugins/cypressRemarkPlugins/tsconfig.json
@@ -11,7 +11,7 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "target": "es2020",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
@@ -26,7 +26,7 @@
 
     /* Modules */
     "module": "CommonJS",                                /* Specify what module code is generated. */
-    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
+    "rootDir": "./src",                                  /* Specify the root folder within your source files. */
     // "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */

--- a/plugins/llm/package.json
+++ b/plugins/llm/package.json
@@ -15,7 +15,7 @@
     "mdast-util-to-string": "^4.0.0",
     "remark-gfm": "^4.0.0",
     "remark-parse": "^11.0.0",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "unified": "^11.0.0",
     "unist-util-visit": "^5.0.0"
   },

--- a/plugins/llm/package.json
+++ b/plugins/llm/package.json
@@ -15,7 +15,7 @@
     "mdast-util-to-string": "^4.0.0",
     "remark-gfm": "^4.0.0",
     "remark-parse": "^11.0.0",
-    "typescript": "^4.7.4",
+    "typescript": "^5.9.3",
     "unified": "^11.0.0",
     "unist-util-visit": "^5.0.0"
   },

--- a/plugins/llm/tsconfig.json
+++ b/plugins/llm/tsconfig.json
@@ -1,9 +1,11 @@
 {
   "compilerOptions": {
-    "target": "es2016",
+    "target": "es2020",
     "module": "CommonJS",
+    "types": ["node"],
     "declaration": true,
     "sourceMap": true,
+    "rootDir": "./src",
     "outDir": "./dist",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,9 @@
   // This file is not used in compilation. It is here just for a nice editor experience.
   "extends": "@docusaurus/tsconfig",
   "compilerOptions": {
-    "baseUrl": ".",
+    // baseUrl is inherited from @docusaurus/tsconfig, which TypeScript 6
+    // deprecates; silence it until Docusaurus drops the option
+    "ignoreDeprecations": "6.0",
     "strict": true,
   },
 }


### PR DESCRIPTION
## Summary

Upgrades TypeScript from `^5.3.3` to `^6.0.3` in the root package and both plugin packages (`plugins/cypressRemarkPlugins`, `plugins/llm`), along with the config and code changes TypeScript 6 requires.

## Why

The `typescript` devDependency was behind: the root declared `^5.3.3` (while the lockfile had already resolved to 5.9.3) and both plugin packages declared a stale `^4.7.4` even though they compile with the root-hoisted compiler. The first commit aligns everything on `^5.9.3`; the second moves to v6, making the adjustments the new major requires:

- **Explicit `rootDir`** in both plugin tsconfigs — TS 6 requires it when `outDir` changes the output layout. Set to `./src`, matching what was previously inferred, so the emitted `dist` layout is unchanged.
- **Compile target `es2016` → `es2020`** in both plugins — TS 6's stricter lib handling flags existing `String.matchAll` / `Array.flatMap` usage. The plugins run in Node 22 during the docs build, so es2020 output is safe.
- **`types: ["node"]`** in the `llm` plugin tsconfig plus `@types/node` in root devDependencies — TS 6 no longer implicitly picks up Node globals (`fs`, `path`, `process`, `__dirname`) there.
- **`alwaysStrict: false`** in the `copyTsToJs` transpile options — TS 6 emits a `"use strict"` prologue by default, which leaked into the TS→JS-transformed code samples rendered on docs pages (caught by the plugin's snapshot test). This restores output identical to TS 5.
- **`ignoreDeprecations: "6.0"` in the root tsconfig** — TS 6 raises a hard error (TS5101) for the deprecated `baseUrl` option, which is set by the extended `@docusaurus/tsconfig`. Cypress's webpack preprocessor compiles the e2e specs against this tsconfig, so every spec failed to bundle (Cloud run #1685 errored with 0 specs completed). Also dropped our own redundant `baseUrl`; the inherited one still applies for editor support.

## Notes for reviewers

- The `"use strict"` fix is the only source-code change; everything else is dependency ranges and tsconfig.
- Verified: both plugin builds compile cleanly, all plugin test suites pass (148 tests via `npm run test:plugins`), a full `npm run build` succeeds end to end — including the LLM export (355 docs, 990 output files) — with no strict prologue in the built output, and the Cypress e2e specs compile and pass locally against the built site after the `ignoreDeprecations` fix.
- The plugin `package.json` files still declare other stale dependency ranges (`unist-util-visit@^2`, `@types/mdast@^3`) that don't match the source code, which builds against the root-hoisted versions. Running `npm install` inside a plugin directory will break the build. Left out of scope here as a pre-existing issue.
- The `ignoreDeprecations` entry can be removed once Docusaurus ships a tsconfig without `baseUrl` (or TS 7 forces the issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N1Gs6stxhKUt6msf9pvreX