### PR TITLE
Add App Quality Config title to elementGroups syntax block, add markup-grouping FAQ

### DIFF
--- a/docs/ui-coverage/configuration/elementgroups.mdx
+++ b/docs/ui-coverage/configuration/elementgroups.mdx
@@ -40,7 +40,7 @@ To add or edit `elementGroups`, open the **App Quality** tab in your project set
 
 ## Syntax
 
-```json
+```json title="App Quality Config"
 {
   "uiCoverage": {
     "elementGroups": [

--- a/docs/ui-coverage/faq.mdx
+++ b/docs/ui-coverage/faq.mdx
@@ -47,6 +47,10 @@ Views are created from URLs your tests actually visit, so a page that no test na
 
 The first matching rule in your [`elementGroups`](/ui-coverage/configuration/elementgroups) configuration wins, so list specific rules before broad catch-all rules. A rule that appears after another rule matching the same elements never applies to them.
 
+### <Icon name="angle-right" /> Can I group elements in my application code instead of Cypress Cloud configuration?
+
+Yes. Add the [`data-cy-ui-group` attribute](/ui-coverage/core-concepts/element-grouping#Grouping-with-markup-attributes) to your markup, and elements sharing the same attribute value are grouped together with no Cloud configuration needed. Placing the attribute on a wrapper element groups every interactive element inside it. Groups defined this way take priority over [`elementGroups`](/ui-coverage/configuration/elementgroups) configuration rules.
+
 ### <Icon name="angle-right" /> Can I group or filter elements inside iframes or shadow DOM?
 
 Yes. The [`elementGroups`](/ui-coverage/configuration/elementgroups), [`elementFilters`](/ui-coverage/configuration/elementfilters), and [`elements`](/ui-coverage/configuration/elements) configuration options all accept a `documentScope` property that limits a rule to elements inside specific iframes or shadow DOM hosts. List one CSS selector per host, ordered from the outermost document to the innermost.


### PR DESCRIPTION
## Summary

Adds the `title="App Quality Config"` label to the Syntax code block on the UI Coverage elementGroups configuration page, and adds a new UI Coverage FAQ entry covering grouping via the `data-cy-ui-group` markup attribute.

## Why

Follow-up to #6680, which rewrote the elementGroups page for implementation accuracy. An audit of that page against the implementation (`configElementGroups.ts`, `uiGroupIdentifier.ts`, `elementProcessingUtils.ts`, and the config validation schemas) confirmed all behavioral claims are accurate, and surfaced two remaining gaps:

- The Syntax block was the only config code block on the rewritten UI Coverage config pages missing the "App Quality Config" title — the elements and elementFilters pages both title their Syntax blocks.
- Grouping directly in application markup with `data-cy-ui-group` was only mentioned in passing inside another FAQ answer, so the common question "can I group elements without Cloud configuration?" had no direct answer for search/AI-assistant discovery. The new entry is picked up automatically by the FAQ structured-data plugin for FAQPage JSON-LD.

## Notes for reviewers

- The new FAQ answer's claims were verified against `discovery/packages/ui-coverage/src/render/grouping/uiGroupIdentifier.ts` in cypress-services: shared attribute values group together, wrapper placement cascades to interactive descendants, and markup groups take priority over `elementGroups` configuration rules (the rule runs first in `grouping/index.ts`).
- Verified locally: both files pass Prettier, and all 36 `faq-structured-data` plugin tests pass, including the integration suite that parses the real FAQ file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013P7v5AqBJCyGrFE4d19R68

---
_Generated by [Claude Code](https://claude.ai/code/session_013P7v5AqBJCyGrFE4d19R68)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, security, or data-handling impact.
> 
> **Overview**
> **Documentation-only** updates to UI Coverage config and FAQ pages.
> 
> The **elementGroups** configuration page now labels its Syntax JSON fence with `title="App Quality Config"`, matching the other rewritten App Quality config pages (e.g. **elements**, **elementFilters**).
> 
> The **UI Coverage FAQ** gains a new entry under element grouping: whether grouping can be done in application code instead of Cloud config. The answer points to **`data-cy-ui-group`**, wrapper cascading, and that markup-defined groups take priority over **`elementGroups`** rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71dfed5e471bf47e0e1d87f61c45046e7efc24ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->