### PR TITLE
docs(ui-coverage): rewrite allowedInteractionCommands page for accuracy and value

### DIFF
--- a/docs/ui-coverage/configuration/allowedinteractioncommands.mdx
+++ b/docs/ui-coverage/configuration/allowedinteractioncommands.mdx
@@ -68,6 +68,7 @@ Understanding the matching behavior is the key to using this option correctly:
 - **Matching a rule replaces the defaults for that element.** Once an element matches a rule, only the commands listed in that rule count as coverage for it. The default commands no longer apply. This is how the option both narrows coverage (a listed command like `click` still counts, an unlisted default like `type` no longer does) and expands it (a listed non-default command like `assert` now counts).
 - **Commands are combined across all matching rules.** If an element matches more than one rule, the commands from every matching rule are allowed for it. Because rules are additive this way, a later rule can never remove a command an earlier rule granted. Favor a high degree of selector specificity so each element matches only the rule you intend.
 - **A custom command listed here doesn't need to be registered anywhere else.** Normally a custom or plugin command (one that isn't a [default command](/ui-coverage/core-concepts/interactivity#Interaction-Commands)) only counts as an interaction if you add it to [`additionalInteractionCommands`](/ui-coverage/configuration/additionalinteractioncommands). Naming it in a rule's `commands` list registers it as well, so a command like `realHover` is recognized here without also appearing in `additionalInteractionCommands`.
+- **Command names are case-sensitive.** Each name in `commands` must match the command exactly as it appears in your test code, and only commands that actually target a DOM element produce coverage.
 
 ## Examples
 
@@ -199,7 +200,6 @@ Some elements are only ever validated, never interacted with, such as a read-onl
 
 ```javascript
 // Assertions against the element count as coverage
-cy.get('[data-cy="order-total"]').should('exist') // ✓ Tracked
 cy.get('[data-cy="order-total"]').should('be.visible') // ✓ Tracked
 cy.get('[data-cy="order-total"]').click() // ✗ Not tracked (`assert` is the only allowed command)
 ```
@@ -297,9 +297,10 @@ cy.get('#embedded-form').then(($iframe) => {
 })
 ```
 
-## Notes
+## See also
 
-- Elements that don't match any rule keep all default interaction commands (plus any `additionalInteractionCommands`).
-- Command names are case-sensitive and must match the command name exactly as it appears in your test code.
-- This configuration works independently of [`additionalInteractionCommands`](/ui-coverage/configuration/additionalinteractioncommands). A command declared here is recognized without also being listed there.
-- Only commands that actually interact with a DOM element (and log a snapshot referencing it) produce coverage. Listing a command that never targets an element has no effect.
+- [`additionalInteractionCommands`](/ui-coverage/configuration/additionalinteractioncommands): count a custom or plugin command as an interaction on every element, not just specific ones.
+- [Interactivity](/ui-coverage/core-concepts/interactivity#Interaction-Commands): the default set of commands UI Coverage tracks and how interactive elements are found.
+- [Custom commands](/api/cypress-api/custom-commands): writing commands that log a snapshot so UI Coverage can attribute them.
+- [Configuration overview](/ui-coverage/configuration/overview): where to set configuration and regenerate reports.
+- [UI Coverage FAQ](/ui-coverage/faq#Interaction-commands): common questions about interaction commands and troubleshooting.

--- a/docs/ui-coverage/configuration/allowedinteractioncommands.mdx
+++ b/docs/ui-coverage/configuration/allowedinteractioncommands.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'allowedInteractionCommands'
-description: 'Use allowedInteractionCommands to limit the interaction commands that are tracked for specific elements in UI Coverage.'
+title: 'allowedInteractionCommands: choose which commands count as coverage'
+description: 'Use allowedInteractionCommands to control which Cypress interaction commands count as coverage for specific elements, so you can require a meaningful interaction or accept commands UI Coverage ignores by default.'
 sidebar_label: 'Limit tracked commands'
 sidebar_position: 100
 ---
@@ -9,18 +9,30 @@ sidebar_position: 100
 
 # Limit tracked commands (`allowedInteractionCommands`)
 
-UI Coverage tracks [all interaction commands](/ui-coverage/core-concepts/interactivity#Interaction-Commands) by default for comprehensive coverage reporting. The `allowedInteractionCommands` configuration allows you to limit which interaction commands are tracked for specific elements by defining rules based on CSS selectors.
+By default, UI Coverage marks an element as tested when it's targeted by one of a [default set of Cypress interaction commands](/ui-coverage/core-concepts/interactivity#Interaction-Commands) — `click`, `type`, `select`, and others. That default is right for most elements, but not all: a chart is really tested by a hover, not the plain `click` that happens to count, and a status banner you only ever assert against is never "interacted with" at all, so it never counts.
 
-This is particularly useful for filtering out irrelevant interactions or focusing coverage tracking on specific interaction patterns for different types of elements.
+The `allowedInteractionCommands` configuration lets you decide, per element, exactly which commands count as coverage. You provide a CSS selector and the list of commands that should count for the elements it matches. For those elements, **only the commands you list count** — every other command is ignored, even commands that normally count. This lets you both **narrow** coverage to a meaningful interaction (a data-visualization widget that must be hovered, not just clicked) and **expand** it to commands UI Coverage ignores by default (crediting an `assert` on a read-only element).
 
 ## Why use allowedInteractionCommands?
 
-- **Focused tracking**: Limit coverage tracking to relevant interaction types for specific elements or components to reduce noise in reports.
-- **Component-specific rules**: Apply different interaction tracking rules based on element types or component categories. For example, you may require specific kinds of interactions on complex data-visualization components that are not required in regular interactive elements.
+- **Require a meaningful interaction**: For components where a plain `click` doesn't prove the feature works — charts, drag-and-drop canvases, custom widgets — restrict coverage to the command that actually exercises it, so a superficial interaction no longer marks the element tested.
+- **Credit commands ignored by default**: Count interactions UI Coverage doesn't track out of the box, such as an `assert` on a read-only element, or a third-party command like `realClick`, as coverage for the elements where they're the interaction that matters.
+- **Reduce noise in reports**: Limit tracking to the interaction types that are relevant for a given element or component, so coverage reflects the interactions your team cares about.
+
+For custom or third-party commands that should count as coverage **everywhere** rather than for specific elements, use [`additionalInteractionCommands`](/ui-coverage/configuration/additionalinteractioncommands) instead. See [Which option do I need?](/ui-coverage/configuration/overview#Which-option-do-I-need) in the configuration overview.
+
+## Setting allowedInteractionCommands
+
+To add or edit `allowedInteractionCommands`, open the **App Quality** tab in your project settings in Cypress Cloud. `allowedInteractionCommands` is a UI Coverage–only option and is always nested under the `uiCoverage` key. See [Setting configuration](/ui-coverage/configuration/overview#Setting-configuration) for details, including how to regenerate past reports with a new configuration without rerunning your tests.
+
+<DocsImage
+  src="/img/ui-coverage/configuration/cypress-ui-coverage-configuration-editor.png"
+  alt="The App Quality tab of a project's settings in Cypress Cloud, showing the configuration editor with JSON configuration"
+/>
 
 ## Syntax
 
-```json
+```json title="App Quality Config"
 {
   "uiCoverage": {
     "allowedInteractionCommands": [
@@ -37,28 +49,42 @@ This is particularly useful for filtering out irrelevant interactions or focusin
 
 ### Options
 
-The `allowedInteractionCommands` property accepts an array of objects, where each object defines a rule for limiting interaction commands for elements matching a specific selector.
+The `allowedInteractionCommands` property accepts an array of objects, where each object defines a rule that limits the interaction commands counted as coverage for elements matching a selector.
 
-| Option          | Required | Default | Description                                                                                                                                                                                                                                 |
-| --------------- | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `selector`      | Required |         | A CSS selector to identify elements. Supports standard CSS selector syntax, including IDs, classes, attributes, and combinators.                                                                                                            |
-| `commands`      | Required |         | An array of command names (strings) that should be tracked as interactions for elements matching the selector. All other interaction commands will be ignored for these elements.                                                           |
-| `documentScope` | Optional |         | An array of CSS selectors that identify document hosts (iframes or shadow DOM hosts) that must be ancestors of the matched element. The selector will only match if all specified document hosts are found in the element's ancestor chain. |
-| `comment`       | Optional |         | A comment describing the purpose of this allowed interaction commands configuration.                                                                                                                                                        |
+| Option          | Required | Default | Description                                                                                                                                                                                                                                  |
+| --------------- | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `selector`      | Required |         | A CSS selector that identifies the elements the rule applies to. Supports standard CSS selector syntax, including IDs, classes, attributes, and combinators.                                                                                 |
+| `commands`      | Required |         | An array of command names (strings) that count as coverage for elements matching the selector. Any command not in this list is ignored for those elements, including commands that would otherwise count by default.                         |
+| `documentScope` | Optional |         | An ordered list of CSS selectors identifying the iframe or shadow DOM hosts that must contain the element, from the outermost document to the innermost. When set, the rule applies only to matching elements inside those nested documents. |
+| `comment`       | Optional |         | A note describing the purpose of the rule. It has no effect on processing.                                                                                                                                                                   |
+
+Each `selector`/`documentScope` combination must be unique across the list; duplicate rules are rejected by validation.
+
+## How rules are applied
+
+Understanding the matching behavior is the key to using this option correctly:
+
+- **Elements that match no rule are unaffected.** They keep the full [default set of interaction commands](/ui-coverage/core-concepts/interactivity#Interaction-Commands), plus anything you've added with [`additionalInteractionCommands`](/ui-coverage/configuration/additionalinteractioncommands).
+- **Matching a rule replaces the defaults for that element.** Once an element matches a rule, only the commands listed in that rule count as coverage for it. The default commands no longer apply — this is how the option both narrows coverage (a listed command like `click` still counts, an unlisted default like `type` no longer does) and expands it (a listed non-default command like `assert` now counts).
+- **Commands are combined across all matching rules.** If an element matches more than one rule, the commands from every matching rule are allowed for it. Because rules are additive this way, a later rule can never remove a command an earlier rule granted — favor a high degree of selector specificity so each element matches only the rule you intend.
+- **Listed commands are recognized automatically.** A command named in `commands` is treated as an interaction even if it isn't a default command and isn't listed in [`additionalInteractionCommands`](/ui-coverage/configuration/additionalinteractioncommands). You do not need to declare it in both places.
 
 ## Examples
 
-### Limiting button interactions to clicks only
+### Requiring a specific interaction for a component
+
+Restrict coverage for a chart component to the command that meaningfully exercises it. Because matching the rule replaces the defaults, a plain `click` no longer marks the chart tested.
 
 #### Config
 
-```json
+```json title="App Quality Config"
 {
   "uiCoverage": {
     "allowedInteractionCommands": [
       {
-        "selector": "button, [role='button']",
-        "commands": ["click", "realClick"]
+        "selector": "[data-cy='revenue-chart']",
+        "commands": ["trigger"],
+        "comment": "Only a hover (dispatched via trigger) proves the chart tooltip works"
       }
     ]
   }
@@ -68,32 +94,32 @@ The `allowedInteractionCommands` property accepts an array of objects, where eac
 #### Usage in tests
 
 ```javascript
-// Only click and realClick will be tracked for buttons
-cy.get('[data-cy="submit-button"]').click() // ✓ Tracked
-cy.get('[data-cy="submit-button"]').realClick() // ✓ Tracked
-cy.get('[data-cy="submit-button"]').hover() // ✗ Not tracked
-cy.get('[data-cy="submit-button"]').focus() // ✗ Not tracked
+// Only `trigger` counts as coverage for the chart
+cy.get('[data-cy="revenue-chart"]').trigger('mouseover') // ✓ Tracked
+cy.get('[data-cy="revenue-chart"]').click() // ✗ Not tracked — a default command, now excluded
 ```
 
 ### Different rules for form elements
 
+Apply distinct command sets to different kinds of form controls. Each control is credited only for the commands relevant to it.
+
 #### Config
 
-```json
+```json title="App Quality Config"
 {
   "uiCoverage": {
     "allowedInteractionCommands": [
       {
         "selector": "input[type='text'], textarea",
-        "commands": ["type", "clear", "realType"]
+        "commands": ["type", "clear"]
       },
       {
         "selector": "select",
-        "commands": ["select", "click"]
+        "commands": ["select"]
       },
       {
         "selector": "input[type='checkbox'], input[type='radio']",
-        "commands": ["check", "uncheck", "click"]
+        "commands": ["check", "uncheck"]
       }
     ]
   }
@@ -103,32 +129,33 @@ cy.get('[data-cy="submit-button"]').focus() // ✗ Not tracked
 #### Usage in tests
 
 ```javascript
-// Text inputs: only type, clear, and realType are tracked
+// Text inputs: only `type` and `clear` count
 cy.get('[data-cy="username"]').type('john_doe') // ✓ Tracked
 cy.get('[data-cy="username"]').clear() // ✓ Tracked
-cy.get('[data-cy="username"]').focus() // ✗ Not tracked
+cy.get('[data-cy="username"]').focus() // ✗ Not tracked — a default command, now excluded
 
-// Select elements: only select and click are tracked
+// Select elements: only `select` counts
 cy.get('[data-cy="country"]').select('US') // ✓ Tracked
-cy.get('[data-cy="country"]').click() // ✓ Tracked
-cy.get('[data-cy="country"]').hover() // ✗ Not tracked
+cy.get('[data-cy="country"]').click() // ✗ Not tracked — a default command, now excluded
 
-// Checkboxes/Radio buttons: check, uncheck, and click are tracked
+// Checkboxes/radios: only `check` and `uncheck` count
 cy.get('[data-cy="agree-terms"]').check() // ✓ Tracked
-cy.get('[data-cy="agree-terms"]').click() // ✓ Tracked
+cy.get('[data-cy="agree-terms"]').click() // ✗ Not tracked — a default command, now excluded
 ```
 
-### Excluding hover interactions for mobile components
+### Counting third-party commands for specific elements
+
+Commands from a plugin such as [`cypress-real-events`](https://github.com/dmtrKovalenko/cypress-real-events) aren't tracked by default. Listing a command here both scopes it to the matching elements and registers it as a recognized interaction, so you don't also need to add it to [`additionalInteractionCommands`](/ui-coverage/configuration/additionalinteractioncommands).
 
 #### Config
 
-```json
+```json title="App Quality Config"
 {
   "uiCoverage": {
     "allowedInteractionCommands": [
       {
-        "selector": "[data-mobile='true']",
-        "commands": ["click", "tap", "swipe", "type"]
+        "selector": "[data-cy='tooltip-trigger']",
+        "commands": ["realHover"]
       }
     ]
   }
@@ -138,24 +165,29 @@ cy.get('[data-cy="agree-terms"]').click() // ✓ Tracked
 #### Usage in tests
 
 ```javascript
-// Mobile components: hover interactions are excluded
-cy.get('[data-mobile="true"][data-cy="menu-item"]').click() // ✓ Tracked
-cy.get('[data-mobile="true"][data-cy="menu-item"]').tap() // ✓ Tracked
-cy.get('[data-mobile="true"][data-cy="menu-item"]').hover() // ✗ Not tracked
+// `realHover` counts as coverage for the tooltip trigger
+cy.get('[data-cy="tooltip-trigger"]').realHover() // ✓ Tracked
+cy.get('[data-cy="tooltip-trigger"]').click() // ✗ Not tracked — a default command, now excluded
 ```
 
-### Allowing assertions as interactions
+:::info
 
-Note that because `allowedInteractionCommands` replaces the allowed interactions, if you add `assert` as an interaction, remember to also add any other acceptable interactions to the list.
+Like custom commands added with [`additionalInteractionCommands`](/ui-coverage/configuration/additionalinteractioncommands), a command listed here only produces coverage if it logs a snapshot that references the subject element. Built-in Cypress commands and well-behaved plugins do this automatically. See [custom commands](/api/cypress-api/custom-commands) for details.
+
+:::
+
+### Counting assertions as coverage
+
+Some elements are only ever validated, never interacted with — a read-only status badge, a computed total. Assertions don't count as coverage by default, but you can list `assert` to credit them. Remember that once a rule matches, only the commands you list count, so include any other commands you also want to accept.
 
 #### Config
 
-```json
+```json title="App Quality Config"
 {
   "uiCoverage": {
     "allowedInteractionCommands": [
       {
-        "selector": "button[data-no-explicit-interaction='true']",
+        "selector": "[data-cy='order-total']",
         "commands": ["assert"]
       }
     ]
@@ -166,19 +198,19 @@ Note that because `allowedInteractionCommands` replaces the allowed interactions
 #### Usage in tests
 
 ```javascript
-// Any assertions on matching elements are tracked
-cy.get('button[data-no-explicit-interaction="true"]').should('exist) // ✓ Tracked
-cy.get('button[data-no-explicit-interaction="true"]').should('be.visible) // ✓ Tracked
-cy.get('button[data-no-explicit-interaction="true"]').click() // ✗ Not tracked
+// Assertions against the element count as coverage
+cy.get('[data-cy="order-total"]').should('exist') // ✓ Tracked
+cy.get('[data-cy="order-total"]').should('be.visible') // ✓ Tracked
+cy.get('[data-cy="order-total"]').click() // ✗ Not tracked — `assert` is the only allowed command
 ```
 
-### Scoping interaction commands to shadow DOM
+### Scoping rules to shadow DOM
 
-When you need to limit interaction commands for elements within a specific shadow DOM host, use the `documentScope` property to scope your selector to that document context.
+When a rule should apply only to elements inside a specific shadow DOM host, use `documentScope` to scope the selector to that document context.
 
 #### Config
 
-```json
+```json title="App Quality Config"
 {
   "uiCoverage": {
     "allowedInteractionCommands": [
@@ -194,12 +226,12 @@ When you need to limit interaction commands for elements within a specific shado
 
 #### HTML
 
-```xml
+```html
 <body>
   <button id="root-button">Root Button</button>
   <custom-component>
-    #shadow-dom
-      <button id="shadow-button">Shadow Button</button>
+    #shadow-root
+    <button id="shadow-button">Shadow Button</button>
   </custom-component>
 </body>
 ```
@@ -207,24 +239,22 @@ When you need to limit interaction commands for elements within a specific shado
 #### Usage in tests
 
 ```javascript
-// Root button: all interactions tracked (default behavior)
+// Root button: unaffected, keeps all default interaction commands
 cy.get('#root-button').click() // ✓ Tracked
-cy.get('#root-button').hover() // ✓ Tracked
+cy.get('#root-button').focus() // ✓ Tracked
 
-// Shadow DOM button: only click tracked
+// Shadow DOM button: matches the rule, so only `click` counts
 cy.get('custom-component').shadow().find('#shadow-button').click() // ✓ Tracked
-cy.get('custom-component').shadow().find('#shadow-button').hover() // ✗ Not tracked
+cy.get('custom-component').shadow().find('#shadow-button').focus() // ✗ Not tracked
 ```
 
----
+### Scoping rules to iframes
 
-### Scoping interaction commands to iframes
-
-You can also scope interaction command rules to elements within specific iframes using `documentScope`.
+`documentScope` also scopes a rule to elements inside a specific iframe. List one selector per nested document, ordered from the outermost document to the innermost.
 
 #### Config
 
-```json
+```json title="App Quality Config"
 {
   "uiCoverage": {
     "allowedInteractionCommands": [
@@ -240,7 +270,7 @@ You can also scope interaction command rules to elements within specific iframes
 
 #### HTML
 
-```xml
+```html
 <body>
   <input id="root-input" />
   <iframe id="embedded-form" src="http://www.foo.com">
@@ -256,11 +286,11 @@ You can also scope interaction command rules to elements within specific iframes
 #### Usage in tests
 
 ```javascript
-// Root input: all interactions tracked (default behavior)
+// Root input: unaffected, keeps all default interaction commands
 cy.get('#root-input').type('text') // ✓ Tracked
 cy.get('#root-input').focus() // ✓ Tracked
 
-// Embedded input: only type and clear tracked
+// Embedded input: matches the rule, so only `type` and `clear` count
 cy.get('#embedded-form').then(($iframe) => {
   cy.wrap($iframe.contents().find('#embedded-input')).type('text') // ✓ Tracked
   cy.wrap($iframe.contents().find('#embedded-input')).focus() // ✗ Not tracked
@@ -269,7 +299,7 @@ cy.get('#embedded-form').then(($iframe) => {
 
 ## Notes
 
-- Elements that don't match any selector will have all interaction commands tracked (default behavior).
-- If an element matches multiple selectors, commands from all matching rules will be allowed. A high degree of specificity for these selectors is recommended.
-- Command names are case-sensitive and must match exactly as they appear in your test code.
-- This configuration works separately from `additionalInteractionCommands`. Custom commands do **not** need to be globally defined as `additionalInteractionCommands` in order to be declared here.
+- Elements that don't match any rule keep all default interaction commands (plus any `additionalInteractionCommands`).
+- Command names are case-sensitive and must match the command name exactly as it appears in your test code.
+- This configuration works independently of [`additionalInteractionCommands`](/ui-coverage/configuration/additionalinteractioncommands). A command declared here is recognized without also being listed there.
+- Only commands that actually interact with a DOM element (and log a snapshot referencing it) produce coverage. Listing a command that never targets an element has no effect.

--- a/docs/ui-coverage/configuration/allowedinteractioncommands.mdx
+++ b/docs/ui-coverage/configuration/allowedinteractioncommands.mdx
@@ -16,7 +16,7 @@ The `allowedInteractionCommands` configuration lets you decide, per element, exa
 ## Why use allowedInteractionCommands?
 
 - **Require a meaningful interaction**: For components where a plain `click` doesn't prove the feature works, such as charts, drag-and-drop canvases, and custom widgets, restrict coverage to the command that actually exercises it, so a superficial interaction no longer marks the element tested.
-- **Credit commands ignored by default**: Count interactions UI Coverage doesn't track out of the box, such as an `assert` on a read-only element, or a third-party command like `realClick`, as coverage for the elements where they're the interaction that matters.
+- **Credit commands ignored by default**: Count interactions UI Coverage doesn't track out of the box, such as an `assert` on a read-only element, as coverage for the specific elements where that interaction is what matters.
 - **Reduce noise in reports**: Limit tracking to the interaction types that are relevant for a given element or component, so coverage reflects the interactions your team cares about.
 
 For custom or third-party commands that should count as coverage **everywhere** rather than for specific elements, use [`additionalInteractionCommands`](/ui-coverage/configuration/additionalinteractioncommands) instead. See [Which option do I need?](/ui-coverage/configuration/overview#Which-option-do-I-need) in the configuration overview.
@@ -56,7 +56,7 @@ The `allowedInteractionCommands` property accepts an array of objects, where eac
 | `selector`      | Required |         | A CSS selector that identifies the elements the rule applies to. Supports standard CSS selector syntax, including IDs, classes, attributes, and combinators.                                                                                 |
 | `commands`      | Required |         | An array of command names (strings) that count as coverage for elements matching the selector. Any command not in this list is ignored for those elements, including commands that would otherwise count by default.                         |
 | `documentScope` | Optional |         | An ordered list of CSS selectors identifying the iframe or shadow DOM hosts that must contain the element, from the outermost document to the innermost. When set, the rule applies only to matching elements inside those nested documents. |
-| `comment`       | Optional |         | A note describing the purpose of the rule. It has no effect on processing.                                                                                                                                                                   |
+| `comment`       | Optional |         | A note about why this rule exists, for your team's benefit. Comments appear only in the configuration itself. They have no effect on processing and are not displayed in reports.                                                            |
 
 Each `selector`/`documentScope` combination must be unique across the list; duplicate rules are rejected by validation.
 
@@ -67,7 +67,7 @@ Understanding the matching behavior is the key to using this option correctly:
 - **Elements that match no rule are unaffected.** They keep the full [default set of interaction commands](/ui-coverage/core-concepts/interactivity#Interaction-Commands), plus anything you've added with [`additionalInteractionCommands`](/ui-coverage/configuration/additionalinteractioncommands).
 - **Matching a rule replaces the defaults for that element.** Once an element matches a rule, only the commands listed in that rule count as coverage for it. The default commands no longer apply. This is how the option both narrows coverage (a listed command like `click` still counts, an unlisted default like `type` no longer does) and expands it (a listed non-default command like `assert` now counts).
 - **Commands are combined across all matching rules.** If an element matches more than one rule, the commands from every matching rule are allowed for it. Because rules are additive this way, a later rule can never remove a command an earlier rule granted. Favor a high degree of selector specificity so each element matches only the rule you intend.
-- **Listed commands are recognized automatically.** A command named in `commands` is treated as an interaction even if it isn't a default command and isn't listed in [`additionalInteractionCommands`](/ui-coverage/configuration/additionalinteractioncommands). You do not need to declare it in both places.
+- **A custom command listed here doesn't need to be registered anywhere else.** Normally a custom or plugin command (one that isn't a [default command](/ui-coverage/core-concepts/interactivity#Interaction-Commands)) only counts as an interaction if you add it to [`additionalInteractionCommands`](/ui-coverage/configuration/additionalinteractioncommands). Naming it in a rule's `commands` list registers it as well, so a command like `realHover` is recognized here without also appearing in `additionalInteractionCommands`.
 
 ## Examples
 
@@ -145,7 +145,7 @@ cy.get('[data-cy="agree-terms"]').click() // ✗ Not tracked (a default command,
 
 ### Counting third-party commands for specific elements
 
-Commands from a plugin such as [`cypress-real-events`](https://github.com/dmtrKovalenko/cypress-real-events) aren't tracked by default. Listing a command here both scopes it to the matching elements and registers it as a recognized interaction, so you don't also need to add it to [`additionalInteractionCommands`](/ui-coverage/configuration/additionalinteractioncommands).
+Commands from a plugin such as [`cypress-real-events`](https://github.com/dmtrKovalenko/cypress-real-events) aren't tracked by default. Listing a command here both scopes it to the matching elements and registers it as a recognized interaction, so you don't also need to add it to [`additionalInteractionCommands`](/ui-coverage/configuration/additionalinteractioncommands). Reach for `allowedInteractionCommands` when the command should only count for certain elements; if you want a plugin command counted on every element, add it to [`additionalInteractionCommands`](/ui-coverage/configuration/additionalinteractioncommands) instead.
 
 #### Config
 

--- a/docs/ui-coverage/configuration/allowedinteractioncommands.mdx
+++ b/docs/ui-coverage/configuration/allowedinteractioncommands.mdx
@@ -9,13 +9,13 @@ sidebar_position: 100
 
 # Limit tracked commands (`allowedInteractionCommands`)
 
-By default, UI Coverage marks an element as tested when it's targeted by one of a [default set of Cypress interaction commands](/ui-coverage/core-concepts/interactivity#Interaction-Commands) — `click`, `type`, `select`, and others. That default is right for most elements, but not all: a chart is really tested by a hover, not the plain `click` that happens to count, and a status banner you only ever assert against is never "interacted with" at all, so it never counts.
+By default, UI Coverage marks an element as tested when it's targeted by one of a [default set of Cypress interaction commands](/ui-coverage/core-concepts/interactivity#Interaction-Commands), such as `click`, `type`, and `select`. That default is right for most elements, but not all: a chart is really tested by a hover, not the plain `click` that happens to count, and a status banner you only ever assert against is never "interacted with" at all, so it never counts.
 
-The `allowedInteractionCommands` configuration lets you decide, per element, exactly which commands count as coverage. You provide a CSS selector and the list of commands that should count for the elements it matches. For those elements, **only the commands you list count** — every other command is ignored, even commands that normally count. This lets you both **narrow** coverage to a meaningful interaction (a data-visualization widget that must be hovered, not just clicked) and **expand** it to commands UI Coverage ignores by default (crediting an `assert` on a read-only element).
+The `allowedInteractionCommands` configuration lets you decide, per element, exactly which commands count as coverage. You provide a CSS selector and the list of commands that should count for the elements it matches. For those elements, **only the commands you list count**, and every other command is ignored, even commands that normally count. This lets you both **narrow** coverage to a meaningful interaction (a data-visualization widget that must be hovered, not just clicked) and **expand** it to commands UI Coverage ignores by default (crediting an `assert` on a read-only element).
 
 ## Why use allowedInteractionCommands?
 
-- **Require a meaningful interaction**: For components where a plain `click` doesn't prove the feature works — charts, drag-and-drop canvases, custom widgets — restrict coverage to the command that actually exercises it, so a superficial interaction no longer marks the element tested.
+- **Require a meaningful interaction**: For components where a plain `click` doesn't prove the feature works, such as charts, drag-and-drop canvases, and custom widgets, restrict coverage to the command that actually exercises it, so a superficial interaction no longer marks the element tested.
 - **Credit commands ignored by default**: Count interactions UI Coverage doesn't track out of the box, such as an `assert` on a read-only element, or a third-party command like `realClick`, as coverage for the elements where they're the interaction that matters.
 - **Reduce noise in reports**: Limit tracking to the interaction types that are relevant for a given element or component, so coverage reflects the interactions your team cares about.
 
@@ -65,8 +65,8 @@ Each `selector`/`documentScope` combination must be unique across the list; dupl
 Understanding the matching behavior is the key to using this option correctly:
 
 - **Elements that match no rule are unaffected.** They keep the full [default set of interaction commands](/ui-coverage/core-concepts/interactivity#Interaction-Commands), plus anything you've added with [`additionalInteractionCommands`](/ui-coverage/configuration/additionalinteractioncommands).
-- **Matching a rule replaces the defaults for that element.** Once an element matches a rule, only the commands listed in that rule count as coverage for it. The default commands no longer apply — this is how the option both narrows coverage (a listed command like `click` still counts, an unlisted default like `type` no longer does) and expands it (a listed non-default command like `assert` now counts).
-- **Commands are combined across all matching rules.** If an element matches more than one rule, the commands from every matching rule are allowed for it. Because rules are additive this way, a later rule can never remove a command an earlier rule granted — favor a high degree of selector specificity so each element matches only the rule you intend.
+- **Matching a rule replaces the defaults for that element.** Once an element matches a rule, only the commands listed in that rule count as coverage for it. The default commands no longer apply. This is how the option both narrows coverage (a listed command like `click` still counts, an unlisted default like `type` no longer does) and expands it (a listed non-default command like `assert` now counts).
+- **Commands are combined across all matching rules.** If an element matches more than one rule, the commands from every matching rule are allowed for it. Because rules are additive this way, a later rule can never remove a command an earlier rule granted. Favor a high degree of selector specificity so each element matches only the rule you intend.
 - **Listed commands are recognized automatically.** A command named in `commands` is treated as an interaction even if it isn't a default command and isn't listed in [`additionalInteractionCommands`](/ui-coverage/configuration/additionalinteractioncommands). You do not need to declare it in both places.
 
 ## Examples
@@ -96,7 +96,7 @@ Restrict coverage for a chart component to the command that meaningfully exercis
 ```javascript
 // Only `trigger` counts as coverage for the chart
 cy.get('[data-cy="revenue-chart"]').trigger('mouseover') // ✓ Tracked
-cy.get('[data-cy="revenue-chart"]').click() // ✗ Not tracked — a default command, now excluded
+cy.get('[data-cy="revenue-chart"]').click() // ✗ Not tracked (a default command, now excluded)
 ```
 
 ### Different rules for form elements
@@ -132,15 +132,15 @@ Apply distinct command sets to different kinds of form controls. Each control is
 // Text inputs: only `type` and `clear` count
 cy.get('[data-cy="username"]').type('john_doe') // ✓ Tracked
 cy.get('[data-cy="username"]').clear() // ✓ Tracked
-cy.get('[data-cy="username"]').focus() // ✗ Not tracked — a default command, now excluded
+cy.get('[data-cy="username"]').focus() // ✗ Not tracked (a default command, now excluded)
 
 // Select elements: only `select` counts
 cy.get('[data-cy="country"]').select('US') // ✓ Tracked
-cy.get('[data-cy="country"]').click() // ✗ Not tracked — a default command, now excluded
+cy.get('[data-cy="country"]').click() // ✗ Not tracked (a default command, now excluded)
 
 // Checkboxes/radios: only `check` and `uncheck` count
 cy.get('[data-cy="agree-terms"]').check() // ✓ Tracked
-cy.get('[data-cy="agree-terms"]').click() // ✗ Not tracked — a default command, now excluded
+cy.get('[data-cy="agree-terms"]').click() // ✗ Not tracked (a default command, now excluded)
 ```
 
 ### Counting third-party commands for specific elements
@@ -167,7 +167,7 @@ Commands from a plugin such as [`cypress-real-events`](https://github.com/dmtrKo
 ```javascript
 // `realHover` counts as coverage for the tooltip trigger
 cy.get('[data-cy="tooltip-trigger"]').realHover() // ✓ Tracked
-cy.get('[data-cy="tooltip-trigger"]').click() // ✗ Not tracked — a default command, now excluded
+cy.get('[data-cy="tooltip-trigger"]').click() // ✗ Not tracked (a default command, now excluded)
 ```
 
 :::info
@@ -178,7 +178,7 @@ Like custom commands added with [`additionalInteractionCommands`](/ui-coverage/c
 
 ### Counting assertions as coverage
 
-Some elements are only ever validated, never interacted with — a read-only status badge, a computed total. Assertions don't count as coverage by default, but you can list `assert` to credit them. Remember that once a rule matches, only the commands you list count, so include any other commands you also want to accept.
+Some elements are only ever validated, never interacted with, such as a read-only status badge or a computed total. Assertions don't count as coverage by default, but you can list `assert` to credit them. Remember that once a rule matches, only the commands you list count, so include any other commands you also want to accept.
 
 #### Config
 
@@ -201,7 +201,7 @@ Some elements are only ever validated, never interacted with — a read-only sta
 // Assertions against the element count as coverage
 cy.get('[data-cy="order-total"]').should('exist') // ✓ Tracked
 cy.get('[data-cy="order-total"]').should('be.visible') // ✓ Tracked
-cy.get('[data-cy="order-total"]').click() // ✗ Not tracked — `assert` is the only allowed command
+cy.get('[data-cy="order-total"]').click() // ✗ Not tracked (`assert` is the only allowed command)
 ```
 
 ### Scoping rules to shadow DOM

--- a/docs/ui-coverage/faq.mdx
+++ b/docs/ui-coverage/faq.mdx
@@ -155,7 +155,7 @@ The most common causes are:
 
 ### <Icon name="angle-right" /> Which commands count as coverage by default?
 
-UI Coverage marks an element as tested when it's targeted by one of a default set of Cypress interaction commands: `blur`, `check`, `clear`, `click`, `dblclick`, `focus`, `rightclick`, `scrollIntoView`, `scrollTo`, `select`, `selectFile`, `submit`, `trigger`, `type`, and `uncheck`. Commands outside this set — including plugin commands like `realClick` and `realHover`, and assertions — don't count until you add them with [`additionalInteractionCommands`](/ui-coverage/configuration/additionalinteractioncommands) or [`allowedInteractionCommands`](/ui-coverage/configuration/allowedinteractioncommands). See [Interaction Commands](/ui-coverage/core-concepts/interactivity#Interaction-Commands).
+UI Coverage marks an element as tested when it's targeted by one of a default set of Cypress interaction commands: `blur`, `check`, `clear`, `click`, `dblclick`, `focus`, `rightclick`, `scrollIntoView`, `scrollTo`, `select`, `selectFile`, `submit`, `trigger`, `type`, and `uncheck`. Commands outside this set, including plugin commands like `realClick` and `realHover` and assertions, don't count until you add them with [`additionalInteractionCommands`](/ui-coverage/configuration/additionalinteractioncommands) or [`allowedInteractionCommands`](/ui-coverage/configuration/allowedinteractioncommands). See [Interaction Commands](/ui-coverage/core-concepts/interactivity#Interaction-Commands).
 
 ### <Icon name="angle-right" /> What's the difference between additionalInteractionCommands and allowedInteractionCommands?
 
@@ -163,7 +163,7 @@ UI Coverage marks an element as tested when it's targeted by one of a default se
 
 ### <Icon name="angle-right" /> How do I require a specific interaction, like a hover, to mark an element tested?
 
-Add an [`allowedInteractionCommands`](/ui-coverage/configuration/allowedinteractioncommands) rule whose `selector` matches the element and whose `commands` list contains only the interaction you require. Because matching a rule replaces the default commands for that element, interactions you didn't list — including a plain `click` — no longer mark it tested, so the element only counts once the meaningful interaction runs.
+Add an [`allowedInteractionCommands`](/ui-coverage/configuration/allowedinteractioncommands) rule whose `selector` matches the element and whose `commands` list contains only the interaction you require. Because matching a rule replaces the default commands for that element, interactions you didn't list, including a plain `click`, no longer mark it tested, so the element only counts once the meaningful interaction runs.
 
 ### <Icon name="angle-right" /> Can I count assertions as UI Coverage?
 
@@ -175,7 +175,7 @@ No. Listing a command in an [`allowedInteractionCommands`](/ui-coverage/configur
 
 ### <Icon name="angle-right" /> Why did an element stop counting as tested after I added an allowedInteractionCommands rule?
 
-Once an element matches an [`allowedInteractionCommands`](/ui-coverage/configuration/allowedinteractioncommands) rule, only the commands listed in the matching rules count for it — the default commands no longer apply. If your tests exercise the element with a command you didn't list, it's now treated as untested. Add that command to the rule, or tighten the `selector` so the rule doesn't match elements you didn't intend to restrict.
+Once an element matches an [`allowedInteractionCommands`](/ui-coverage/configuration/allowedinteractioncommands) rule, only the commands listed in the matching rules count for it, and the default commands no longer apply. If your tests exercise the element with a command you didn't list, it's now treated as untested. Add that command to the rule, or tighten the `selector` so the rule doesn't match elements you didn't intend to restrict.
 
 ## Configuration
 

--- a/docs/ui-coverage/faq.mdx
+++ b/docs/ui-coverage/faq.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'UI Coverage FAQ'
-description: 'Get answers to common questions about Cypress UI Coverage, including scores, view and URL grouping, element identification, grouping and filtering, iframes and shadow DOM, and configuration.'
+description: 'Get answers to common questions about Cypress UI Coverage, including scores, view and URL grouping, element identification, grouping and filtering, iframes and shadow DOM, interaction commands, and configuration.'
 sidebar_label: FAQ
 sidebar_position: 160
 ---
@@ -150,6 +150,32 @@ The most common causes are:
 - An earlier rule matches the same attribute first, and the first matching rule wins. List specific `include: true` exceptions before broad `include: false` rules.
 - The rule targets a tag name or sibling position. Only attributes and individual `class` tokens can be filtered, not an element's tag name or `nth-child` position.
 - The report was processed before you saved the configuration. Regenerate the run to apply the current configuration.
+
+## Interaction commands
+
+### <Icon name="angle-right" /> Which commands count as coverage by default?
+
+UI Coverage marks an element as tested when it's targeted by one of a default set of Cypress interaction commands: `blur`, `check`, `clear`, `click`, `dblclick`, `focus`, `rightclick`, `scrollIntoView`, `scrollTo`, `select`, `selectFile`, `submit`, `trigger`, `type`, and `uncheck`. Commands outside this set — including plugin commands like `realClick` and `realHover`, and assertions — don't count until you add them with [`additionalInteractionCommands`](/ui-coverage/configuration/additionalinteractioncommands) or [`allowedInteractionCommands`](/ui-coverage/configuration/allowedinteractioncommands). See [Interaction Commands](/ui-coverage/core-concepts/interactivity#Interaction-Commands).
+
+### <Icon name="angle-right" /> What's the difference between additionalInteractionCommands and allowedInteractionCommands?
+
+[`additionalInteractionCommands`](/ui-coverage/configuration/additionalinteractioncommands) _extends_ the set of commands recognized as interactions everywhere, so a custom or plugin command counts as coverage on any element. [`allowedInteractionCommands`](/ui-coverage/configuration/allowedinteractioncommands) works _per element_: for elements matching a selector, only the commands you list count, which lets you both restrict coverage to a meaningful interaction and accept commands that are otherwise ignored. Use `additionalInteractionCommands` to recognize a command globally, and `allowedInteractionCommands` to control which commands matter for specific elements.
+
+### <Icon name="angle-right" /> How do I require a specific interaction, like a hover, to mark an element tested?
+
+Add an [`allowedInteractionCommands`](/ui-coverage/configuration/allowedinteractioncommands) rule whose `selector` matches the element and whose `commands` list contains only the interaction you require. Because matching a rule replaces the default commands for that element, interactions you didn't list — including a plain `click` — no longer mark it tested, so the element only counts once the meaningful interaction runs.
+
+### <Icon name="angle-right" /> Can I count assertions as UI Coverage?
+
+Yes. Assertions don't count by default, but an [`allowedInteractionCommands`](/ui-coverage/configuration/allowedinteractioncommands) rule listing `assert` credits assertions against the matching elements. This is useful for read-only elements such as status badges or computed totals that your tests validate but never interact with. Remember that the rule replaces the defaults for those elements, so include any other commands you also want to accept alongside `assert`.
+
+### <Icon name="angle-right" /> Do commands in allowedInteractionCommands also need to be in additionalInteractionCommands?
+
+No. Listing a command in an [`allowedInteractionCommands`](/ui-coverage/configuration/allowedinteractioncommands) rule automatically registers it as a recognized interaction, so a custom or plugin command works without also appearing in [`additionalInteractionCommands`](/ui-coverage/configuration/additionalinteractioncommands). As with any custom command, it only produces coverage if it logs a snapshot that references the subject element.
+
+### <Icon name="angle-right" /> Why did an element stop counting as tested after I added an allowedInteractionCommands rule?
+
+Once an element matches an [`allowedInteractionCommands`](/ui-coverage/configuration/allowedinteractioncommands) rule, only the commands listed in the matching rules count for it — the default commands no longer apply. If your tests exercise the element with a command you didn't list, it's now treated as untested. Add that command to the rule, or tighten the `selector` so the rule doesn't match elements you didn't intend to restrict.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary

Rewrites the UI Coverage [`allowedInteractionCommands`](https://docs.cypress.io/ui-coverage/configuration/allowedinteractioncommands) configuration page to match the actual discovery implementation, leads with the value of the option, and adds an "Interaction commands" section to the UI Coverage FAQ.

## Why

The page contained inaccuracies and misconceptions that didn't reflect how the feature actually works in the processing/render code:

- It claimed UI Coverage tracks **"all interaction commands" by default**. In reality it tracks a **defined default set** (`blur`, `check`, `clear`, `click`, `dblclick`, `focus`, `rightclick`, `scrollIntoView`, `scrollTo`, `select`, `selectFile`, `submit`, `trigger`, `type`, `uncheck`). Notably `hover` is not among them, and `cy.hover()` isn't even a real Cypress command — yet examples used `.hover()` as a "not tracked" case, which demonstrated nothing.
- The single most important behavior — **matching a rule replaces the default command set for that element** (only the listed commands then count) — was buried in one aside. It's now a first-class "How rules are applied" section.
- Missing/updated concepts, all verified against the implementation: commands combine additively across all matching rules; a command listed in a rule is auto-registered as a recognized interaction (no need to also add it to `additionalInteractionCommands`); duplicate `selector`/`documentScope` rules are rejected by validation; `documentScope` is ordered outermost-to-innermost.
- Several examples were fixed: realistic commands replace the non-command `.hover()`, malformed assertions were corrected, and `realClick` was removed from the "credit ignored commands" framing since a command you want counted everywhere belongs in `additionalInteractionCommands`, not here.

The page now also leads with value, adds an SEO-oriented title/description, a "Setting configuration" section, and an "App Quality Config" title on every config example, consistent with the other configuration pages. A question-based "Interaction commands" FAQ section was added for discoverability.

## Notes for reviewers

- Behavior was verified against the discovery implementation (the interactivity render logic, the interaction pre-filter, and the `allowedInteractionCommands` validation schema). No product code changes — docs only.
- Two files changed: `docs/ui-coverage/configuration/allowedinteractioncommands.mdx` (rewrite) and `docs/ui-coverage/faq.mdx` (new "Interaction commands" section + description update).
- `prettier --check` and the frontmatter linter both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015yLHeT7Ju4FpYxVW3muUXw

---
_Generated by [Claude Code](https://claude.ai/code/session_015yLHeT7Ju4FpYxVW3muUXw)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to MDX; no product or runtime behavior is modified.
> 
> **Overview**
> Rewrites the **`allowedInteractionCommands`** configuration doc so it matches how UI Coverage actually scores interactions, and adds an **Interaction commands** FAQ section.
> 
> The page no longer claims **all** interaction commands count by default; it documents the **fixed default command set** and stresses that a matching rule **replaces** defaults so only listed commands count (narrowing or expanding coverage per selector). New material includes **How rules are applied** (additive multi-rule matching, per-rule command registration vs `additionalInteractionCommands`, duplicate `selector`/`documentScope` validation, `documentScope` ordering), **Setting configuration** (App Quality / `uiCoverage`), updated SEO title/description, and cross-links to the configuration overview.
> 
> Examples are reworked around realistic scenarios (chart `trigger`, form controls, `realHover`, `assert` on read-only elements, shadow DOM / iframes) and drop misleading cases such as non-existent `.hover()` and malformed assertions. The FAQ adds Q&A on default commands, `additionalInteractionCommands` vs `allowedInteractionCommands`, requiring hovers, assertions as coverage, and why elements can stop counting after adding a rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a9010930bbe7b5a80ee8ce5449d8ffe239c4ab2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->