### PR TITLE
Rewrite UI Coverage elementGroups doc for accuracy and clarity, add UI Coverage FAQ

### DIFF
--- a/docs/ui-coverage/configuration/elementgroups.mdx
+++ b/docs/ui-coverage/configuration/elementgroups.mdx
@@ -15,7 +15,7 @@ UI Coverage already [groups elements automatically](/ui-coverage/core-concepts/e
 
 - **Consolidate repeated elements**: Collapse dynamic or repeated elements, such as items in a list, carousel, or data table, into one logical group.
 - **Correct the automatic grouping**: Split apart elements that were grouped together incorrectly, or unite elements that the automatic rules kept separate.
-- **Make reports readable**: Replace machine-generated selectors with meaningful names like "Add Button" or "Shipping Method Option", so anyone reading the report understands what needs testing.
+- **Make reports readable**: Replace machine-generated selectors with meaningful names like "Remove Item Button" or "Shipping Method Option", so anyone reading the report understands what needs testing.
 - **Group across markup differences**: Combine elements that share behavior but not structure, such as form controls and their labels.
 
 To add or edit `elementGroups`, open the **App Quality** tab in your project settings in Cypress Cloud. See [Setting configuration](/ui-coverage/configuration/overview#Setting-configuration) for details, including how to regenerate past reports with a new configuration without rerunning your tests.
@@ -75,7 +75,7 @@ Cypress Cloud rejects a configuration when:
 
 ### Consolidate repeated elements
 
-Elements generated from data, like product listings, often have dynamic attribute values. One rule with an attribute prefix selector collapses all of them into a single group. Without a `name`, the group is displayed under its selector.
+Elements generated from data often have dynamic attribute values, like an add to cart button rendered for each product in a listing. One rule with an attribute prefix selector collapses all of them into a single group. Without a `name`, the group is displayed under its selector.
 
 #### Config
 
@@ -84,7 +84,7 @@ Elements generated from data, like product listings, often have dynamic attribut
   "uiCoverage": {
     "elementGroups": [
       {
-        "selector": "[data-cy^='item-']"
+        "selector": "[data-cy^='add-to-cart-']"
       }
     ]
   }
@@ -95,23 +95,23 @@ Elements generated from data, like product listings, often have dynamic attribut
 
 ```xml
 <body>
-  <button data-cy="item-1"></button>
-  <button data-cy="item-2"></button>
-  <button data-cy="item-3"></button>
+  <button data-cy="add-to-cart-101">Add to Cart</button>
+  <button data-cy="add-to-cart-102">Add to Cart</button>
+  <button data-cy="add-to-cart-103">Add to Cart</button>
 </body>
 ```
 
 #### Elements shown in UI
 
 ```
-[data-cy^='item-'] (3 instances)
+[data-cy^='add-to-cart-'] (3 instances)
 ```
 
 ---
 
 ### Give a group a readable name
 
-Add a `name` so the report describes the interface instead of your selectors. Here, buttons with IDs starting with `listbox-button-` appear as a single "Add Button" group.
+Add a `name` so the report describes the interface instead of your selectors. Here, the remove buttons in a shopping cart appear as a single "Remove Item Button" group, no matter which products the cart contains.
 
 #### Config
 
@@ -120,8 +120,8 @@ Add a `name` so the report describes the interface instead of your selectors. He
   "uiCoverage": {
     "elementGroups": [
       {
-        "selector": "[id^='listbox-button-']",
-        "name": "Add Button"
+        "selector": "[id^='remove-item-']",
+        "name": "Remove Item Button"
       }
     ]
   }
@@ -132,24 +132,24 @@ Add a `name` so the report describes the interface instead of your selectors. He
 
 ```xml
 <body>
-  <button id="listbox-button-1">+</button>
-  <button id="listbox-button-2">+</button>
-  <button id="listbox-button-3">+</button>
-  <button id="listbox-button-4">+</button>
+  <button id="remove-item-101">Remove</button>
+  <button id="remove-item-102">Remove</button>
+  <button id="remove-item-103">Remove</button>
+  <button id="remove-item-104">Remove</button>
 </body>
 ```
 
 #### Elements shown in UI
 
 ```
-Add Button (4 instances)
+Remove Item Button (4 instances)
 ```
 
 ---
 
 ### Group all elements in a container
 
-Use a descendant combinator to group every interactive element inside a container. This example collapses a date picker's day buttons, which would otherwise appear as dozens of separate elements, into one group. The selector must match the interactive elements themselves, not just the container.
+Use a descendant combinator to group every interactive element inside a container. This example collapses a delivery date picker's day buttons, which would otherwise appear as dozens of separate elements, into one group. The selector must match the interactive elements themselves, not just the container.
 
 #### Config
 
@@ -230,7 +230,7 @@ Shipping Method Option (4 instances)
 
 ### Group elements inside a shadow DOM
 
-Use `documentScope` to apply a rule only to elements inside a specific shadow DOM host. Here, only buttons inside the `custom-component` shadow root are grouped; the identical button in the main document is unaffected.
+Third-party widgets and design system components often render inside a shadow DOM. Use `documentScope` to apply a rule only to elements inside a specific shadow DOM host. Here, only the buttons inside the `<support-chat>` component's shadow root are grouped; the button in the main document also matches the `button` selector, but stays separate because it's outside the scope.
 
 #### Config
 
@@ -240,8 +240,8 @@ Use `documentScope` to apply a rule only to elements inside a specific shadow DO
     "elementGroups": [
       {
         "selector": "button",
-        "name": "Shadow DOM Buttons",
-        "documentScope": ["custom-component"]
+        "name": "Support Chat Actions",
+        "documentScope": ["support-chat"]
       }
     ]
   }
@@ -252,27 +252,27 @@ Use `documentScope` to apply a rule only to elements inside a specific shadow DO
 
 ```xml
 <body>
-  <button id="root-button">Root Button</button>
-  <custom-component>
+  <button id="open-support-chat">Chat with us</button>
+  <support-chat>
     #shadow-dom
-      <button id="shadow-button-1">Shadow Button 1</button>
-      <button id="shadow-button-2">Shadow Button 2</button>
-  </custom-component>
+      <button id="send-message">Send</button>
+      <button id="attach-file">Attach</button>
+  </support-chat>
 </body>
 ```
 
 #### Elements shown in UI
 
 ```
-#root-button
-Shadow DOM Buttons (2 instances)
+#open-support-chat
+Support Chat Actions (2 instances)
 ```
 
 ---
 
 ### Group elements inside an iframe
 
-`documentScope` works the same way for iframes. The selector for the scope matches the `iframe` element itself in its parent document. Here, only the buttons inside the `#embedded-widget` iframe are grouped, while the save button in the main document remains a separate element.
+`documentScope` works the same way for embedded services that render inside an iframe, such as a payment provider on a checkout page. The scope selector matches the `iframe` element itself in its parent document. Here, only the buttons inside the `#payment-provider` iframe are grouped, while the coupon button in the main document remains a separate element.
 
 #### Config
 
@@ -282,8 +282,8 @@ Shadow DOM Buttons (2 instances)
     "elementGroups": [
       {
         "selector": "[data-action]",
-        "name": "Embedded Actions",
-        "documentScope": ["#embedded-widget"]
+        "name": "Payment Widget Actions",
+        "documentScope": ["#payment-provider"]
       }
     ]
   }
@@ -294,12 +294,12 @@ Shadow DOM Buttons (2 instances)
 
 ```xml
 <body>
-  <button data-action="save">Save (Root)</button>
-  <iframe id="embedded-widget" src="https://widget.example.com">
+  <button data-action="apply-coupon">Apply Coupon</button>
+  <iframe id="payment-provider" src="https://payments.example.com">
     <html>
       <body>
-        <button data-action="save">Save (Embedded)</button>
-        <button data-action="cancel">Cancel (Embedded)</button>
+        <button data-action="submit-payment">Pay Now</button>
+        <button data-action="change-method">Change Payment Method</button>
       </body>
     </html>
   </iframe>
@@ -309,11 +309,11 @@ Shadow DOM Buttons (2 instances)
 #### Elements shown in UI
 
 ```
-[data-action="save"]
-Embedded Actions (2 instances)
+[data-action="apply-coupon"]
+Payment Widget Actions (2 instances)
 ```
 
-For nested documents, list one selector per host from outermost to innermost, for example `"documentScope": ["#outer-iframe", "custom-component"]`.
+For nested documents, list one selector per host from outermost to innermost, for example `"documentScope": ["#payment-provider", "secure-card-input"]`.
 
 ## See also
 

--- a/docs/ui-coverage/configuration/elementgroups.mdx
+++ b/docs/ui-coverage/configuration/elementgroups.mdx
@@ -11,12 +11,32 @@ sidebar_position: 80
 
 The `elementGroups` configuration combines related elements into a single unit in your UI Coverage report. A group counts once toward your coverage score, and an interaction with any element in the group marks the whole group as tested. This means a list of 50 untested product cards no longer appears as 50 untested elements dragging down your score. Instead, it appears as one clearly named group that a single test can cover.
 
+Without meaningful groups, a report can fill up with elements listed under machine-generated names that are hard to act on:
+
+<DocsImage
+  src="/img/ui-coverage/guides/cypress-ui-coverage-untested-elements-expanded.png"
+  alt="The UI Coverage report listing thousands of untested elements, several of which appear under machine-generated names derived from their DOM structure"
+/>
+
 UI Coverage already [groups elements automatically](/ui-coverage/core-concepts/element-grouping) based on their structure in the DOM. Use `elementGroups` when the automatic grouping doesn't match how your application actually behaves:
 
 - **Consolidate repeated elements**: Collapse dynamic or repeated elements, such as items in a list, carousel, or data table, into one logical group.
 - **Correct the automatic grouping**: Split apart elements that were grouped together incorrectly, or unite elements that the automatic rules kept separate.
 - **Make reports readable**: Replace machine-generated selectors with meaningful names like "Remove Item Button" or "Shipping Method Option", so anyone reading the report understands what needs testing.
 - **Group across markup differences**: Combine elements that share behavior but not structure, such as form controls and their labels.
+
+## Which option do I need?
+
+UI Coverage has several options that change how elements appear in reports. Check that `elementGroups` matches your goal before you start:
+
+| Your goal                                                           | Use                                                                                                         |
+| ------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| Combine repeated or related elements so they count as one           | `elementGroups` (this page)                                                                                 |
+| Rename or stabilize the identity of a single element                | [`elements`](/ui-coverage/configuration/elements)                                                           |
+| Remove elements from reports and scores entirely                    | [`elementFilters`](/ui-coverage/configuration/elementfilters)                                               |
+| Define groups in your application's markup instead of configuration | [`data-cy-ui-group` attribute](/ui-coverage/core-concepts/element-grouping#Grouping-with-markup-attributes) |
+
+## Setting elementGroups
 
 To add or edit `elementGroups`, open the **App Quality** tab in your project settings in Cypress Cloud. See [Setting configuration](/ui-coverage/configuration/overview#Setting-configuration) for details, including how to regenerate past reports with a new configuration without rerunning your tests.
 
@@ -60,7 +80,7 @@ A few behaviors are worth knowing:
 - **Custom groups override automatic grouping.** An element that matches an `elementGroups` rule is grouped by that rule alone. This includes links, which would otherwise be grouped by their `href` patterns.
 - **A group forms even with one match.** Unlike the automatic rules, which require at least two similar elements, an `elementGroups` rule that matches a single element still produces a named group in the report.
 - **Filtered elements are never grouped.** Elements excluded from reports by [`elementFilters`](/ui-coverage/configuration/elementfilters) are not considered for grouping.
-- **The `data-cy-ui-group` attribute wins.** Elements that declare a group directly in your markup with the `data-cy-ui-group` attribute keep that group, even if they also match an `elementGroups` rule.
+- **The `data-cy-ui-group` attribute wins.** Elements that declare a group directly in your markup with the [`data-cy-ui-group` attribute](/ui-coverage/core-concepts/element-grouping#Grouping-with-markup-attributes) keep that group, even if they also match an `elementGroups` rule.
 
 ### Validation rules
 
@@ -103,6 +123,16 @@ Elements generated from data often have dynamic attribute values, like an add to
 
 #### Elements shown in UI
 
+Without the rule, the result depends on the automatic grouping heuristics. The buttons may appear individually or under a machine-generated name:
+
+```
+[data-cy="add-to-cart-101"]
+[data-cy="add-to-cart-102"]
+[data-cy="add-to-cart-103"]
+```
+
+With the rule, the buttons always appear as one group:
+
 ```
 [data-cy^='add-to-cart-'] (3 instances)
 ```
@@ -143,6 +173,48 @@ Add a `name` so the report describes the interface instead of your selectors. He
 
 ```
 Remove Item Button (4 instances)
+```
+
+---
+
+### Order specific rules before broad ones
+
+Each element joins the first rule that matches it, so list narrower rules first. Here, the featured product's button gets its own group because its rule comes before the catch-all rule. If the rules were reversed, the catch-all would capture all three buttons and the "Featured Buy Now Button" rule would never match anything.
+
+#### Config
+
+```json title="App Quality Config"
+{
+  "uiCoverage": {
+    "elementGroups": [
+      {
+        "selector": "[data-cy='buy-now-featured']",
+        "name": "Featured Buy Now Button"
+      },
+      {
+        "selector": "[data-cy^='buy-now-']",
+        "name": "Buy Now Button"
+      }
+    ]
+  }
+}
+```
+
+#### HTML
+
+```xml
+<body>
+  <button data-cy="buy-now-featured">Buy Now</button>
+  <button data-cy="buy-now-101">Buy Now</button>
+  <button data-cy="buy-now-102">Buy Now</button>
+</body>
+```
+
+#### Elements shown in UI
+
+```
+Featured Buy Now Button (1 instance)
+Buy Now Button (2 instances)
 ```
 
 ---
@@ -315,9 +387,15 @@ Payment Widget Actions (2 instances)
 
 For nested documents, list one selector per host from outermost to innermost, for example `"documentScope": ["#payment-provider", "secure-card-input"]`.
 
+:::tip
+
+After saving configuration changes, regenerate a recent run to preview your groups without rerunning your tests. See [Setting configuration](/ui-coverage/configuration/overview#Setting-configuration) for how to regenerate a report.
+
+:::
+
 ## See also
 
-- [Element Grouping](/ui-coverage/core-concepts/element-grouping) explains the automatic grouping rules that apply when no `elementGroups` rule matches.
+- [Element Grouping](/ui-coverage/core-concepts/element-grouping) explains the automatic grouping rules that apply when no `elementGroups` rule matches, and the `data-cy-ui-group` markup attribute.
 - [`elements`](/ui-coverage/configuration/elements) assigns a stable identity and name to a single element rather than a group.
 - [`elementFilters`](/ui-coverage/configuration/elementfilters) removes elements from reports entirely instead of grouping them.
 - [Configuration overview](/ui-coverage/configuration/overview) covers where configuration lives and how to regenerate reports after changing it.

--- a/docs/ui-coverage/configuration/elementgroups.mdx
+++ b/docs/ui-coverage/configuration/elementgroups.mdx
@@ -25,16 +25,7 @@ UI Coverage already [groups elements automatically](/ui-coverage/core-concepts/e
 - **Make reports readable**: Replace machine-generated selectors with meaningful names like "Remove Item Button" or "Shipping Method Option", so anyone reading the report understands what needs testing.
 - **Group across markup differences**: Combine elements that share behavior but not structure, such as form controls and their labels.
 
-## Which option do I need?
-
-UI Coverage has several options that change how elements appear in reports. Check that `elementGroups` matches your goal before you start:
-
-| Your goal                                                           | Use                                                                                                         |
-| ------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| Combine repeated or related elements so they count as one           | `elementGroups` (this page)                                                                                 |
-| Rename or stabilize the identity of a single element                | [`elements`](/ui-coverage/configuration/elements)                                                           |
-| Remove elements from reports and scores entirely                    | [`elementFilters`](/ui-coverage/configuration/elementfilters)                                               |
-| Define groups in your application's markup instead of configuration | [`data-cy-ui-group` attribute](/ui-coverage/core-concepts/element-grouping#Grouping-with-markup-attributes) |
+If your goal is different, such as renaming a single element or removing elements from reports entirely, see [Which option do I need?](/ui-coverage/configuration/overview#Which-option-do-I-need) in the configuration overview.
 
 ## Setting elementGroups
 

--- a/docs/ui-coverage/configuration/elementgroups.mdx
+++ b/docs/ui-coverage/configuration/elementgroups.mdx
@@ -9,7 +9,7 @@ sidebar_position: 80
 
 # elementGroups
 
-The `elementGroups` configuration combines related elements into a single unit in your UI Coverage report. A group counts once toward your coverage score, and an interaction with any element in the group marks the whole group as tested. This means a list of 50 untested product cards no longer appears as 50 untested elements dragging down your score — it appears as one clearly named group that a single test can cover.
+The `elementGroups` configuration combines related elements into a single unit in your UI Coverage report. A group counts once toward your coverage score, and an interaction with any element in the group marks the whole group as tested. This means a list of 50 untested product cards no longer appears as 50 untested elements dragging down your score. Instead, it appears as one clearly named group that a single test can cover.
 
 UI Coverage already [groups elements automatically](/ui-coverage/core-concepts/element-grouping) based on their structure in the DOM. Use `elementGroups` when the automatic grouping doesn't match how your application actually behaves:
 

--- a/docs/ui-coverage/configuration/elementgroups.mdx
+++ b/docs/ui-coverage/configuration/elementgroups.mdx
@@ -314,3 +314,11 @@ Embedded Actions (2 instances)
 ```
 
 For nested documents, list one selector per host from outermost to innermost, for example `"documentScope": ["#outer-iframe", "custom-component"]`.
+
+## See also
+
+- [Element Grouping](/ui-coverage/core-concepts/element-grouping) explains the automatic grouping rules that apply when no `elementGroups` rule matches.
+- [`elements`](/ui-coverage/configuration/elements) assigns a stable identity and name to a single element rather than a group.
+- [`elementFilters`](/ui-coverage/configuration/elementfilters) removes elements from reports entirely instead of grouping them.
+- [Configuration overview](/ui-coverage/configuration/overview) covers where configuration lives and how to regenerate reports after changing it.
+- [Guide: Reduce noise in UI Coverage reports](/ui-coverage/guides/reduce-noise) walks through combining these options to clean up a report.

--- a/docs/ui-coverage/configuration/elementgroups.mdx
+++ b/docs/ui-coverage/configuration/elementgroups.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'elementGroups: group elements with custom logic'
-description: 'The `elementGroups` configuration groups related elements into a single unit in UI Coverage, so testing one element counts as testing them all.'
+title: 'elementGroups: group related elements in UI Coverage'
+description: 'The elementGroups configuration in Cypress UI Coverage groups related elements into a single unit, so testing one element counts as testing them all.'
 sidebar_label: elementGroups
 sidebar_position: 80
 ---
@@ -17,6 +17,8 @@ Without meaningful groups, a report can fill up with elements listed under machi
   src="/img/ui-coverage/guides/cypress-ui-coverage-untested-elements-expanded.png"
   alt="The UI Coverage report listing thousands of untested elements, several of which appear under machine-generated names derived from their DOM structure"
 />
+
+## Why use elementGroups?
 
 UI Coverage already [groups elements automatically](/ui-coverage/core-concepts/element-grouping) based on their structure in the DOM. Use `elementGroups` when the automatic grouping doesn't match how your application actually behaves:
 
@@ -62,7 +64,7 @@ To add or edit `elementGroups`, open the **App Quality** tab in your project set
 | `documentScope` | Optional |            | An ordered array of CSS selectors that match document hosts (iframes or shadow DOM hosts) in the element's ancestor chain, from outermost to innermost. Use this to group only elements inside a specific iframe or shadow DOM. Hosts that aren't listed may appear between the ones that are. |
 | `comment`       | Optional |            | A note about why this rule exists, for your team's benefit. Comments have no effect on how elements are grouped.                                                                                                                                                                               |
 
-### How rules are applied
+### How are elementGroups rules applied?
 
 Rules are evaluated in order, and each element joins the group of the **first** rule whose `selector` matches it. Elements that match no rules fall back to the automatic [element grouping rules](/ui-coverage/core-concepts/element-grouping).
 
@@ -391,3 +393,4 @@ After saving configuration changes, regenerate a recent run to preview your grou
 - [`elementFilters`](/ui-coverage/configuration/elementfilters) removes elements from reports entirely instead of grouping them.
 - [Configuration overview](/ui-coverage/configuration/overview) covers where configuration lives and how to regenerate reports after changing it.
 - [Guide: Reduce noise in UI Coverage reports](/ui-coverage/guides/reduce-noise) walks through combining these options to clean up a report.
+- [UI Coverage FAQ](/ui-coverage/faq) answers common questions about grouping, scores, and configuration.

--- a/docs/ui-coverage/configuration/elementgroups.mdx
+++ b/docs/ui-coverage/configuration/elementgroups.mdx
@@ -15,10 +15,15 @@ UI Coverage already [groups elements automatically](/ui-coverage/core-concepts/e
 
 - **Consolidate repeated elements**: Collapse dynamic or repeated elements, such as items in a list, carousel, or data table, into one logical group.
 - **Correct the automatic grouping**: Split apart elements that were grouped together incorrectly, or unite elements that the automatic rules kept separate.
-- **Make reports readable**: Replace machine-generated selectors with meaningful names like "Add Button" or "Animal Option", so anyone reading the report understands what needs testing.
+- **Make reports readable**: Replace machine-generated selectors with meaningful names like "Add Button" or "Shipping Method Option", so anyone reading the report understands what needs testing.
 - **Group across markup differences**: Combine elements that share behavior but not structure, such as form controls and their labels.
 
 To add or edit `elementGroups`, open the **App Quality** tab in your project settings in Cypress Cloud. See [Setting configuration](/ui-coverage/configuration/overview#Setting-configuration) for details, including how to regenerate past reports with a new configuration without rerunning your tests.
+
+<DocsImage
+  src="/img/ui-coverage/configuration/cypress-ui-coverage-configuration-editor.png"
+  alt="The App Quality tab of a project's settings in Cypress Cloud, showing the configuration editor with JSON configuration"
+/>
 
 ## Syntax
 
@@ -74,7 +79,7 @@ Elements generated from data, like product listings, often have dynamic attribut
 
 #### Config
 
-```json
+```json title="App Quality Config"
 {
   "uiCoverage": {
     "elementGroups": [
@@ -110,7 +115,7 @@ Add a `name` so the report describes the interface instead of your selectors. He
 
 #### Config
 
-```json
+```json title="App Quality Config"
 {
   "uiCoverage": {
     "elementGroups": [
@@ -144,16 +149,17 @@ Add Button (4 instances)
 
 ### Group all elements in a container
 
-Standard CSS combinators work in selectors, so you can group every matching element inside a container. Remember that the selector must match the interactive elements themselves, not just the container.
+Use a descendant combinator to group every interactive element inside a container. This example collapses a date picker's day buttons, which would otherwise appear as dozens of separate elements, into one group. The selector must match the interactive elements themselves, not just the container.
 
 #### Config
 
-```json
+```json title="App Quality Config"
 {
   "uiCoverage": {
     "elementGroups": [
       {
-        "selector": "#calendar button"
+        "selector": "#datepicker button",
+        "name": "Datepicker Day"
       }
     ]
   }
@@ -164,10 +170,10 @@ Standard CSS combinators work in selectors, so you can group every matching elem
 
 ```xml
 <body>
-  <div id="calendar">
-    <button id="jan"></button>
-    <button id="feb"></button>
-    <button id="mar"></button>
+  <div id="datepicker">
+    <button id="day-1">1</button>
+    <button id="day-2">2</button>
+    <button id="day-3">3</button>
   </div>
 </body>
 ```
@@ -175,24 +181,24 @@ Standard CSS combinators work in selectors, so you can group every matching elem
 #### Elements shown in UI
 
 ```
-#calendar button (3 instances)
+Datepicker Day (3 instances)
 ```
 
 ---
 
 ### Group form controls with their labels
 
-A comma-separated selector list can unite elements with different markup. This example groups a set of radio inputs together with their clickable labels, using `:has()` to match the labels.
+A comma-separated selector list can unite elements with different markup. This example groups a checkout page's shipping method radio inputs together with their clickable labels, using `:has()` to match the labels.
 
 #### Config
 
-```json
+```json title="App Quality Config"
 {
   "uiCoverage": {
     "elementGroups": [
       {
-        "selector": "input[name='animal'], label:has(input[name='animal'])",
-        "name": "Animal Option"
+        "selector": "input[name='shipping'], label:has(input[name='shipping'])",
+        "name": "Shipping Method Option"
       }
     ]
   }
@@ -204,10 +210,12 @@ A comma-separated selector list can unite elements with different markup. This e
 ```xml
 <body>
   <label>
-    <input id="bear" name="animal" />
+    <input type="radio" id="standard" name="shipping" />
+    Standard
   </label>
   <label>
-    <input id="lion" name="animal" />
+    <input type="radio" id="express" name="shipping" />
+    Express
   </label>
 </body>
 ```
@@ -215,7 +223,7 @@ A comma-separated selector list can unite elements with different markup. This e
 #### Elements shown in UI
 
 ```
-Animal Option (4 instances)
+Shipping Method Option (4 instances)
 ```
 
 ---
@@ -226,7 +234,7 @@ Use `documentScope` to apply a rule only to elements inside a specific shadow DO
 
 #### Config
 
-```json
+```json title="App Quality Config"
 {
   "uiCoverage": {
     "elementGroups": [
@@ -268,7 +276,7 @@ Shadow DOM Buttons (2 instances)
 
 #### Config
 
-```json
+```json title="App Quality Config"
 {
   "uiCoverage": {
     "elementGroups": [

--- a/docs/ui-coverage/configuration/elementgroups.mdx
+++ b/docs/ui-coverage/configuration/elementgroups.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'elementGroups: group elements with custom logic'
-description: 'The `elementGroups` configuration allows you to group elements in UI Coverage using custom logic.'
+description: 'The `elementGroups` configuration groups related elements into a single unit in UI Coverage, so testing one element counts as testing them all.'
 sidebar_label: elementGroups
 sidebar_position: 80
 ---
@@ -9,14 +9,16 @@ sidebar_position: 80
 
 # elementGroups
 
-UI Coverage provides logic to automatically [group](/ui-coverage/core-concepts/element-grouping) elements based on their structure in the DOM. However, there are scenarios where you may want to customize these groups to better align with your application's functionality or testing requirements. The `elementGroups` configuration allows you to define custom logic for grouping elements, improving coverage clarity and simplifying analysis.
+The `elementGroups` configuration combines related elements into a single unit in your UI Coverage report. A group counts once toward your coverage score, and an interaction with any element in the group marks the whole group as tested. This means a list of 50 untested product cards no longer appears as 50 untested elements dragging down your score — it appears as one clearly named group that a single test can cover.
 
-## Why use element groups?
+UI Coverage already [groups elements automatically](/ui-coverage/core-concepts/element-grouping) based on their structure in the DOM. Use `elementGroups` when the automatic grouping doesn't match how your application actually behaves:
 
-- **Improve Grouping Accuracy**: Ensure elements with shared attributes but different roles are correctly grouped, avoiding misclassification.
-- **Simplify Test Coverage Reports**: Grouping similar elements, like navigation buttons or list items, reduces clutter in reports and provides a more concise view of test coverage.
-- **Highlight Key Areas**: Use meaningful group names to draw attention to critical application areas, such as form controls.
-- **Streamline Dynamic Elements**: Consolidate dynamic or repeated elements, such as items in a carousel or list, into a single logical group.
+- **Consolidate repeated elements**: Collapse dynamic or repeated elements, such as items in a list, carousel, or data table, into one logical group.
+- **Correct the automatic grouping**: Split apart elements that were grouped together incorrectly, or unite elements that the automatic rules kept separate.
+- **Make reports readable**: Replace machine-generated selectors with meaningful names like "Add Button" or "Animal Option", so anyone reading the report understands what needs testing.
+- **Group across markup differences**: Combine elements that share behavior but not structure, such as form controls and their labels.
+
+To add or edit `elementGroups`, open the **App Quality** tab in your project settings in Cypress Cloud. See [Setting configuration](/ui-coverage/configuration/overview#Setting-configuration) for details, including how to regenerate past reports with a new configuration without rerunning your tests.
 
 ## Syntax
 
@@ -37,18 +39,38 @@ UI Coverage provides logic to automatically [group](/ui-coverage/core-concepts/e
 
 ### Options
 
-For every element considered by UI Coverage, the first `elementGroup` rule for which the `selector` property matches the element is used to group the element. Elements that do not match any rules are grouped by the default UI Coverage [element grouping rules](/ui-coverage/core-concepts/element-grouping).
+| Option          | Required | Default    | Description                                                                                                                                                                                                                                                                                    |
+| --------------- | -------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `selector`      | Required |            | A CSS selector matched against each interactive element. Supports standard CSS selector syntax, including IDs, classes, attributes, combinators, and functional pseudo-classes like `:has()`.                                                                                                  |
+| `name`          | Optional | `selector` | A human-readable name for the group, displayed in UI Coverage reports. Each group's name must be unique.                                                                                                                                                                                       |
+| `documentScope` | Optional |            | An ordered array of CSS selectors that match document hosts (iframes or shadow DOM hosts) in the element's ancestor chain, from outermost to innermost. Use this to group only elements inside a specific iframe or shadow DOM. Hosts that aren't listed may appear between the ones that are. |
+| `comment`       | Optional |            | A note about why this rule exists, for your team's benefit. Comments have no effect on how elements are grouped.                                                                                                                                                                               |
 
-| Option          | Required | Default    | Description                                                                                                                                                                                                                                 |
-| --------------- | -------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `selector`      | Required |            | A CSS selector to identify elements. Supports standard CSS selector syntax, including IDs, classes, attributes, and combinators.                                                                                                            |
-| `name`          | Optional | `selector` | A human-readable name for the group, displayed in UI Coverage reports.                                                                                                                                                                      |
-| `documentScope` | Optional |            | An array of CSS selectors that identify document hosts (iframes or shadow DOM hosts) that must be ancestors of the matched element. The selector will only match if all specified document hosts are found in the element's ancestor chain. |
-| `comment`       | Optional |            | A comment describing the purpose of this element group configuration.                                                                                                                                                                       |
+### How rules are applied
+
+Rules are evaluated in order, and each element joins the group of the **first** rule whose `selector` matches it. Elements that match no rules fall back to the automatic [element grouping rules](/ui-coverage/core-concepts/element-grouping).
+
+A few behaviors are worth knowing:
+
+- **Custom groups override automatic grouping.** An element that matches an `elementGroups` rule is grouped by that rule alone. This includes links, which would otherwise be grouped by their `href` patterns.
+- **A group forms even with one match.** Unlike the automatic rules, which require at least two similar elements, an `elementGroups` rule that matches a single element still produces a named group in the report.
+- **Filtered elements are never grouped.** Elements excluded from reports by [`elementFilters`](/ui-coverage/configuration/elementfilters) are not considered for grouping.
+- **The `data-cy-ui-group` attribute wins.** Elements that declare a group directly in your markup with the `data-cy-ui-group` attribute keep that group, even if they also match an `elementGroups` rule.
+
+### Validation rules
+
+Cypress Cloud rejects a configuration when:
+
+- Two rules have the same `selector` (with the same `documentScope`). Duplicates can never both apply, because the first matching rule wins.
+- Two rules have the same `name`, or one rule's `name` matches another rule's `selector`. Groups are identified by these values, so they must be unique.
+- A `selector` or `documentScope` entry isn't valid CSS selector syntax.
+- A rule contains a property other than the four listed above.
 
 ## Examples
 
-### Groups elements by selector
+### Consolidate repeated elements
+
+Elements generated from data, like product listings, often have dynamic attribute values. One rule with an attribute prefix selector collapses all of them into a single group. Without a `name`, the group is displayed under its selector.
 
 #### Config
 
@@ -68,9 +90,9 @@ For every element considered by UI Coverage, the first `elementGroup` rule for w
 
 ```xml
 <body>
-  <button data-cy="item-1"></button> <!-- Group: [data-cy^='item-'] -->
-  <button data-cy="item-2"></button> <!-- Group: [data-cy^='item-'] -->
-  <button data-cy="item-3"></button> <!-- Group: [data-cy^='item-'] -->
+  <button data-cy="item-1"></button>
+  <button data-cy="item-2"></button>
+  <button data-cy="item-3"></button>
 </body>
 ```
 
@@ -82,7 +104,47 @@ For every element considered by UI Coverage, the first `elementGroup` rule for w
 
 ---
 
-### Groups all elements in a container
+### Give a group a readable name
+
+Add a `name` so the report describes the interface instead of your selectors. Here, buttons with IDs starting with `listbox-button-` appear as a single "Add Button" group.
+
+#### Config
+
+```json
+{
+  "uiCoverage": {
+    "elementGroups": [
+      {
+        "selector": "[id^='listbox-button-']",
+        "name": "Add Button"
+      }
+    ]
+  }
+}
+```
+
+#### HTML
+
+```xml
+<body>
+  <button id="listbox-button-1">+</button>
+  <button id="listbox-button-2">+</button>
+  <button id="listbox-button-3">+</button>
+  <button id="listbox-button-4">+</button>
+</body>
+```
+
+#### Elements shown in UI
+
+```
+Add Button (4 instances)
+```
+
+---
+
+### Group all elements in a container
+
+Standard CSS combinators work in selectors, so you can group every matching element inside a container. Remember that the selector must match the interactive elements themselves, not just the container.
 
 #### Config
 
@@ -118,7 +180,9 @@ For every element considered by UI Coverage, the first `elementGroup` rule for w
 
 ---
 
-### Groups form controls with labels
+### Group form controls with their labels
+
+A comma-separated selector list can unite elements with different markup. This example groups a set of radio inputs together with their clickable labels, using `:has()` to match the labels.
 
 #### Config
 
@@ -140,10 +204,10 @@ For every element considered by UI Coverage, the first `elementGroup` rule for w
 ```xml
 <body>
   <label>
-    <input id="bear" name="animal"></input>
+    <input id="bear" name="animal" />
   </label>
   <label>
-    <input id="lion" name="animal"></input>
+    <input id="lion" name="animal" />
   </label>
 </body>
 ```
@@ -154,79 +218,11 @@ For every element considered by UI Coverage, the first `elementGroup` rule for w
 Animal Option (4 instances)
 ```
 
-### Groups dynamic elements
-
-#### Config
-
-```json
-{
-  "uiCoverage": {
-    "elementGroups": [
-      {
-        "selector": "[id^='product']"
-      }
-    ]
-  }
-}
-```
-
-#### HTML
-
-```xml
-<body>
-  <button id="product125">Product 1</button>
-  <button id="product514">Product 2</button>
-  <button id="product256">Product 3</button>
-</body>
-```
-
-#### Elements shown in UI
-
-```
-[id^='product'] (3 instances)
-```
-
-### Giving groups custom names
-
-Sometimes you may want to group elements by a common attribute but give the group a more descriptive name. In the following example, we group buttons with IDs starting with `listbox-button-` and name the group `Add Button`.
-
-#### Config
-
-```json
-{
-  "uiCoverage": {
-    "elementGroups": [
-      {
-        "selector": "[id^='listbox-button-']",
-        "name": "Add Button"
-      }
-    ]
-  }
-}
-```
-
-#### HTML
-
-```xml
-<body>
-  <button id='listbox-button-1'>+</button>
-  <button id='listbox-button-2'>+</button>
-  <button id='listbox-button-3'>+</button>
-  <button id='listbox-button-4'>+</button>
-</body>
-```
-
-#### Elements shown in UI
-
-```
-Add Button (4 instances)
-```
-
 ---
 
-### Grouping elements within shadow DOM
+### Group elements inside a shadow DOM
 
-When you need to group elements within a specific shadow DOM host, use the `documentScope` property to scope your selector to that document context.
+Use `documentScope` to apply a rule only to elements inside a specific shadow DOM host. Here, only buttons inside the `custom-component` shadow root are grouped; the identical button in the main document is unaffected.
 
 #### Config
 
@@ -264,13 +260,11 @@ When you need to group elements within a specific shadow DOM host, use the `docu
 Shadow DOM Buttons (2 instances)
 ```
 
-Only the buttons inside the shadow DOM are grouped together, while the root button remains separate.
-
 ---
 
-### Grouping elements within iframes
+### Group elements inside an iframe
 
-You can also scope element grouping to elements within specific iframes using `documentScope`.
+`documentScope` works the same way for iframes. The selector for the scope matches the `iframe` element itself in its parent document. Here, only the buttons inside the `#embedded-widget` iframe are grouped, while the save button in the main document remains a separate element.
 
 #### Config
 
@@ -293,7 +287,7 @@ You can also scope element grouping to elements within specific iframes using `d
 ```xml
 <body>
   <button data-action="save">Save (Root)</button>
-  <iframe id="embedded-widget" src="http://www.foo.com">
+  <iframe id="embedded-widget" src="https://widget.example.com">
     <html>
       <body>
         <button data-action="save">Save (Embedded)</button>
@@ -307,8 +301,8 @@ You can also scope element grouping to elements within specific iframes using `d
 #### Elements shown in UI
 
 ```
-[data-action="save"] (from root document)
+[data-action="save"]
 Embedded Actions (2 instances)
 ```
 
-Only the buttons inside the iframe are grouped together.
+For nested documents, list one selector per host from outermost to innermost, for example `"documentScope": ["#outer-iframe", "custom-component"]`.

--- a/docs/ui-coverage/configuration/overview.mdx
+++ b/docs/ui-coverage/configuration/overview.mdx
@@ -48,6 +48,19 @@ For a quick overview of the practical application of the most common UI Coverage
 
 :::
 
+### Which option do I need?
+
+Several options change what appears in reports and how it's organized. Pick the one that matches your goal:
+
+| Your goal                                                           | Use                                                                                                         |
+| ------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| Combine repeated or related elements so they count as one           | [`elementGroups`](/ui-coverage/configuration/elementgroups)                                                 |
+| Rename or stabilize the identity of a single element                | [`elements`](/ui-coverage/configuration/elements)                                                           |
+| Remove elements from reports and scores entirely                    | [`elementFilters`](/ui-coverage/configuration/elementfilters)                                               |
+| Define groups in your application's markup instead of configuration | [`data-cy-ui-group` attribute](/ui-coverage/core-concepts/element-grouping#Grouping-with-markup-attributes) |
+| Control how URLs are grouped into views                             | [`views`](/ui-coverage/configuration/views)                                                                 |
+| Remove entire views from reports                                    | [`viewFilters`](/ui-coverage/configuration/viewfilters)                                                     |
+
 ### Comments
 
 All configuration objects support an optional `comment` property that you can use to provide context and explanations for why certain values are set. This helps make your configuration easier to understand and maintain, especially when working in teams or revisiting configuration after some time.

--- a/docs/ui-coverage/configuration/overview.mdx
+++ b/docs/ui-coverage/configuration/overview.mdx
@@ -58,8 +58,13 @@ Several options change what appears in reports and how it's organized. Pick the 
 | Rename or stabilize the identity of a single element                | [`elements`](/ui-coverage/configuration/elements)                                                           |
 | Remove elements from reports and scores entirely                    | [`elementFilters`](/ui-coverage/configuration/elementfilters)                                               |
 | Define groups in your application's markup instead of configuration | [`data-cy-ui-group` attribute](/ui-coverage/core-concepts/element-grouping#Grouping-with-markup-attributes) |
+| Stop dynamic or generated attributes from identifying elements      | [`attributeFilters`](/ui-coverage/configuration/attributefilters)                                           |
+| Prioritize your own attributes for identifying and naming elements  | [`significantAttributes`](/ui-coverage/configuration/significantattributes)                                 |
 | Control how URLs are grouped into views                             | [`views`](/ui-coverage/configuration/views)                                                                 |
 | Remove entire views from reports                                    | [`viewFilters`](/ui-coverage/configuration/viewfilters)                                                     |
+| Count your custom commands as interactions                          | [`additionalInteractionCommands`](/ui-coverage/configuration/additionalinteractioncommands)                 |
+| Limit which interaction commands count for specific elements        | [`allowedInteractionCommands`](/ui-coverage/configuration/allowedinteractioncommands)                       |
+| Apply different configuration to runs based on run tags             | [`profiles`](/ui-coverage/configuration/profiles)                                                           |
 
 ### Comments
 

--- a/docs/ui-coverage/core-concepts/element-grouping.mdx
+++ b/docs/ui-coverage/core-concepts/element-grouping.mdx
@@ -47,6 +47,25 @@ Consider a table where each row contains a delete button:
 
 In this case, UI Coverage groups the delete buttons together in accordance with our grouping rules. Interacting with one delete button is equivalent to testing all delete buttons in the table.
 
+## Grouping with markup attributes
+
+You can define groups directly in your application's markup with the `data-cy-ui-group` attribute, without any Cypress Cloud configuration. Elements that share the same attribute value are grouped together, and the group appears in reports under a selector formatted with that value, such as `[data-cy-ui-group="pagination"]`.
+
+```html
+<button data-cy-ui-group="pagination">1</button>
+<button data-cy-ui-group="pagination">2</button>
+<button data-cy-ui-group="pagination">3</button>
+```
+
+The attribute follows these rules:
+
+- Placing the attribute on an interactive element applies the group to that element only.
+- Placing the attribute on a wrapper or parent element applies the group to all interactive elements inside it.
+- When wrappers with the attribute are nested, each interactive element joins the group of its closest ancestor with the attribute.
+- Groups defined with this attribute take priority over every other grouping mechanism, including [`elementGroups`](/ui-coverage/configuration/elementgroups) configuration rules.
+
+Use the attribute when the team that owns the markup also owns the grouping decisions, and use [`elementGroups`](/ui-coverage/configuration/elementgroups) configuration when you want to manage grouping centrally in Cypress Cloud without changing application code.
+
 ## Customizing element grouping
 
 You can customize element grouping to suit your application's structure and behavior. Refer to the [Element Groups](/ui-coverage/configuration/elementgroups) configuration guide to learn how to define custom groups and group elements based on specific attributes or selectors.

--- a/docs/ui-coverage/faq.mdx
+++ b/docs/ui-coverage/faq.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Frequently asked questions (FAQ) about UI Coverage'
+title: 'UI Coverage FAQ'
 description: 'Get answers to common questions about Cypress UI Coverage, including scores, element grouping, iframes and shadow DOM, and configuration.'
 sidebar_label: FAQ
 sidebar_position: 160

--- a/docs/ui-coverage/faq.mdx
+++ b/docs/ui-coverage/faq.mdx
@@ -1,0 +1,67 @@
+---
+title: 'Frequently asked questions (FAQ) about UI Coverage'
+description: 'Get answers to common questions about Cypress UI Coverage, including scores, element grouping, iframes and shadow DOM, and configuration.'
+sidebar_label: FAQ
+sidebar_position: 160
+---
+
+<ProductHeading product="ui-coverage" />
+
+# UI Coverage FAQ
+
+## General
+
+### <Icon name="angle-right" /> What is UI Coverage?
+
+[UI Coverage](/ui-coverage/get-started/introduction) is a Cypress Cloud feature that shows you which interactive elements of your application your tests actually exercise. Every recorded run produces a visual report of tested and untested elements across all of your application's [views](/ui-coverage/core-concepts/views), along with a coverage score you can track over time.
+
+### <Icon name="angle-right" /> Do I need to install anything to use UI Coverage?
+
+No. UI Coverage requires no code changes or instrumentation. Reports are generated from [Test Replay](/cloud/features/test-replay) data, so any run recorded to Cypress Cloud with Test Replay on Cypress v13 or later is ready to use. See [setup](/ui-coverage/get-started/setup) for details.
+
+### <Icon name="angle-right" /> How is the UI Coverage score calculated?
+
+The score compares the number of tested interactive elements to the total number of interactive elements in your application. [Grouped elements](/ui-coverage/core-concepts/element-grouping) count as a single unit: the group counts once toward the total, and an interaction with any element in the group marks the whole group as tested.
+
+## Element grouping and identification
+
+### <Icon name="angle-right" /> What happens if two elementGroups rules match the same element?
+
+The first matching rule in your [`elementGroups`](/ui-coverage/configuration/elementgroups) configuration wins, so list specific rules before broad catch-all rules. A rule that appears after another rule matching the same elements never applies to them.
+
+### <Icon name="angle-right" /> Can I group or filter elements inside iframes or shadow DOM?
+
+Yes. The [`elementGroups`](/ui-coverage/configuration/elementgroups), [`elementFilters`](/ui-coverage/configuration/elementfilters), and [`elements`](/ui-coverage/configuration/elements) configuration options all accept a `documentScope` property that limits a rule to elements inside specific iframes or shadow DOM hosts. List one CSS selector per host, ordered from the outermost document to the innermost.
+
+### <Icon name="angle-right" /> Why isn't my element group showing up in the report?
+
+The most common causes are:
+
+- An earlier `elementGroups` rule matches the same elements, and the first matching rule wins.
+- The elements are excluded by [`elementFilters`](/ui-coverage/configuration/elementfilters), so they're never considered for grouping.
+- The elements declare a group in markup with the `data-cy-ui-group` attribute, which takes priority over configuration rules.
+- The selector matches a container rather than the interactive elements themselves.
+- The report was processed before you saved the configuration. Regenerate the run to apply the current configuration.
+
+### <Icon name="angle-right" /> Why does one element appear as multiple elements in the report?
+
+This usually means the element's identifying attributes change between snapshots, for example auto-generated IDs or dynamic class names. Use [`attributeFilters`](/ui-coverage/configuration/attributefilters) to ignore the dynamic attributes, or [`elements`](/ui-coverage/configuration/elements) to define the element's identity explicitly. See [troubleshooting](/ui-coverage/troubleshooting) for more scenarios.
+
+## Configuration
+
+### <Icon name="angle-right" /> Where do I set UI Coverage configuration?
+
+In the **App Quality** tab of your project settings in Cypress Cloud. By default, only Admin users can edit configuration; your Cypress point-of-contact can change this on request. See [Setting configuration](/ui-coverage/configuration/overview#Setting-configuration).
+
+### <Icon name="angle-right" /> Do I need to rerun my tests after changing configuration?
+
+No. You can regenerate any historical run from its **Properties** tab, and the report is reprocessed with the current configuration. This lets you iterate on configuration and see the effects immediately without running your Cypress tests again.
+
+### <Icon name="angle-right" /> Can I use different configuration for different runs?
+
+Yes. The [`profiles`](/ui-coverage/configuration/profiles) property applies configuration overrides based on [run tags](/app/references/command-line#cypress-run-tag-lt-tag-gt), so a smoke-test run and a full regression run can each use their own settings.
+
+## See also
+
+- [Configuration overview](/ui-coverage/configuration/overview) lists every configuration option and what each one is for.
+- [Troubleshooting UI Coverage](/ui-coverage/troubleshooting) covers common report problems and their solutions.

--- a/plugins/faq-structured-data.js
+++ b/plugins/faq-structured-data.js
@@ -14,6 +14,7 @@ const path = require('path')
 const STRUCTURED_DATA_PAGES = [
   { route: '/app/faq', file: 'docs/app/faq.mdx' },
   { route: '/cloud/faq', file: 'docs/cloud/faq.mdx' },
+  { route: '/ui-coverage/faq', file: 'docs/ui-coverage/faq.mdx' },
   {
     route: '/app/references/error-messages',
     file: 'docs/app/references/error-messages.mdx',
@@ -41,7 +42,8 @@ function loadPartialMap(siteDir) {
   const componentsFile = path.join(siteDir, 'src/theme/MDXComponents.js')
   if (!fs.existsSync(componentsFile)) return map
   const source = fs.readFileSync(componentsFile, 'utf8')
-  const importRe = /import\s+(\w+)\s+from\s+["']@site\/docs\/partials\/(_[\w-]+\.mdx)["']/g
+  const importRe =
+    /import\s+(\w+)\s+from\s+["']@site\/docs\/partials\/(_[\w-]+\.mdx)["']/g
   let match
   while ((match = importRe.exec(source))) {
     map[match[1]] = path.join(siteDir, 'docs/partials', match[2])
@@ -63,11 +65,17 @@ function inlinePartials(content, partialMap, seen = new Set(), depth = 0) {
     if (!seen.has(name) && fs.existsSync(file)) {
       const nextSeen = new Set(seen).add(name)
       const body = stripFrontmatter(fs.readFileSync(file, 'utf8'))
-      replacement = '\n' + inlinePartials(body, partialMap, nextSeen, depth + 1) + '\n'
+      replacement =
+        '\n' + inlinePartials(body, partialMap, nextSeen, depth + 1) + '\n'
     }
-    const paired = new RegExp('<' + name + '(?:\\s[^>]*?)?>[\\s\\S]*?</' + name + '>', 'g')
+    const paired = new RegExp(
+      '<' + name + '(?:\\s[^>]*?)?>[\\s\\S]*?</' + name + '>',
+      'g'
+    )
     const selfClosing = new RegExp('<' + name + '(?:\\s[^>]*?)?/>', 'g')
-    result = result.replace(paired, () => replacement).replace(selfClosing, () => replacement)
+    result = result
+      .replace(paired, () => replacement)
+      .replace(selfClosing, () => replacement)
   }
   return result
 }

--- a/plugins/faq-structured-data.test.js
+++ b/plugins/faq-structured-data.test.js
@@ -28,15 +28,15 @@ afterEach(() => {
 
 describe('toPlainText', () => {
   test('strips JSX / HTML tags', () => {
-    expect(toPlainText('<Icon name="angle-right" /> Hello <strong>there</strong>')).toBe(
-      'Hello there'
-    )
+    expect(
+      toPlainText('<Icon name="angle-right" /> Hello <strong>there</strong>')
+    ).toBe('Hello there')
   })
 
   test('unwraps markdown links to their text', () => {
-    expect(toPlainText('See the [install guide](/app/get-started/install).')).toBe(
-      'See the install guide.'
-    )
+    expect(
+      toPlainText('See the [install guide](/app/get-started/install).')
+    ).toBe('See the install guide.')
   })
 
   test('removes images entirely', () => {
@@ -51,9 +51,9 @@ describe('toPlainText', () => {
   })
 
   test('unwraps inline code and emphasis markers', () => {
-    expect(toPlainText('Use `cy.get()` with **bold** and _italic_ and ~~strike~~')).toBe(
-      'Use cy.get() with bold and italic and strike'
-    )
+    expect(
+      toPlainText('Use `cy.get()` with **bold** and _italic_ and ~~strike~~')
+    ).toBe('Use cy.get() with bold and italic and strike')
   })
 
   test('drops admonition / directive markers', () => {
@@ -173,9 +173,11 @@ describe('parseFaq', () => {
   })
 
   test('drops questions whose answer is empty', () => {
-    const content = ['### Question with no answer?', '', '## Next section'].join(
-      '\n'
-    )
+    const content = [
+      '### Question with no answer?',
+      '',
+      '## Next section',
+    ].join('\n')
     expect(parseFaq(content)).toEqual([])
   })
 
@@ -419,9 +421,11 @@ function countHeadings(raw, { iconOnly = false } = {}) {
 }
 
 describe('integration with repository FAQ pages', () => {
-  const faqFiles = ['docs/app/faq.mdx', 'docs/cloud/faq.mdx'].filter((file) =>
-    fs.existsSync(path.join(siteDir, file))
-  )
+  const faqFiles = [
+    'docs/app/faq.mdx',
+    'docs/cloud/faq.mdx',
+    'docs/ui-coverage/faq.mdx',
+  ].filter((file) => fs.existsSync(path.join(siteDir, file)))
 
   test.each(faqFiles)(
     'every ### heading in %s yields a well-formed FAQPage entry',


### PR DESCRIPTION
## Summary

Rewrites the UI Coverage `elementGroups` configuration page to lead with the feature's value and match its actual implementation, adds a dedicated UI Coverage FAQ page with FAQPage structured data, documents the `data-cy-ui-group` markup attribute, and adds a goal-to-option routing table to the configuration overview.

## Why

The `elementGroups` page was audited against its implementation in `cypress-services` (discovery `ui-coverage` rendering, compaction hooks, and config validation schemas). The audit found the page never explained why grouping matters (a group counts once toward the score and one interaction tests the whole group), misdescribed `documentScope` (it is an ordered outermost-to-innermost host list, with gaps allowed), and omitted several verified behaviors: custom groups override all automatic grouping including href-based link grouping, single-match rules still form a group, `elementFilters`-excluded elements are never grouped, the `data-cy-ui-group` attribute takes priority over config rules, and Cypress Cloud enforces validation rules (unique selectors/names, no name/selector overlap, valid CSS, no unknown properties). The `data-cy-ui-group` attribute also had no documentation anywhere on the site outside the changelog.

## Notes for reviewers

- **elementgroups.mdx**: value-led intro with a report screenshot as motivation, "Why use elementGroups?" and "How are elementGroups rules applied?" sections, validation rules, a before/after report comparison in the first example, and a new rule-ordering example. Examples are reworked into a cohesive storefront/checkout theme (add to cart buttons, cart remove buttons, delivery date picker, shipping method radios, support chat web component, payment provider iframe). Instance counts and selector/documentScope semantics were kept accurate to the implementation.
- **element-grouping.mdx** (core concepts): new "Grouping with markup attributes" section documenting `data-cy-ui-group`, verified against the `uiGroupIdentifier` rule (same-value grouping, wrapper cascading, closest-ancestor resolution for nested wrappers, precedence over config).
- **overview.mdx**: new "Which option do I need?" table covering all 10 configuration options plus the markup attribute.
- **faq.mdx** (new): ten questions on scores, grouping, iframes/shadow DOM, and configuration, modeled on the existing app/cloud FAQ pages. Registered in `plugins/faq-structured-data.js` so it emits FAQPage JSON-LD, and added to the plugin's integration test. Verified by running the plugin's parser against the page: all 10 entries produce well-formed JSON-LD.
- SEO tweaks: the elementGroups title now includes "UI Coverage" and its meta description no longer contains backticks.
- Follow-ups intentionally left out: a purpose-made before/after screenshot of a named group in the report, a family-wide title pass for the other configuration pages, stable explicit heading IDs, and an `llms.txt` for the site.
- Prettier and the frontmatter linter pass on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016PemR4XhKMhfe3Dr5xQ3WK

---
_Generated by [Claude Code](https://claude.ai/code/session_016PemR4XhKMhfe3Dr5xQ3WK)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and Docusaurus FAQ structured-data plugin/test updates only; no runtime or security-sensitive application code.
> 
> **Overview**
> **Documentation overhaul** for Cypress UI Coverage grouping and configuration discovery—no product code changes.
> 
> The **`elementGroups`** page is rewritten to explain **why** grouping matters (one group = one score unit; any interaction tests the group), adds setup guidance, screenshots, rule-application and **Cloud validation** behavior, and replaces examples with a cohesive checkout/storefront theme (including rule ordering and `documentScope` for shadow DOM/iframes).
> 
> **`element-grouping`** now documents the **`data-cy-ui-group`** markup attribute (precedence over config). **`configuration/overview`** adds a **“Which option do I need?”** table mapping goals to the right config options.
> 
> A new **`/ui-coverage/faq`** page (10 Q&As) is registered in **`faq-structured-data`** for FAQPage JSON-LD, with integration tests updated to include the new file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 745876cac2957aa573fd50cf6fb6531b3148db9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->