### PR TITLE
Set endOfLine to lf for Prettier / Windows compatibility

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+# See https://editorconfig.org
+
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
<!--
Fill in every section. This template doubles as the historical record of the
change, so future readers can understand not just what changed but
why. Delete a section only if it is genuinely not applicable, and say so.
-->

## Summary

Follow advice in Prettier [End of Line](https://prettier.io/docs/options#end-of-line) documentation.

1. Create [.gitattributes](https://git-scm.com/docs/gitattributes) with

    ```text
    * text=auto eol=lf
    ```

2. Create [.editorconfig](https://editorconfig.org/) with the following:

    ```text
    # See https://editorconfig.org
    root = true
    [*]
    end_of_line = lf
    insert_final_newline = true
    ```

This affects only the use of the repo on Windows. It changes the end-of-line character from CR/LF to LF, consistent with Linux which already uses LF as end-of-line character.

## Why

The repo is set up to lint with Prettier using:

```shell
"lint": "npm run lint:markdown && npm run lint:frontmatter"
```

If `npm run lint` is run under Windows it shows all 340 files with incorrect formatting. This is due to a mismatch between Prettier's default LF end-of-line setting, and the git default of CR/LF on Windows.

On Linux (for instance Ubuntu), linting works correctly.

## Notes for reviewers

### Verification

On Windows 11 25H2, Node.js 24.18.0 LTS:

Using an existing clone of the https://github.com/cypress-io/cypress-documentation repo on Windows, execute the following to re-write line endings:

```shell
git rm --cached -r .
git reset --hard
npm ci
npm run lint
```

or make a fresh clone:

```shell
cd $(mktemp -d)
git clone https://github.com/cypress-io/cypress-documentation
cd cypress-documentation
npm ci
npm run lint
```

The output should be similar to the following:

```console
$ npm run lint

> cypress-docusaurus-ts@0.0.0 lint
> npm run lint:markdown && npm run lint:frontmatter


> cypress-docusaurus-ts@0.0.0 lint:markdown
> prettier --check '**/*.{md,mdx}'

Checking formatting...
All matched files use Prettier code style!

> cypress-docusaurus-ts@0.0.0 lint:frontmatter
> node scripts/lint-frontmatter.js

Frontmatter OK in 318 doc(s).
```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling-only changes with no runtime, auth, or data impact; affects line endings in working trees on Windows after re-checkout.
> 
> **Overview**
> Adds **`.gitattributes`** (`* text=auto eol=lf`) so Git normalizes checked-out text files to LF, and **`.editorconfig`** (`end_of_line = lf`, `insert_final_newline = true`) so editors match that convention.
> 
> Together these align the repo with Prettier’s default LF expectation so `npm run lint` on Windows no longer flags hundreds of markdown files for CRLF-only line-ending differences.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e71303fc35656d8d8b6779daf2f2632fb6e28db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->