### PR TITLE
Remove archived @swimlane/cy-dom-diff plugin; request review on nightly plugin-data PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Plugins data — review requested automatically on PRs touching these files,
+# including the nightly update-plugins-data automation.
+/src/data/plugins.json @jennifer-shehane
+/src/data/plugins-generated.json @jennifer-shehane
+/.github/workflows/update-plugins-data.yml @jennifer-shehane

--- a/.github/workflows/update-plugins-data.yml
+++ b/.github/workflows/update-plugins-data.yml
@@ -49,6 +49,7 @@ jobs:
           delete-branch: true
           commit-message: 'chore: update plugins data (nightly)'
           title: 'chore: update plugins data'
+          reviewers: jennifer-shehane
           body: |
             Nightly refresh of `src/data/plugins-generated.json` via `npm run enrich:plugins`.
 

--- a/src/data/plugins-generated.json
+++ b/src/data/plugins-generated.json
@@ -237,15 +237,6 @@
       "lastPublished": "2024-07-16T14:01:26.695Z",
       "cypressVersion": "12.13.0"
     },
-    "@swimlane/cy-dom-diff": {
-      "npm": "@swimlane/cy-dom-diff",
-      "version": "2.0.0",
-      "lastPublished": "2021-02-02T18:40:01.242Z",
-      "cypressVersion": "^5.2.0",
-      "archived": true,
-      "deprecated": true,
-      "deprecatedReason": "Source repository is archived."
-    },
     "cy-spok": {
       "npm": "cy-spok",
       "version": "1.7.0",

--- a/src/data/plugins-generated.json
+++ b/src/data/plugins-generated.json
@@ -72,8 +72,8 @@
     },
     "@cypress/vite-dev-server": {
       "npm": "@cypress/vite-dev-server",
-      "version": "7.3.3",
-      "lastPublished": "2026-05-20T01:25:49.937Z",
+      "version": "7.3.4",
+      "lastPublished": "2026-07-06T13:58:07.769Z",
       "cypressVersion": ">=15.0.0"
     },
     "@cypress/webpack-dev-server": {
@@ -241,7 +241,10 @@
       "npm": "@swimlane/cy-dom-diff",
       "version": "2.0.0",
       "lastPublished": "2021-02-02T18:40:01.242Z",
-      "cypressVersion": "^5.2.0"
+      "cypressVersion": "^5.2.0",
+      "archived": true,
+      "deprecated": true,
+      "deprecatedReason": "Source repository is archived."
     },
     "cy-spok": {
       "npm": "cy-spok",

--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -484,13 +484,6 @@
           "badge": "community"
         },
         {
-          "name": "@swimlane/cy-dom-diff",
-          "description": "cy-dom-diff allows matching chunks of DOM against HTML; including dynamic content.",
-          "link": "https://github.com/swimlane/cy-dom-diff",
-          "keywords": ["dom", "assertions", "html", "snapshot"],
-          "badge": "community"
-        },
-        {
           "name": "cy-spok",
           "description": "Adds assertions from Spok library for easy schema and value validations.",
           "link": "https://github.com/bahmutov/cy-spok",


### PR DESCRIPTION
## Summary

Removes the `@swimlane/cy-dom-diff` plugin from the plugins directory (its source repository is archived), and updates the `update-plugins-data` automation so nightly plugin-data PRs request review from @jennifer-shehane.

## Why

The nightly plugins-data refresh (#6676) flagged `@swimlane/cy-dom-diff` as archived/deprecated — its GitHub repository is archived and its last npm publish was in 2021 — so it's being removed from the curated list rather than shown with a deprecation notice. The same refresh surfaced that nobody is automatically asked to review these nightly PRs, so:

- The `peter-evans/create-pull-request` step in `.github/workflows/update-plugins-data.yml` now sets `reviewers: jennifer-shehane`.
- A new `.github/CODEOWNERS` makes @jennifer-shehane the code owner of `src/data/plugins.json`, `src/data/plugins-generated.json`, and the workflow file, so review is also auto-requested on any PR touching those files.

This PR also carries the nightly data refresh from #6676 (the `@cypress/vite-dev-server` 7.3.4 bump), so it supersedes that PR — #6676 can be closed once this merges (the automation will also close it on its next run when it finds no remaining diff).

## Notes for reviewers

- `src/data/plugins-generated.json` is normally machine-generated; the plugin's entry was removed by hand here to match the curated-list removal, and the next nightly `enrich:plugins` run will produce the same result since the plugin is gone from the source list.
- Both JSON files were validated to parse, and no other files reference `cy-dom-diff`.
- The `reviewers` input and the CODEOWNERS entry are intentionally redundant: the former covers the nightly PR directly, the latter also covers manual edits to the plugins data files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018QX6HaXg5bAj3pKJKZP1nj

---
_Generated by [Claude Code](https://claude.ai/code/session_018QX6HaXg5bAj3pKJKZP1nj)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to static plugin catalog data and GitHub review routing; no runtime or security-sensitive application logic.
> 
> **Overview**
> Drops **@swimlane/cy-dom-diff** from the curated plugins list and generated metadata because its repo is archived, and routes plugin-data changes to a designated reviewer.
> 
> **Review automation:** Adds `.github/CODEOWNERS` for `plugins.json`, `plugins-generated.json`, and `update-plugins-data.yml`, and sets `reviewers: jennifer-shehane` on the nightly `create-pull-request` step so automated and manual edits to those files request review.
> 
> **Data refresh:** Updates `@cypress/vite-dev-server` to **7.3.4** in `plugins-generated.json` (nightly enrich output bundled in this PR).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65ede32aadcbeb0176bb124374f12d3ed00c906f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->