### PR TITLE
Remove verified plugin badge; relabel as community

### DIFF
--- a/AGENTS_REFERENCE.md
+++ b/AGENTS_REFERENCE.md
@@ -122,8 +122,8 @@ Images go in `static/img/...` and are referenced via `/img/...`.
 
 To add a plugin to the plugins list, add an entry to `src/data/plugins.json`
 (name, description, repo link, keywords). Entries are grouped in this order:
-`official` (Cypress-owned) → `verified` (community, verified by Cypress) →
-`community` (unverified) → `deprecated` (unmaintained / incompatible with v10+).
+`official` (Cypress-owned) → `community` (community-owned) → `deprecated`
+(unmaintained / incompatible with v10+).
 
 ## Writing style
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,7 +114,7 @@ Each entry supports the following fields:
 | `description` | yes      | Short summary of what the plugin does. Basic HTML is allowed.                                                              |
 | `link`        | yes      | URL to the plugin's source or documentation.                                                                               |
 | `keywords`    | no       | Array of tags used for search and filtering.                                                                               |
-| `badge`       | no       | One of `official`, `verified`, or `community` (defaults to `community`).                                                   |
+| `badge`       | no       | One of `official` or `community` (defaults to `community`).                                                                |
 | `npm`         | no       | The npm package name. Set this only when it differs from `name` (for example an official monorepo package or scoped name). |
 
 Signals shown on each card — latest version, last published date, and Cypress
@@ -151,8 +151,7 @@ category by badge tier and then by most recently published first (so the entry
 order in `plugins.json` does not matter):
 
 - official (Cypress owned)
-- verified (community owned and verified by Cypress)
-- community (community owned and unverified)
+- community (community owned)
 - deprecated (npm registry missing, source repo archived or incompatible with v10+)
 
 The `deprecated` state is applied automatically by `npm run enrich:plugins` when

--- a/cypress/e2e/plugins_list.cy.ts
+++ b/cypress/e2e/plugins_list.cy.ts
@@ -21,7 +21,6 @@ describe('Plugins list', () => {
   it('explains every badge in the legend', () => {
     cy.get('[aria-label="What the badges mean"]').within(() => {
       cy.contains('official').should('be.visible')
-      cy.contains('verified').should('be.visible')
       cy.contains('community').should('be.visible')
       cy.contains('deprecated').should('be.visible')
       // The key message for the largest group.
@@ -96,7 +95,7 @@ describe('Plugins list', () => {
 
   it('sorts each category by badge tier', () => {
     cy.get(categoryFilter).select('Component Testing')
-    const rank = { official: 0, verified: 1, community: 2, deprecated: 3 }
+    const rank = { official: 0, community: 1, deprecated: 2 }
     cy.get('li.card').then(($cards) => {
       const ranks = [...$cards].map((card) => {
         const badge = card
@@ -105,7 +104,7 @@ describe('Plugins list', () => {
           .toLowerCase()
         return rank[badge] ?? 9
       })
-      // Ranks appear in non-decreasing order (official → verified → community).
+      // Ranks appear in non-decreasing order (official → community → deprecated).
       expect(ranks).to.deep.equal([...ranks].sort((a, b) => a - b))
     })
   })

--- a/src/components/plugins-list/index.tsx
+++ b/src/components/plugins-list/index.tsx
@@ -19,10 +19,10 @@ function createMarkup(html) {
 
 const GENERATED = (generatedJSON && generatedJSON.plugins) || {}
 
-const BADGE_ORDER = ['official', 'verified', 'community', 'deprecated']
+const BADGE_ORDER = ['official', 'community', 'deprecated']
 const BADGE_RANK = Object.fromEntries(BADGE_ORDER.map((b, i) => [b, i]))
 
-/** Sort by badge tier (official → verified → community → deprecated), then by
+/** Sort by badge tier (official → community → deprecated), then by
  *  most recently published first. Entries without a publish date sort last,
  *  with a stable alphabetical fallback. */
 function comparePlugins(a, b) {
@@ -41,7 +41,6 @@ function comparePlugins(a, b) {
 
 const BADGE_INFO = {
   official: 'Built and maintained by the Cypress team.',
-  verified: 'Community-owned and reviewed by the Cypress team.',
   community:
     'Community-owned and not reviewed by Cypress. Evaluate before use.',
   deprecated:

--- a/src/components/plugins-list/style.module.css
+++ b/src/components/plugins-list/style.module.css
@@ -105,10 +105,6 @@ ul.pluginsList li p {
   background-color: var(--ifm-color-teal-500);
 }
 
-.badgePill.badgeVerified {
-  background-color: var(--ifm-color-jade-500);
-}
-
 .badgePill.badgeCommunity {
   background-color: var(--ifm-color-indigo-500);
 }

--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -467,7 +467,7 @@
             "dom-testing-library",
             "react-testing-library"
           ],
-          "badge": "verified"
+          "badge": "community"
         },
         {
           "name": "cypress-wait-until",
@@ -481,7 +481,7 @@
             "check-async-value",
             "check-value"
           ],
-          "badge": "verified"
+          "badge": "community"
         },
         {
           "name": "@swimlane/cy-dom-diff",
@@ -885,7 +885,7 @@
           "name": "Applitools",
           "description": "Fast, easy and reliable visual UI testing with Cypress.",
           "link": "https://applitools.com/tutorials/sdks/cypress/quickstart/getting-started",
-          "badge": "verified",
+          "badge": "community",
           "keywords": ["screenshots", "visual regression", "visual-ai"]
         },
         {
@@ -899,7 +899,7 @@
             "visual testing",
             "ci"
           ],
-          "badge": "verified"
+          "badge": "community"
         },
         {
           "name": "Happo",
@@ -911,7 +911,7 @@
             "visual testing",
             "cross-browser"
           ],
-          "badge": "verified"
+          "badge": "community"
         },
         {
           "name": "Percy",
@@ -923,7 +923,7 @@
             "visual testing",
             "cross-browser"
           ],
-          "badge": "verified"
+          "badge": "community"
         },
         {
           "name": "SmartBear VisualTest",
@@ -936,7 +936,7 @@
             "visual regression",
             "screenshots comparison"
           ],
-          "badge": "verified"
+          "badge": "community"
         },
         {
           "name": "Sauce Labs Visual",
@@ -1053,7 +1053,7 @@
           "description": "NTLM authentication support for Cypress.",
           "link": "https://github.com/bjowes/cypress-ntlm-auth",
           "keywords": ["authentication", "ntlm", "auth", "windows", "sso"],
-          "badge": "verified"
+          "badge": "community"
         },
         {
           "name": "Cypress AWS Secrets Manager",


### PR DESCRIPTION
## Summary

Removes the "verified" badge tier from the Plugins list entirely and relabels all previously verified plugins as "community". The badge tiers are now: official → community → deprecated.

## Why

The verified tier was being collapsed into community, so plugins are now presented as either official (Cypress-owned) or community-owned, with no separate "reviewed by Cypress" distinction.

## Notes for reviewers

Changes span:
- `src/data/plugins.json` — reassigned all 8 `"verified"` entries to `"community"` (now 103 community, 0 verified).
- `src/components/plugins-list/index.tsx` — dropped `verified` from the badge order, legend, sort tiers, and `BADGE_INFO`.
- `src/components/plugins-list/style.module.css` — removed the `.badgeVerified` pill styling.
- `cypress/e2e/plugins_list.cy.ts` — removed the verified legend assertion and updated the badge-tier rank map.
- `CONTRIBUTING.md` & `AGENTS_REFERENCE.md` — updated documented badge tiers to no longer mention `verified`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EU4ba6apbada7naPbK5C9N

---
_Generated by [Claude Code](https://claude.ai/code/session_01EU4ba6apbada7naPbK5C9N)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-site presentation and static plugin metadata only; no runtime auth or enrichment pipeline logic changes beyond badge display and sorting.
> 
> **Overview**
> Removes the **verified** plugin badge tier from the Plugins list. Tiers are now **official → community → deprecated**, with no separate “reviewed by Cypress” label.
> 
> All entries that were `"verified"` in `plugins.json` are relabeled **`community`**. The plugins list UI drops verified from sort order, the badge legend, filter options, and `BADGE_INFO`, and removes the jade **verified** pill styling. E2E coverage no longer expects a verified legend entry and uses the updated tier ranking.
> 
> **CONTRIBUTING.md** and **AGENTS_REFERENCE.md** now document only `official` and `community` badge values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a58744600d1dcfc0ef12edd92cf585fde93097b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->