### PR TITLE
docs: document plugin dependency convention in agents files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,3 +114,10 @@ Each rule is a hard convention. See the linked section for the how and why.
 - Links to `www.cypress.io` / `on.cypress.io` / `learn.cypress.io` need UTM
   params (`utm_source=docs.cypress.io` + a placement `utm_medium`). Do not add
   them to internal links or `cloud.cypress.io`.
+
+**Plugins** — [details](./AGENTS_REFERENCE.md#project-layout)
+
+- The sub-packages in `plugins/` are never installed on their own; all of their
+  dependencies resolve from the repository root's `node_modules`. Declare new
+  dependencies in the **root** `package.json`, never in a plugin's own
+  `package.json` (pins there are never installed and just drift stale).

--- a/AGENTS_REFERENCE.md
+++ b/AGENTS_REFERENCE.md
@@ -14,6 +14,15 @@ This is the **Cypress Documentation** site, built with
 - The LLM-docs pipeline lives in `plugins/llm`. At build time it reprocesses
   content into stripped-down markdown and chunked JSON published under `/llm`,
   with `/llms.txt` as the index (both are build output, not committed files).
+- The plugin sub-packages (`plugins/cypressRemarkPlugins`, `plugins/llm`) are
+  **never installed on their own**: they have no lockfiles and are not npm
+  workspaces, and the root's `npm --prefix … run build`/`run test` scripts only
+  run their scripts. Everything they use (typescript, prettier, vitest, the
+  remark/unist ecosystem, etc.) resolves from the repository root's
+  `node_modules`, so their `package.json` files intentionally declare **no**
+  `dependencies`/`devDependencies`. Declare any new plugin dependency in the
+  **root** `package.json` — pins added to a plugin's own `package.json` are
+  never installed and just drift stale.
 - Reusable React/MDX components live in `src/components` and are registered in
   `src/theme/MDXComponents.js`.
 


### PR DESCRIPTION
## Summary

Records in `AGENTS.md` and `AGENTS_REFERENCE.md` the convention established by #6657: the sub-packages under `plugins/` are never installed on their own, so all plugin dependencies must be declared in the root `package.json`.

## Why

#6657 removed the never-installed `dependencies`/`devDependencies` blocks from `plugins/cypressRemarkPlugins` and `plugins/llm` and left `"//"` notes in each `package.json` explaining that everything resolves from the repository root's `node_modules`. The agents files didn't mention this, so an agent (or contributor) adding a plugin dependency could plausibly re-add a pin to a plugin's own `package.json`, where it would never be installed and just drift stale again. This PR captures the convention where agents actually read it: a short always-apply rule in `AGENTS.md` (new **Plugins** rules group) and the full explanation in `AGENTS_REFERENCE.md`'s Project layout section, keeping the two files in sync as `AGENTS_REFERENCE.md` requires.

## Notes for reviewers

- Wording was verified against the current state of `main`, including #6658 (which removed dead scripts from the `cypressRemarkPlugins` `package.json` after #6657 merged).
- `AGENTS.md`'s new rule links to the `AGENTS_REFERENCE.md#project-layout` section for the detail, matching the existing rule/reference structure.
- Prettier (`lint:fix` / lint-staged) passes with no changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S53WXKvWtaCzkS4GhUTZH2

---
_Generated by [Claude Code](https://claude.ai/code/session_01S53WXKvWtaCzkS4GhUTZH2)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to AGENTS.md and AGENTS_REFERENCE.md with no runtime or build behavior changes.
> 
> **Overview**
> Documents the **`plugins/` dependency convention** in the agent guides so contributors and automation do not re-add pins to per-plugin `package.json` files.
> 
> **`AGENTS.md`** adds a **Plugins** rules group (linked to Project layout) stating that `plugins/` sub-packages are never installed alone and that new dependencies belong in the **root** `package.json`.
> 
> **`AGENTS_REFERENCE.md`** expands the same rule in **Project layout**: no lockfiles/workspaces, root `node_modules` resolution, and intentional empty `dependencies`/`devDependencies` on plugin packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c71e3b5dd110c94d71994e8f2d0db481689b075. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->