### PR TITLE
Declare tailwindcss as a direct dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,8 @@
         "react-dom": "^19.2.7",
         "remark-directive": "^4.0.0",
         "sass": "^1.101.0",
-        "sharp": "^0.35.3"
+        "sharp": "^0.35.3",
+        "tailwindcss": "^3.4.19"
       },
       "devDependencies": {
         "@docusaurus/module-type-aliases": "^3.10.1",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "react-dom": "^19.2.7",
     "remark-directive": "^4.0.0",
     "sass": "^1.101.0",
-    "sharp": "^0.35.3"
+    "sharp": "^0.35.3",
+    "tailwindcss": "^3.4.19"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "^3.10.1",


### PR DESCRIPTION
## Summary

Adds `tailwindcss` (`^3.4.19`) to `package.json` dependencies and updates `package-lock.json` accordingly. No versions in the resolved tree change — the lockfile diff only records tailwindcss as a direct dependency of the root package.

## Why

`docusaurus.config.js` calls `require('tailwindcss')` in its PostCSS plugin setup, but `tailwindcss` was not declared in `package.json` — it only resolved because `@cypress-design/css` depends on `tailwindcss ^3.4.3` and npm hoists it. If that design package ever dropped or upgraded Tailwind (e.g. to v4), the build would break. Declaring it explicitly removes the phantom dependency.

Closes <!-- no issue -->

## Notes for reviewers

- The range is pinned to `^3.4.19` (the version already resolved in the lockfile) rather than `^3.4.3`, which also guards against an accidental jump to Tailwind v4.
- It's placed in `dependencies` rather than `devDependencies` to sit alongside `postcss` and `autoprefixer`, which are already declared there for the same PostCSS setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LbaCVvQ1uSQL7D2DjriGsM

---
_Generated by [Claude Code](https://claude.ai/code/session_01LbaCVvQ1uSQL7D2DjriGsM)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency declaration only; no runtime or build logic changes beyond making an existing implicit require explicit in the lockfile.
> 
> **Overview**
> Adds **`tailwindcss` `^3.4.19`** to root **`dependencies`** in **`package.json`** and updates **`package-lock.json`** so the package is a declared direct dependency (not only hoisted via **`@cypress-design/css`**).
> 
> The Docusaurus PostCSS plugin in **`docusaurus.config.js`** already **`require('tailwindcss')`** alongside **`postcss`** and **`autoprefixer`**; this change makes that import explicit and stable if transitive Tailwind versions change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9fa8cf23bfa19f823b72cf2538b6171254d3cd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->