### PR TITLE
Rewrite AI Skills doc: lead with value, verify against ai-toolkit, improve structure and SEO

### DIFF
--- a/docs/app/tooling/ai-skills.mdx
+++ b/docs/app/tooling/ai-skills.mdx
@@ -336,9 +336,20 @@ Installation steps vary by tool.
 
 ### Check your installed version
 
-Each skill declares its version in its `SKILL.md` file. Check that file to see
-which version you have installed. Skills don't have automatic update
-notifications, so check back periodically for new releases.
+Each skill declares its version in the frontmatter of its `SKILL.md` file,
+under the `metadata.version` key:
+
+```md title="skills/cypress-author/SKILL.md"
+---
+name: cypress-author
+description: 'Creates, updates, and fixes Cypress tests ...'
+metadata:
+  version: 1.0.1
+---
+```
+
+Check that file to see which version you have installed. Skills don't have
+automatic update notifications, so check back periodically for new releases.
 
 ## How to use Cypress AI Skills
 

--- a/docs/app/tooling/ai-skills.mdx
+++ b/docs/app/tooling/ai-skills.mdx
@@ -353,10 +353,15 @@ automatic update notifications, so check back periodically for new releases.
 
 ## How to use Cypress AI Skills
 
-You can invoke a skill explicitly with a slash command like `/cypress-author`
-or `/cypress-explain`, or let your AI tool load it automatically when your
-prompt is relevant. The example prompts below show a few ways to put the
-skills to work. They are not exhaustive.
+You can invoke a skill explicitly with a slash command, or let your AI tool
+load it automatically when your prompt is relevant:
+
+```bash
+/cypress-author
+```
+
+The example prompts below show a few ways to put the skills to work. They are
+not exhaustive.
 
 ### Scaffold tests from acceptance criteria
 

--- a/docs/app/tooling/ai-skills.mdx
+++ b/docs/app/tooling/ai-skills.mdx
@@ -255,10 +255,45 @@ bunx skills add https://github.com/cypress-io/ai-toolkit --skill cypress-docs
 </Tabs>
 
 Skills installed this way don't update automatically. To update your installed
-skills to their latest versions, run `npx skills update`. Note that the update
-check only tracks project-level installs, not global ones. See
-[skills.sh](https://skills.sh/) for the full CLI reference, including how to
-list and remove installed skills.
+skills to their latest versions, run:
+
+<Tabs>
+  <TabItem value="npm">
+
+```shell
+npx skills update
+```
+
+  </TabItem>
+
+  <TabItem value="yarn">
+
+```shell
+yarn dlx skills update
+```
+
+  </TabItem>
+
+  <TabItem value="pnpm">
+
+```shell
+pnpm dlx skills update
+```
+
+  </TabItem>
+
+  <TabItem value="bun">
+
+```shell
+bunx skills update
+```
+
+  </TabItem>
+</Tabs>
+
+Note that the update check only tracks project-level installs, not global ones.
+See [skills.sh](https://skills.sh/) for the full CLI reference, including how
+to list and remove installed skills.
 
 ### <Icon name="github" /> Install with the GitHub CLI
 

--- a/docs/app/tooling/ai-skills.mdx
+++ b/docs/app/tooling/ai-skills.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Cypress AI skills'
-description: Instruction sets that unlock common Cypress workflow patterns for your AI tool.
+title: 'Cypress AI Skills'
+description: 'Cypress AI Skills teach AI coding tools like Cursor, Claude Code, and GitHub Copilot to write, review, and explain Cypress tests using best practices.'
 sidebar_label: 'AI Skills'
 sidebar_position: 10
 sidebar_custom_props: { 'ai_icon': true, 'new_label': true }
@@ -14,87 +14,208 @@ sidebar_custom_props: { 'ai_icon': true, 'new_label': true }
 
 <WhatYoullLearn />
 
-- What AI Skills are and when to use them
-- What each Cypress skill provides beyond generic AI knowledge
+- Why Cypress AI Skills produce better results than a generic AI tool alone
+- What each Cypress skill does and when to use it
 - How to install and use Cypress skills with your AI tool
+- How to troubleshoot a skill that isn't triggering or isn't producing what you want
 
 ::::
 
-## Introduction
+Cypress AI Skills teach your AI coding tool to write, review, and explain
+Cypress tests the way an experienced Cypress engineer would. Instead of generic
+test code built on brittle selectors and arbitrary waits, your AI tool produces
+tests that follow Cypress best practices and match the conventions already in
+your project.
 
-Cypress AI Skills are instruction sets that unlock common Cypress workflow
-patterns for your AI tool — helping it converge on consistent conventions,
-standards, and agentic behavior across tasks like authoring, reviewing, and
-explaining tests.
+With Cypress AI Skills, your AI tool can:
 
-Skills are published in the open-source
+- Generate tests that follow Cypress best practices out of the box
+- Avoid flaky patterns like weak selectors, arbitrary waits, and inter-test
+  dependencies
+- Match your project's language, custom commands, helpers, and fixtures instead
+  of reinventing them
+- Ground answers in official Cypress documentation rather than outdated
+  training data
+- Behave consistently across your team, no matter who writes the prompt
+
+Skills work with any AI coding tool that supports agent skills or custom
+instructions, including Cursor, Claude Code, and GitHub Copilot. They are
+published in the open source
 [Cypress AI Toolkit](https://github.com/cypress-io/ai-toolkit).
 
 ## What are AI Skills?
 
-Think of a generic AI as a brilliant but inexperienced new hire. Without guidance,
-it will do its best — but it won't know your team's standards, your project's
-conventions, or what good Cypress looks like. A skill is the expert SOP manual you
-hand them on day one.
+AI Skills are instruction sets that tell your AI tool how to approach a
+specific Cypress workflow: what conventions to follow, how to reason about the
+task, and what good output looks like.
 
-Skills are instruction sets that tell your AI tool how to approach a specific Cypress
-workflow — what conventions to follow, how to reason about the task, and what good
-output looks like.
-
-Use skills when you want your AI tool to:
-
-- Apply Cypress best practices to generated and reviewed tests
-- Steer away from brittle patterns and weak selectors
-- Produce more Cypress-focused explanations and critiques
-- Establish consistent AI behavior across your team and workflows
+Think of a generic AI tool as a brilliant but inexperienced new hire. Without
+guidance, it will do its best, but it won't know your team's standards, your
+project's conventions, or what good Cypress looks like. A skill is the expert
+SOP manual you hand them on day one.
 
 ## Available Cypress skills
 
-### [`cypress-author`](https://github.com/cypress-io/ai-toolkit/tree/main/skills/cypress-author)
+Cypress publishes three skills. They are designed to work together:
+`cypress-author` writes and fixes tests, `cypress-explain` reviews and explains
+them, and `cypress-docs` grounds both in official documentation.
 
-Improves how AI tools create, update, and fix Cypress tests. Use it when you're writing new tests or fixing broken ones.
+### `cypress-author`: create, update, and fix tests
 
-Before writing a single line, the cypress-author skill reads your project: your config, existing specs, custom commands, and fixtures. Everything it produces is shaped by what is already there, not what a generic Cypress project might look like.
+[`cypress-author`](https://github.com/cypress-io/ai-toolkit/tree/main/skills/cypress-author)
+improves how AI tools create, update, and fix Cypress end-to-end and component
+tests. Use it when you're writing new tests or fixing broken or flaky ones.
+
+Before writing a single line, the skill reads your project: your Cypress
+config, `package.json`, support files, existing specs, custom commands, and
+fixtures. Everything it produces is shaped by what is already there, not by
+what a generic Cypress project might look like.
 
 In practice, that means:
 
-- **Selectors that hold up.** The skill follows a defined hierarchy (`data-cy`, `data-test`, `data-testid`) and flags selectors that are likely to break under normal maintenance.
-- **Code that fits your project.** It matches your language (TypeScript or JavaScript) and existing type patterns, and reuses your existing helpers and custom commands rather than reinventing them.
-- **Only APIs your Cypress version supports.** The skill checks your Cypress version and limits suggestions to what is actually available to your project.
+- **Selectors that hold up.** The skill honors your
+  [`Cypress.ElementSelector`](/api/cypress-api/element-selector-api)
+  configuration if you have one. Otherwise it prefers dedicated test attributes
+  (`data-cy`, `data-test`, `data-testid`, and similar) over CSS classes and DOM
+  structure, and suggests adding a `data-cy` attribute to your app code when no
+  stable selector exists.
+- **Tests built for stability.** It never adds arbitrary waits like
+  `cy.wait(5000)`, relying instead on `cy.intercept()` with aliases and
+  assertions that retry automatically. Tests are written to run independently,
+  with application state prepared programmatically rather than through slow UI
+  flows.
+- **Code that fits your project.** It matches your language (TypeScript or
+  JavaScript) and existing type patterns, and reuses your helpers, custom
+  commands, and fixtures rather than reinventing them.
+- **Only APIs your Cypress version supports.** The skill detects your Cypress
+  version and limits suggestions to what is actually available in your project.
 
-### [`cypress-docs`](https://github.com/cypress-io/ai-toolkit/tree/main/skills/cypress-docs)
+### `cypress-explain`: understand and review tests
 
-Gives your AI tool reliable access to accurate, up-to-date Cypress documentation. Use it when you need to look up commands, APIs, configuration options, or confirm how a feature works in a specific Cypress version.
+[`cypress-explain`](https://github.com/cypress-io/ai-toolkit/tree/main/skills/cypress-explain)
+helps you understand, describe, and critique existing tests. Use it when
+auditing a suite, onboarding a new team member, or investigating a brittle test
+before rewriting it.
 
 Beyond what a generic AI tool knows, this skill:
 
-- **Searches official sources first.** It routes queries to the correct section of docs.cypress.io — commands, guides, configuration, error messages — before your model reaches for Cypress data it already knows, which may be outdated.
-- **Uses LLM-optimized documentation.** The skill fetches structured Markdown content from `/llm/*` paths on docs.cypress.io, giving cleaner and more reliable results than scraping HTML.
-- **Grounded in docs, not training data.** If a claim cannot be verified in official docs, it says so rather than inventing an API or behavior — reducing the chance of a confident but incorrect answer.
-- **Version-aware.** When a Cypress version is detected in your project, it scopes answers to what is actually available in that version and calls out differences explicitly.
+- **Classifies your question first.** Whether you're asking about a Cypress
+  concept or a specific test, it applies the right approach for each rather
+  than treating them the same.
+- **Goes deep on test review.** When reviewing a spec, it identifies intent,
+  structure, Cypress mechanics, and hidden dependencies that aren't obvious
+  from reading the code alone.
+- **Flags what will bite you.** Brittle selectors, timing assumptions,
+  unnecessary waits, UI coupling, and missing assertions are all called out
+  explicitly.
+- **Catches bad metadata.** Misleading or incorrect test titles and comments
+  are flagged and corrected, not silently accepted.
+- **Uses accurate Cypress terminology.** Command chains, subjects, assertions,
+  network stubbing. It speaks Cypress, not generic testing jargon.
+- **Keeps explanations concise and practical.** Focused on how things are
+  used, not exhaustive API walkthroughs.
 
-### [`cypress-explain`](https://github.com/cypress-io/ai-toolkit/tree/main/skills/cypress-explain)
+### `cypress-docs`: look up accurate documentation
 
-Helps you understand, describe, and critique existing tests. Use it when auditing a suite, onboarding a new team member, or investigating a brittle test before rewriting it.
+[`cypress-docs`](https://github.com/cypress-io/ai-toolkit/tree/main/skills/cypress-docs)
+gives your AI tool reliable access to accurate, up-to-date Cypress
+documentation. Use it to look up commands, APIs, and configuration options, or
+to confirm how a feature works in a specific Cypress version. It also supports
+the other Cypress skills, which consult official documentation while they work.
 
 Beyond what a generic AI tool knows, this skill:
 
-- **Classifies your question first.** Whether you are asking about a Cypress concept or a specific test, it applies the right approach for each rather than treating them the same.
-- **Uses accurate Cypress terminology.** Command chains, subjects, assertions, network stubbing. It speaks Cypress, not generic testing jargon.
-- **Keeps explanations concise and practical.** Focused on how things are used, not exhaustive API walkthroughs.
-- **Goes deep on test review.** When reviewing a spec, it identifies intent, structure, Cypress mechanics, and hidden dependencies that are not obvious from reading the code alone.
-- **Flags what will bite you.** Brittle selectors, timing assumptions, unnecessary waits, UI coupling, and missing assertions are all called out explicitly.
-- **Catches bad metadata.** Misleading or incorrect test titles and comments are flagged and corrected, not silently accepted.
+- **Searches official sources first.** It routes queries to the correct
+  section of docs.cypress.io (commands, guides, configuration, error messages)
+  before your model reaches for Cypress knowledge it already has, which may be
+  outdated.
+- **Uses LLM-optimized documentation.** The skill discovers structured
+  Markdown content through the `/llms.txt` index on docs.cypress.io, giving
+  cleaner and more reliable results than scraping HTML.
+- **Grounds answers in docs, not training data.** If a claim can't be verified
+  in official documentation, it says so rather than inventing an API or
+  behavior, reducing the chance of a confident but incorrect answer.
+- **Stays version-aware.** When a Cypress version is detected in your project,
+  it scopes answers to what is available in that version and calls out
+  differences explicitly.
 
-## Example Prompts
+## Install Cypress AI Skills
 
-Below are a few examples of how you can leverage Cypress Skills. These are not exhaustive.
+Cypress skills work with any AI coding tool that supports custom instructions,
+including Cursor, Claude Code, GitHub Copilot, and others.
 
-Skills can be invoke explicitly with `/cypress-author` or `/cypress-explain`, or your AI tool load it automatically when relevant based on the language used in your prompt.
+### Install with the skills CLI
 
-### Scaffold from requirements
+The [`skills`](https://skills.sh/) package is the fastest way to install
+Cypress skills.
 
-This prompt example describes acceptance criteria for the "Mark all complete" behavior of the TODO app in the our [Kitchen Sink Example](https://github.com/cypress-io/cypress-example-kitchensink).
+Install all skills by running:
+
+```bash
+npx skills add cypress-io/ai-toolkit
+```
+
+Or install each skill individually:
+
+```bash
+npx skills add https://github.com/cypress-io/ai-toolkit --skill cypress-author
+npx skills add https://github.com/cypress-io/ai-toolkit --skill cypress-explain
+npx skills add https://github.com/cypress-io/ai-toolkit --skill cypress-docs
+```
+
+For update and remove commands, see [skills.sh](https://skills.sh/).
+
+### Install with the GitHub CLI
+
+The [GitHub CLI](https://cli.github.com/manual/gh_skill) also supports
+installing agent skills.
+
+Install all skills by running:
+
+```bash
+gh skill install cypress-io/ai-toolkit
+```
+
+Or install each skill individually:
+
+```bash
+gh skill install cypress-io/ai-toolkit cypress-author
+gh skill install cypress-io/ai-toolkit cypress-explain
+gh skill install cypress-io/ai-toolkit cypress-docs
+```
+
+### Install manually
+
+Installation steps vary by tool.
+
+1. Download the skill directory from the
+   [Cypress AI Toolkit](https://github.com/cypress-io/ai-toolkit/tree/main/skills).
+2. Decide whether you want the skill installed globally or scoped to a single
+   project.
+3. Copy it into your agent's skills location. Common locations:
+   - **Cursor** (global): `~/.cursor/skills`
+   - **Claude Code** (project): `{PROJECT_DIR}/.claude/skills`
+   - **Other tools**: check your tool's documentation for its skills or custom
+     instructions directory.
+
+### Check your installed version
+
+Each skill declares its version in its `SKILL.md` file. Check that file to see
+which version you have installed. Skills don't have automatic update
+notifications, so check back periodically for new releases.
+
+## How to use Cypress AI Skills
+
+You can invoke a skill explicitly with a slash command like `/cypress-author`
+or `/cypress-explain`, or let your AI tool load it automatically when your
+prompt is relevant. The example prompts below show a few ways to put the
+skills to work. They are not exhaustive.
+
+### Scaffold tests from acceptance criteria
+
+This prompt describes acceptance criteria for the "Mark all complete" behavior
+of the TODO app in our
+[Kitchen Sink example](https://github.com/cypress-io/cypress-example-kitchensink).
 
 ```skill
 Review the acceptance criteria of the "Mark all complete" flow:
@@ -103,23 +224,28 @@ Review the acceptance criteria of the "Mark all complete" flow:
 - The footer shows 0 active items are left
 - The Clear Completed button appears
 
-Using the Cypress Explain skill, review the existing tests to check if these requirements are already tested. If any requirements have not been asserted in tests, using the Cypress Author to either update the existing tests or scaffold new test(s) for the untested behavior.
+Using the Cypress Explain skill, review the existing tests to check if these requirements are already tested. If any requirements have not been asserted in tests, use the Cypress Author skill to either update the existing tests or scaffold new test(s) for the untested behavior.
 ```
 
 :::tip
 
-**Pro-Tip:** Connect your agent to your ticket or planning tool so it can pull in requirements and context about the behavior being changed — the more it understands about what needs to be tested, the better the output.
+**Pro-Tip:** Connect your agent to your ticket or planning tool so it can pull
+in requirements and context about the behavior being changed. The more it
+understands about what needs to be tested, the better the output.
 
 :::
 
-### Generate using cy.prompt()
+### Generate tests that use cy.prompt()
 
-[`cy.prompt()`](/api/commands/prompt) can reduce test maintenance by using AI-driven element resolution and self-healing when the UI changes, so you depend less on brittle hand-written selectors for those steps.
+[`cy.prompt()`](/api/commands/prompt) can reduce test maintenance by using
+AI-driven element resolution and self-healing when the UI changes, so you
+depend less on brittle hand-written selectors for those steps.
 
-You can ask your coding agent to author tests that call `cy.prompt()` so those behaviors are built into the specs it generates.
+You can ask your coding agent to author tests that call `cy.prompt()` so those
+behaviors are built into the specs it generates.
 
 ```skill
-Write an new Cypress test that uses cy.prompt() to:
+Write a new Cypress test that uses cy.prompt() to:
 1. Visit the shopping cart page
 2. Remove the "Vegetables" item from the cart
 3. Increase the quantity of the "Chocolate" item to 6
@@ -133,7 +259,8 @@ How does cy.intercept() work, and when should I use cy.wait('@alias') with it?
 
 ### Look up official Cypress documentation
 
-Use the cypress-docs skill to get verified answers directly from docs.cypress.io instead of relying on answers that may be outdated.
+Use the cypress-docs skill to get verified answers directly from
+docs.cypress.io instead of relying on answers that may be outdated.
 
 ```skill
 /cypress-docs What configuration options are available for cy.intercept() in Cypress 13? Show me the full options object with types and defaults.
@@ -147,10 +274,11 @@ Use the cypress-docs skill to get verified answers directly from docs.cypress.io
 
 ### Write component tests
 
-Prompt for component tests when you'd rather not wire up cy.mount, providers, stubs, and baseline assertions by hand.
+Prompt for component tests when you'd rather not wire up `cy.mount()`,
+providers, stubs, and baseline assertions by hand.
 
 ```skill
-Write component tests for the CheckoutSummary component. Review the current implementation before starting. The tests should verify it correctly render with an empty cart, shows a line item for each product, and disables the "Place order" button when stock is unavailable.
+Write component tests for the CheckoutSummary component. Review the current implementation before starting. The tests should verify it renders correctly with an empty cart, shows a line item for each product, and disables the "Place order" button when stock is unavailable.
 ```
 
 ### Fix a failing test
@@ -161,89 +289,82 @@ The "verify there are 2 notifications" test in notifications.cy.ts is failing wi
 
 :::tip
 
-**Pro-Tip:** If you are recording tests to Cypress Cloud, connect your agent to [Cloud MCP](/cloud/integrations/cloud-mcp) to quickly iterate and resolve real-time run failures.
+**Pro-Tip:** If you are recording tests to Cypress Cloud, connect your agent to
+[Cloud MCP](/cloud/integrations/cloud-mcp) to quickly iterate and resolve
+real-time run failures.
 
 :::
 
-### Get test intent summaries
+### Summarize test coverage in plain language
 
 ```skill
 Summarize what the tests in cypress/e2e/onboarding.cy.ts cover in plain language, as if explaining it to a product manager.
 ```
 
-## Install a skill
-
-Cypress skills work with any AI coding tool that supports custom instructions,
-including Cursor, Claude Code, GitHub Copilot, and others.
-
-### Install via skills
-
-The [`skills`](https://skills.sh/) package is the fastest way to install Cypress skills.
-
-Install all skills by running:
-
-```bash
-npx skills add cypress-io/ai-toolkit
-```
-
-or install each skill with:
-
-```bash
-npx skills add https://github.com/cypress-io/ai-toolkit --skill cypress-author
-npx skills add https://github.com/cypress-io/ai-toolkit --skill cypress-docs
-npx skills add https://github.com/cypress-io/ai-toolkit --skill cypress-explain
-```
-
-For update and remove commands, see [skills.sh](https://skills.sh/).
-
-### Manual install
-
-Installation steps vary by tool.
-
-1. Download the skill directory from the
-   [Cypress AI Toolkit](https://github.com/cypress-io/ai-toolkit/tree/main/skills).
-2. Copy it into your agent's skills location. Common locations:
-   - **Cursor** (global): `~/.cursor/skills`
-   - **Claude Code** (project): `{PROJECT_DIR}/.claude/skills`
-   - **Other tools**: check your tool's documentation for its skills or custom instructions directory.
-
-### Versions
-
-Each skill includes a version in its `SKILL.md` file. Check that file to see
-which version you have installed. Skills don't have automatic update
-notifications, so check back periodically for new releases.
-
 ## Troubleshooting
 
-If a skill is producing incorrect output, missing a Cypress pattern, or behaving in a way that seems wrong, [open an issue](https://github.com/cypress-io/ai-toolkit/issues) in the Cypress AI Toolkit repository.
+If a skill is producing incorrect output, missing a Cypress pattern, or
+behaving in a way that seems wrong,
+[open an issue](https://github.com/cypress-io/ai-toolkit/issues) in the Cypress
+AI Toolkit repository.
 
-### How do I know the skill is triggering?
+### How do I know a skill is triggering?
 
-Each agent is different, but usually you can look in the conversation history to ensure your agent is invoking the skill based on your prompt - the agent will typically print out that fact.
+Each agent is different, but you can usually check the conversation history to
+confirm your agent invoked the skill. Most agents print out that they loaded a
+skill.
 
-### The skill isn't triggering
+### A skill isn't triggering
 
-1. Verify it's installed and configured in the appropriate context. Skills can be user or project specific and the setup depends on your Agent of Choice.
-2. Skills attempt to listen for keywords and concepts, but depending on your agent, model, and other skills it may not be triggered. You can improve your odds by using the word "Cypress".
-3. Most agents allow you to verify a skill is installed and/or force a skill to be used by using a slash command, i.e. `/cypress-author`.
+1. Verify the skill is installed and configured in the appropriate context.
+   Skills can be user-scoped or project-scoped, and the setup depends on your
+   agent of choice.
+2. Skills listen for keywords and concepts, but depending on your agent, model,
+   and other installed skills, a skill may not trigger. You can improve your
+   odds by using the word "Cypress" in your prompt.
+3. Most agents let you verify a skill is installed and force it to run with a
+   slash command, for example `/cypress-author`.
+
+### A skill is using too many tokens
+
+Skills sometimes prompt the agent to read foundational files like your
+`package.json` or Cypress config. Limit this by telling the agent to do
+"minimal exploration," or point it directly at the file you want it to use:
+"use `my_spec.cy.js` as a pattern."
+
+Also review your `AGENTS.md`, `CLAUDE.md`, or similar agent configuration
+files. These often reference files that are helpful in principle but large in
+practice. Consider adding instructions to scope how agents use them.
 
 ### The output isn't what I want
 
-Skills set general guidelines. Add your own steps, instructions, or anti-patterns directly in your prompt to override or extend them. The skill will mix your additions with its own.
+Skills set general guidelines. Add your own steps, instructions, or
+anti-patterns directly in your prompt to override or extend them. The skill
+will mix your additions with its own.
 
-For teams with consistent preferences, consider contributing your improvements back to the [Cypress AI Toolkit repository](https://github.com/cypress-io/ai-toolkit/), or define a project-level skill that builds on top of the defaults.
+For teams with consistent preferences, consider contributing your improvements
+back to the
+[Cypress AI Toolkit repository](https://github.com/cypress-io/ai-toolkit/), or
+define a project-level skill that builds on top of the defaults.
+
+### Results are slow
+
+The model you choose has the biggest impact on speed versus quality. For faster
+results, try a faster model. For higher-quality output where speed matters
+less, try a larger, slower model.
 
 ## See also
 
-Skills are one part of the broader Cypress AI experience. Each of the following can
-extend or complement your agentic workflows:
+Skills are one part of the broader Cypress AI experience. Each of the following
+can extend or complement your agentic workflows:
 
-- **[Cypress AI](/cloud/features/cypress-ai-features)** — Overview of all AI
+- **[Cypress AI](/cloud/features/cypress-ai-features)**: Overview of all AI
   capabilities across the Cypress App and Cloud.
-- **[cy.prompt()](/api/commands/prompt)** — Replace brittle selectors in
-  skills-generated tests with natural language steps that self-heal when the UI changes.
-- **[Studio AI](/app/guides/cypress-studio)** — Walk through your app visually after
-  generation to catch assertions your agent might have missed.
-- **[Cloud MCP](/cloud/integrations/cloud-mcp)** — Give your AI agent direct access
-  to Cypress Cloud test results and failure data to investigate and fix issues without
-  leaving your coding environment.
+- **[cy.prompt()](/api/commands/prompt)**: Replace brittle selectors in
+  skills-generated tests with natural language steps that self-heal when the UI
+  changes.
+- **[Studio AI](/app/guides/cypress-studio)**: Walk through your app visually
+  after generation to catch assertions your agent might have missed.
+- **[Cloud MCP](/cloud/integrations/cloud-mcp)**: Give your AI agent direct
+  access to Cypress Cloud test results and failure data to investigate and fix
+  issues without leaving your coding environment.

--- a/docs/app/tooling/ai-skills.mdx
+++ b/docs/app/tooling/ai-skills.mdx
@@ -51,7 +51,7 @@ task, and what good output looks like.
 
 Think of a generic AI tool as a brilliant but inexperienced new hire. Without
 guidance, it will do its best, but it won't know your team's standards, your
-project's conventions, or what good Cypress looks like. A skill is the expert
+project's conventions, or what good Cypress tests look like. A skill is the expert
 SOP manual you hand them on day one.
 
 ## Available Cypress skills
@@ -88,7 +88,8 @@ In practice, that means:
   JavaScript) and existing type patterns, and reuses your helpers, custom
   commands, and fixtures rather than reinventing them.
 - **Only APIs your Cypress version supports.** The skill detects your Cypress
-  version and limits suggestions to what is actually available in your project.
+  version and limits suggestions to what is actually available in that Cypress
+  version.
 
 ### `cypress-explain`: understand and review tests
 
@@ -151,21 +152,91 @@ Cypress skills.
 
 Install all skills by running:
 
-```bash
+<Tabs>
+  <TabItem value="npm">
+
+```shell
 npx skills add cypress-io/ai-toolkit
 ```
 
+  </TabItem>
+
+  <TabItem value="yarn">
+
+```shell
+yarn dlx skills add cypress-io/ai-toolkit
+```
+
+  </TabItem>
+
+  <TabItem value="pnpm">
+
+```shell
+pnpm dlx skills add cypress-io/ai-toolkit
+```
+
+  </TabItem>
+
+  <TabItem value="bun">
+
+```shell
+bunx skills add cypress-io/ai-toolkit
+```
+
+  </TabItem>
+</Tabs>
+
 Or install each skill individually:
 
-```bash
+<Tabs>
+  <TabItem value="npm">
+
+```shell
 npx skills add https://github.com/cypress-io/ai-toolkit --skill cypress-author
 npx skills add https://github.com/cypress-io/ai-toolkit --skill cypress-explain
 npx skills add https://github.com/cypress-io/ai-toolkit --skill cypress-docs
 ```
 
-For update and remove commands, see [skills.sh](https://skills.sh/).
+  </TabItem>
 
-### Install with the GitHub CLI
+  <TabItem value="yarn">
+
+```shell
+yarn dlx skills add https://github.com/cypress-io/ai-toolkit --skill cypress-author
+yarn dlx skills add https://github.com/cypress-io/ai-toolkit --skill cypress-explain
+yarn dlx skills add https://github.com/cypress-io/ai-toolkit --skill cypress-docs
+```
+
+  </TabItem>
+
+  <TabItem value="pnpm">
+
+```shell
+pnpm dlx skills add https://github.com/cypress-io/ai-toolkit --skill cypress-author
+pnpm dlx skills add https://github.com/cypress-io/ai-toolkit --skill cypress-explain
+pnpm dlx skills add https://github.com/cypress-io/ai-toolkit --skill cypress-docs
+```
+
+  </TabItem>
+
+  <TabItem value="bun">
+
+```shell
+bunx skills add https://github.com/cypress-io/ai-toolkit --skill cypress-author
+bunx skills add https://github.com/cypress-io/ai-toolkit --skill cypress-explain
+bunx skills add https://github.com/cypress-io/ai-toolkit --skill cypress-docs
+```
+
+  </TabItem>
+</Tabs>
+
+Skills installed this way don't update automatically. To update your installed
+skills to their latest versions, run `npx skills update`. Note that the update
+check only tracks project-level installs, not global ones. See
+[skills.sh](https://skills.sh/) for the full CLI reference, including how to
+list and remove installed skills.
+
+### <Icon name="github" /> Install with the GitHub CLI
 
 The [GitHub CLI](https://cli.github.com/manual/gh_skill) also supports
 installing agent skills.
@@ -193,10 +264,11 @@ Installation steps vary by tool.
 2. Decide whether you want the skill installed globally or scoped to a single
    project.
 3. Copy it into your agent's skills location. Common locations:
-   - **Cursor** (global): `~/.cursor/skills`
-   - **Claude Code** (project): `{PROJECT_DIR}/.claude/skills`
-   - **Other tools**: check your tool's documentation for its skills or custom
-     instructions directory.
+   - <Icon name="hexagon-nodes" /> **Cursor** (global): `~/.cursor/skills`
+   - <Icon name="claude" /> **Claude Code** (project):
+     `{PROJECT_DIR}/.claude/skills`
+   - <Icon name="laptop-code" /> **Other tools**: check your tool's
+     documentation for its skills or custom instructions directory.
 
 ### Check your installed version
 
@@ -343,7 +415,7 @@ anti-patterns directly in your prompt to override or extend them. The skill
 will mix your additions with its own.
 
 For teams with consistent preferences, consider contributing your improvements
-back to the
+back to the open source
 [Cypress AI Toolkit repository](https://github.com/cypress-io/ai-toolkit/), or
 define a project-level skill that builds on top of the defaults.
 

--- a/docs/app/tooling/ai-skills.mdx
+++ b/docs/app/tooling/ai-skills.mdx
@@ -265,8 +265,7 @@ Installation steps vary by tool.
    project.
 3. Copy it into your agent's skills location. Common locations:
    - <Icon name="hexagon-nodes" /> **Cursor** (global): `~/.cursor/skills`
-   - <Icon name="claude" /> **Claude Code** (project):
-     `{PROJECT_DIR}/.claude/skills`
+   - <Icon name="claude" /> **Claude Code** (project): `.claude/skills`
    - <Icon name="laptop-code" /> **Other tools**: check your tool's
      documentation for its skills or custom instructions directory.
 

--- a/docs/app/tooling/ai-skills.mdx
+++ b/docs/app/tooling/ai-skills.mdx
@@ -193,7 +193,13 @@ Or install each skill individually:
 
 ```shell
 npx skills add https://github.com/cypress-io/ai-toolkit --skill cypress-author
+```
+
+```shell
 npx skills add https://github.com/cypress-io/ai-toolkit --skill cypress-explain
+```
+
+```shell
 npx skills add https://github.com/cypress-io/ai-toolkit --skill cypress-docs
 ```
 
@@ -203,7 +209,13 @@ npx skills add https://github.com/cypress-io/ai-toolkit --skill cypress-docs
 
 ```shell
 yarn dlx skills add https://github.com/cypress-io/ai-toolkit --skill cypress-author
+```
+
+```shell
 yarn dlx skills add https://github.com/cypress-io/ai-toolkit --skill cypress-explain
+```
+
+```shell
 yarn dlx skills add https://github.com/cypress-io/ai-toolkit --skill cypress-docs
 ```
 
@@ -213,7 +225,13 @@ yarn dlx skills add https://github.com/cypress-io/ai-toolkit --skill cypress-doc
 
 ```shell
 pnpm dlx skills add https://github.com/cypress-io/ai-toolkit --skill cypress-author
+```
+
+```shell
 pnpm dlx skills add https://github.com/cypress-io/ai-toolkit --skill cypress-explain
+```
+
+```shell
 pnpm dlx skills add https://github.com/cypress-io/ai-toolkit --skill cypress-docs
 ```
 
@@ -223,7 +241,13 @@ pnpm dlx skills add https://github.com/cypress-io/ai-toolkit --skill cypress-doc
 
 ```shell
 bunx skills add https://github.com/cypress-io/ai-toolkit --skill cypress-author
+```
+
+```shell
 bunx skills add https://github.com/cypress-io/ai-toolkit --skill cypress-explain
+```
+
+```shell
 bunx skills add https://github.com/cypress-io/ai-toolkit --skill cypress-docs
 ```
 
@@ -251,7 +275,13 @@ Or install each skill individually:
 
 ```bash
 gh skill install cypress-io/ai-toolkit cypress-author
+```
+
+```bash
 gh skill install cypress-io/ai-toolkit cypress-explain
+```
+
+```bash
 gh skill install cypress-io/ai-toolkit cypress-docs
 ```
 

--- a/docs/app/tooling/ai-skills.mdx
+++ b/docs/app/tooling/ai-skills.mdx
@@ -370,7 +370,7 @@ of the TODO app in our
 [Kitchen Sink example](https://github.com/cypress-io/cypress-example-kitchensink).
 
 ```skill
-Review the acceptance criteria of the "Mark all complete" flow:
+/cypress-explain Review the acceptance criteria of the "Mark all complete" flow:
 - Clicking the checkbox toggles every task's completed state to completed
 - All tasks move to the "Completed" task list
 - The footer shows 0 active items are left
@@ -397,7 +397,7 @@ You can ask your coding agent to author tests that call `cy.prompt()` so those
 behaviors are built into the specs it generates.
 
 ```skill
-Write a new Cypress test that uses cy.prompt() to:
+/cypress-author Write a new Cypress test that uses cy.prompt() to:
 
 1. Visit the shopping cart page
 2. Remove the "Vegetables" item from the cart
@@ -407,7 +407,7 @@ Write a new Cypress test that uses cy.prompt() to:
 ### Explain a Cypress concept
 
 ```skill
-How does cy.intercept() work, and when should I use cy.wait('@alias') with it?
+/cypress-explain How does cy.intercept() work, and when should I use cy.wait('@alias') with it?
 ```
 
 ### Look up official Cypress documentation
@@ -431,13 +431,13 @@ Prompt for component tests when you'd rather not wire up `cy.mount()`,
 providers, stubs, and baseline assertions by hand.
 
 ```skill
-Write component tests for the CheckoutSummary component. Review the current implementation before starting. The tests should verify it renders correctly with an empty cart, shows a line item for each product, and disables the "Place order" button when stock is unavailable.
+/cypress-author Write component tests for the CheckoutSummary component. Review the current implementation before starting. The tests should verify it renders correctly with an empty cart, shows a line item for each product, and disables the "Place order" button when stock is unavailable.
 ```
 
 ### Fix a failing test
 
 ```skill
-The "verify there are 2 notifications" test in notifications.cy.ts is failing with an ".notification is not visible" error. Fix it.
+/cypress-author The "verify there are 2 notifications" test in notifications.cy.ts is failing with an ".notification is not visible" error. Fix it.
 ```
 
 :::tip
@@ -451,7 +451,7 @@ real-time run failures.
 ### Summarize test coverage in plain language
 
 ```skill
-Summarize what the tests in cypress/e2e/onboarding.cy.ts cover in plain language, as if explaining it to a product manager.
+/cypress-explain Summarize what the tests in cypress/e2e/onboarding.cy.ts cover in plain language, as if explaining it to a product manager.
 ```
 
 ## Troubleshooting

--- a/docs/app/tooling/ai-skills.mdx
+++ b/docs/app/tooling/ai-skills.mdx
@@ -398,6 +398,7 @@ behaviors are built into the specs it generates.
 
 ```skill
 Write a new Cypress test that uses cy.prompt() to:
+
 1. Visit the shopping cart page
 2. Remove the "Vegetables" item from the cart
 3. Increase the quantity of the "Chocolate" item to 6

--- a/docs/app/tooling/ai-skills.mdx
+++ b/docs/app/tooling/ai-skills.mdx
@@ -10,6 +10,12 @@ sidebar_custom_props: { 'ai_icon': true, 'new_label': true }
 
 # Cypress AI Skills
 
+Cypress AI Skills teach your AI coding tool to write, review, and explain
+Cypress tests the way an experienced Cypress engineer would. Instead of generic
+test code built on brittle selectors and arbitrary waits, your AI tool produces
+tests that follow Cypress best practices and match the conventions already in
+your project.
+
 ::::info
 
 <WhatYoullLearn />
@@ -20,12 +26,6 @@ sidebar_custom_props: { 'ai_icon': true, 'new_label': true }
 - How to troubleshoot a skill that isn't triggering or isn't producing what you want
 
 ::::
-
-Cypress AI Skills teach your AI coding tool to write, review, and explain
-Cypress tests the way an experienced Cypress engineer would. Instead of generic
-test code built on brittle selectors and arbitrary waits, your AI tool produces
-tests that follow Cypress best practices and match the conventions already in
-your project.
 
 With Cypress AI Skills, your AI tool can:
 


### PR DESCRIPTION
## Summary

Rewrites the Cypress AI Skills page (`docs/app/tooling/ai-skills.mdx`) to lead with the value of the feature, correct it against the actual skills in [cypress-io/ai-toolkit](https://github.com/cypress-io/ai-toolkit), and improve structure and SEO/AEO.

### Lead with value
- The page now opens with what the feature does for you (writes, reviews, and explains Cypress tests like an experienced Cypress engineer) followed by concrete benefit bullets, before any definitions
- The lead paragraph sits above the "What you'll learn" callout

### Accuracy fixes (verified against the SKILL.md sources)
- Selector guidance now reflects the real behavior: `Cypress.ElementSelector` configuration takes priority, then dedicated test attributes, with a suggestion to add `data-cy` when no stable selector exists (links the ElementSelector API page)
- Added a "Tests built for stability" bullet for `cypress-author` (no arbitrary waits, programmatic state setup, independent tests)
- `cypress-docs` description matches how the skill actually discovers LLM-optimized content (via the `/llms.txt` index) and notes it supports the other skills
- Added the GitHub CLI install method and two troubleshooting sections (token usage, slow results) that exist in the toolkit README but were missing here
- Fixed typos in prose and example prompts

### Structure
- Skill headings describe function, not just name (e.g. "`cypress-author`: create, update, and fix tests")
- Skills reordered to author → explain → docs with a one-line "how they fit together" intro
- Install now comes before usage examples
- npm/yarn/pnpm/bun tabs for the skills CLI install blocks, plus concrete update guidance (`npx skills update`)
- Icons on the GitHub CLI heading and the manual install tool list

### SEO/AEO
- Answer-shaped meta description naming Cursor, Claude Code, and GitHub Copilot
- Snippet-ready definition in the first paragraph and question-form headings where natural
- Consistent "Cypress AI Skills" terminology throughout
- All em dashes removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DcTabktEuyxTEHerFaaks4

---
_Generated by [Claude Code](https://claude.ai/code/session_01DcTabktEuyxTEHerFaaks4)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to a single MDX page; no runtime, auth, or application code affected.
> 
> **Overview**
> **Rewrites** `docs/app/tooling/ai-skills.mdx` so the page opens with what Cypress AI Skills do for users (benefit bullets and tooling names in meta copy) before definitions, and uses consistent **Cypress AI Skills** terminology.
> 
> **Skill content** is reordered and expanded (author → explain → docs): `cypress-author` now documents `Cypress.ElementSelector`, stability practices (`cy.intercept`, no arbitrary waits), and project-aware behavior; `cypress-explain` and `cypress-docs` get fuller capability lists, with docs discovery corrected to the **`/llms.txt`** index instead of `/llm/*` paths.
> 
> **Install and usage** move install ahead of examples, add **npm/yarn/pnpm/bun** tabbed `skills` CLI commands plus **`npx skills update`**, **GitHub CLI** (`gh skill install`), manual install paths with icons, and version checks via `SKILL.md` metadata. Example prompts use explicit **`/cypress-*`** slash commands and small typo fixes.
> 
> **Troubleshooting** grows with token usage, output tuning, and slow-results guidance; **What you'll learn** and **See also** lists are updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 833d5a600d2a1c24fba4a031d66f265bca3f9e69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->