### PR TITLE
fix: skip plugins update workflow in forks

### DIFF
--- a/.github/workflows/update-plugins-data.yml
+++ b/.github/workflows/update-plugins-data.yml
@@ -16,12 +16,7 @@ concurrency:
 
 jobs:
   update-plugins-data:
-    # Only run on the main branch of the parent repository. In forks,
-    # GitHub Actions is not permitted to create pull requests, so the
-    # "Open pull request if changed" step would fail with a fatal error.
-    # Note for forks: scheduled workflows still start (and are skipped by
-    # this condition) until you manually disable this workflow under the
-    # repository's Actions tab.
+    # Skip in forks, where Actions cannot create pull requests
     if: (github.ref == 'refs/heads/main') &&
       (github.repository == 'cypress-io/cypress-documentation')
     runs-on: ubuntu-latest

--- a/.github/workflows/update-plugins-data.yml
+++ b/.github/workflows/update-plugins-data.yml
@@ -16,6 +16,14 @@ concurrency:
 
 jobs:
   update-plugins-data:
+    # Only run on the main branch of the parent repository. In forks,
+    # GitHub Actions is not permitted to create pull requests, so the
+    # "Open pull request if changed" step would fail with a fatal error.
+    # Note for forks: scheduled workflows still start (and are skipped by
+    # this condition) until you manually disable this workflow under the
+    # repository's Actions tab.
+    if: (github.ref == 'refs/heads/main') &&
+      (github.repository == 'cypress-io/cypress-documentation')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,10 +132,6 @@ Each rule is a hard convention. See the linked section for the how and why.
     (github.repository == 'cypress-io/cypress-documentation')
   ```
 
-- Add a comment near the guard noting that forks should manually disable
-  scheduled workflows in their Actions tab, since the guard only skips the job;
-  the schedule still triggers it.
-
 **Plugins** — [details](./AGENTS_REFERENCE.md#project-layout)
 
 - The sub-packages in `plugins/` are never installed on their own; all of their

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,6 +118,24 @@ Each rule is a hard convention. See the linked section for the how and why.
   params (`utm_source=docs.cypress.io` + a placement `utm_medium`). Do not add
   them to internal links or `cloud.cypress.io`.
 
+**GitHub Actions workflows**
+
+- This repository is frequently forked, and scheduled (`cron`) workflows are
+  copied into every fork, where they run with reduced permissions (for example,
+  GitHub Actions cannot create or approve pull requests in a fork by default).
+  Guard any job that pushes commits, creates pull requests, or uses repo
+  secrets with a job-level condition so it only runs in the parent repository
+  on the default branch:
+
+  ```yml
+  if: (github.ref == 'refs/heads/main') &&
+    (github.repository == 'cypress-io/cypress-documentation')
+  ```
+
+- Add a comment near the guard noting that forks should manually disable
+  scheduled workflows in their Actions tab, since the guard only skips the job;
+  the schedule still triggers it.
+
 **Plugins** — [details](./AGENTS_REFERENCE.md#project-layout)
 
 - The sub-packages in `plugins/` are never installed on their own; all of their

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,20 +118,6 @@ Each rule is a hard convention. See the linked section for the how and why.
   params (`utm_source=docs.cypress.io` + a placement `utm_medium`). Do not add
   them to internal links or `cloud.cypress.io`.
 
-**GitHub Actions workflows**
-
-- This repository is frequently forked, and scheduled (`cron`) workflows are
-  copied into every fork, where they run with reduced permissions (for example,
-  GitHub Actions cannot create or approve pull requests in a fork by default).
-  Guard any job that pushes commits, creates pull requests, or uses repo
-  secrets with a job-level condition so it only runs in the parent repository
-  on the default branch:
-
-  ```yml
-  if: (github.ref == 'refs/heads/main') &&
-    (github.repository == 'cypress-io/cypress-documentation')
-  ```
-
 **Plugins** — [details](./AGENTS_REFERENCE.md#project-layout)
 
 - The sub-packages in `plugins/` are never installed on their own; all of their
@@ -144,3 +130,8 @@ Each rule is a hard convention. See the linked section for the how and why.
 - When adding or editing a workflow in `.github/workflows/`, look up each
   action's latest major release on its GitHub repository at the time of
   writing and pin that major tag.
+- Workflows are copied into forks, where they run with reduced permissions
+  (Actions cannot create or approve pull requests there). Guard any job that
+  pushes commits, creates pull requests, or uses repo secrets with a job-level
+  `if` restricting it to the `main` branch of
+  `cypress-io/cypress-documentation`.

--- a/AGENTS_REFERENCE.md
+++ b/AGENTS_REFERENCE.md
@@ -448,3 +448,16 @@ workflow:
   here.
 - After a new or changed workflow runs, read its logs and bump any action the
   runner flags with a deprecation warning.
+- This repository is frequently forked, and workflows (including scheduled
+  `cron` jobs) are copied into every fork, where they run with reduced
+  permissions: GitHub Actions cannot create or approve pull requests in a fork
+  by default, so an unguarded job fails with a fatal error. Guard any job that
+  pushes commits, creates pull requests, or uses repo secrets with a job-level
+  condition so it only runs on the default branch of the parent repository:
+
+  ```yml
+  jobs:
+    my-job:
+      if: (github.ref == 'refs/heads/main') &&
+        (github.repository == 'cypress-io/cypress-documentation')
+  ```


### PR DESCRIPTION
## Summary

Adds a job-level `if` guard to the `update-plugins-data` workflow so it only runs on the `main` branch of `cypress-io/cypress-documentation`, and documents the fork-guard convention in the "GitHub Actions workflows" sections of `AGENTS.md` and `AGENTS_REFERENCE.md`.

## Why

The nightly `update-plugins-data` workflow is copied into forks, where GitHub Actions is not permitted to create pull requests. Its scheduled runs there fail with a fatal error ("GitHub Actions is not permitted to create or approve pull requests"), for instance right after someone syncs a fork with the parent repo. Guarding the job on `github.ref == 'refs/heads/main'` and `github.repository == 'cypress-io/cypress-documentation'` skips it everywhere else, as suggested in the issue.

Closes #6699

## Notes for reviewers

- The guard is applied at the job level rather than only on the PR-creation step, since running the data refresh in a fork would be wasted work anyway.
- The agent-docs rule landed as a bullet in the existing "GitHub Actions workflows" sections (added to `main` while this branch was open), with the short rule in `AGENTS.md` and the explanation plus example in `AGENTS_REFERENCE.md`, rather than as a new standalone section.
- The issue also suggested a comment noting that forks should manually disable the scheduled workflow; that was intentionally left out to keep the workflow comment short — the guard alone makes fork runs a no-op skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S5z7aJLAkGuQpKkEHTWG5B

---
_Generated by [Claude Code](https://claude.ai/code/session_01S5z7aJLAkGuQpKkEHTWG5B)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and documentation only; no runtime app, auth, or data-path changes.
> 
> **Overview**
> **Prevents the nightly `update-plugins-data` workflow from running in forks**, where GitHub Actions cannot open pull requests and scheduled runs were failing after fork syncs.
> 
> The `update-plugins-data` job now has a job-level `if` on `github.ref == 'refs/heads/main'` and `github.repository == 'cypress-io/cypress-documentation'`, so the enrich-and-PR automation only runs on the upstream repo (not wasted work in forks either).
> 
> **Documents the fork-guard convention** for future workflows: a short rule in `AGENTS.md` and a fuller explanation plus example YAML in `AGENTS_REFERENCE.md` for jobs that push, open PRs, or use repo secrets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee180f825613f68fc7f8a76ca9b4bbdf9a7f3477. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->