### PR TITLE
chore: remove dead scripts from cypressRemarkPlugins package.json

### DIFF
--- a/plugins/cypressRemarkPlugins/package.json
+++ b/plugins/cypressRemarkPlugins/package.json
@@ -6,10 +6,7 @@
   "scripts": {
     "prebuild": "rm -rf ./dist",
     "build": "tsc",
-    "build:watch": "yarn prebuild && tsc --watch",
-    "test": "vitest run",
-    "test2": "jest",
-    "test:watch": "jest --watch"
+    "test": "vitest run"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
## Summary

Removes three dead npm scripts from `plugins/cypressRemarkPlugins/package.json`: `test2` and `test:watch` (both invoke jest, which is not installed anywhere in the repo — vitest is the actual test runner) and `build:watch` (invokes `yarn` in a repo that uses npm, per `package-lock.json`).

## Why

These scripts cannot run successfully and are misleading to anyone browsing the package. The working scripts (`test`, `build`, `prebuild`) are untouched. No issue associated.

## Notes for reviewers

Verified before removal: `jest` does not appear in any `dependencies`/`devDependencies` in the repo, the root `package.json` declares `vitest`, and there is no `yarn.lock` — only `package-lock.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018fkD9zX6BaGk3hqTbKrZan

---
_Generated by [Claude Code](https://claude.ai/code/session_018fkD9zX6BaGk3hqTbKrZan)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Package.json script-only cleanup with no runtime or dependency changes.
> 
> **Overview**
> Cleans up **`plugins/cypressRemarkPlugins/package.json`** by deleting three scripts that could not work in this repo.
> 
> **Removed:** `build:watch` (used `yarn` while the monorepo is npm/`package-lock.json`-based), plus `test2` and `test:watch` (both targeted **jest**, which is not a dependency). **`test`** remains as `vitest run`, alongside unchanged **`build`** and **`prebuild`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 721d1e2a85fea3c17f6553f2bff227e656bb511a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->