### PR TITLE
Remove never-installed dependency pins from plugin sub-packages

### DIFF
--- a/plugins/cypressRemarkPlugins/package.json
+++ b/plugins/cypressRemarkPlugins/package.json
@@ -2,6 +2,7 @@
   "name": "tstojs",
   "version": "1.0.0",
   "description": "",
+  "//": "This package is never installed on its own — it has no lockfile and is not an npm workspace; `npm --prefix` only runs its scripts. All dependencies (typescript, prettier, unist-util-visit, @types/*, vitest, etc.) resolve from the repository root's node_modules, so declare any new dependency in the root package.json.",
   "main": "dist/index.js",
   "scripts": {
     "prebuild": "rm -rf ./dist",
@@ -13,17 +14,7 @@
   },
   "author": "",
   "license": "ISC",
-  "dependencies": {
-    "@types/prettier": "^2.6.3",
-    "prettier": "^2.7.1",
-    "typescript": "^6.0.3",
-    "unist-util-visit": "^2.0.3"
-  },
   "files": [
     "dist"
-  ],
-  "devDependencies": {
-    "@types/mdast": "^3.0.10",
-    "@types/unist": "^2.0.6"
-  }
+  ]
 }

--- a/plugins/cypressRemarkPlugins/readme.md
+++ b/plugins/cypressRemarkPlugins/readme.md
@@ -6,6 +6,12 @@ variations in Tabs/code-blocks for Cypress config samples.
 This is developed as a separate package so it can be in TS and have its own
 tests/builds outside of the main docs.
 
+Note that this package is never installed on its own — it has no lockfile and
+is not an npm workspace, and the `npm --prefix` build/test scripts only run
+its scripts. All of its dependencies (typescript, prettier, unist-util-visit,
+vitest, etc.) resolve from the repository root's `node_modules`, so declare
+any new dependency in the root `package.json`.
+
 To build, from the _project root_ run `npm run build:plugins`
 
 To test, from the _project root_ run run `npm run test:plugins`

--- a/plugins/llm/package.json
+++ b/plugins/llm/package.json
@@ -2,6 +2,7 @@
   "name": "llm-export-plugin",
   "version": "0.0.0",
   "description": "Docusaurus plugin to export Cypress docs into an LLM-friendly corpus",
+  "//": "This package is never installed on its own — it has no lockfile and is not an npm workspace; `npm --prefix` only runs its scripts. All dependencies (typescript, gray-matter, the remark/unist ecosystem, vitest, etc.) resolve from the repository root's node_modules, so declare any new dependency in the root package.json.",
   "main": "dist/index.js",
   "scripts": {
     "prebuild": "rm -rf ./dist",
@@ -10,18 +11,6 @@
   },
   "author": "",
   "license": "ISC",
-  "dependencies": {
-    "gray-matter": "^4.0.3",
-    "mdast-util-to-string": "^4.0.0",
-    "remark-gfm": "^4.0.0",
-    "remark-parse": "^11.0.0",
-    "typescript": "^6.0.3",
-    "unified": "^11.0.0",
-    "unist-util-visit": "^5.0.0"
-  },
-  "devDependencies": {
-    "@types/mdast": "^4.0.4"
-  },
   "files": [
     "dist"
   ]


### PR DESCRIPTION
## Summary

Removes the `dependencies`/`devDependencies` blocks from the two plugin sub-packages (`plugins/cypressRemarkPlugins`, `plugins/llm`) and documents in each `package.json` (plus the cypressRemarkPlugins readme) that all dependencies resolve from the repository root's `node_modules`.

## Why

These sub-packages are never installed on their own: they have no lockfiles, no npm workspace setup, and the root's `npm --prefix ... run build` / `run test` scripts only run their scripts — nothing ever installs their `dependencies` blocks. Everything resolves from the root instead, so the pins were misleading. Notably, `cypressRemarkPlugins` pinned `prettier ^2.7.1`, `@types/prettier ^2.6.3`, and `unist-util-visit ^2.0.3`, while what actually loads at build/runtime is the root's prettier 3.9.4, unist-util-visit 5.0.0 hoisted by Docusaurus, and no `@types/prettier` at all (prettier 3 ships its own types).

## Notes for reviewers

- I removed the blocks rather than updating the pins to match reality: updated pins would still never be installed and would just drift stale again (the `llm` plugin's block, accurate today, would eventually go the same way). A `"//"` note in each `package.json` now points contributors to declare new dependencies in the root `package.json`.
- Verified after the change: `npm run build:plugins` compiles both plugins cleanly and `npm run test:plugins` passes all 148 tests, confirming the blocks were inert (`tsc`/`vitest` resolve from the root's `node_modules/.bin`).
- Intentionally left out: converting the plugins to real npm workspaces. That would be a structural change to install/CI behavior and wasn't needed to fix the misleading metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Shq9duEBxAZZAQUdQAYDG

---
_Generated by [Claude Code](https://claude.ai/code/session_019Shq9duEBxAZZAQUdQAYDG)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata and contributor docs only; no application or build-script behavior changes beyond removing misleading pins.
> 
> **Overview**
> Removes **`dependencies`** and **`devDependencies`** from `plugins/cypressRemarkPlugins` and `plugins/llm` because those packages are never installed independently—root **`npm --prefix … run build` / `run test`** only executes their scripts, and **`tsc`**, **vitest**, **prettier**, and remark tooling already resolve from the repo root **`node_modules`**.
> 
> Adds a **`"//"`** comment in each plugin **`package.json`** and matching notes in **`plugins/cypressRemarkPlugins/readme.md`** so contributors add new deps in the **root** **`package.json`** instead of stale sub-package pins (e.g. outdated **prettier 2** / **unist-util-visit 2** metadata that did not reflect what actually ran).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11303d7de7ace5059fd249c5604b07c0275f7727. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->