### PR TITLE
Update the banner

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -178,9 +178,9 @@ const config = {
       // Styles for this are controlled in src/css/announcement-bar.scss
       announcementBar: {
         //give id a unique value to get a new announcement bar to appear
-        id: 'cloud-mcp-april-2026',
+        id: 'leadership-webinar-2026',
         // Visual content (including Cypress Design icon) is rendered in src/theme/AnnouncementBar/Content
-        content: `🌟 Close the context gap. Bring real-time test data to your AI assistant with Cloud MCP &mdash; <a href="/cloud/integrations/cloud-mcp?utm_medium=announcement-bar&utm_source=docs.cypress.io&utm_campaign=cloud-mcp">Learn more</a>`,
+        content: `🌟 Join our Leadership Webinar &mdash; <a href="#">Learn more</a>`,
         isCloseable: true,
       },
       footer: {


### PR DESCRIPTION
<!--
Fill in every section. This template doubles as the historical record of the
change, so future readers can understand not just what changed but
why. Delete a section only if it is genuinely not applicable, and say so.
-->

## Summary

<!-- What does this PR change, in one or two sentences? Write for a reader who
has never seen the task. -->

Update the banner for the new leadership webinar coming soon

## Why

<!-- The motivation and context. If this originated from an issue, a Slack/
Discord thread, a broken link, an outdated example, or a release, capture it
here so the reasoning survives after the source is gone. -->

Closes #<!-- issue number, or remove this line if none -->

## Notes for reviewers

<!-- Anything a reviewer should focus on: decisions made, alternatives
considered, areas of uncertainty, or follow-ups intentionally left out. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Marketing-only config change with no auth, data, or app logic impact; the placeholder `#` link should be fixed before launch.
> 
> **Overview**
> Swaps the docs site **announcement bar** from the Cloud MCP campaign to a **Leadership Webinar** message.
> 
> In `docusaurus.config.js`, the bar `id` is updated to `leadership-webinar-2026` so visitors who closed the previous bar see this one. Copy now reads “Join our Leadership Webinar” with a **Learn more** link; the href is currently **`#`** (placeholder), replacing the prior Cloud MCP URL and UTM-tagged link.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 900620d0658b336ee20722564b60305d8afa2bc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->