### PR TITLE
chore: update deprecated node20 actions in plugins update workflow

### DIFF
--- a/.github/workflows/update-plugins-data.yml
+++ b/.github/workflows/update-plugins-data.yml
@@ -19,12 +19,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: main
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.node-version'
           cache: npm
@@ -42,7 +42,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Open pull request if changed
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           add-paths: src/data/plugins-generated.json
           branch: automation/update-plugins-data

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,3 +124,11 @@ Each rule is a hard convention. See the linked section for the how and why.
   dependencies resolve from the repository root's `node_modules`. Declare new
   dependencies in the **root** `package.json`, never in a plugin's own
   `package.json` (pins there are never installed and just drift stale).
+
+**GitHub Actions workflows** — [details](./AGENTS_REFERENCE.md#github-actions-workflows)
+
+- When adding or editing a workflow in `.github/workflows/`, never pin an
+  action version from memory or by copying an existing workflow — both go
+  stale. Look up each action's latest major release on its GitHub repo and pin
+  that (e.g. `actions/checkout@v7`, not `@v4`). Older majors target Node.js
+  runtimes GitHub has deprecated and log warnings on every run.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,8 +127,6 @@ Each rule is a hard convention. See the linked section for the how and why.
 
 **GitHub Actions workflows** — [details](./AGENTS_REFERENCE.md#github-actions-workflows)
 
-- When adding or editing a workflow in `.github/workflows/`, never pin an
-  action version from memory or by copying an existing workflow — both go
-  stale. Look up each action's latest major release on its GitHub repo and pin
-  that (e.g. `actions/checkout@v7`, not `@v4`). Older majors target Node.js
-  runtimes GitHub has deprecated and log warnings on every run.
+- When adding or editing a workflow in `.github/workflows/`, look up each
+  action's latest major release on its GitHub repository at the time of
+  writing and pin that major tag.

--- a/AGENTS_REFERENCE.md
+++ b/AGENTS_REFERENCE.md
@@ -437,32 +437,14 @@ that already embed the correct params rather than re-writing the URL.
 
 ## GitHub Actions workflows
 
-Repo automation lives in `.github/workflows/`. The recurring failure mode when
-writing a workflow from memory is pinning the action versions that were current
-in training data (`actions/checkout@v4`, `actions/setup-node@v4`,
-`peter-evans/create-pull-request@v7`). Those majors target Node.js 20, which
-GitHub deprecated on its runners in September 2025, so every run logs warnings
-like:
-
-> Node.js 20 is deprecated. The following actions target Node.js 20 but are
-> being forced to run on Node.js 24: actions/checkout@v4, actions/setup-node@v4
-> …
-
-This exact problem was reported in
-[#6698](https://github.com/cypress-io/cypress-documentation/issues/6698); don't
-reintroduce it. When adding or editing a workflow:
+Repo automation lives in `.github/workflows/`. When adding or editing a
+workflow:
 
 - **Look up the current major version of every action you use.** Check the
   action's own GitHub repository (its releases or tags page) at the time you
-  write the workflow. Never trust remembered version numbers, examples from
-  docs or blog posts, or versions copied from another workflow file — any of
-  them may already be stale.
-- Pin to the latest major tag (for example `uses: actions/checkout@v7`),
+  write the workflow, and use the latest major version published there.
+- Pin each action to its latest major tag (`uses: <owner>/<action>@v<major>`),
   matching this repo's existing style. Pinning to a commit SHA is not required
   here.
-- Known-good floors as of July 2026 — treat these as minimums to exceed, not as
-  answers to copy, and re-verify against each action's repo:
-  `actions/checkout@v7`, `actions/setup-node@v6`,
-  `peter-evans/create-pull-request@v8`.
 - After a new or changed workflow runs, read its logs and bump any action the
   runner flags with a deprecation warning.

--- a/AGENTS_REFERENCE.md
+++ b/AGENTS_REFERENCE.md
@@ -434,3 +434,35 @@ that already embed the correct params rather than re-writing the URL.
 - **Plugin unit tests** (Vitest) cover the remark plugins in `plugins/`. Run them
   with `npm run test:plugins`, and run them whenever you change anything under
   `plugins/`.
+
+## GitHub Actions workflows
+
+Repo automation lives in `.github/workflows/`. The recurring failure mode when
+writing a workflow from memory is pinning the action versions that were current
+in training data (`actions/checkout@v4`, `actions/setup-node@v4`,
+`peter-evans/create-pull-request@v7`). Those majors target Node.js 20, which
+GitHub deprecated on its runners in September 2025, so every run logs warnings
+like:
+
+> Node.js 20 is deprecated. The following actions target Node.js 20 but are
+> being forced to run on Node.js 24: actions/checkout@v4, actions/setup-node@v4
+> …
+
+This exact problem was reported in
+[#6698](https://github.com/cypress-io/cypress-documentation/issues/6698); don't
+reintroduce it. When adding or editing a workflow:
+
+- **Look up the current major version of every action you use.** Check the
+  action's own GitHub repository (its releases or tags page) at the time you
+  write the workflow. Never trust remembered version numbers, examples from
+  docs or blog posts, or versions copied from another workflow file — any of
+  them may already be stale.
+- Pin to the latest major tag (for example `uses: actions/checkout@v7`),
+  matching this repo's existing style. Pinning to a commit SHA is not required
+  here.
+- Known-good floors as of July 2026 — treat these as minimums to exceed, not as
+  answers to copy, and re-verify against each action's repo:
+  `actions/checkout@v7`, `actions/setup-node@v6`,
+  `peter-evans/create-pull-request@v8`.
+- After a new or changed workflow runs, read its logs and bump any action the
+  runner flags with a deprecation warning.


### PR DESCRIPTION
## Summary

Updates the three actions in `.github/workflows/update-plugins-data.yml` to their latest node24-compatible majors (`actions/checkout@v7`, `actions/setup-node@v6`, `peter-evans/create-pull-request@v8`), and adds a GitHub Actions workflows rule to `AGENTS.md` / `AGENTS_REFERENCE.md` instructing agents to look up each action's latest major release at the time of writing and pin that tag.

## Why

The nightly `update-plugins-data` workflow logged deprecation warnings on every run because its pinned action majors target Node.js 20, which GitHub deprecated on its runners. The agents-file rule prevents the same stale versions from being reintroduced when future workflows are written from memory or copied from older examples.

Closes #6698

## Notes for reviewers

- The agents guidance is intentionally forward-looking only: it names no specific actions or version numbers (which would themselves go stale) and keeps the repo's existing major-tag pinning style rather than requiring commit-SHA pins.
- The workflow change is version bumps only; no step inputs needed to change for the new majors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G693td4fo4HRu7F4Bru6LQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01G693td4fo4HRu7F4Bru6LQ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only CI workflow updates plus contributor/agent documentation; no app runtime or security-sensitive logic changes.
> 
> **Overview**
> Bumps the three actions in **`update-plugins-data`** to newer majors (`actions/checkout@v7`, `actions/setup-node@v6`, `peter-evans/create-pull-request@v8`) so the nightly job stops hitting Node 20 deprecation warnings on GitHub-hosted runners. Step inputs are unchanged.
> 
> Adds a **GitHub Actions workflows** rule to **`AGENTS.md`** and a fuller section in **`AGENTS_REFERENCE.md`**: when editing `.github/workflows/`, look up each action’s latest major at write time, pin `@v<major>`, and bump anything the runner flags after a run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 510bf95104b993c94d3ee49e3ea1cd5f72df0d63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->