### PR TITLE
Update npm approve-scripts example for npm@12.0.0

### DIFF
--- a/docs/app/get-started/install-cypress.mdx
+++ b/docs/app/get-started/install-cypress.mdx
@@ -77,17 +77,26 @@ Cypress is installed using one of the following supported package managers:
 
 #### npm configuration
 
-npm runs Cypress' `postinstall` script on install by default, which downloads the Cypress binary into the [binary cache](/app/references/advanced-installation#Binary-cache).
+Cypress uses a `postinstall` script to download the Cypress binary into the [binary cache](/app/references/advanced-installation#Binary-cache).
+This method is affected by hardening changes introduced into npm.
 
-Starting in npm version 12, npm blocks dependency install scripts (`preinstall`, `install`, and `postinstall`) by default. When install scripts are blocked, npm skips Cypress' `postinstall` script and the Cypress binary is not downloaded. To allow Cypress to run its `postinstall` script, use one of the following approaches.
+Starting in npm 11.16.0, a warning is issued, then starting in npm 12.0.0, npm blocks `postinstall` lifecycle scripts by default.
+When install scripts are blocked, npm skips Cypress' `postinstall` script and the Cypress binary is not downloaded.
+To allow Cypress to run its `postinstall` script, use one of the following approaches.
 
-Allowlist `cypress` so npm runs its `postinstall` script on install. You can use the CLI:
+After installing Cypress, you can use the `npm install-scripts` CLI command to add `cypress` to the `allowScripts` list so npm runs the `postinstall` script on install.
+Use the `--no-allow-scripts-pin` option if you want to allow also future versions of Cypress, or omit if not.
+`npm rebuild` re-runs the installation to install the Cypress binary after its installation has been allowed.
 
 ```shell
-npm approve-scripts cypress
+npm install cypress --save-dev
+npm install-scripts approve cypress --no-allow-scripts-pin
+npm rebuild cypress
 ```
 
-Or add `cypress` to `allowScripts` in `package.json` manually:
+In npm v11 >=11.16.0 warnings are issued. Check the warning prompt for the recommended CLI command.
+
+For all npm versions >=11.16.0 you can add `cypress` to `allowScripts` in `package.json` manually instead of using a CLI command:
 
 ```json title="package.json"
 {
@@ -97,7 +106,7 @@ Or add `cypress` to `allowScripts` in `package.json` manually:
 }
 ```
 
-Alternatively, if you'd rather not modify your allowlist, install the Cypress binary explicitly after install completes:
+Alternatively, if you'd rather not modify your `allowScripts` list, install the Cypress binary explicitly after install completes:
 
 ```shell
 npx cypress install


### PR DESCRIPTION
## Summary

Extend the npm installation instructions in [Package Manager](https://docs.cypress.io/app/get-started/install-cypress#Package-Manager) to:

```shell
npm install cypress --save-dev
npm install-scripts approve cypress --no-allow-scripts-pin
npm rebuild cypress
```

and reword the description, taking account of progressive changes which started with npm@11.16.0.

## Why

The instructions in [Package Manager](https://docs.cypress.io/app/get-started/install-cypress#Package-Manager) for `approve-script` with npm are incomplete.

```shell
npm approve-script cypress
```

is only available after `cypress` has already been installed. Executing this command only prepares npm for the next installation, and if not followed by other commands, it will leave the Cypress binary uninstalled.

The text also does not mention that `npm@11.16.0` introduced a related warning.

## Notes for reviewers

[npm@12.0.0](https://github.com/npm/cli/releases/tag/v12.0.0) was released on Jul 8, 2026

### Verification

Ubuntu 26.04 LTS, Node.js 26.5.0 LTS

```shell
npm install npm@12 -g
cd $(mktemp -d)
rm -rf ~/.cache/Cypress
npm install cypress --save-dev
npm install-scripts approve cypress --no-allow-scripts-pin
npm rebuild cypress
npx cypress verify
```

## Approve commands

| npm       | Command                                                      |
| --------- | ------------------------------------------------------------ |
| >=11.15.0 | no `scripts` command available                               |
| 11.16.0   | `npm approve-scripts cypress --no-allow-scripts-pin`         |
| 11.17.0   | `npm approve-scripts cypress --no-allow-scripts-pin`         |
| 11.18.0   | `npm install-scripts approve cypress --no-allow-scripts-pin` |
| 12.0.0    | `npm install-scripts approve cypress --no-allow-scripts-pin` |

Note that approval is only possible if cypress is already installed, otherwise the error is:

```console
npm error code ENOMATCH
npm error No installed packages match: cypress
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to installation instructions with no runtime or application code impact.
> 
> **Overview**
> Updates the **npm configuration** section in `install-cypress.mdx` so Cypress installs correctly when npm blocks `postinstall` scripts.
> 
> The doc now explains the **npm 11.16.0 warning** and **npm 12.0.0 default block** on lifecycle scripts, and replaces the standalone `npm approve-scripts cypress` example with a complete sequence: `npm install cypress --save-dev`, then `npm install-scripts approve cypress --no-allow-scripts-pin`, then `npm rebuild cypress` so the binary actually downloads after approval.
> 
> It also clarifies **`--no-allow-scripts-pin`**, points npm 11.16+ users at warning text for the right CLI, and rewords the manual `allowScripts` and `npx cypress install` alternatives.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 519e86ebe984f2bef60140f06b5144e2cab246ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->