### PR TITLE
docs: document TypeScript 7 support

### DIFF
--- a/docs/app/references/changelog.mdx
+++ b/docs/app/references/changelog.mdx
@@ -8,6 +8,14 @@ sidebar_label: Changelog
 
 # Changelog
 
+## 15.19.0
+
+_Released TBD_
+
+**Features:**
+
+- Added support for TypeScript 7 when preprocessing TypeScript spec and support files. The component testing setup wizard now accepts TypeScript 7 as well. Addresses [#34258](https://github.com/cypress-io/cypress/issues/34258). Addressed in [#34277](https://github.com/cypress-io/cypress/pull/34277).
+
 ## 15.18.1
 
 _Released Jul 7, 2026_

--- a/docs/app/tooling/typescript-support.mdx
+++ b/docs/app/tooling/typescript-support.mdx
@@ -75,7 +75,7 @@ manual synchronization.
 
 ### Install TypeScript
 
-To use TypeScript with Cypress, you will need TypeScript 5.x or TypeScript 6.x. If you do not
+To use TypeScript with Cypress, you will need TypeScript 5.x, 6.x, or 7.x. If you do not
 already have TypeScript installed as a part of your framework, you will need to
 install it:
 
@@ -699,6 +699,7 @@ sets of globals no longer interfere with each other.
 
 | Version                                      | Changes                                                                                                                                       |
 | -------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| [15.19.0](/app/references/changelog#15-19-0) | Added support for TypeScript 7.0                                                                                                              |
 | [15.14.0](/app/references/changelog#15-14-0) | Added support for TypeScript 6.0                                                                                                              |
 | [15.0.0](/app/references/changelog#15-0-0)   | Raised minimum required TypeScript version from 4.0+ to 5.0+ and replaced `ts-node` with `tsx` to parse and run the `cypress.config.ts` file. |
 | [13.0.0](/app/references/changelog#13-0-0)   | Raised minimum required TypeScript version from 3.4+ to 4.0+                                                                                  |


### PR DESCRIPTION
## Summary

Documents TypeScript 7 support on the TypeScript support page: updates the supported-version requirement to include 7.x and adds a History entry.

## Why

Cypress now supports TypeScript 7 for spec and support file preprocessing (cypress-io/cypress#34277, closing cypress-io/cypress#34258). TypeScript 7 is the native compiler and ships without the JavaScript compiler API that ts-loader relied on; Cypress now transpiles TypeScript spec/support files without it. The docs previously stated only 5.x and 6.x were supported, so the requirement and version history needed updating to reflect 7.x.

## Notes for reviewers

- Two changes only, both in `docs/app/tooling/typescript-support.mdx`: the "Install TypeScript" version requirement line and a new `15.19.0` row in the History table.
- The History row links to the `15-19-0` changelog anchor, which lands when the app's `15.19.0` release notes are published.
- Base branch is `release/15.19.0` so this merges alongside the release it documents.
- The page doesn't currently document spec transpilation internals (ts-loader vs. babel), so the known TypeScript 7 differences (JSX automatic runtime requiring React in scope; legacy-decorator/`reflect-metadata` behavior) are intentionally left out to match the page's existing depth. Happy to add a "Known limitations" note if preferred.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to version requirements and release notes; no product or security behavior changes.
> 
> **Overview**
> Documents **TypeScript 7.x** as a supported version alongside 5.x and 6.x on the TypeScript support page, and adds matching **15.19.0** release notes.
> 
> The **Install TypeScript** requirement in `typescript-support.mdx` now lists **7.x**, and the page **History** table gains a **15.19.0** row linking to the changelog. `changelog.mdx` introduces a **15.19.0** (TBD) section describing TypeScript 7 support for spec/support preprocessing and the component testing setup wizard, referencing [#34258](https://github.com/cypress-io/cypress/issues/34258) / [#34277](https://github.com/cypress-io/cypress/pull/34277).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28250ea5d92ecd6073baad2c15ae7c41703d43d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->