### PR TITLE
Add npm allowScripts for lifecycle scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,5 +96,10 @@
   },
   "lint-staged": {
     "**/*.{md,mdx}": "prettier --write"
+  },
+  "allowScripts": {
+    "@parcel/watcher": true,
+    "core-js": true,
+    "cypress": true
   }
 }


### PR DESCRIPTION
## Summary

Execute the following under Node.js 24.18.0 (with npm@11.16.0):

```shell
npm approve-scripts --all --no-allow-scripts-pin
```

to add the following to [package.json](https://github.com/cypress-io/cypress-documentation/blob/main/package.json):

```json
  "allowScripts": {
    "@parcel/watcher": true,
    "core-js": true,
    "cypress": true
  }
```

## Why

Starting with `npm@11.16.0`, npm warns when installation attempts to run lifecycle scripts.

Currently, this repo is pinned with [.node-version](https://github.com/cypress-io/cypress-documentation/blob/main/.node-version) to 22.23.1, which uses `npm@10.9.8` and so it does not yet warn with `allow-scripts`. This is however only enforced in CI.

Using Node.js 24.18.0 LTS locally will already provoke the warnings. npm@12 converts the warnings to a block instead. npm@12 has just been released and is not yet in widespread use.

Adding the `allowScripts` entries into [package.json](https://github.com/cypress-io/cypress-documentation/blob/main/package.json) prevents warnings and installation blocks of the related lifecycle scripts for future upgrades of Node.js or local use where the user is not complying with the recommended Node.js version.

## Notes for reviewers

### Verification

To test, temporarily use Node.js 24.18.0 LTS and execute:

```shell
npm ci
npm rebuild
```

Confirm that there are no `allow-scripts` warnings.

Note that npm is still changing in the `allow-scripts` hardening area. Bugs are being fixed, command syntax is being changed, and log text is also changing. It has not yet reached a stable state.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling-only manifest change with no runtime or application logic impact; only affects which dependency install scripts npm is permitted to run.
> 
> **Overview**
> Adds an **`allowScripts`** block to **`package.json`** so npm can run install lifecycle scripts for **`@parcel/watcher`**, **`core-js`**, and **`cypress`** under npm 11.16+ (warnings) and npm 12+ (blocked by default).
> 
> This is ahead of moving off the repo’s pinned Node 22 / npm 10 setup in CI and avoids **`npm ci`** / **`npm rebuild`** friction when developers use newer Node/npm locally.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e8a75d8936ae74d842bf4d1a5f4390e1c527e46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->