### PR TITLE
Use task-based sidebar labels for UI Coverage and Accessibility config pages

### DIFF
--- a/docs/accessibility/configuration/attributefilters.mdx
+++ b/docs/accessibility/configuration/attributefilters.mdx
@@ -1,8 +1,8 @@
 ---
 title: Control element identification in Cypress Accessibility
 description: 'Use attributeFilters to exclude attribute patterns from element identification and grouping in Cypress Accessibility.'
-sidebar_label: attributeFilters
-sidebar_position: 20
+sidebar_label: 'Ignore attributes for identification'
+sidebar_position: 80
 ---
 
 <ProductHeading product="accessibility" />

--- a/docs/accessibility/configuration/attributefilters.mdx
+++ b/docs/accessibility/configuration/attributefilters.mdx
@@ -7,7 +7,7 @@ sidebar_position: 80
 
 <ProductHeading product="accessibility" />
 
-# attributeFilters
+# Ignore attributes for identification (`attributeFilters`)
 
 Cypress Accessibility [identifies elements](/ui-coverage/core-concepts/element-identification) based on a combination of attributes and the surrounding DOM structure.
 

--- a/docs/accessibility/configuration/attributefilters.mdx
+++ b/docs/accessibility/configuration/attributefilters.mdx
@@ -2,7 +2,7 @@
 title: Control element identification in Cypress Accessibility
 description: 'Use attributeFilters to exclude attribute patterns from element identification and grouping in Cypress Accessibility.'
 sidebar_label: attributeFilters
-sidebar_position: 50
+sidebar_position: 20
 ---
 
 <ProductHeading product="accessibility" />

--- a/docs/accessibility/configuration/axe-core-configuration.mdx
+++ b/docs/accessibility/configuration/axe-core-configuration.mdx
@@ -2,7 +2,7 @@
 title: 'Configure Axe Core® rules in Cypress Accessibility'
 description: 'Enable, disable, and tune individual Axe Core® rules to control which accessibility checks run in Cypress.'
 sidebar_label: 'Axe Core® configuration'
-sidebar_position: 30
+sidebar_position: 50
 ---
 
 <ProductHeading product="accessibility" />

--- a/docs/accessibility/configuration/axe-core-configuration.mdx
+++ b/docs/accessibility/configuration/axe-core-configuration.mdx
@@ -2,6 +2,7 @@
 title: 'Configure Axe Core® rules in Cypress Accessibility'
 description: 'Enable, disable, and tune individual Axe Core® rules to control which accessibility checks run in Cypress.'
 sidebar_label: 'Axe Core® configuration'
+sidebar_position: 30
 ---
 
 <ProductHeading product="accessibility" />

--- a/docs/accessibility/configuration/components.mdx
+++ b/docs/accessibility/configuration/components.mdx
@@ -7,7 +7,7 @@ sidebar_position: 90
 
 <ProductHeading product="accessibility" />
 
-# components
+# Define components (`components`)
 
 The `accessibility.components` options provide a small but powerful set of controls for how elements are identified in Cypress Accessibility. This helps provide guaranteed "breadcrumbs" to place accessibility findings in context quickly and easily, for fast review by developers and testers, and when using AI agents to triage reports through Cypress Cloud MCP.
 

--- a/docs/accessibility/configuration/components.mdx
+++ b/docs/accessibility/configuration/components.mdx
@@ -1,8 +1,8 @@
 ---
 title: Component attributes in Cypress Accessibility
 description: 'The accessibility components configuration controls how component-related HTML attributes appear in stable violation-target selectors.'
-sidebar_label: components
-sidebar_position: 40
+sidebar_label: 'Define components'
+sidebar_position: 90
 ---
 
 <ProductHeading product="accessibility" />

--- a/docs/accessibility/configuration/components.mdx
+++ b/docs/accessibility/configuration/components.mdx
@@ -2,7 +2,7 @@
 title: Component attributes in Cypress Accessibility
 description: 'The accessibility components configuration controls how component-related HTML attributes appear in stable violation-target selectors.'
 sidebar_label: components
-sidebar_position: 45
+sidebar_position: 40
 ---
 
 <ProductHeading product="accessibility" />

--- a/docs/accessibility/configuration/elementfilters.mdx
+++ b/docs/accessibility/configuration/elementfilters.mdx
@@ -2,7 +2,7 @@
 title: 'elementFilters: exclude elements from scans'
 description: 'The `elementFilters` property allows you to specify selectors for elements that should be excluded from Cypress Accessibility.'
 sidebar_label: elementFilters
-sidebar_position: 30
+sidebar_position: 50
 ---
 
 <ProductHeading product="accessibility" />

--- a/docs/accessibility/configuration/elementfilters.mdx
+++ b/docs/accessibility/configuration/elementfilters.mdx
@@ -1,8 +1,8 @@
 ---
 title: 'elementFilters: exclude elements from scans'
 description: 'The `elementFilters` property allows you to specify selectors for elements that should be excluded from Cypress Accessibility.'
-sidebar_label: elementFilters
-sidebar_position: 60
+sidebar_label: 'Exclude elements'
+sidebar_position: 40
 ---
 
 <ProductHeading product="accessibility" />

--- a/docs/accessibility/configuration/elementfilters.mdx
+++ b/docs/accessibility/configuration/elementfilters.mdx
@@ -7,6 +7,6 @@ sidebar_position: 40
 
 <ProductHeading product="accessibility" />
 
-# elementFilters
+# Exclude elements (`elementFilters`)
 
 <ElementFilters />

--- a/docs/accessibility/configuration/elementfilters.mdx
+++ b/docs/accessibility/configuration/elementfilters.mdx
@@ -2,7 +2,7 @@
 title: 'elementFilters: exclude elements from scans'
 description: 'The `elementFilters` property allows you to specify selectors for elements that should be excluded from Cypress Accessibility.'
 sidebar_label: elementFilters
-sidebar_position: 50
+sidebar_position: 60
 ---
 
 <ProductHeading product="accessibility" />

--- a/docs/accessibility/configuration/ignoring-rules-per-element.mdx
+++ b/docs/accessibility/configuration/ignoring-rules-per-element.mdx
@@ -2,7 +2,7 @@
 title: Ignore accessibility rules per element
 description: 'Use the data-a11y-ignore attribute to exclude specific accessibility rules from elements in Cypress Accessibility.'
 sidebar_label: 'Ignore rules for specific elements'
-sidebar_position: 70
+sidebar_position: 60
 ---
 
 <ProductHeading product="accessibility" />

--- a/docs/accessibility/configuration/ignoring-rules-per-element.mdx
+++ b/docs/accessibility/configuration/ignoring-rules-per-element.mdx
@@ -7,7 +7,7 @@ sidebar_position: 60
 
 <ProductHeading product="accessibility" />
 
-# data-a11y-ignore
+# Ignore rules per element (`data-a11y-ignore`)
 
 Cypress Accessibility configuration allows you to exclude [elements](/accessibility/configuration/elementfilters) or whole [pages](/accessibility/configuration/viewfilters) from the accessibility report, but sometimes there are situations where you may want to keep an element in your accessibility report, but ignore some accessibility rules for that element.
 

--- a/docs/accessibility/configuration/ignoring-rules-per-element.mdx
+++ b/docs/accessibility/configuration/ignoring-rules-per-element.mdx
@@ -1,8 +1,8 @@
 ---
 title: 'data-a11y-ignore: ignore accessibility rules per element'
 description: 'Use the data-a11y-ignore attribute to exclude specific accessibility rules from elements in Cypress Accessibility.'
-sidebar_label: data-a11y-ignore
-sidebar_position: 50
+sidebar_label: 'Ignore rules per element'
+sidebar_position: 60
 ---
 
 <ProductHeading product="accessibility" />

--- a/docs/accessibility/configuration/ignoring-rules-per-element.mdx
+++ b/docs/accessibility/configuration/ignoring-rules-per-element.mdx
@@ -1,13 +1,13 @@
 ---
-title: Ignore accessibility rules per element
+title: 'data-a11y-ignore: ignore accessibility rules per element'
 description: 'Use the data-a11y-ignore attribute to exclude specific accessibility rules from elements in Cypress Accessibility.'
-sidebar_label: 'Ignore rules for specific elements'
-sidebar_position: 60
+sidebar_label: data-a11y-ignore
+sidebar_position: 50
 ---
 
 <ProductHeading product="accessibility" />
 
-# Ignore rules for specific elements
+# data-a11y-ignore
 
 Cypress Accessibility configuration allows you to exclude [elements](/accessibility/configuration/elementfilters) or whole [pages](/accessibility/configuration/viewfilters) from the accessibility report, but sometimes there are situations where you may want to keep an element in your accessibility report, but ignore some accessibility rules for that element.
 

--- a/docs/accessibility/configuration/overview.mdx
+++ b/docs/accessibility/configuration/overview.mdx
@@ -7,7 +7,7 @@ sidebar_position: 10
 
 <ProductHeading product="accessibility" />
 
-# Configuration
+# Configuration overview
 
 Configuration allows you to customize and fine-tune accessibility reports in Cypress. While Cypress Accessibility is designed to work seamlessly out of the box, there are instances where custom configuration may be necessary, or preferred. Using configuration, you can avoid reporting on pages or elements that don't matter to your team, combine related urls together into a single View, and modify the element identification and deduplication behavior to reflect your application's specific structure.
 

--- a/docs/accessibility/configuration/profiles.mdx
+++ b/docs/accessibility/configuration/profiles.mdx
@@ -7,6 +7,6 @@ sidebar_position: 100
 
 <ProductHeading product="accessibility" />
 
-# profiles
+# Override config by run tag (`profiles`)
 
 <Profiles />

--- a/docs/accessibility/configuration/profiles.mdx
+++ b/docs/accessibility/configuration/profiles.mdx
@@ -1,8 +1,8 @@
 ---
 title: 'profiles: apply config overrides by run tag'
 description: 'Use the profiles property to apply Cypress Accessibility configuration overrides based on run tags.'
-sidebar_label: profiles
-sidebar_position: 70
+sidebar_label: 'Override config by run tag'
+sidebar_position: 100
 ---
 
 <ProductHeading product="accessibility" />

--- a/docs/accessibility/configuration/profiles.mdx
+++ b/docs/accessibility/configuration/profiles.mdx
@@ -2,7 +2,7 @@
 title: 'profiles: apply config overrides by run tag'
 description: 'Use the profiles property to apply Cypress Accessibility configuration overrides based on run tags.'
 sidebar_label: profiles
-sidebar_position: 100
+sidebar_position: 70
 ---
 
 <ProductHeading product="accessibility" />

--- a/docs/accessibility/configuration/significantattributes.mdx
+++ b/docs/accessibility/configuration/significantattributes.mdx
@@ -7,7 +7,7 @@ sidebar_position: 70
 
 <ProductHeading product="accessibility" />
 
-# significantAttributes
+# Prioritize identifying attributes (`significantAttributes`)
 
 The `significantAttributes` property allows you to specify which attributes should be considered significant when identifying elements in Cypress Accessibility.
 

--- a/docs/accessibility/configuration/significantattributes.mdx
+++ b/docs/accessibility/configuration/significantattributes.mdx
@@ -1,8 +1,8 @@
 ---
 title: 'significantAttributes: prioritize element attributes'
 description: 'The significantAttributes configuration property allows users to specify custom attributes that should be considered "significant" for the purpose of identification and grouping.'
-sidebar_label: significantAttributes
-sidebar_position: 80
+sidebar_label: 'Prioritize identifying attributes'
+sidebar_position: 70
 ---
 
 <ProductHeading product="accessibility" />

--- a/docs/accessibility/configuration/significantattributes.mdx
+++ b/docs/accessibility/configuration/significantattributes.mdx
@@ -2,7 +2,7 @@
 title: 'significantAttributes: prioritize element attributes'
 description: 'The significantAttributes configuration property allows users to specify custom attributes that should be considered "significant" for the purpose of identification and grouping.'
 sidebar_label: significantAttributes
-sidebar_position: 40
+sidebar_position: 80
 ---
 
 <ProductHeading product="accessibility" />

--- a/docs/accessibility/configuration/viewfilters.mdx
+++ b/docs/accessibility/configuration/viewfilters.mdx
@@ -1,8 +1,8 @@
 ---
 title: 'viewFilters: exclude URLs from scans'
 description: 'The viewFilters property allows you to specify URL patterns for URLs that should be excluded from Accessibility.'
-sidebar_label: viewFilters
-sidebar_position: 90
+sidebar_label: 'Exclude views'
+sidebar_position: 30
 ---
 
 <ProductHeading product="accessibility" />

--- a/docs/accessibility/configuration/viewfilters.mdx
+++ b/docs/accessibility/configuration/viewfilters.mdx
@@ -7,6 +7,6 @@ sidebar_position: 30
 
 <ProductHeading product="accessibility" />
 
-# viewFilters
+# Exclude views (`viewFilters`)
 
 <ViewFilters />

--- a/docs/accessibility/configuration/viewfilters.mdx
+++ b/docs/accessibility/configuration/viewfilters.mdx
@@ -2,7 +2,7 @@
 title: 'viewFilters: exclude URLs from scans'
 description: 'The viewFilters property allows you to specify URL patterns for URLs that should be excluded from Accessibility.'
 sidebar_label: viewFilters
-sidebar_position: 20
+sidebar_position: 90
 ---
 
 <ProductHeading product="accessibility" />

--- a/docs/accessibility/configuration/views.mdx
+++ b/docs/accessibility/configuration/views.mdx
@@ -1,8 +1,8 @@
 ---
 title: 'Views: URLs and components in Accessibility'
 description: 'Cypress Accessibility automatically groups certain URL patterns to create views. For URLs that are not automatically grouped, the views property allows you to specify your own URL patterns that represent views.'
-sidebar_label: views
-sidebar_position: 100
+sidebar_label: 'Group & name views'
+sidebar_position: 20
 ---
 
 <ProductHeading product="accessibility" />

--- a/docs/accessibility/configuration/views.mdx
+++ b/docs/accessibility/configuration/views.mdx
@@ -7,7 +7,7 @@ sidebar_position: 20
 
 <ProductHeading product="accessibility" />
 
-# views
+# Group & name views (`views`)
 
 Views work the same way in Cypress Accessibility and UI Coverage. To learn how views are created by default, see [Views in UI Coverage](/ui-coverage/core-concepts/views).
 

--- a/docs/accessibility/configuration/views.mdx
+++ b/docs/accessibility/configuration/views.mdx
@@ -2,7 +2,7 @@
 title: 'Views: URLs and components in Accessibility'
 description: 'Cypress Accessibility automatically groups certain URL patterns to create views. For URLs that are not automatically grouped, the views property allows you to specify your own URL patterns that represent views.'
 sidebar_label: views
-sidebar_position: 10
+sidebar_position: 100
 ---
 
 <ProductHeading product="accessibility" />

--- a/docs/ui-coverage/configuration/additionalinteractioncommands.mdx
+++ b/docs/ui-coverage/configuration/additionalinteractioncommands.mdx
@@ -2,7 +2,7 @@
 title: 'additionalInteractionCommands'
 description: 'Use additionalInteractionCommands to extend the default set of interaction command types recognized by UI Coverage.'
 sidebar_label: additionalInteractionCommands
-sidebar_position: 90
+sidebar_position: 20
 ---
 
 <ProductHeading product="ui-coverage" />

--- a/docs/ui-coverage/configuration/additionalinteractioncommands.mdx
+++ b/docs/ui-coverage/configuration/additionalinteractioncommands.mdx
@@ -7,7 +7,7 @@ sidebar_position: 90
 
 <ProductHeading product="ui-coverage" />
 
-# additionalInteractionCommands
+# Track custom commands (`additionalInteractionCommands`)
 
 UI Coverage automatically tracks how elements are used in tests using a predefined set of [Cypress interaction commands](/ui-coverage/core-concepts/interactivity#Interaction-Commands) such as `click`, `type`, `dblclick`, and more.
 

--- a/docs/ui-coverage/configuration/additionalinteractioncommands.mdx
+++ b/docs/ui-coverage/configuration/additionalinteractioncommands.mdx
@@ -1,8 +1,8 @@
 ---
 title: 'additionalInteractionCommands'
 description: 'Use additionalInteractionCommands to extend the default set of interaction command types recognized by UI Coverage.'
-sidebar_label: additionalInteractionCommands
-sidebar_position: 20
+sidebar_label: 'Track custom commands'
+sidebar_position: 90
 ---
 
 <ProductHeading product="ui-coverage" />

--- a/docs/ui-coverage/configuration/allowedinteractioncommands.mdx
+++ b/docs/ui-coverage/configuration/allowedinteractioncommands.mdx
@@ -7,7 +7,7 @@ sidebar_position: 100
 
 <ProductHeading product="ui-coverage" />
 
-# allowedInteractionCommands
+# Limit tracked commands (`allowedInteractionCommands`)
 
 UI Coverage tracks [all interaction commands](/ui-coverage/core-concepts/interactivity#Interaction-Commands) by default for comprehensive coverage reporting. The `allowedInteractionCommands` configuration allows you to limit which interaction commands are tracked for specific elements by defining rules based on CSS selectors.
 

--- a/docs/ui-coverage/configuration/allowedinteractioncommands.mdx
+++ b/docs/ui-coverage/configuration/allowedinteractioncommands.mdx
@@ -2,7 +2,7 @@
 title: 'allowedInteractionCommands'
 description: 'Use allowedInteractionCommands to limit the interaction commands that are tracked for specific elements in UI Coverage.'
 sidebar_label: allowedInteractionCommands
-sidebar_position: 100
+sidebar_position: 30
 ---
 
 <ProductHeading product="ui-coverage" />

--- a/docs/ui-coverage/configuration/allowedinteractioncommands.mdx
+++ b/docs/ui-coverage/configuration/allowedinteractioncommands.mdx
@@ -1,8 +1,8 @@
 ---
 title: 'allowedInteractionCommands'
 description: 'Use allowedInteractionCommands to limit the interaction commands that are tracked for specific elements in UI Coverage.'
-sidebar_label: allowedInteractionCommands
-sidebar_position: 30
+sidebar_label: 'Limit tracked commands'
+sidebar_position: 100
 ---
 
 <ProductHeading product="ui-coverage" />

--- a/docs/ui-coverage/configuration/attributefilters.mdx
+++ b/docs/ui-coverage/configuration/attributefilters.mdx
@@ -1,8 +1,8 @@
 ---
 title: 'attributeFilters: control element identification'
 description: 'Use attributeFilters to exclude attribute patterns from element identification and grouping in UI Coverage.'
-sidebar_label: attributeFilters
-sidebar_position: 40
+sidebar_label: 'Ignore attributes for identification'
+sidebar_position: 80
 ---
 
 <ProductHeading product="ui-coverage" />

--- a/docs/ui-coverage/configuration/attributefilters.mdx
+++ b/docs/ui-coverage/configuration/attributefilters.mdx
@@ -2,7 +2,7 @@
 title: 'attributeFilters: control element identification'
 description: 'Use attributeFilters to exclude attribute patterns from element identification and grouping in UI Coverage.'
 sidebar_label: attributeFilters
-sidebar_position: 60
+sidebar_position: 40
 ---
 
 <ProductHeading product="ui-coverage" />

--- a/docs/ui-coverage/configuration/attributefilters.mdx
+++ b/docs/ui-coverage/configuration/attributefilters.mdx
@@ -7,7 +7,7 @@ sidebar_position: 80
 
 <ProductHeading product="ui-coverage" />
 
-# attributeFilters
+# Ignore attributes for identification (`attributeFilters`)
 
 UI Coverage [identifies](/ui-coverage/core-concepts/element-identification) and [groups](/ui-coverage/core-concepts/element-grouping) elements based on their attributes and structure in the DOM.
 

--- a/docs/ui-coverage/configuration/elementfilters.mdx
+++ b/docs/ui-coverage/configuration/elementfilters.mdx
@@ -1,8 +1,8 @@
 ---
 title: 'elementFilters: exclude elements from UI Coverage'
 description: 'The elementFilters property allows you to specify selectors for elements that should be excluded from UI Coverage.'
-sidebar_label: elementFilters
-sidebar_position: 50
+sidebar_label: 'Exclude elements'
+sidebar_position: 40
 ---
 
 <ProductHeading product="ui-coverage" />

--- a/docs/ui-coverage/configuration/elementfilters.mdx
+++ b/docs/ui-coverage/configuration/elementfilters.mdx
@@ -7,7 +7,7 @@ sidebar_position: 40
 
 <ProductHeading product="ui-coverage" />
 
-# elementFilters
+# Exclude elements (`elementFilters`)
 
 <ElementFilters />
 

--- a/docs/ui-coverage/configuration/elementfilters.mdx
+++ b/docs/ui-coverage/configuration/elementfilters.mdx
@@ -2,7 +2,7 @@
 title: 'elementFilters: exclude elements from UI Coverage'
 description: 'The elementFilters property allows you to specify selectors for elements that should be excluded from UI Coverage.'
 sidebar_label: elementFilters
-sidebar_position: 40
+sidebar_position: 50
 ---
 
 <ProductHeading product="ui-coverage" />

--- a/docs/ui-coverage/configuration/elementgroups.mdx
+++ b/docs/ui-coverage/configuration/elementgroups.mdx
@@ -2,7 +2,7 @@
 title: 'elementGroups: group related elements in UI Coverage'
 description: 'The elementGroups configuration in Cypress UI Coverage groups related elements into a single unit, so testing one element counts as testing them all.'
 sidebar_label: elementGroups
-sidebar_position: 80
+sidebar_position: 60
 ---
 
 <ProductHeading product="ui-coverage" />

--- a/docs/ui-coverage/configuration/elementgroups.mdx
+++ b/docs/ui-coverage/configuration/elementgroups.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'elementGroups: group related elements in UI Coverage'
 description: 'The elementGroups configuration in Cypress UI Coverage groups related elements into a single unit, so testing one element counts as testing them all.'
-sidebar_label: elementGroups
+sidebar_label: 'Group related elements'
 sidebar_position: 60
 ---
 

--- a/docs/ui-coverage/configuration/elementgroups.mdx
+++ b/docs/ui-coverage/configuration/elementgroups.mdx
@@ -7,7 +7,7 @@ sidebar_position: 60
 
 <ProductHeading product="ui-coverage" />
 
-# elementGroups
+# Group related elements (`elementGroups`)
 
 The `elementGroups` configuration combines related elements into a single unit in your UI Coverage report. A group counts once toward your coverage score, and an interaction with any element in the group marks the whole group as tested. This means a list of 50 untested product cards no longer appears as 50 untested elements dragging down your score. Instead, it appears as one clearly named group that a single test can cover.
 

--- a/docs/ui-coverage/configuration/elements.mdx
+++ b/docs/ui-coverage/configuration/elements.mdx
@@ -7,7 +7,7 @@ sidebar_position: 50
 
 <ProductHeading product="ui-coverage" />
 
-# elements
+# Stabilize element identity (`elements`)
 
 The `elements` configuration assigns a stable identity and a display name to a single element in your UI Coverage report.
 

--- a/docs/ui-coverage/configuration/elements.mdx
+++ b/docs/ui-coverage/configuration/elements.mdx
@@ -1,8 +1,8 @@
 ---
 title: 'elements: rename and stabilize element identity in UI Coverage'
 description: 'Rename elements and give them a stable identity in Cypress UI Coverage reports, so dynamic attributes do not create duplicate untested elements.'
-sidebar_label: elements
-sidebar_position: 70
+sidebar_label: 'Stabilize element identity'
+sidebar_position: 50
 ---
 
 <ProductHeading product="ui-coverage" />

--- a/docs/ui-coverage/configuration/overview.mdx
+++ b/docs/ui-coverage/configuration/overview.mdx
@@ -7,7 +7,7 @@ sidebar_position: 10
 
 <ProductHeading product="ui-coverage" />
 
-# Configuration
+# Configuration overview
 
 Configuration enables you to customize and fine-tune UI Coverage in Cypress to suit the unique needs of your application. While UI Coverage is designed to work seamlessly out of the box, there are scenarios where fine-tuning may be necessary—such as dealing with dynamic attributes, filtering out irrelevant elements, or grouping related components. These guides explain how to configure UI Coverage effectively to improve accuracy and usability.
 

--- a/docs/ui-coverage/configuration/profiles.mdx
+++ b/docs/ui-coverage/configuration/profiles.mdx
@@ -2,7 +2,7 @@
 title: 'profiles: apply config overrides by run tag'
 description: 'Use the profiles property to apply UI Coverage configuration overrides based on run tags.'
 sidebar_label: profiles
-sidebar_position: 100
+sidebar_position: 80
 ---
 
 <ProductHeading product="ui-coverage" />

--- a/docs/ui-coverage/configuration/profiles.mdx
+++ b/docs/ui-coverage/configuration/profiles.mdx
@@ -7,6 +7,6 @@ sidebar_position: 110
 
 <ProductHeading product="ui-coverage" />
 
-# profiles
+# Override config by run tag (`profiles`)
 
 <Profiles />

--- a/docs/ui-coverage/configuration/profiles.mdx
+++ b/docs/ui-coverage/configuration/profiles.mdx
@@ -1,8 +1,8 @@
 ---
 title: 'profiles: apply config overrides by run tag'
 description: 'Use the profiles property to apply UI Coverage configuration overrides based on run tags.'
-sidebar_label: profiles
-sidebar_position: 80
+sidebar_label: 'Override config by run tag'
+sidebar_position: 110
 ---
 
 <ProductHeading product="ui-coverage" />

--- a/docs/ui-coverage/configuration/significantattributes.mdx
+++ b/docs/ui-coverage/configuration/significantattributes.mdx
@@ -1,8 +1,8 @@
 ---
 title: 'significantAttributes: prioritize element attributes'
 description: 'The significantAttributes configuration property allows users to specify custom attributes that should be considered "significant" for the purpose of identification and grouping in UI Coverage.'
-sidebar_label: significantAttributes
-sidebar_position: 90
+sidebar_label: 'Prioritize identifying attributes'
+sidebar_position: 70
 ---
 
 <ProductHeading product="ui-coverage" />

--- a/docs/ui-coverage/configuration/significantattributes.mdx
+++ b/docs/ui-coverage/configuration/significantattributes.mdx
@@ -2,7 +2,7 @@
 title: 'significantAttributes: prioritize element attributes'
 description: 'The significantAttributes configuration property allows users to specify custom attributes that should be considered "significant" for the purpose of identification and grouping in UI Coverage.'
 sidebar_label: significantAttributes
-sidebar_position: 50
+sidebar_position: 90
 ---
 
 <ProductHeading product="ui-coverage" />

--- a/docs/ui-coverage/configuration/significantattributes.mdx
+++ b/docs/ui-coverage/configuration/significantattributes.mdx
@@ -7,7 +7,7 @@ sidebar_position: 70
 
 <ProductHeading product="ui-coverage" />
 
-# significantAttributes
+# Prioritize identifying attributes (`significantAttributes`)
 
 The `significantAttributes` property allows you to specify which attributes should be considered significant when identifying elements in UI Coverage.
 

--- a/docs/ui-coverage/configuration/viewfilters.mdx
+++ b/docs/ui-coverage/configuration/viewfilters.mdx
@@ -1,8 +1,8 @@
 ---
 title: 'viewFilters: exclude URLs from UI Coverage'
 description: 'The viewFilters property allows you to specify URL patterns for URLs that should be excluded from UI Coverage.'
-sidebar_label: viewFilters
-sidebar_position: 100
+sidebar_label: 'Exclude views'
+sidebar_position: 30
 ---
 
 <ProductHeading product="ui-coverage" />

--- a/docs/ui-coverage/configuration/viewfilters.mdx
+++ b/docs/ui-coverage/configuration/viewfilters.mdx
@@ -7,6 +7,6 @@ sidebar_position: 30
 
 <ProductHeading product="ui-coverage" />
 
-# viewFilters
+# Exclude views (`viewFilters`)
 
 <ViewFilters />

--- a/docs/ui-coverage/configuration/viewfilters.mdx
+++ b/docs/ui-coverage/configuration/viewfilters.mdx
@@ -2,7 +2,7 @@
 title: 'viewFilters: exclude URLs from UI Coverage'
 description: 'The viewFilters property allows you to specify URL patterns for URLs that should be excluded from UI Coverage.'
 sidebar_label: viewFilters
-sidebar_position: 30
+sidebar_position: 100
 ---
 
 <ProductHeading product="ui-coverage" />

--- a/docs/ui-coverage/configuration/views.mdx
+++ b/docs/ui-coverage/configuration/views.mdx
@@ -2,7 +2,7 @@
 title: 'views: group URLs with URL patterns in UI Coverage'
 description: 'The `views` configuration groups related URLs into a single view in UI Coverage using URL patterns, so reports and scores reflect the actual pages of your application.'
 sidebar_label: views
-sidebar_position: 20
+sidebar_position: 110
 ---
 
 <ProductHeading product="ui-coverage" />

--- a/docs/ui-coverage/configuration/views.mdx
+++ b/docs/ui-coverage/configuration/views.mdx
@@ -1,8 +1,8 @@
 ---
 title: 'views: group URLs with URL patterns in UI Coverage'
 description: 'The `views` configuration groups related URLs into a single view in UI Coverage using URL patterns, so reports and scores reflect the actual pages of your application.'
-sidebar_label: views
-sidebar_position: 110
+sidebar_label: 'Group & name views'
+sidebar_position: 20
 ---
 
 <ProductHeading product="ui-coverage" />

--- a/docs/ui-coverage/configuration/views.mdx
+++ b/docs/ui-coverage/configuration/views.mdx
@@ -7,7 +7,7 @@ sidebar_position: 20
 
 <ProductHeading product="ui-coverage" />
 
-# views
+# Group & name views (`views`)
 
 This page is the configuration reference for the `views` property. To learn how UI Coverage creates views by default, and when you'd reach for this property, see the [Views core concept](/ui-coverage/core-concepts/views).
 


### PR DESCRIPTION
## Summary

Renames the UI Coverage → Configuration and Accessibility → Configuration sidebar labels and page H1s to describe what each option does for users (e.g. `elementFilters` → "Exclude elements"), keeps the config key in each H1 in parentheses, and reorders both sections by typical usage priority with Overview kept first.

## Why

The configuration sidebars listed pages by config key names (`attributeFilters`, `significantAttributes`, `elementFilters`, ...), which tell a newcomer scanning the sidebar nothing about when they'd want each page, and several keys are near-indistinguishable from each other. Task-based labels make the sections scannable by what the user is trying to accomplish, and matching H1s confirm you landed where you clicked. The config keys remain in every H1, title, and page body for anyone searching by key name. While renumbering, two pre-existing issues were also fixed: the Axe Core® configuration page had no `sidebar_position` at all, and the Accessibility `overview.mdx` and `views.mdx` both had position 10, leaving their relative order ambiguous.

## Notes for reviewers

- Changes are limited to `sidebar_label` and `sidebar_position` frontmatter and each page's H1; page body content and URLs are untouched. The one exception is the "Ignore rules for specific elements" page, whose `title:` frontmatter was also updated to feature `data-a11y-ignore`, the attribute it documents.
- H1 pattern is "Task phrase (`configKey`)", e.g. "Exclude elements (`elementFilters`)"; the two overview pages became "Configuration overview" instead of bare "Configuration".
- Labels use "views" terminology rather than "pages", and the Axe Core® configuration label and H1 are kept as-is.
- Ordering is driven by `sidebar_position` in increments of 10, ordered by typical usage priority: view grouping/filtering first, then element filtering, then identification tuning, with profiles last as the most advanced option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vhy3dTuMtngxYeoaJo81k1