### PR TITLE
Rewrite "How to use Plugins" guide: lead with value, registration patterns, troubleshooting, and issue triage

### DIFF
--- a/docs/app/plugins/plugins-guide.mdx
+++ b/docs/app/plugins/plugins-guide.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'How to Use Cypress Plugins: Install, Register, and Verify'
-description: 'Install Cypress plugins from npm, register them in setupNodeEvents or your support file, and verify they work. Includes a full @cypress/grep setup example.'
+description: 'Install Cypress plugins from npm, register them in setupNodeEvents or your support file, vet community plugins for security, and troubleshoot plugin issues.'
 sidebar_label: 'How to use Plugins'
 sidebar_position: 10
 ---
@@ -9,9 +9,9 @@ sidebar_position: 10
 
 # How to Use Cypress Plugins
 
-Plugins add capabilities that don't ship with Cypress itself: accessibility and
-visual testing, custom commands, code coverage, richer reporters, framework
-integrations, and more. They're versioned npm packages, so you can add one to
+Plugins add capabilities that don't ship with Cypress itself: visual testing,
+custom commands, code coverage, richer reporters, framework integrations, and
+more. They're versioned npm packages, so you can add one to
 your project in a couple of minutes and update it independently of Cypress.
 
 :::info
@@ -19,9 +19,12 @@ your project in a couple of minutes and update it independently of Cypress.
 <WhatYoullLearn />
 
 - Where to find plugins and what they can do
+- How to evaluate a community plugin before adding it to your project
 - How to install a plugin with npm, Yarn, pnpm, or Bun
 - Where to register a plugin: `setupNodeEvents`, your support file, or both
 - How to verify a plugin works and fix common setup mistakes
+- How to tell whether a bug belongs to a plugin or to Cypress, and where to
+  report it
 
 :::
 
@@ -29,9 +32,40 @@ your project in a couple of minutes and update it independently of Cypress.
 
 Browse the [list of plugins](/app/plugins/plugins-list) maintained by Cypress.
 It curates official and community plugins across categories like custom
-commands, visual testing, accessibility, network and API helpers, reporters,
-and CI integrations. Each entry shows its latest version, supported Cypress
-versions, and how recently it was updated, so you can pick one with confidence.
+commands, visual testing, network and API helpers, reporters, and CI
+integrations. Each entry shows its latest version, supported Cypress versions,
+and how recently it was updated, so you can pick one with confidence.
+
+## Security considerations
+
+A plugin is third-party code that runs with significant access, in two
+sensitive places:
+
+- Code registered in `setupNodeEvents` runs in Node with the same permissions
+  as Cypress itself: it can read and write files, make network requests, and
+  read environment variables, including any secrets available in CI.
+- Code registered in your support file runs in the browser alongside your
+  tests, with access to your application under test and any data your tests
+  handle, such as session cookies, tokens, and test account credentials.
+
+Cypress builds and maintains plugins with the **Official** badge on the
+[list of plugins](/app/plugins/plugins-list), and reviews those with the
+**Verified** badge. **Community** plugins are not reviewed by Cypress, and
+inclusion on the list is not a security endorsement. Before adding one, apply
+the same diligence you would to any other dependency:
+
+- **Check the maintenance signals** on the list: how recently it was updated,
+  and whether it supports your Cypress version. An abandoned plugin won't
+  receive security fixes.
+- **Review the source.** Most plugins are small. Look at what the plugin does
+  with your configuration, environment variables, and network access, and
+  check its own dependencies.
+- **Pin the version** with a lockfile and review changes when you update,
+  rather than floating on the latest release.
+- **Include plugins in your dependency scanning**, such as `npm audit` or an
+  automated tool like Dependabot, the same as your other dev dependencies.
+- **Limit what CI secrets can reach.** Only expose the environment variables a
+  test run actually needs, so a compromised dependency has less to steal.
 
 ## Installing a plugin
 
@@ -195,6 +229,36 @@ these checks:
   the [list of plugins](/app/plugins/plugins-list) with your installed Cypress
   version.
 
+## Plugin issue or Cypress issue?
+
+When something breaks in a project that uses plugins, isolate which side owns
+the problem before reporting it, so your issue lands where it can be fixed:
+
+1. **Read the error and stack trace.** A stack trace that points into the
+   plugin's package in `node_modules` is a strong signal the plugin is
+   involved.
+2. **Disable the plugin and run again.** Comment out its registration in
+   `setupNodeEvents` and your support file, then re-run the failing command or
+   test.
+3. **Report it where it reproduces:**
+   - If the problem still occurs with the plugin disabled, it isn't caused by
+     the plugin. Work through the
+     [troubleshooting guide](/app/references/troubleshooting), search
+     [existing Cypress issues](https://github.com/cypress-io/cypress/issues),
+     and if it's new,
+     [open an issue against Cypress](https://github.com/cypress-io/cypress/issues/new/choose)
+     with a reproducible example.
+   - If the problem only occurs with the plugin registered, report it on the
+     plugin's own repository, not the Cypress repository. Search its existing
+     issues first, and include your Cypress version, the plugin version, and a
+     minimal reproduction. The Cypress team doesn't maintain community plugins
+     and can't fix bugs in them.
+
+If the failure started right after a Cypress upgrade, first check that the
+plugin supports the new version. A compatibility gap is a plugin issue: the
+plugin's repository is the right place to report it, even though the Cypress
+upgrade surfaced it.
+
 ## Writing your own plugin
 
 Anyone can create and publish a plugin. If no existing plugin covers your use
@@ -213,3 +277,5 @@ so others can find it.
   `setupNodeEvents` and other options
 - [Writing and Organizing Tests](/app/core-concepts/writing-and-organizing-tests#Support-file):
   how the support file works
+- [Troubleshooting](/app/references/troubleshooting): isolate and report
+  problems in Cypress itself

--- a/docs/app/plugins/plugins-guide.mdx
+++ b/docs/app/plugins/plugins-guide.mdx
@@ -1,28 +1,41 @@
 ---
-title: 'How to use Cypress plugins'
-description: 'Learn how to install and use Cypress plugins.'
+title: 'How to Use Cypress Plugins: Install, Register, and Verify'
+description: 'Install Cypress plugins from npm, register them in setupNodeEvents or your support file, and verify they work. Includes a full @cypress/grep setup example.'
 sidebar_label: 'How to use Plugins'
 sidebar_position: 10
 ---
 
 <ProductHeading product="app" />
 
-# How to use Cypress Plugins
+# How to Use Cypress Plugins
+
+Plugins add capabilities that don't ship with Cypress itself: accessibility and
+visual testing, custom commands, code coverage, richer reporters, framework
+integrations, and more. They're versioned npm packages, so you can add one to
+your project in a couple of minutes and update it independently of Cypress.
 
 :::info
 
 <WhatYoullLearn />
 
-- How to install a plugin
-- How to use a plugin
+- Where to find plugins and what they can do
+- How to install a plugin with npm, Yarn, pnpm, or Bun
+- Where to register a plugin: `setupNodeEvents`, your support file, or both
+- How to verify a plugin works and fix common setup mistakes
 
 :::
 
-Cypress maintains a curated list of plugins created by us and the community.
-Plugins from our [official list](/app/plugins/plugins-list) are npm modules. This enables them to
-be versioned and updated separately without needing to update Cypress itself.
+## Find a plugin
 
-You can install any published plugin using npm:
+Browse the [list of plugins](/app/plugins/plugins-list) maintained by Cypress.
+It curates official and community plugins across categories like custom
+commands, visual testing, accessibility, network and API helpers, reporters,
+and CI integrations. Each entry shows its latest version, supported Cypress
+versions, and how recently it was updated, so you can pick one with confidence.
+
+## Installing a plugin
+
+Install the plugin as a dev dependency with your package manager:
 
 <Tabs>
   <TabItem value="npm">
@@ -58,23 +71,145 @@ bun add --dev <plugin name>
   </TabItem>
 </Tabs>
 
+Before installing, check the plugin's supported Cypress versions, shown as a
+badge on the [list of plugins](/app/plugins/plugins-list) and usually stated in
+the plugin's README.
+
 ## Using a plugin
 
-Add your plugin to the
-[`setupNodeEvents`](/app/references/configuration#setupNodeEvents)
-function in the [Cypress configuration](/app/references/configuration). Please follow any additional instructions provided by the plugin's documentation.
-Here's an example of what this might look like:
+Installing the package isn't enough on its own: you also need to register the
+plugin with Cypress. Where you register it depends on where the plugin's code
+needs to run, and the plugin's README will tell you which it needs:
+
+- **In [`setupNodeEvents`](/app/references/configuration#setupNodeEvents) in
+  your Cypress configuration** for plugins that run in Node: preprocessors,
+  browser launch handling, tasks, and anything that touches the file system or
+  test results.
+- **In your
+  [support file](/app/core-concepts/writing-and-organizing-tests#Support-file)**
+  for plugins that run in the browser alongside your tests: custom commands,
+  assertion libraries, and overrides of built-in behavior.
+- **In both**, for plugins with a Node piece and a browser piece.
+
+### Register in the Cypress configuration
+
+Node-side plugins typically export a setup function that you call inside
+`setupNodeEvents`, passing along `on` and `config` so the plugin can bind to
+[Node events](/api/node-events/overview):
 
 :::cypress-config-plugin-example
 
 ```ts
-// bind to the event we care about
-on('<event>', (arg1, arg2) => {
-  // plugin stuff here
-})
+import { configurePlugin } from 'my-cypress-plugin'
+```
+
+```ts
+configurePlugin(on, config)
+
+// return the config so any changes the plugin makes take effect
+return config
 ```
 
 :::
 
-For information on writing plugins, please check out our
-[Node Events Overview](/api/node-events/overview).
+:::caution
+
+Code in `setupNodeEvents` executes in Node, not the browser. It has direct
+access to the file system and operating system, but you cannot call `cy`
+commands or the `Cypress` API there. If a plugin adds custom commands, it
+belongs in the support file instead.
+
+:::
+
+### Register in the support file
+
+Browser-side plugins are imported (or registered with a function call) in your
+support file, which loads before every spec:
+
+```ts title="cypress/support/e2e.js"
+import 'my-cypress-plugin'
+```
+
+Any custom commands the plugin adds are then available in all of your tests.
+
+### Example: setting up @cypress/grep
+
+[`@cypress/grep`](https://github.com/cypress-io/cypress/tree/develop/npm/grep)
+filters which tests run by title or tag, and is a good example of a plugin that
+registers in both places. Install it:
+
+```shell
+npm install @cypress/grep --save-dev
+```
+
+Register it in your support file so it can filter tests in the browser:
+
+```ts title="cypress/support/e2e.js"
+import { register as registerCypressGrep } from '@cypress/grep'
+
+registerCypressGrep()
+```
+
+Add its Node plugin to your configuration so it can skip loading specs with no
+matching tests:
+
+:::cypress-config-plugin-example
+
+```ts
+import { plugin } from '@cypress/grep/plugin'
+```
+
+```ts
+plugin(config)
+
+return config
+```
+
+:::
+
+Then verify it works by running only tests with "login" in the title:
+
+```shell
+npx cypress run --expose grep=login
+```
+
+## Troubleshooting
+
+If a plugin doesn't seem to do anything, or errors on startup, work through
+these checks:
+
+- **Follow the plugin's own README.** Registration details vary between
+  plugins, and some require extra configuration beyond the patterns shown
+  above.
+- **Confirm you registered it in the right place.** An error like
+  `cy is not defined` inside `setupNodeEvents` means browser-side code is
+  running in Node; move that registration to your support file.
+- **Return the `config` object** from `setupNodeEvents` if the plugin modifies
+  configuration. Forgetting to return it silently discards the plugin's
+  changes.
+- **Restart Cypress after configuration changes.** Changes to the Cypress
+  configuration file, including newly registered plugins, require restarting
+  `cypress open`.
+- **Check version compatibility.** A plugin built for an older Cypress major
+  version may fail on the current one. Compare the supported versions badge on
+  the [list of plugins](/app/plugins/plugins-list) with your installed Cypress
+  version.
+
+## Writing your own plugin
+
+Anyone can create and publish a plugin. If no existing plugin covers your use
+case, read the [Node Events Overview](/api/node-events/overview) to learn how
+plugins hook into Cypress, then
+[submit it to the plugins list](https://github.com/cypress-io/cypress-documentation/blob/master/CONTRIBUTING.md#adding-plugins)
+so others can find it.
+
+## See also
+
+- [List of plugins](/app/plugins/plugins-list): browse official and community
+  plugins
+- [Node Events Overview](/api/node-events/overview): the events available in
+  `setupNodeEvents`
+- [Configuration](/app/references/configuration#setupNodeEvents): reference for
+  `setupNodeEvents` and other options
+- [Writing and Organizing Tests](/app/core-concepts/writing-and-organizing-tests#Support-file):
+  how the support file works

--- a/docs/app/plugins/plugins-guide.mdx
+++ b/docs/app/plugins/plugins-guide.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'How to Use Cypress Plugins: Install, Register, and Verify'
-description: 'Install Cypress plugins from npm, register them in setupNodeEvents or your support file, vet community plugins for security, and troubleshoot plugin issues.'
+description: 'Install Cypress plugins from npm, register them in setupNodeEvents or your support file, and troubleshoot plugin issues. Includes a @cypress/grep example.'
 sidebar_label: 'How to use Plugins'
 sidebar_position: 10
 ---
@@ -19,7 +19,7 @@ your project in a couple of minutes and update it independently of Cypress.
 <WhatYoullLearn />
 
 - Where to find plugins and what they can do
-- How to evaluate a community plugin before adding it to your project
+- Where plugin code runs: in Node, in the browser, or both
 - How to install a plugin with npm, Yarn, pnpm, or Bun
 - Where to register a plugin: `setupNodeEvents`, your support file, or both
 - How to verify a plugin works and fix common setup mistakes
@@ -39,32 +39,12 @@ and how recently it was updated, so you can pick one with confidence.
 ## Security considerations
 
 A plugin is a regular npm dependency, so the habits you already use for other
-packages apply here too. The badges on the
-[list of plugins](/app/plugins/plugins-list) are a good starting point:
-**Official** plugins are built and maintained by the Cypress team, **Verified**
-plugins are community-owned and reviewed by Cypress, and **Community** plugins
-are published independently, so it's worth a closer look before adopting one.
+packages apply here too.
 
 It also helps to know where plugin code runs. Code registered in
 `setupNodeEvents` runs in Node, where it can access the file system, the
 network, and environment variables. Code registered in your support file runs
-in the browser alongside your tests and your application under test. Neither is
-cause for concern with a well-maintained plugin; it's simply more reach than a
-typical utility library, which makes the usual dependency habits worth
-following:
-
-- **Check the maintenance signals** on the list: how recently the plugin was
-  updated, and whether it supports your Cypress version. An actively
-  maintained plugin will keep receiving fixes.
-- **Skim the source.** Most plugins are small, so a few minutes of reading
-  shows you what the plugin does with your configuration and environment.
-- **Pin the version** with a lockfile and review changes when you update, the
-  same way you handle other dependencies.
-- **Include plugins in your dependency scanning**, such as `npm audit` or an
-  automated tool like Dependabot, alongside your other dev dependencies.
-- **Give test runs only the environment variables they need.** This is good
-  practice for any CI job, and it keeps your configuration tidy as your suite
-  grows.
+in the browser alongside your tests and your application under test.
 
 ## Installing a plugin
 

--- a/docs/app/plugins/plugins-guide.mdx
+++ b/docs/app/plugins/plugins-guide.mdx
@@ -36,15 +36,15 @@ commands, visual testing, network and API helpers, reporters, and CI
 integrations. Each entry shows its latest version, supported Cypress versions,
 and how recently it was updated, so you can pick one with confidence.
 
-## Security considerations
+## Where plugin code runs
 
-A plugin is a regular npm dependency, so the habits you already use for other
-packages apply here too.
+Code registered in `setupNodeEvents` runs in Node, where it can access the
+file system, the network, and environment variables. Code registered in your
+support file runs in the browser alongside your tests and your application
+under test.
 
-It also helps to know where plugin code runs. Code registered in
-`setupNodeEvents` runs in Node, where it can access the file system, the
-network, and environment variables. Code registered in your support file runs
-in the browser alongside your tests and your application under test.
+Beyond that, a plugin is a regular npm dependency, so the habits you already
+use for other packages apply here too.
 
 ## Installing a plugin
 

--- a/docs/app/plugins/plugins-guide.mdx
+++ b/docs/app/plugins/plugins-guide.mdx
@@ -125,15 +125,6 @@ return config
 
 :::
 
-:::caution
-
-Code in `setupNodeEvents` executes in Node, not the browser. It has direct
-access to the file system and operating system, but you cannot call `cy`
-commands or the `Cypress` API there. If a plugin adds custom commands, it
-belongs in the support file instead.
-
-:::
-
 ### Register in the support file
 
 Browser-side plugins are imported (or registered with a function call) in your

--- a/docs/app/plugins/plugins-guide.mdx
+++ b/docs/app/plugins/plugins-guide.mdx
@@ -38,34 +38,33 @@ and how recently it was updated, so you can pick one with confidence.
 
 ## Security considerations
 
-A plugin is third-party code that runs with significant access, in two
-sensitive places:
+A plugin is a regular npm dependency, so the habits you already use for other
+packages apply here too. The badges on the
+[list of plugins](/app/plugins/plugins-list) are a good starting point:
+**Official** plugins are built and maintained by the Cypress team, **Verified**
+plugins are community-owned and reviewed by Cypress, and **Community** plugins
+are published independently, so it's worth a closer look before adopting one.
 
-- Code registered in `setupNodeEvents` runs in Node with the same permissions
-  as Cypress itself: it can read and write files, make network requests, and
-  read environment variables, including any secrets available in CI.
-- Code registered in your support file runs in the browser alongside your
-  tests, with access to your application under test and any data your tests
-  handle, such as session cookies, tokens, and test account credentials.
+It also helps to know where plugin code runs. Code registered in
+`setupNodeEvents` runs in Node, where it can access the file system, the
+network, and environment variables. Code registered in your support file runs
+in the browser alongside your tests and your application under test. Neither is
+cause for concern with a well-maintained plugin; it's simply more reach than a
+typical utility library, which makes the usual dependency habits worth
+following:
 
-Cypress builds and maintains plugins with the **Official** badge on the
-[list of plugins](/app/plugins/plugins-list), and reviews those with the
-**Verified** badge. **Community** plugins are not reviewed by Cypress, and
-inclusion on the list is not a security endorsement. Before adding one, apply
-the same diligence you would to any other dependency:
-
-- **Check the maintenance signals** on the list: how recently it was updated,
-  and whether it supports your Cypress version. An abandoned plugin won't
-  receive security fixes.
-- **Review the source.** Most plugins are small. Look at what the plugin does
-  with your configuration, environment variables, and network access, and
-  check its own dependencies.
-- **Pin the version** with a lockfile and review changes when you update,
-  rather than floating on the latest release.
+- **Check the maintenance signals** on the list: how recently the plugin was
+  updated, and whether it supports your Cypress version. An actively
+  maintained plugin will keep receiving fixes.
+- **Skim the source.** Most plugins are small, so a few minutes of reading
+  shows you what the plugin does with your configuration and environment.
+- **Pin the version** with a lockfile and review changes when you update, the
+  same way you handle other dependencies.
 - **Include plugins in your dependency scanning**, such as `npm audit` or an
-  automated tool like Dependabot, the same as your other dev dependencies.
-- **Limit what CI secrets can reach.** Only expose the environment variables a
-  test run actually needs, so a compromised dependency has less to steal.
+  automated tool like Dependabot, alongside your other dev dependencies.
+- **Give test runs only the environment variables they need.** This is good
+  practice for any CI job, and it keeps your configuration tidy as your suite
+  grows.
 
 ## Installing a plugin
 


### PR DESCRIPTION
## Summary

Rewrites the "How to use Plugins" guide (`docs/app/plugins/plugins-guide.mdx`) from a short install-only page into a complete task guide: what plugins do, how to find and install one, where to register it (`setupNodeEvents` vs. the support file), a full verified `@cypress/grep` walkthrough, a troubleshooting checklist, and guidance on whether to report a bug to the plugin's repository or to Cypress.

## Why

The previous page covered only the npm install command and a placeholder `on('<event>')` snippet in `setupNodeEvents`. It never mentioned support-file registration, which is how a large share of plugins (custom commands, assertion libraries) are actually wired up, so readers following it could not get many plugins working. It also gave no way to verify success, no troubleshooting help, and no guidance on where to report plugin bugs, which sends plugin issues to the Cypress issue tracker.

Specific changes:

- Lead with the value of plugins, then a short "Find a plugin" section pointing to the plugins list.
- New "Where plugin code runs" section explaining the Node and browser execution contexts, with a note that plugins are regular npm dependencies deserving the same handling as any other package.
- "Using a plugin" now covers both registration points and when each applies, with a realistic config example (setup function receiving `on`/`config`) instead of the placeholder.
- Full `@cypress/grep` example registering in both places, verified against the plugin's actual exports and README in the cypress monorepo, including the Cypress 15 `--expose` flag.
- New "Troubleshooting" section: wrong registration point (`cy is not defined` in Node), forgetting to return `config`, restarting after config changes, version compatibility.
- New "Plugin issue or Cypress issue?" section: disable the plugin and re-run, then report where the problem reproduces, so plugin bugs go to the plugin's repository instead of cypress-io/cypress.
- SEO/AEO: frontmatter title and description rewritten around the install/register/verify tasks; added a "See also" section.
- Removed "accessibility" from the plugin capability examples since Cypress Accessibility is a Cypress product, not a plugin category.

The `#Using-a-plugin` anchor is preserved; 16 pages (including the shared `setupNodeEvents` warning partial) link to it.

## Notes for reviewers

- The security-oriented content was intentionally slimmed during review to the short "Where plugin code runs" section; the badge-tier explanation and dependency-vetting checklist were removed.
- The generic config example uses a fictional `my-cypress-plugin` package; the `copyTsToJs` transform cannot convert aliased imports (`import { plugin as x }`), so both directive examples use plain named imports.
- The sibling plugins list page (`plugins-list.mdx`) still mentions "accessibility" in its intro; left out of scope here but may warrant the same edit.
- Verified with `npm run lint:fix` and a full `npm run build` (broken links/anchors fail the build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NWQPVcN67Z7UzgPXnVM3Ex

---
_Generated by [Claude Code](https://claude.ai/code/session_01NWQPVcN67Z7UzgPXnVM3Ex)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to a single MDX guide; no runtime, auth, or build logic affected beyond normal docs site builds.
> 
> **Overview**
> Expands **`plugins-guide.mdx`** from a short install-and-placeholder-config page into a full how-to for Cypress plugins.
> 
> **Frontmatter and intro** now emphasize install, register, and verify; the info callout lists discovery, Node vs browser execution, package managers, registration sites, troubleshooting, and where to report bugs. Plugin examples no longer mention accessibility as a plugin category.
> 
> **New structure** adds **Find a plugin**, **Where plugin code runs** (Node in `setupNodeEvents` vs browser in the support file), and splits **Using a plugin** into config vs support registration with a realistic `configurePlugin(on, config)` + `return config` example instead of `on('<event>')`.
> 
> **`@cypress/grep`** is documented end-to-end (support `register`, Node `plugin(config)`, and `npx cypress run --expose grep=login`).
> 
> **Troubleshooting** covers README, wrong context (`cy is not defined`), returning `config`, restarting after config changes, and version badges.
> 
> **Plugin issue or Cypress issue?** gives a disable-and-re-run triage flow and where to file issues; **Writing your own plugin** and **See also** round out the page. The **`#Using-a-plugin`** anchor is kept for existing inbound links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fe52759ceeb95fbefece86ac9e72a0828ecf7c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->