### PR TITLE
docs: add Yarn Modern postinstall configuration instructions

### DIFF
--- a/docs/app/get-started/install-cypress.mdx
+++ b/docs/app/get-started/install-cypress.mdx
@@ -103,10 +103,29 @@ Alternatively, if you'd rather not modify your allowlist, install the Cypress bi
 npx cypress install
 ```
 
-#### Yarn users
+#### Yarn configuration
 
 [Yarn (Modern)](https://yarnpkg.com/) configuration using [nodeLinker: "node-modules"](https://yarnpkg.com/configuration/yarnrc#nodeLinker)
 is preferred. Cypress [Component Testing](/app/core-concepts/testing-types#What-is-Component-Testing) is not currently compatible with the default setting [nodeLinker: "pnp"](https://yarnpkg.com/configuration/yarnrc#nodeLinker) which uses [Yarn Plug'n'Play](https://yarnpkg.com/features/pnp).
+
+Starting in Yarn Modern version 4.14.0, the [enableScripts](https://yarnpkg.com/configuration/yarnrc#enableScripts) configuration option is set to `false` by default, which blocks dependency lifecycle scripts. When scripts are blocked, Yarn skips Cypress' `postinstall` script and the Cypress binary is not downloaded into the [binary cache](/app/references/advanced-installation#Binary-cache).
+
+To allow Cypress to run its `postinstall` script, set `enableScripts` to `true` and add `cypress` to the [npmPreapprovedPackages](https://yarnpkg.com/configuration/yarnrc#npmPreapprovedPackages) list (available in Yarn Modern >=4.10.0) in your project's `.yarnrc.yml` file:
+
+```yaml title=".yarnrc.yml"
+enableScripts: true
+
+npmPreapprovedPackages:
+  - cypress
+```
+
+`enableScripts` can also be set using the CLI:
+
+```shell
+yarn config set enableScripts true
+```
+
+Setting the list of `npmPreapprovedPackages` is less convenient via the CLI and is easier done by editing `.yarnrc.yml` directly.
 
 #### pnpm configuration
 


### PR DESCRIPTION
## Summary

Adds Yarn Modern configuration instructions to the Install Cypress page, documenting the `.yarnrc.yml` settings (`enableScripts: true` and `cypress` in `npmPreapprovedPackages`) needed to allow Cypress' `postinstall` script to download the Cypress binary.

## Why

The [Package Manager](https://docs.cypress.io/app/get-started/install-cypress#Package-Manager) section already covers `postinstall` script configuration for npm, pnpm, and Bun, but not for Yarn Modern. Yarn Modern >=4.14.0 sets [`enableScripts`](https://yarnpkg.com/configuration/yarnrc#enableScripts) to `false` by default, which blocks Cypress' `postinstall` script so the Cypress binary is never downloaded.

Closes #6688

## Notes for reviewers

- The existing `#### Yarn users` heading was renamed to `#### Yarn configuration` for consistency with the neighboring "npm configuration", "pnpm configuration", and "Bun configuration" headings. No other page links to the old anchor.
- The existing `nodeLinker` / Plug'n'Play guidance in that section is unchanged; the new content is appended after it.
- The recommended settings and version numbers (`enableScripts` default change in 4.14.0, `npmPreapprovedPackages` available since 4.10.0) come directly from the issue and the linked Yarn documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GQ6rLsSAnS4cHnb8VkTbHu

---
_Generated by [Claude Code](https://claude.ai/code/session_01GQ6rLsSAnS4cHnb8VkTbHu)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to install instructions; no runtime or security-sensitive code paths.
> 
> **Overview**
> Aligns **Yarn Modern** install guidance with npm, pnpm, and Bun by documenting how to let Cypress' **`postinstall`** script run when Yarn **≥4.14.0** defaults **`enableScripts`** to `false`.
> 
> The new content explains that blocked lifecycle scripts skip binary download into the **binary cache**, and recommends **`enableScripts: true`** plus listing **`cypress`** under **`npmPreapprovedPackages`** in **`.yarnrc.yml`** (with a CLI example for `enableScripts` only). Existing **nodeLinker** / Plug'n'Play notes are unchanged.
> 
> The section heading is renamed from **`#### Yarn users`** to **`#### Yarn configuration`** for consistency with neighboring package-manager sections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7cd207c8779af9a1b234529597de8e7aa83772b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->