### PR TITLE
chore: add nightly GitHub Action to update plugins data

### DIFF
--- a/.github/workflows/update-plugins-data.yml
+++ b/.github/workflows/update-plugins-data.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 concurrency:
   group: update-plugins-data
@@ -40,14 +41,15 @@ jobs:
           # checking whether plugin repos are archived.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Commit and push if changed
-        run: |
-          if git diff --quiet -- src/data/plugins-generated.json; then
-            echo "Plugins data is already up to date."
-            exit 0
-          fi
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add src/data/plugins-generated.json
-          git commit -m "chore: update plugins data (nightly)"
-          git push origin main
+      - name: Open pull request if changed
+        uses: peter-evans/create-pull-request@v7
+        with:
+          add-paths: src/data/plugins-generated.json
+          branch: automation/update-plugins-data
+          delete-branch: true
+          commit-message: 'chore: update plugins data (nightly)'
+          title: 'chore: update plugins data'
+          body: |
+            Nightly refresh of `src/data/plugins-generated.json` via `npm run enrich:plugins`.
+
+            Automated by the `update-plugins-data` workflow.

--- a/.github/workflows/update-plugins-data.yml
+++ b/.github/workflows/update-plugins-data.yml
@@ -1,0 +1,53 @@
+name: Update plugins data
+
+on:
+  schedule:
+    # Nightly at 05:00 UTC
+    - cron: '0 5 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: update-plugins-data
+  cancel-in-progress: false
+
+jobs:
+  update-plugins-data:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.node-version'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          HUSKY: 0
+
+      - name: Refresh plugins data
+        run: npm run enrich:plugins
+        env:
+          # Authenticated GitHub requests get a higher rate limit when
+          # checking whether plugin repos are archived.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Commit and push if changed
+        run: |
+          if git diff --quiet -- src/data/plugins-generated.json; then
+            echo "Plugins data is already up to date."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add src/data/plugins-generated.json
+          git commit -m "chore: update plugins data (nightly)"
+          git push origin main


### PR DESCRIPTION
## Summary

Adds a nightly GitHub Actions workflow (`.github/workflows/update-plugins-data.yml`) that runs `npm run enrich:plugins` and opens a pull request refreshing `src/data/plugins-generated.json` — and only that file — whenever the data has changed.

## Why

`scripts/enrich-plugins.mjs` enriches the curated plugin list with live signals from the npm registry and GitHub (latest version, publish date, Cypress compatibility, deprecation/archived flags). The generated file is committed so the site builds without network access, and the script's own docs call for re-running it periodically in CI on a schedule — but nothing was automating that, so the data goes stale. This workflow runs it nightly at 05:00 UTC (plus `workflow_dispatch` for manual runs).

No associated issue.

## Notes for reviewers

- The workflow uses `peter-evans/create-pull-request` to open (or update) a PR from an `automation/update-plugins-data` branch rather than pushing to `main` directly, so branch protection is respected. If no data changed, no commit or PR is created; if a previous night's PR is still open, it's updated in place instead of stacking new ones.
- Only `src/data/plugins-generated.json` is staged (`add-paths`), so nothing else the install or script touches can leak into the automated PR.
- The built-in `GITHUB_TOKEN` is passed to the enrich script for authenticated GitHub API rate limits. Known limitation: PRs created with `GITHUB_TOKEN` don't trigger other workflows (e.g. CI) on the automated PR — switching to a PAT/App token is a possible follow-up if CI needs to run there.
- Node version comes from `.node-version` via `actions/setup-node`, with npm caching; `HUSKY=0` skips git hooks during `npm ci`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mt82vcbsvRsZ3m5uvj92g7

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only automation with scoped file staging and no application or auth logic changes; main caveat is automated PRs may not trigger downstream workflows when using the default token.
> 
> **Overview**
> Adds **`.github/workflows/update-plugins-data.yml`**, a scheduled GitHub Action that keeps **`src/data/plugins-generated.json`** up to date without manual runs.
> 
> The workflow runs **nightly at 05:00 UTC** (and on **`workflow_dispatch`**), checks out `main`, runs **`npm ci`** and **`npm run enrich:plugins`**, and passes **`GITHUB_TOKEN`** so the enrich script can hit GitHub with better rate limits. If the generated file changes, **`peter-evans/create-pull-request`** opens or updates a PR on **`automation/update-plugins-data`**, staging **only** `plugins-generated.json`. Concurrency is grouped so overlapping runs don’t fight each other.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26dd35f4e1662ba46a0c7e984721e87878ac89c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->