### PR TITLE
Speed up page_titles spec by checking SSR titles via cy.request

### DIFF
--- a/cypress/e2e/page_titles.cy.ts
+++ b/cypress/e2e/page_titles.cy.ts
@@ -16,11 +16,6 @@ function selectUrls(urls: string[]): string[] {
   })
 }
 
-// The suffix is server-rendered into the static HTML (see src/sectionTitles.js
-// and src/theme/DocItem/Metadata), so instead of a full cy.visit per page —
-// which loads and hydrates the whole app — we cy.request each page and read
-// the <title> straight out of the response body. Pages are checked in
-// per-section batches, and every failing page in a batch is reported at once.
 const PAGES_PER_TEST = 50
 
 function titleFromHtml(html: string): string {
@@ -79,9 +74,6 @@ describe('Page titles have the correct appended suffix', () => {
   })
 })
 
-// The suffix is applied by a React component (src/theme/DocItem/Metadata), so
-// also spot-check the *hydrated* document.title with a real visit — one page
-// per distinct suffix — in case hydration ever diverges from the SSR HTML.
 describe('Page titles survive hydration (one page per suffix)', () => {
   const samples: Record<string, string> = {}
   URLs.forEach((url) => {

--- a/cypress/e2e/page_titles.cy.ts
+++ b/cypress/e2e/page_titles.cy.ts
@@ -16,19 +16,86 @@ function selectUrls(urls: string[]): string[] {
   })
 }
 
+// The suffix is server-rendered into the static HTML (see src/sectionTitles.js
+// and src/theme/DocItem/Metadata), so instead of a full cy.visit per page —
+// which loads and hydrates the whole app — we cy.request each page and read
+// the <title> straight out of the response body. Pages are checked in
+// per-section batches, and every failing page in a batch is reported at once.
+const PAGES_PER_TEST = 50
+
+function titleFromHtml(html: string): string {
+  const match = html.match(/<title[^>]*>([^<]*)<\/title>/)
+  return match ? match[1].trim() : ''
+}
+
 // Every page title must end with " | <site or section suffix>":
 //   accessibility/*  -> " | Cypress Accessibility Documentation"
 //   ui-coverage/*    -> " | Cypress UI Coverage Documentation"
 //   everything else  -> " | Cypress Documentation"
 describe('Page titles have the correct appended suffix', () => {
-  selectUrls(URLs).forEach((URL) => {
+  const urlsBySection: Record<string, string[]> = {}
+  selectUrls(URLs).forEach((url) => {
+    const section = url.split('/')[0]
+    ;(urlsBySection[section] = urlsBySection[section] || []).push(url)
+  })
+
+  Object.entries(urlsBySection).forEach(([section, urls]) => {
+    const batches: string[][] = []
+    for (let i = 0; i < urls.length; i += PAGES_PER_TEST) {
+      batches.push(urls.slice(i, i + PAGES_PER_TEST))
+    }
+
+    batches.forEach((batch, i) => {
+      const name =
+        batches.length > 1
+          ? `${section} (${i + 1}/${batches.length}, ${batch.length} pages)`
+          : `${section} (${batch.length} pages)`
+
+      it(name, () => {
+        const failures: string[] = []
+
+        batch.forEach((URL) => {
+          const expectedSuffix = ` | ${sectionTitles.titleSuffixForUrl(URL)}`
+          cy.request({ url: URL, log: false }).then((response) => {
+            const title = titleFromHtml(response.body)
+            if (!title.endsWith(expectedSuffix)) {
+              failures.push(
+                `${URL}: title "${title}" should end with "${expectedSuffix}"`
+              )
+            }
+          })
+        })
+
+        cy.then(() => {
+          expect(
+            failures.length,
+            failures.length
+              ? `${failures.length} page(s) with a bad title:\n${failures.join('\n')}`
+              : 'all titles correct'
+          ).to.eq(0)
+        })
+      })
+    })
+  })
+})
+
+// The suffix is applied by a React component (src/theme/DocItem/Metadata), so
+// also spot-check the *hydrated* document.title with a real visit — one page
+// per distinct suffix — in case hydration ever diverges from the SSR HTML.
+describe('Page titles survive hydration (one page per suffix)', () => {
+  const samples: Record<string, string> = {}
+  URLs.forEach((url) => {
+    const suffix = sectionTitles.titleSuffixForUrl(url)
+    if (!samples[suffix]) samples[suffix] = url
+  })
+
+  Object.entries(samples).forEach(([suffix, URL]) => {
     it(`${URL}`, () => {
-      const expectedSuffix = ` | ${sectionTitles.titleSuffixForUrl(URL)}`
       cy.visit(URL)
       cy.title().should((title) => {
         expect(
-          title.endsWith(expectedSuffix),
-          `title "${title}" should end with "${expectedSuffix}"`
+          title.endsWith(` | ${suffix}`),
+          `title "${title}" should end with " | ${suffix}"`
         ).to.eq(true)
       })
     })


### PR DESCRIPTION
## Summary

Rewrites `cypress/e2e/page_titles.cy.ts` to check page-title suffixes by reading the `<title>` tag from the server-rendered HTML via `cy.request` (batched 50 pages per test, grouped by section) instead of doing a full `cy.visit` per page. The full ~317-page sweep now runs in ~15 seconds locally instead of several minutes.

## Why

`page_titles.cy.ts` generated one `cy.visit`-based test per docs page. Because it is a single spec file, Cypress Cloud load balancing can't split it across the 8 parallel CI machines, so one machine ran the entire spec and it became the long pole of every CI run.

The title suffix is server-rendered into the static HTML by the swizzled `src/theme/DocItem/Metadata` component, so the assertion doesn't need a browser page load or React hydration — reading the `<title>` out of the response body checks the same thing at a fraction of the cost.

## Notes for reviewers

- **Failure reporting got better, not worse:** each batch collects every mismatching page before asserting, so a single run reports all bad pages with actual vs. expected titles (verified by temporarily sabotaging the accessibility suffix — only the `accessibility (31 pages)` batch failed, listing the pages).
- **Hydration coverage is kept via sampling:** a second describe still does a real `cy.visit` + `cy.title()` check for one page per distinct suffix (5 pages), in case the hydrated `document.title` ever diverges from the SSR HTML. The trade-off: a page whose title only breaks after hydration would no longer be caught exhaustively — but the suffix logic lives in one shared component, so sampling seems safe.
- The `limitPerSection` env option and `npm run test:titles` workflow are unchanged and still work.
- Verified locally against a fresh production build: 13 tests / 317 pages, all passing in 15s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018uM2NvbqB8EkWpYjBixLSC

---
_Generated by [Claude Code](https://claude.ai/code/session_018uM2NvbqB8EkWpYjBixLSC)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to Cypress e2e; production title logic is unchanged, with a small trade-off that post-hydration-only title bugs would only be caught on sampled pages.
> 
> **Overview**
> **Rewrites the bulk page-title check** so it no longer does a full `cy.visit` for every docs URL. URLs are grouped by top-level section, split into batches of 50, and each batch is one test that `cy.request`s each page and asserts the `<title>` suffix via a small `titleFromHtml` helper—same suffix rules as before, much faster and easier to parallelize in CI.
> 
> **Improves failure output** by collecting every bad page in a batch before a single assertion, so one run lists all mismatches with actual vs expected titles.
> 
> **Adds a separate hydration smoke suite** that still `cy.visit`s one representative URL per distinct title suffix (via `titleSuffixForUrl`), so client-side `document.title` is spot-checked without visiting hundreds of pages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af1beb2d8fa003925a54643d2a0a4b6fc8ae1c0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->