### PR TITLE
Rewrite UI Coverage elements config doc for accuracy, value, and clarity

### DIFF
--- a/docs/ui-coverage/configuration/elements.mdx
+++ b/docs/ui-coverage/configuration/elements.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'elements: assign a stable identity and name to an element'
-description: 'The elements configuration in Cypress UI Coverage gives a single element a stable identity and a readable name, so reports stay accurate when attributes change between snapshots.'
+title: 'elements: rename and stabilize element identity in UI Coverage'
+description: 'Rename elements and give them a stable identity in Cypress UI Coverage reports, so dynamic attributes do not create duplicate untested elements.'
 sidebar_label: elements
 sidebar_position: 70
 ---
@@ -9,7 +9,14 @@ sidebar_position: 70
 
 # elements
 
-The `elements` configuration pins down the identity of a single element in your UI Coverage report. When an element's attributes change between snapshots, such as a generated `id` or a rotating class name, UI Coverage can see each variation as a different element, so one dropdown appears as several untested elements and drags down your score. An `elements` rule identifies that element by a selector you choose, so it counts once, and can display it under a readable name like "Help Popover" instead of a machine-generated selector.
+The `elements` configuration assigns a stable identity and a display name to a single element in your UI Coverage report. When an element's attributes change between snapshots, such as a generated `id` or a rotating class name, UI Coverage can see each variation as a different element. One dropdown then appears as several untested elements and drags down your score. An `elements` rule identifies that element by a selector you choose, so it counts once, and renames it to something readable like "Help Popover" instead of a machine-generated selector.
+
+Without stable identities and names, a report can list controls under machine-generated selectors that are hard to recognize and act on:
+
+<DocsImage
+  src="/img/ui-coverage/guides/cypress-ui-coverage-untested-elements-expanded.png"
+  alt="The UI Coverage report listing untested elements, several of which appear under machine-generated names derived from their DOM structure"
+/>
 
 ## Why use elements?
 
@@ -17,9 +24,9 @@ UI Coverage already [identifies elements automatically](/ui-coverage/core-concep
 
 - **Stabilize dynamic attributes**: Identify an element by a selector that stays the same across snapshots, even when its `id` or other attributes are regenerated on every render.
 - **Ensure unique identification**: Give an element that lacks stable, unique attributes an explicit identity so it isn't confused with other elements or duplicated in reports.
-- **Make reports readable**: Display a human-readable name in place of a machine-generated selector, so anyone reading the report understands what needs testing.
+- **Rename elements in reports**: Display a human-readable name in place of a machine-generated selector, so anyone reading the report understands what needs testing.
 
-Each `elements` rule targets exactly one element. If your goal is different, such as combining repeated elements so they count as one, or removing elements from reports entirely, see [Which option do I need?](/ui-coverage/configuration/overview#Which-option-do-I-need) in the configuration overview.
+If your goal is different, such as combining repeated elements so they count as one, or removing elements from reports entirely, see [Which option do I need?](/ui-coverage/configuration/overview#Which-option-do-I-need) in the configuration overview.
 
 ## Setting elements
 
@@ -66,6 +73,8 @@ In each snapshot captured by your tests, every rule is evaluated independently:
 - **Rules match in any document unless scoped.** A rule without `documentScope` can match elements in the main document, in iframes, and in shadow DOMs. Add `documentScope` to restrict a rule to one of those documents, for example when the same selector appears both inside and outside an iframe.
 - **Later rules take precedence.** When more than one rule matches the same element, the last matching rule in the list determines its identity and name.
 - **Filtered elements are never matched.** Elements excluded from reports by [`elementFilters`](/ui-coverage/configuration/elementfilters) are not considered, and don't count toward a rule's one-match limit.
+
+If a rule doesn't seem to take effect, see [Why isn't my elements rule applying?](/ui-coverage/faq#Why-isnt-my-elements-rule-applying) in the UI Coverage FAQ.
 
 ### Validation rules
 
@@ -129,6 +138,8 @@ With the rule, it appears once, displayed under the rule's selector because no `
 #my-form [id^='dropdown']
 ```
 
+An `elements` rule is the right tool when one specific element needs a stable identity. If many elements share the same generated attribute, fix the attribute instead: an [`attributeFilters`](/ui-coverage/configuration/attributefilters) rule stops it from identifying any element.
+
 ---
 
 ### Give an element a readable name
@@ -166,9 +177,9 @@ Help Popover
 
 ---
 
-### Identify an element inside a shadow DOM
+### Identify an element inside a shadow DOM or iframe
 
-Use `documentScope` to identify an element inside a specific shadow DOM host. Here, the button inside the `<custom-component>` shadow root shares its `id` with a button in the main document. The scope restricts the rule to the shadow DOM, so the rule matches exactly one element and applies. Without `documentScope`, the rule would match both buttons and be skipped.
+Use `documentScope` to identify an element inside a specific shadow DOM host or iframe. Here, the button inside the `<custom-component>` shadow root shares its `id` with a button in the main document. The scope restricts the rule to the shadow DOM, so the rule matches exactly one element and applies. Without `documentScope`, the rule would match both buttons and be skipped.
 
 #### Config
 
@@ -207,13 +218,7 @@ Custom Component Button
 
 The button inside the shadow DOM appears under its configured name, while the button in the main document keeps its default identity.
 
----
-
-### Identify an element inside an iframe
-
-`documentScope` works the same way for embedded content that renders inside an iframe. The scope selector matches the `iframe` element itself in its parent document. Here, only the submit button inside the `#embedded-form` iframe is identified by the rule.
-
-#### Config
+`documentScope` works the same way for embedded content that renders inside an iframe. The scope selector matches the `iframe` element itself in its parent document:
 
 ```json title="App Quality Config"
 {
@@ -229,29 +234,7 @@ The button inside the shadow DOM appears under its configured name, while the bu
 }
 ```
 
-#### HTML
-
-```xml
-<body>
-  <button id="submit">Submit (Root)</button>
-  <iframe id="embedded-form" src="https://forms.example.com">
-    <html>
-      <body>
-        <button id="submit">Submit (Embedded)</button>
-      </body>
-    </html>
-  </iframe>
-</body>
-```
-
-#### Elements shown in UI
-
-```
-#submit
-Embedded Form Submit
-```
-
-For nested documents, list one selector per host from outermost to innermost, for example `"documentScope": ["#embedded-form", "secure-input"]`.
+For nested documents, list one selector per host from outermost to innermost, for example `"documentScope": ["#embedded-form", "secure-card-input"]`.
 
 :::tip
 

--- a/docs/ui-coverage/configuration/elements.mdx
+++ b/docs/ui-coverage/configuration/elements.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'elements: identify elements with custom logic'
-description: 'The elements configuration allows you to uniquely identify elements in UI Coverage using custom logic.'
+title: 'elements: assign a stable identity and name to an element'
+description: 'The elements configuration in Cypress UI Coverage gives a single element a stable identity and a readable name, so reports stay accurate when attributes change between snapshots.'
 sidebar_label: elements
 sidebar_position: 70
 ---
@@ -9,15 +9,26 @@ sidebar_position: 70
 
 # elements
 
-UI Coverage provides automatic logic to [identify](/ui-coverage/core-concepts/element-identification) elements based on their DOM structure. However, in complex applications, elements may lack stable identifiers or have dynamic attributes that vary across snapshots, leading to incorrect identification. The `elements` configuration allows you to specify selectors to uniquely identify elements, ensuring consistency across snapshots and simplifying your coverage reports.
+The `elements` configuration pins down the identity of a single element in your UI Coverage report. When an element's attributes change between snapshots, such as a generated `id` or a rotating class name, UI Coverage can see each variation as a different element, so one dropdown appears as several untested elements and drags down your score. An `elements` rule identifies that element by a selector you choose, so it counts once, and can display it under a readable name like "Help Popover" instead of a machine-generated selector.
 
-The `elements` configuration is used as the element's identity if **only one element** per snapshot matches. If there are multiple matches in the same snapshot, this configuration is ignored and the default [identify](/ui-coverage/core-concepts/element-identification) strategy is used.
+## Why use elements?
 
-## Why use elements configuration?
+UI Coverage already [identifies elements automatically](/ui-coverage/core-concepts/element-identification) using significant attributes, location, and other DOM signals. Use `elements` when the automatic identity for a specific element isn't stable or isn't readable:
 
-- **Handle Dynamic Attributes**: Ensure elements are consistently identified across snapshots, even when attributes change.
-- **Ensure Unique Identification**: Use custom selectors to uniquely identify elements across snapshots that lack unique attributes or have dynamic values, avoiding misclassification.
-- **Simplify Debugging**: Assign human-readable names to elements to make reports more interpretable and debugging easier.
+- **Stabilize dynamic attributes**: Identify an element by a selector that stays the same across snapshots, even when its `id` or other attributes are regenerated on every render.
+- **Ensure unique identification**: Give an element that lacks stable, unique attributes an explicit identity so it isn't confused with other elements or duplicated in reports.
+- **Make reports readable**: Display a human-readable name in place of a machine-generated selector, so anyone reading the report understands what needs testing.
+
+Each `elements` rule targets exactly one element. If your goal is different, such as combining repeated elements so they count as one, or removing elements from reports entirely, see [Which option do I need?](/ui-coverage/configuration/overview#Which-option-do-I-need) in the configuration overview.
+
+## Setting elements
+
+To add or edit `elements`, open the **App Quality** tab in your project settings in Cypress Cloud. See [Setting configuration](/ui-coverage/configuration/overview#Setting-configuration) for details, including how to regenerate past reports with a new configuration without rerunning your tests.
+
+<DocsImage
+  src="/img/ui-coverage/configuration/cypress-ui-coverage-configuration-editor.png"
+  alt="The App Quality tab of a project's settings in Cypress Cloud, showing the configuration editor with JSON configuration"
+/>
 
 ## Syntax
 
@@ -38,24 +49,42 @@ The `elements` configuration is used as the element's identity if **only one ele
 
 ### Options
 
-For every element considered by UI Coverage, the first applicable rule, determined by a match with the `selector` property, is used for identification. Elements that do not match any rules are identified by the default UI Coverage [element identification rules](/ui-coverage/core-concepts/element-identification).
+| Option          | Required | Default    | Description                                                                                                                                                                                                                                                                                    |
+| --------------- | -------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `selector`      | Required |            | A CSS selector that identifies the element. Supports standard CSS selector syntax, including IDs, classes, attributes, combinators, and functional pseudo-classes like `:has()`. The rule applies only when exactly one interactive element matches.                                           |
+| `name`          | Optional | `selector` | A human-readable name for the element, displayed in UI Coverage reports in place of the selector. Each rule's name must be unique.                                                                                                                                                             |
+| `documentScope` | Optional |            | An ordered array of CSS selectors that match document hosts (iframes or shadow DOM hosts) in the element's ancestor chain, from outermost to innermost. Use this to identify an element inside a specific iframe or shadow DOM. Hosts that aren't listed may appear between the ones that are. |
+| `comment`       | Optional |            | A note about why this rule exists, for your team's benefit. Comments have no effect on how elements are identified.                                                                                                                                                                            |
 
-If multiple elements within the same snapshot satisfy the same rule, the rule cannot uniquely identify these elements. In such cases, the rule is bypassed, and either subsequent rules or the default element identification logic are applied.
+### How are elements rules applied?
 
-| Option          | Required | Default    | Description                                                                                                                                                                                                                                 |
-| --------------- | -------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `selector`      | Required |            | A CSS selector to identify elements. Supports standard CSS selector syntax, including IDs, classes, attributes, and combinators.                                                                                                            |
-| `name`          | Optional | `selector` | A human-readable name for the element, displayed in UI Coverage reports.                                                                                                                                                                    |
-| `documentScope` | Optional |            | An array of CSS selectors that identify document hosts (iframes or shadow DOM hosts) that must be ancestors of the matched element. The selector will only match if all specified document hosts are found in the element's ancestor chain. |
-| `comment`       | Optional |            | A comment describing the purpose of this element configuration.                                                                                                                                                                             |
+In each snapshot captured by your tests, every rule is evaluated independently:
+
+- **A rule applies only when it matches exactly one element.** The `selector` can match any number of DOM nodes, but it must match exactly one of the [interactive elements](/ui-coverage/core-concepts/interactivity) that UI Coverage tracks in that snapshot. When it matches more than one, the rule is skipped and those elements keep their default identity. To give multiple elements a shared identity, use [`elementGroups`](/ui-coverage/configuration/elementgroups) instead.
+- **Matching is evaluated per snapshot.** A rule can apply in one snapshot and be skipped in another where its selector matches several elements at once.
+- **A matched element is identified by the rule's `selector` alone.** Its identity no longer depends on its attributes, structure, or the default [element identification rules](/ui-coverage/core-concepts/element-identification), so it stays one element across snapshots even as dynamic attributes change. The report displays the rule's `name`, or its `selector` when no name is given. This includes links, which are otherwise displayed by their URL.
+- **Rules match in any document unless scoped.** A rule without `documentScope` can match elements in the main document, in iframes, and in shadow DOMs. Add `documentScope` to restrict a rule to one of those documents, for example when the same selector appears both inside and outside an iframe.
+- **Later rules take precedence.** When more than one rule matches the same element, the last matching rule in the list determines its identity and name.
+- **Filtered elements are never matched.** Elements excluded from reports by [`elementFilters`](/ui-coverage/configuration/elementfilters) are not considered, and don't count toward a rule's one-match limit.
+
+### Validation rules
+
+Cypress Cloud rejects a configuration when:
+
+- Two rules have the same `selector` (with the same `documentScope`).
+- Two rules have the same `name`, or one rule's `name` matches another rule's `selector`. Elements are identified by these values, so they must be unique.
+- A `selector` or `documentScope` entry isn't valid CSS selector syntax.
+- A rule contains a property other than the four listed above.
 
 ## Examples
 
-### Identify elements by dynamic selector across snapshots
+### Stabilize an element with a dynamic ID
+
+This form's dropdown gets a newly generated `id` on every page load, so each snapshot produces what looks like a new element. A rule with an attribute prefix selector identifies it as one element across snapshots.
 
 #### Config
 
-```json
+```json title="App Quality Config"
 {
   "uiCoverage": {
     "elements": [
@@ -73,31 +102,42 @@ If multiple elements within the same snapshot satisfy the same rule, the rule ca
 <!-- Snapshot 1 -->
 <body>
   <form id="my-form">
-    <input id="dropdown-142"></input>
+    <input id="dropdown-142" />
   </form>
 </body>
 
 <!-- Snapshot 2 -->
 <body>
   <form id="my-form">
-    <input id="dropdown-980"></input>
+    <input id="dropdown-980" />
   </form>
 </body>
 ```
 
-#### Elements shown in UI Coverage
+#### Elements shown in UI
+
+Without the rule, the dropdown can appear as two untested elements:
 
 ```
-#my-form [id^="dropdown"]
+#dropdown-142
+#dropdown-980
+```
+
+With the rule, it appears once, displayed under the rule's selector because no `name` is given:
+
+```
+#my-form [id^='dropdown']
 ```
 
 ---
 
-### Identify elements with human-readable names
+### Give an element a readable name
+
+Add a `name` so the report describes the interface instead of your selectors.
 
 #### Config
 
-```json
+```json title="App Quality Config"
 {
   "uiCoverage": {
     "elements": [
@@ -118,7 +158,7 @@ If multiple elements within the same snapshot satisfy the same rule, the rule ca
 </body>
 ```
 
-#### Elements shown in UI Coverage
+#### Elements shown in UI
 
 ```
 Help Popover
@@ -126,13 +166,13 @@ Help Popover
 
 ---
 
-### Scoping element identification to shadow DOM
+### Identify an element inside a shadow DOM
 
-When you need to uniquely identify elements within a specific shadow DOM host, use the `documentScope` property to scope your selector to that document context.
+Use `documentScope` to identify an element inside a specific shadow DOM host. Here, the button inside the `<custom-component>` shadow root shares its `id` with a button in the main document. The scope restricts the rule to the shadow DOM, so the rule matches exactly one element and applies. Without `documentScope`, the rule would match both buttons and be skipped.
 
 #### Config
 
-```json
+```json title="App Quality Config"
 {
   "uiCoverage": {
     "elements": [
@@ -158,24 +198,24 @@ When you need to uniquely identify elements within a specific shadow DOM host, u
 </body>
 ```
 
-#### Elements shown in UI Coverage
+#### Elements shown in UI
 
 ```
-#my-button (from root document)
-Custom Component Button (from shadow DOM)
+#my-button
+Custom Component Button
 ```
 
-Only the button inside the shadow DOM is identified using the custom name, while the button in the root document uses the default identification.
+The button inside the shadow DOM appears under its configured name, while the button in the main document keeps its default identity.
 
 ---
 
-### Scoping element identification to iframes
+### Identify an element inside an iframe
 
-You can also scope element identification to elements within specific iframes using `documentScope`.
+`documentScope` works the same way for embedded content that renders inside an iframe. The scope selector matches the `iframe` element itself in its parent document. Here, only the submit button inside the `#embedded-form` iframe is identified by the rule.
 
 #### Config
 
-```json
+```json title="App Quality Config"
 {
   "uiCoverage": {
     "elements": [
@@ -194,7 +234,7 @@ You can also scope element identification to elements within specific iframes us
 ```xml
 <body>
   <button id="submit">Submit (Root)</button>
-  <iframe id="embedded-form" src="http://www.foo.com">
+  <iframe id="embedded-form" src="https://forms.example.com">
     <html>
       <body>
         <button id="submit">Submit (Embedded)</button>
@@ -204,11 +244,26 @@ You can also scope element identification to elements within specific iframes us
 </body>
 ```
 
-#### Elements shown in UI Coverage
+#### Elements shown in UI
 
 ```
-#submit (from root document)
-Embedded Form Submit (from iframe)
+#submit
+Embedded Form Submit
 ```
 
-Only the button inside the iframe is identified using the custom name.
+For nested documents, list one selector per host from outermost to innermost, for example `"documentScope": ["#embedded-form", "secure-input"]`.
+
+:::tip
+
+After saving configuration changes, regenerate a recent run to preview the effect of your rules without rerunning your tests. See [Setting configuration](/ui-coverage/configuration/overview#Setting-configuration) for how to regenerate a report.
+
+:::
+
+## See also
+
+- [Element Identification](/ui-coverage/core-concepts/element-identification) explains the automatic identification rules that apply when no `elements` rule matches.
+- [`elementGroups`](/ui-coverage/configuration/elementgroups) combines multiple related elements into a single named group rather than identifying one element.
+- [`attributeFilters`](/ui-coverage/configuration/attributefilters) stops dynamic attributes from being used for identification across all elements, instead of targeting one element.
+- [`elementFilters`](/ui-coverage/configuration/elementfilters) removes elements from reports entirely.
+- [Configuration overview](/ui-coverage/configuration/overview) covers where configuration lives and how to regenerate reports after changing it.
+- [UI Coverage FAQ](/ui-coverage/faq) answers common questions about identity, scores, and configuration.

--- a/docs/ui-coverage/configuration/elements.mdx
+++ b/docs/ui-coverage/configuration/elements.mdx
@@ -11,7 +11,7 @@ sidebar_position: 70
 
 The `elements` configuration assigns a stable identity and a display name to a single element in your UI Coverage report.
 
-As your tests run, UI Coverage captures snapshots of your application's DOM, and the same element usually appears in many of them: on every page load, in every test that visits its page. To count that element once, UI Coverage must recognize it as the same element in every snapshot. When one of its attributes is different on each appearance, such as an `id` generated on every page load, that recognition fails, and each appearance is reported as a new element. One dropdown then shows up as several untested elements and drags down your score.
+As your tests run, UI Coverage captures [snapshots](/ui-coverage/core-concepts/element-identification#Snapshots) of your application's DOM, and the same element usually appears in many of them: on every page load, in every test that visits its page. To count that element once, UI Coverage must recognize it as the same element in every snapshot. When one of its attributes is different on each appearance, such as an `id` generated on every page load, that recognition fails, and each appearance is reported as a new element. One dropdown then shows up as several untested elements and drags down your score.
 
 An `elements` rule fixes this by identifying the element with a selector you choose that matches in every snapshot. The element counts once, and you can rename it to something readable like "Help Popover" instead of a machine-generated selector.
 

--- a/docs/ui-coverage/configuration/elements.mdx
+++ b/docs/ui-coverage/configuration/elements.mdx
@@ -247,9 +247,9 @@ After saving configuration changes, regenerate a recent run to preview the effec
 
 ## See also
 
-- [Element Identification](/ui-coverage/core-concepts/element-identification) explains the automatic identification rules that apply when no `elements` rule matches.
-- [`elementGroups`](/ui-coverage/configuration/elementgroups) combines multiple related elements into a single named group rather than identifying one element.
-- [`attributeFilters`](/ui-coverage/configuration/attributefilters) stops dynamic attributes from being used for identification across all elements, instead of targeting one element.
-- [`elementFilters`](/ui-coverage/configuration/elementfilters) removes elements from reports entirely.
-- [Configuration overview](/ui-coverage/configuration/overview) covers where configuration lives and how to regenerate reports after changing it.
-- [UI Coverage FAQ](/ui-coverage/faq) answers common questions about identity, scores, and configuration.
+- [Element Identification](/ui-coverage/core-concepts/element-identification): how elements are identified automatically.
+- [`elementGroups`](/ui-coverage/configuration/elementgroups): combine related elements into one group.
+- [`attributeFilters`](/ui-coverage/configuration/attributefilters): stop dynamic attributes from identifying elements.
+- [`elementFilters`](/ui-coverage/configuration/elementfilters): remove elements from reports entirely.
+- [Configuration overview](/ui-coverage/configuration/overview): where to set configuration and regenerate reports.
+- [UI Coverage FAQ](/ui-coverage/faq): common questions and troubleshooting.

--- a/docs/ui-coverage/configuration/elements.mdx
+++ b/docs/ui-coverage/configuration/elements.mdx
@@ -39,7 +39,7 @@ To add or edit `elements`, open the **App Quality** tab in your project settings
 
 ## Syntax
 
-```json
+```json title="App Quality Config"
 {
   "uiCoverage": {
     "elements": [

--- a/docs/ui-coverage/configuration/elements.mdx
+++ b/docs/ui-coverage/configuration/elements.mdx
@@ -9,7 +9,11 @@ sidebar_position: 70
 
 # elements
 
-The `elements` configuration assigns a stable identity and a display name to a single element in your UI Coverage report. When an element's attributes change between snapshots, such as a generated `id` or a rotating class name, UI Coverage can see each variation as a different element. One dropdown then appears as several untested elements and drags down your score. An `elements` rule identifies that element by a selector you choose, so it counts once, and renames it to something readable like "Help Popover" instead of a machine-generated selector.
+The `elements` configuration assigns a stable identity and a display name to a single element in your UI Coverage report.
+
+As your tests run, UI Coverage captures snapshots of your application's DOM, and the same element usually appears in many of them: on every page load, in every test that visits its page. To count that element once, UI Coverage must recognize it as the same element in every snapshot. When one of its attributes is different on each appearance, such as an `id` generated on every page load, that recognition fails, and each appearance is reported as a new element. One dropdown then shows up as several untested elements and drags down your score.
+
+An `elements` rule fixes this by identifying the element with a selector you choose that matches in every snapshot. The element counts once, and you can rename it to something readable like "Help Popover" instead of a machine-generated selector.
 
 Without stable identities and names, a report can list controls under machine-generated selectors that are hard to recognize and act on:
 

--- a/docs/ui-coverage/configuration/elements.mdx
+++ b/docs/ui-coverage/configuration/elements.mdx
@@ -22,8 +22,7 @@ Without stable identities and names, a report can list controls under machine-ge
 
 UI Coverage already [identifies elements automatically](/ui-coverage/core-concepts/element-identification) using significant attributes, location, and other DOM signals. Use `elements` when the automatic identity for a specific element isn't stable or isn't readable:
 
-- **Stabilize dynamic attributes**: Identify an element by a selector that stays the same across snapshots, even when its `id` or other attributes are regenerated on every render.
-- **Ensure unique identification**: Give an element that lacks stable, unique attributes an explicit identity so it isn't confused with other elements or duplicated in reports.
+- **Stabilize an element's identity**: Identify an element by a selector that stays the same across snapshots, even when its `id` or other attributes are regenerated on every render, so it isn't duplicated in reports.
 - **Rename elements in reports**: Display a human-readable name in place of a machine-generated selector, so anyone reading the report understands what needs testing.
 
 If your goal is different, such as combining repeated elements so they count as one, or removing elements from reports entirely, see [Which option do I need?](/ui-coverage/configuration/overview#Which-option-do-I-need) in the configuration overview.
@@ -67,7 +66,7 @@ To add or edit `elements`, open the **App Quality** tab in your project settings
 
 In each snapshot captured by your tests, every rule is evaluated independently:
 
-- **A rule applies only when it matches exactly one element.** The `selector` can match any number of DOM nodes, but it must match exactly one of the [interactive elements](/ui-coverage/core-concepts/interactivity) that UI Coverage tracks in that snapshot. When it matches more than one, the rule is skipped and those elements keep their default identity. To give multiple elements a shared identity, use [`elementGroups`](/ui-coverage/configuration/elementgroups) instead.
+- **A rule applies only when it matches exactly one element.** A rule identifies a single element, so UI Coverage counts how many of the [interactive elements](/ui-coverage/core-concepts/interactivity) it tracks match the rule's `selector` in the snapshot. If exactly one matches, the rule applies to that element. If two or more match, the rule is skipped and the elements keep their default identity, because applying it would merge separate elements into one. To intentionally treat several elements as one unit, use [`elementGroups`](/ui-coverage/configuration/elementgroups) instead. Matches against parts of the page that UI Coverage doesn't track, such as wrapper containers or static text, don't count.
 - **Matching is evaluated per snapshot.** A rule can apply in one snapshot and be skipped in another where its selector matches several elements at once.
 - **A matched element is identified by the rule's `selector` alone.** Its identity no longer depends on its attributes, structure, or the default [element identification rules](/ui-coverage/core-concepts/element-identification), so it stays one element across snapshots even as dynamic attributes change. The report displays the rule's `name`, or its `selector` when no name is given. This includes links, which are otherwise displayed by their URL.
 - **Rules match in any document unless scoped.** A rule without `documentScope` can match elements in the main document, in iframes, and in shadow DOMs. Add `documentScope` to restrict a rule to one of those documents, for example when the same selector appears both inside and outside an iframe.

--- a/docs/ui-coverage/configuration/overview.mdx
+++ b/docs/ui-coverage/configuration/overview.mdx
@@ -141,8 +141,27 @@ A complete configuration with all available options looks as follows:
         "comment": string
       }
     ],
+    "elements": [
+      {
+        "selector": string,
+        "name": string,
+        "documentScope": [string],
+        "comment": string
+      }
+    ],
     "significantAttributes": [
       string
+    ],
+    "additionalInteractionCommands": [
+      string
+    ],
+    "allowedInteractionCommands": [
+      {
+        "selector": string,
+        "commands": [string],
+        "documentScope": [string],
+        "comment": string
+      }
     ]
   }
 }

--- a/docs/ui-coverage/core-concepts/element-identification.mdx
+++ b/docs/ui-coverage/core-concepts/element-identification.mdx
@@ -61,3 +61,22 @@ Define custom significant attributes to prioritize specific selectors that align
 ```
 
 Refer to the [Significant Attributes](/ui-coverage/configuration/significantattributes) guide for detailed instructions.
+
+### Elements
+
+Assign a stable identity and a readable name to a specific element whose attributes change between snapshots. An element matched by an `elements` rule is identified by the rule's selector alone, so it stays one element across snapshots. For example:
+
+```json
+{
+  "uiCoverage": {
+    "elements": [
+      {
+        "selector": "#my-form [id^='dropdown']",
+        "name": "Country Dropdown"
+      }
+    ]
+  }
+}
+```
+
+Refer to the [`elements`](/ui-coverage/configuration/elements) guide for how rules are matched.

--- a/docs/ui-coverage/core-concepts/element-identification.mdx
+++ b/docs/ui-coverage/core-concepts/element-identification.mdx
@@ -11,6 +11,14 @@ sidebar_position: 20
 
 UI Coverage uniquely identifies elements across views and snapshots using a combination of HTML attributes, location, and other signals in the DOM. Stable and unique identifiers are crucial for accurately tracking and de-duplicating elements throughout the various snapshots captured in your tests.
 
+## Snapshots
+
+A snapshot is a capture of your application's DOM at one moment during a test. As your tests run, the same capture protocol that powers [Test Replay](/cloud/features/test-replay) records snapshots automatically as your application changes state, on page loads, interactions, and other DOM updates, with no extra code or configuration.
+
+UI Coverage analyzes the snapshots in a recorded run: it detects the [interactive elements](/ui-coverage/core-concepts/interactivity) in each one and computes an identity for each element using the rules on this page. Elements that produce the same identity in different snapshots count as one element, and [views](/ui-coverage/core-concepts/views) group snapshots by URL.
+
+This is why stable identities matter. The same button can appear in hundreds of snapshots across a run, and it should count as a single element, marked as tested when any snapshot captures an interaction with it. An identity that changes between snapshots, for example one built from a generated `id`, splits that one button into many untested elements.
+
 ## Significant attributes for identification
 
 Certain attributes are prioritized by UI Coverage for element identification and grouping. These include:

--- a/docs/ui-coverage/faq.mdx
+++ b/docs/ui-coverage/faq.mdx
@@ -65,6 +65,16 @@ The most common causes are:
 
 This usually means the element's identifying attributes change between snapshots, for example auto-generated IDs or dynamic class names. Use [`attributeFilters`](/ui-coverage/configuration/attributefilters) to ignore the dynamic attributes, or [`elements`](/ui-coverage/configuration/elements) to define the element's identity explicitly. See [troubleshooting](/ui-coverage/troubleshooting) for more scenarios.
 
+### <Icon name="angle-right" /> Why isn't my elements rule applying?
+
+An [`elements`](/ui-coverage/configuration/elements) rule applies only when its selector matches exactly one interactive element in a snapshot. The most common causes are:
+
+- The selector matches more than one interactive element in the same snapshot, so the rule is skipped for that snapshot. Add [`documentScope`](/ui-coverage/configuration/elements#Options) or a more specific selector, or use [`elementGroups`](/ui-coverage/configuration/elementgroups) if several elements should share an identity.
+- The selector only matches non-interactive elements, such as a wrapper around the actual button or input.
+- The element is excluded by [`elementFilters`](/ui-coverage/configuration/elementfilters), so it's never considered.
+- A later `elements` rule matches the same element, and the last matching rule wins.
+- The report was processed before you saved the configuration. Regenerate the run to apply the current configuration.
+
 ## Configuration
 
 ### <Icon name="angle-right" /> Where do I set UI Coverage configuration?

--- a/docs/ui-coverage/faq.mdx
+++ b/docs/ui-coverage/faq.mdx
@@ -63,7 +63,7 @@ The most common causes are:
 
 ### <Icon name="angle-right" /> Why does one element appear as multiple elements in the report?
 
-This usually means the element's identifying attributes change between snapshots, for example auto-generated IDs or dynamic class names. Use [`attributeFilters`](/ui-coverage/configuration/attributefilters) to ignore the dynamic attributes, or [`elements`](/ui-coverage/configuration/elements) to define the element's identity explicitly. See [troubleshooting](/ui-coverage/troubleshooting) for more scenarios.
+This usually means the element's identifying attributes change between [snapshots](/ui-coverage/core-concepts/element-identification#Snapshots), for example auto-generated IDs or dynamic class names. Use [`attributeFilters`](/ui-coverage/configuration/attributefilters) to ignore the dynamic attributes, or [`elements`](/ui-coverage/configuration/elements) to define the element's identity explicitly. See [troubleshooting](/ui-coverage/troubleshooting) for more scenarios.
 
 ### <Icon name="angle-right" /> Why isn't my elements rule applying?
 

--- a/docs/ui-coverage/get-started/introduction.mdx
+++ b/docs/ui-coverage/get-started/introduction.mdx
@@ -166,7 +166,7 @@ UI Coverage provides an interactive, visual map of test coverage for your applic
 
 - **Effortless Setup**: No extra configuration is required. UI Coverage uses the same capture protocol as Test Replay, so no additional code or configuration is needed.
 - **Dynamic Coverage Mapping**: Each interactive element is identified and highlighted as tested or untested, giving you a clear view of your test coverage across all pages and components.
-- **DOM Snapshots**: Each tested and untested element is accompanied by a full-page, inspectable DOM snapshot, highlighting the exact location and context of element.
+- **DOM Snapshots**: Each tested and untested element is accompanied by a full-page, inspectable [DOM snapshot](/ui-coverage/core-concepts/element-identification#Snapshots), highlighting the exact location and context of the element.
 - **Comprehensive Scoring**: A UI Coverage score is calculated by comparing tested elements to the total interactable elements in your application.
 - **Actionable Reports**: Sortable and filterable views provide insights into which areas are tested and which need improvement.
 - **Test Generation**: Quickly close coverage gaps with AI-powered test generation of untested elements and links surfaced in reports.

--- a/docs/ui-coverage/guides/reduce-noise.mdx
+++ b/docs/ui-coverage/guides/reduce-noise.mdx
@@ -9,13 +9,13 @@ sidebar_position: 60
 
 # Reduce noise
 
-A clean and focused UI Coverage report enables you to make informed decisions about your testing strategy. Cypress UI Coverage provides tools to reduce noise in your reports by properly grouping elements, special attribute handling, and grouping views that share common URL patterns. This guide explains how and why to create a streamlined report.
+A clean and focused UI Coverage report enables you to make informed decisions about your testing strategy. Cypress UI Coverage provides tools to reduce noise in your reports by properly grouping elements, stabilizing element identities, special attribute handling, and grouping views that share common URL patterns. This guide explains how and why to create a streamlined report.
 
 ## Group views by URL patterns
 
-Cypress attempts to groups views with similar URL patterns (like when a URL contains a user ID) to provide a more consolidated view of coverage metrics.
+Cypress attempts to group views with similar URL patterns (like when a URL contains a user ID) to provide a more consolidated view of coverage metrics.
 
-Customozing views with similar URL patterns allows you to consolidate coverage metrics for pages you know are related. To add or modify the configuration for your project, navigate to the **App Quality** tab in your project settings and add an **viewGroups** configuration.
+Customizing views with similar URL patterns allows you to consolidate coverage metrics for pages you know are related. To add or modify the configuration for your project, navigate to the **App Quality** tab in your project settings and add a **views** configuration.
 
 ### Example: Grouping user profiles
 
@@ -75,6 +75,27 @@ nav [id^=nav-button] (3 instances)
 ```
 
 To learn more about the configuration options, refer to the [Element Groups](/ui-coverage/configuration/elementgroups) documentation.
+
+## Stabilize a single element's identity
+
+When one element appears as several untested elements because a generated attribute changes between snapshots, an `elements` rule identifies it by a selector you choose and can rename it in the report. To add or modify the configuration for your project, navigate to the **App Quality** tab in your project settings and add an **elements** configuration under **uiCoverage**.
+
+```json
+{
+  "uiCoverage": {
+    "elements": [
+      {
+        "selector": "#search [id^='combobox']",
+        "name": "Search Combobox"
+      }
+    ]
+  }
+}
+```
+
+The rule applies only when its selector matches exactly one interactive element in a snapshot. If many elements share the same generated attribute, use [Attribute Filters](/ui-coverage/configuration/attributefilters) instead.
+
+To learn more about the configuration options, refer to the [Elements](/ui-coverage/configuration/elements) documentation.
 
 ## Configure attribute handling
 


### PR DESCRIPTION
## Summary

Rewrites the UI Coverage `elements` configuration page to match the actual implementation, lead with the value the option provides, and follow the structure of the recently rewritten `elementGroups` and Views pages. Also adds a Snapshots section to the Element Identification core concept, a troubleshooting question to the UI Coverage FAQ, and cross-links to `elements` from the pages that were missing them.

## Why

Continues the UI Coverage docs accuracy series (#6680, #6682). The `elements` page contained claims that contradict the implementation in cypress-services, verified against `applyElementIdentityConfig`, the identity logic in the render pipeline, the Zod config schema, and their unit tests:

- **Rule precedence was backwards.** The page said "the first applicable rule … is used"; in the implementation every rule is evaluated and the last matching rule wins.
- **The one-match requirement was underspecified.** A rule applies only when its selector matches exactly one *tracked interactive* element per snapshot; non-interactive matches and `elementFilters`-excluded elements don't count, and matching is re-evaluated per snapshot.
- **The iframe/shadow DOM examples implied `documentScope` is what reaches into nested documents.** Unscoped rules match there too; `documentScope` restricts matching.
- **`documentScope` was described as an unordered "all hosts present" check.** It's an ordered outermost-to-innermost host list with gaps allowed.

Missing concepts were added: the identity effect (a matched element is identified by the configured selector alone; the report displays the `name` or the selector, including for links), validation rules, a Setting elements section, and a snapshots-over-time explanation so the duplicate-element problem makes sense before the examples.

Review feedback incorporated: merged overlapping "Why use elements?" bullets, rewrote the one-match bullet step by step, explained snapshots in the intro and gave the concept a canonical home (Element Identification `#Snapshots`) linked from the intro, the product introduction, and the FAQ, titled all config code blocks with "App Quality Config", and shortened the See also descriptions.

## Notes for reviewers

- **Last-rule-wins is documented as implemented**, though it's the opposite of `elementGroups` (first rule wins). If the team would rather treat that asymmetry as a bug, the doc line is easy to flip later.
- The intro reuses the untested-elements screenshot that the `elementGroups` page also uses; a dedicated before/after shot of a renamed element would be a good swap when someone can capture one.
- Side fixes bundled in: the Reduce noise guide told readers to add a **viewGroups** configuration, which isn't a real property (it's `views`); the configuration overview's complete example was missing `elements`, `additionalInteractionCommands`, and `allowedInteractionCommands`; and two small typos.
- The new FAQ question is picked up automatically by the faq-structured-data plugin (35/35 tests pass). Prettier and the frontmatter linter pass on all changed files.
- Follow-up intentionally left out: repo-wide ` ```xml ` → ` ```html ` fence conversion and any `keywords` frontmatter adoption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015CCVdGJTdxLfNBY7ihW3GT

---
_Generated by [Claude Code](https://claude.ai/code/session_015CCVdGJTdxLfNBY7ihW3GT)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or API impact; risk is limited to possible doc inaccuracies if implementation details were misinterpreted.
> 
> **Overview**
> **Rewrites the UI Coverage `elements` configuration guide** so it matches product behavior and reads like the updated `elementGroups` docs: stable identity and readable names, snapshot-based duplicate-element problem, App Quality setup, options table, per-snapshot rule application (**last matching rule wins**), validation, and refreshed examples (dynamic IDs, naming, `documentScope` for shadow DOM/iframes).
> 
> **Adds supporting docs around the same concepts:** a **Snapshots** section on Element Identification; an **`elements`** subsection there; a new FAQ **“Why isn’t my elements rule applying?”**; cross-links from introduction and duplicate-element FAQ; a **Stabilize a single element’s identity** section on Reduce noise.
> 
> **Small fixes bundled:** configuration overview complete JSON now includes `elements`, `additionalInteractionCommands`, and `allowedInteractionCommands`; Reduce noise corrects `viewGroups` → `views` and typos.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75a5212991516c46e939c1f9b30ad37d0d022392. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->