### PR TITLE
Fix double dotted underline on links wrapping code tags

### DIFF
--- a/src/css/markdown.scss
+++ b/src/css/markdown.scss
@@ -121,8 +121,10 @@ div.markdown {
 
   .alert,
   & {
-    // add border bottom to code tags that are in a link
-    a:has(> code) {
+    // give links that wrap a code tag a pill-style border; :not(.cy-button-width)
+    // raises specificity above the base link rule so its dotted border-bottom
+    // doesn't double up with the code tag's dotted text-decoration underline
+    a:not(.cy-button-width):has(> code) {
       &,
       &:hover {
         border: 0.1rem solid rgba(0, 0, 0, 0.1);


### PR DESCRIPTION
## Summary

Links that wrap a `<code>` tag (e.g. [`cypress-author`](...) style links) were showing two dotted underlines stacked a couple of pixels apart: the code text's intentional dotted `text-decoration` plus the base link rule's dotted `border-bottom` leaking through under the pill border. This PR raises the specificity of the code-pill selector in `src/css/markdown.scss` so its solid pill border wins on all four sides, leaving a single dotted underline under the word only.

Also removes the intro sentence from the "See also" section of the AI Skills page (`docs/app/tooling/ai-skills.mdx`) so the section goes straight to the link list.

## Why

Reported from a screenshot of the `/app/tooling/ai-skills` page, where the `cypress-author` heading link showed a doubled dotted underline. The root cause: the pill rule `a:has(> code)` has lower specificity (0,1,3 under `div.markdown`) than the base link rule `a:not(.cy-button-width)` (0,2,2), so the base rule's `border-bottom: 1px dotted` was overriding the pill's solid bottom border. Adding `:not(.cy-button-width)` to the pill selector bumps it to (0,2,3) so the pill border applies cleanly.

## Notes for reviewers

- Verified in a live dev server with Playwright on both the `cypress-author` heading (`/app/tooling/ai-skills`) and an inline `cy.intercept()` paragraph link (`/app/guides/network-requests`): the link's computed `border-bottom` is now the pill's `1px solid rgba(0,0,0,0.1)` and only the `code` element carries `underline dotted`.
- Hover behavior is unchanged — the pill border stays solid and the word's dotted underline still switches to solid via the existing `a:hover > code` rule.
- Admonition (`.alert`) links are covered too, since the pill rule is nested under both `.alert` and the markdown root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LfYK9x75YK4pscecMr9Mc2