### PR TITLE
docs: document `cypress install` CLI command

### DIFF
--- a/docs/app/references/command-line.mdx
+++ b/docs/app/references/command-line.mdx
@@ -915,9 +915,43 @@ detection.
 Installs the Cypress binary that matches the version of the `cypress` npm
 package into the [global cache](/app/references/advanced-installation#Binary-cache).
 
+<Tabs groupId="package-manager"
+  defaultValue="npm"
+  values={[
+    {label: 'npm', value: 'npm'},
+    {label: 'Yarn', value: 'yarn'},
+    {label: 'pnpm', value: 'pnpm'},
+    {label: 'Bun', value: 'bun'},
+  ]}>
+  <TabItem value="npm">
+
 ```shell
-cypress install
+npx cypress install
 ```
+
+  </TabItem>
+  <TabItem value="yarn">
+
+```shell
+yarn cypress install
+```
+
+  </TabItem>
+  <TabItem value="pnpm">
+
+```shell
+pnpm cypress install
+```
+
+  </TabItem>
+  <TabItem value="bun">
+
+```shell
+bunx cypress install
+```
+
+  </TabItem>
+</Tabs>
 
 This command normally runs automatically as a `postinstall` step when you add
 `cypress` with your package manager, so you rarely need to run it yourself.
@@ -938,10 +972,47 @@ Running it explicitly is useful when the binary was not downloaded during
   by running the download on its own with
   [debug logging](/app/references/troubleshooting#Print-DEBUG-logs) enabled.
 
+<Tabs groupId="package-manager"
+  defaultValue="npm"
+  values={[
+    {label: 'npm', value: 'npm'},
+    {label: 'Yarn', value: 'yarn'},
+    {label: 'pnpm', value: 'pnpm'},
+    {label: 'Bun', value: 'bun'},
+  ]}>
+  <TabItem value="npm">
+
 ```shell
 CYPRESS_INSTALL_BINARY=0 npm install cypress --save-dev
 DEBUG=cypress:cli* npx cypress install
 ```
+
+  </TabItem>
+  <TabItem value="yarn">
+
+```shell
+CYPRESS_INSTALL_BINARY=0 yarn add cypress --dev
+DEBUG=cypress:cli* yarn cypress install
+```
+
+  </TabItem>
+  <TabItem value="pnpm">
+
+```shell
+CYPRESS_INSTALL_BINARY=0 pnpm add --save-dev cypress
+DEBUG=cypress:cli* pnpm cypress install
+```
+
+  </TabItem>
+  <TabItem value="bun">
+
+```shell
+CYPRESS_INSTALL_BINARY=0 bun add --dev cypress
+DEBUG=cypress:cli* bunx cypress install
+```
+
+  </TabItem>
+</Tabs>
 
 If a matching binary is already present in the cache, `cypress install` does
 nothing. Pass `--force` to download and reinstall the binary anyway.
@@ -951,8 +1022,7 @@ cypress install --force
 ```
 
 The binary that gets installed, the cache location, and the download source can
-be customized through environment variables such as `CYPRESS_INSTALL_BINARY`,
-`CYPRESS_CACHE_FOLDER`, and `CYPRESS_DOWNLOAD_MIRROR`. See
+be customized through environment variables. See
 [Advanced Installation](/app/references/advanced-installation) for details.
 
 ### `cypress verify`

--- a/docs/app/references/command-line.mdx
+++ b/docs/app/references/command-line.mdx
@@ -915,43 +915,7 @@ detection.
 Installs the Cypress binary that matches the version of the `cypress` npm
 package into the [global cache](/app/references/advanced-installation#Binary-cache).
 
-<Tabs groupId="package-manager"
-  defaultValue="npm"
-  values={[
-    {label: 'npm', value: 'npm'},
-    {label: 'Yarn', value: 'yarn'},
-    {label: 'pnpm', value: 'pnpm'},
-    {label: 'Bun', value: 'bun'},
-  ]}>
-  <TabItem value="npm">
-
-```shell
-npx cypress install
-```
-
-  </TabItem>
-  <TabItem value="yarn">
-
-```shell
-yarn cypress install
-```
-
-  </TabItem>
-  <TabItem value="pnpm">
-
-```shell
-pnpm cypress install
-```
-
-  </TabItem>
-  <TabItem value="bun">
-
-```shell
-bunx cypress install
-```
-
-  </TabItem>
-</Tabs>
+<CypressCommandTabs command="install" />
 
 This command normally runs automatically as a `postinstall` step when you add
 `cypress` with your package manager, so you rarely need to run it yourself.
@@ -972,54 +936,17 @@ Running it explicitly is useful when the binary was not downloaded during
   by running the download on its own with
   [debug logging](/app/references/troubleshooting#Print-DEBUG-logs) enabled.
 
-<Tabs groupId="package-manager"
-  defaultValue="npm"
-  values={[
-    {label: 'npm', value: 'npm'},
-    {label: 'Yarn', value: 'yarn'},
-    {label: 'pnpm', value: 'pnpm'},
-    {label: 'Bun', value: 'bun'},
-  ]}>
-  <TabItem value="npm">
+For example, add `cypress` while skipping the binary download, then run the
+install on its own with debug logging enabled:
 
-```shell
-CYPRESS_INSTALL_BINARY=0 npm install cypress --save-dev
-DEBUG=cypress:cli* npx cypress install
-```
+<PackageManagerTabs install="cypress" dev env="CYPRESS_INSTALL_BINARY=0" />
 
-  </TabItem>
-  <TabItem value="yarn">
-
-```shell
-CYPRESS_INSTALL_BINARY=0 yarn add cypress --dev
-DEBUG=cypress:cli* yarn cypress install
-```
-
-  </TabItem>
-  <TabItem value="pnpm">
-
-```shell
-CYPRESS_INSTALL_BINARY=0 pnpm add --save-dev cypress
-DEBUG=cypress:cli* pnpm cypress install
-```
-
-  </TabItem>
-  <TabItem value="bun">
-
-```shell
-CYPRESS_INSTALL_BINARY=0 bun add --dev cypress
-DEBUG=cypress:cli* bunx cypress install
-```
-
-  </TabItem>
-</Tabs>
+<CypressCommandTabs command="install" env="DEBUG=cypress:cli*" />
 
 If a matching binary is already present in the cache, `cypress install` does
 nothing. Pass `--force` to download and reinstall the binary anyway.
 
-```shell
-cypress install --force
-```
+<CypressCommandTabs command="install --force" />
 
 The binary that gets installed, the cache location, and the download source can
 be customized through environment variables. See

--- a/docs/app/references/command-line.mdx
+++ b/docs/app/references/command-line.mdx
@@ -943,14 +943,25 @@ install on its own with debug logging enabled:
 
 <CypressCommandTabs command="install" env="DEBUG=cypress:cli*" />
 
-If a matching binary is already present in the cache, `cypress install` does
-nothing. Pass `--force` to download and reinstall the binary anyway.
-
-<CypressCommandTabs command="install --force" />
-
 The binary that gets installed, the cache location, and the download source can
 be customized through environment variables. See
 [Advanced Installation](/app/references/advanced-installation) for details.
+
+#### Options
+
+| Option          | Description                                                      |
+| --------------- | --------------------------------------------------------------- |
+| `--force`, `-f` | [Force install the Cypress binary](#cypress-install-force)      |
+| `--help`, `-h`  | Output usage information                                         |
+
+#### `cypress install --force` {#cypress-install-force}
+
+By default, `cypress install` does nothing when a binary matching the package
+version is already present in the
+[cache](/app/references/advanced-installation#Binary-cache). Pass `--force` to
+download and reinstall the binary anyway, overwriting any existing installation.
+
+<CypressCommandTabs command="install --force" />
 
 ### `cypress verify`
 

--- a/docs/app/references/command-line.mdx
+++ b/docs/app/references/command-line.mdx
@@ -920,11 +920,23 @@ cypress install
 ```
 
 This command normally runs automatically as a `postinstall` step when you add
-`cypress` with your package manager, so you rarely need to run it yourself. It is
-useful when the automatic install was skipped — for example when
-`CYPRESS_INSTALL_BINARY=0` was set — or when you want to
-[troubleshoot the installation](/app/references/advanced-installation#Troubleshoot-installation)
-with [debug logging](/app/references/troubleshooting#Print-DEBUG-logs) enabled.
+`cypress` with your package manager, so you rarely need to run it yourself.
+Running it explicitly is useful when the binary was not downloaded during
+`npm install`, including these scenarios:
+
+- Your package manager blocks lifecycle scripts (for example with
+  `--ignore-scripts`, or because a security policy disallows `postinstall`), so
+  you install the binary yourself at a later stage instead of granting Cypress
+  install-time script access.
+- You want to download and cache the binary on one machine (such as a CI
+  "install" stage), then skip the download on every subsequent machine that
+  reuses that [cache](/app/references/advanced-installation#Binary-cache).
+- The automatic install was skipped on purpose by setting
+  `CYPRESS_INSTALL_BINARY=0`.
+- You want to
+  [troubleshoot the installation](/app/references/advanced-installation#Troubleshoot-installation)
+  by running the download on its own with
+  [debug logging](/app/references/troubleshooting#Print-DEBUG-logs) enabled.
 
 ```shell
 CYPRESS_INSTALL_BINARY=0 npm install cypress --save-dev

--- a/docs/app/references/command-line.mdx
+++ b/docs/app/references/command-line.mdx
@@ -949,10 +949,10 @@ be customized through environment variables. See
 
 #### Options
 
-| Option          | Description                                                      |
-| --------------- | --------------------------------------------------------------- |
-| `--force`, `-f` | [Force install the Cypress binary](#cypress-install-force)      |
-| `--help`, `-h`  | Output usage information                                         |
+| Option          | Description                                                |
+| --------------- | ---------------------------------------------------------- |
+| `--force`, `-f` | [Force install the Cypress binary](#cypress-install-force) |
+| `--help`, `-h`  | Output usage information                                   |
 
 #### `cypress install --force` {#cypress-install-force}
 

--- a/docs/app/references/command-line.mdx
+++ b/docs/app/references/command-line.mdx
@@ -910,6 +910,39 @@ System Memory: 17.2 GB free 670 MB
 to `cypress:launcher:*` when running `cypress info` to troubleshoot browser
 detection.
 
+### `cypress install`
+
+Installs the Cypress binary that matches the version of the `cypress` npm
+package into the [global cache](/app/references/advanced-installation#Binary-cache).
+
+```shell
+cypress install
+```
+
+This command normally runs automatically as a `postinstall` step when you add
+`cypress` with your package manager, so you rarely need to run it yourself. It is
+useful when the automatic install was skipped — for example when
+`CYPRESS_INSTALL_BINARY=0` was set — or when you want to
+[troubleshoot the installation](/app/references/advanced-installation#Troubleshoot-installation)
+with [debug logging](/app/references/troubleshooting#Print-DEBUG-logs) enabled.
+
+```shell
+CYPRESS_INSTALL_BINARY=0 npm install cypress --save-dev
+DEBUG=cypress:cli* npx cypress install
+```
+
+If a matching binary is already present in the cache, `cypress install` does
+nothing. Pass `--force` to download and reinstall the binary anyway.
+
+```shell
+cypress install --force
+```
+
+The binary that gets installed, the cache location, and the download source can
+be customized through environment variables such as `CYPRESS_INSTALL_BINARY`,
+`CYPRESS_CACHE_FOLDER`, and `CYPRESS_DOWNLOAD_MIRROR`. See
+[Advanced Installation](/app/references/advanced-installation) for details.
+
 ### `cypress verify`
 
 Verify that Cypress is installed correctly and is executable.


### PR DESCRIPTION
## Summary

Adds a `cypress install` section to the Command Line reference (`docs/app/references/command-line.mdx`). The command was a real, first-class CLI command but was entirely missing from the Commands list.

## Why

Reported in cypress-io/cypress-documentation#6585: `cypress --help` lists `install` alongside `open`, `run`, `verify`, `cache`, and `info`, but the Command Line reference documented every command except `install`. It was only mentioned in passing on the Advanced Installation page.

Verified against the `cypress` repo implementation:
- `cli/lib/cli.ts` registers `program.command('install')` — description "Installs the Cypress executable matching this package's version" — with a single `-f, --force` option.
- `cli/lib/tasks/install.ts` backs the command: it no-ops when a matching binary is already cached, honors `--force` to reinstall, and respects env vars such as `CYPRESS_INSTALL_BINARY`, `CYPRESS_CACHE_FOLDER`, and `CYPRESS_DOWNLOAD_MIRROR`.

The new section covers the purpose, the `--force` flag, and the practical reasons to run it explicitly: a package manager that blocks lifecycle/`postinstall` scripts, install-once-and-cache workflows (e.g. CI), a deliberately skipped install (`CYPRESS_INSTALL_BINARY=0`), and troubleshooting with debug logging.

Closes #6585

## Notes for reviewers

- The section is placed between `cypress open`/`info` and `cypress verify`, matching the CLI's own help ordering (install → verify).
- Command examples use the site's `CypressCommandTabs` / `PackageManagerTabs` shortcut components so the npm/Yarn/pnpm/Bun variants stay DRY and sync with the rest of the page.
- Scoped intentionally to the CLI reference: `cypress install` is **not** part of the Module API (`cli/lib/cypress.ts` and `cli/types/cypress-npm-api.d.ts` expose only `run`, `open`, `cli`, `defineConfig`, `defineComponentFramework`), so nothing was added to the Module API docs.
- No changelog/History-table entry was added since this documents a long-existing command rather than a CLI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkQQRD8Qqok1EbAAC6exii

---
_Generated by [Claude Code](https://claude.ai/code/session_01GkQQRD8Qqok1EbAAC6exii)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or CLI behavior modifications.
> 
> **Overview**
> Adds a **`cypress install`** section to the Command Line reference so it matches `cypress --help` and sits between **`cypress info`** and **`cypress verify`**.
> 
> The new content explains that the command installs the matching Cypress binary into the global cache (usually via `postinstall`), when to run it explicitly (blocked lifecycle scripts, CI cache workflows, `CYPRESS_INSTALL_BINARY=0`, troubleshooting with debug logs), and documents **`--force` / `-f`** and **`--help`**. Examples use **`CypressCommandTabs`** and **`PackageManagerTabs`** like the rest of the page, with links to Advanced Installation and troubleshooting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a5ca605af47de8ab63b0cad91bf297dc0c8cfc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->