### PR TITLE
Rename AI Tooling MCP plugin label to 'Cloud MCP'

### DIFF
--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -140,7 +140,7 @@
       "description": "Connect AI coding assistants and agents to Cypress so they write, understand, and debug tests more reliably. See our <a target=\"_blank\" href=\"/app/tooling/ai-skills\">Cypress AI Skills</a> guide to get started.",
       "plugins": [
         {
-          "name": "Cypress MCP",
+          "name": "Cloud MCP",
           "description": "Model Context Protocol server that connects AI coding assistants directly to Cypress Cloud, giving them access to your application's health and test stability data.",
           "link": "/cloud/integrations/cloud-mcp",
           "keywords": ["ai", "mcp", "cloud", "agents"],


### PR DESCRIPTION
## Summary

Renames the AI Tooling plugin previously labeled "Cypress MCP" to "Cloud MCP" on the plugins list page.

## Why

The plugin points to Cypress Cloud's MCP server (`/cloud/integrations/cloud-mcp`), so "Cloud MCP" is the accurate, consistent label for it on the plugins list.

## Notes for reviewers

Only the display `name` in `src/data/plugins.json` was changed. The description, link, keywords, and badge are unchanged.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QgSpw1Rw323DgWE2c5gW7p)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single display-string change in static docs data with no runtime or integration impact.
> 
> **Overview**
> Updates the **AI Tooling** entry on the plugins list so the official MCP plugin is labeled **Cloud MCP** instead of **Cypress MCP**.
> 
> Only the display `name` in `src/data/plugins.json` changes; description, link (`/cloud/integrations/cloud-mcp`), keywords, and badge stay the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f99569084768bbcc7da3063ac1f7b4e100d406a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->