### PR TITLE
docs(ui-coverage): rewrite additionalInteractionCommands for accuracy and value

### DIFF
--- a/docs/ui-coverage/configuration/additionalinteractioncommands.mdx
+++ b/docs/ui-coverage/configuration/additionalinteractioncommands.mdx
@@ -167,9 +167,10 @@ cy.get('[data-testid="due-date"]').selectDate('2026-01-01')
 cy.get('[data-testid="card"]').dragAndDrop('[data-testid="done-column"]')
 ```
 
-## Notes
+## See also
 
-- Command names are case-sensitive and must match exactly as they appear in your test code.
-- The additional commands are merged with the built-in interaction commands; the defaults are not replaced.
-- Only commands that actually interact with a DOM element should be listed here.
-- A listed command is still ignored unless it logs a snapshot that references the subject element. See [Requirements for a custom command](#Requirements-for-a-custom-command) and [Custom Commands](/api/cypress-api/custom-commands).
+- [Interactivity](/ui-coverage/core-concepts/interactivity): how UI Coverage detects interactive elements and which commands count as interactions.
+- [`allowedInteractionCommands`](/ui-coverage/configuration/allowedinteractioncommands): limit which interaction commands count for specific elements.
+- [Custom Commands](/api/cypress-api/custom-commands): create custom commands and overwrite built-in ones.
+- [Configuration overview](/ui-coverage/configuration/overview): where to set configuration and regenerate reports.
+- [UI Coverage FAQ](/ui-coverage/faq): common questions and troubleshooting.

--- a/docs/ui-coverage/configuration/additionalinteractioncommands.mdx
+++ b/docs/ui-coverage/configuration/additionalinteractioncommands.mdx
@@ -55,6 +55,8 @@ A command you list here counts as an interaction only when it logs a [snapshot](
 Keep these behaviors in mind:
 
 - **Your list is added to the defaults, not a replacement for them.** The built-in commands keep counting; you're extending the set, not overriding it. To _limit_ which commands count for specific elements, use [`allowedInteractionCommands`](/ui-coverage/configuration/allowedinteractioncommands).
+- **Listing a built-in command has no effect.** The [built-in interaction commands](/ui-coverage/core-concepts/interactivity#Interaction-Commands) already count on their own. `additionalInteractionCommands` is only for names UI Coverage doesn't already recognize.
+- **Overwriting a built-in command keeps its name.** UI Coverage matches on the name a command logs under, so a built-in interaction command customized with [`Cypress.Commands.overwrite`](/api/cypress-api/custom-commands#Overwrite-Existing-Commands) stays recognized automatically under its original name, without being listed here, as long as your version still logs a snapshot referencing the subject. Only a brand-new command name added with `Cypress.Commands.add` needs to be listed.
 - **Custom command names are matched case-sensitively.** `"realClick"` matches `realClick` but not `realclick`. Copy the name exactly as you registered it with `Cypress.Commands.add`. (The built-in commands are matched case-insensitively; this exact-match rule applies to the names you add here.)
 
 ### Requirements for a custom command
@@ -140,6 +142,8 @@ cy.get('[data-cy="button"]').realClick()
 cy.get('[data-cy="input"]').realType('Hello World')
 cy.get('[data-cy="tooltip-trigger"]').realHover()
 ```
+
+Any plugin that adds commands acting on an element works the same way. `cypress-real-events` also provides `realPress`, `realSwipe`, and `realMouseDown`; other common examples are `drag` and `move` from [`@4tw/cypress-drag-drop`](https://www.npmjs.com/package/@4tw/cypress-drag-drop) and `tab` from [`cypress-plugin-tab`](https://www.npmjs.com/package/cypress-plugin-tab). Whichever plugin you use, the command counts only if it meets the [requirement above](#How-additional-interaction-commands-are-applied): it must log a snapshot that references the element it acts on.
 
 ### Track your own custom commands
 

--- a/docs/ui-coverage/configuration/additionalinteractioncommands.mdx
+++ b/docs/ui-coverage/configuration/additionalinteractioncommands.mdx
@@ -46,20 +46,11 @@ To add or edit `additionalInteractionCommands`, open the **App Quality** tab in 
 }
 ```
 
-Each entry is the name of a Cypress command, such as `"realClick"` or `"selectDate"`, written exactly as it appears in your test code. Entries are command names only: not CSS selectors and not the `cy.` prefix.
-
-### Options
-
-| Option                          | Required | Default | Description                                                                                                        |
-| ------------------------------- | -------- | ------- | ------------------------------------------------------------------------------------------------------------------ |
-| `additionalInteractionCommands` | Optional | `[]`    | An array of command names (strings) recognized as interaction commands in addition to the [built-in set](/ui-coverage/core-concepts/interactivity#Interaction-Commands). |
+Each entry is the name of a Cypress command, such as `"realClick"` or `"selectDate"`, written exactly as it appears in your test code. Entries are command names only: not CSS selectors and not the `cy.` prefix. The property is optional and defaults to an empty list, so the [built-in interaction commands](/ui-coverage/core-concepts/interactivity#Interaction-Commands) always apply on their own.
 
 ## How additional interaction commands are applied
 
-For each command your test runs, UI Coverage decides whether it counts as an interaction:
-
-1. **The command must reference the element it acts on.** UI Coverage attributes an interaction to an element only when the command logs a [snapshot](/ui-coverage/core-concepts/element-identification#Snapshots) that highlights the subject element. Built-in commands do this automatically. A custom command must do it explicitly (see [Requirements for a custom command](#Requirements-for-a-custom-command)). A command with no subject-referencing snapshot is ignored even when it's listed here.
-2. **The command name must match.** If the command is one of the [built-in interaction commands](/ui-coverage/core-concepts/interactivity#Interaction-Commands), it counts automatically. Otherwise it counts only if its name appears in `additionalInteractionCommands` (or in [`allowedInteractionCommands`](#Relationship-to-allowedInteractionCommands)).
+A command you list here counts as an interaction only when it logs a [snapshot](/ui-coverage/core-concepts/element-identification#Snapshots) that highlights the element it acts on. UI Coverage reads that snapshot to know which element the interaction belongs to, so a command with no subject-referencing snapshot is ignored even when its name is listed. Built-in commands log this snapshot automatically; a custom command must do it explicitly (see [Requirements for a custom command](#Requirements-for-a-custom-command)).
 
 Keep these behaviors in mind:
 
@@ -69,7 +60,7 @@ Keep these behaviors in mind:
 
 ### Requirements for a custom command
 
-Listing a command name isn't enough on its own. For UI Coverage to attribute the interaction to an element, the custom command must give UI Coverage an element to attribute it to, by logging a snapshot that references the subject element. In practice that means the command should:
+Listing a command name isn't enough on its own. For UI Coverage to credit the interaction to an element, the custom command must give it an element to credit, by logging a snapshot that references the subject element. In practice that means the command should:
 
 1. Receive the element as its subject, by registering with [`prevSubject`](/api/cypress-api/custom-commands#Arguments).
 2. Log the interaction against that element with [`Cypress.log`](/api/cypress-api/cypress-log), passing the subject as `$el`.
@@ -93,7 +84,7 @@ Cypress.Commands.add(
 )
 ```
 
-Beyond letting UI Coverage attribute the interaction, logging a snapshot that references the subject is what renders element highlights for the command in Cypress open mode and [Test Replay](/cloud/features/test-replay). See [Custom Commands](/api/cypress-api/custom-commands) for the full API.
+Beyond letting UI Coverage credit the interaction, logging a snapshot that references the subject is what renders element highlights for the command in Cypress open mode and [Test Replay](/cloud/features/test-replay). See [Custom Commands](/api/cypress-api/custom-commands) for the full API.
 
 ### Relationship to allowedInteractionCommands
 
@@ -126,7 +117,7 @@ cy.get('[data-cy="tooltip-trigger"]').realHover()
 
 ### Track your own custom commands
 
-List the custom commands your team defines with `Cypress.Commands.add`. Make sure each one meets the [requirements for a custom command](#Requirements-for-a-custom-command) so UI Coverage can attribute the interaction to an element.
+List the custom commands your team defines with `Cypress.Commands.add`. Make sure each one meets the [requirements for a custom command](#Requirements-for-a-custom-command) so UI Coverage can credit the interaction to an element.
 
 #### Config
 

--- a/docs/ui-coverage/configuration/additionalinteractioncommands.mdx
+++ b/docs/ui-coverage/configuration/additionalinteractioncommands.mdx
@@ -56,7 +56,6 @@ Keep these behaviors in mind:
 
 - **Your list is added to the defaults, not a replacement for them.** The built-in commands keep counting; you're extending the set, not overriding it. To _limit_ which commands count for specific elements, use [`allowedInteractionCommands`](/ui-coverage/configuration/allowedinteractioncommands).
 - **Custom command names are matched case-sensitively.** `"realClick"` matches `realClick` but not `realclick`. Copy the name exactly as you registered it with `Cypress.Commands.add`. (The built-in commands are matched case-insensitively; this exact-match rule applies to the names you add here.)
-- **Duplicate names are rejected.** Each command name may appear once; a repeated entry fails configuration validation.
 
 ### Requirements for a custom command
 
@@ -66,7 +65,10 @@ Listing a command name isn't enough on its own. For UI Coverage to credit the in
 2. Log the interaction against that element with [`Cypress.log`](/api/cypress-api/cypress-log), passing the subject as `$el`.
 3. Capture at least one snapshot on that log entry.
 
-```javascript
+<Tabs groupId="cypress-lang">
+<TabItem value="js" label="JavaScript">
+
+```js title="cypress/support/commands.js"
 // A custom command that UI Coverage can track
 Cypress.Commands.add(
   'selectDate',
@@ -83,6 +85,30 @@ Cypress.Commands.add(
   }
 )
 ```
+
+</TabItem>
+<TabItem value="ts" label="TypeScript">
+
+```ts title="cypress/support/commands.ts"
+// A custom command that UI Coverage can track
+Cypress.Commands.add(
+  'selectDate',
+  { prevSubject: ['element'] },
+  (subject: JQuery<HTMLElement>, date: string) => {
+    const log = Cypress.log({ $el: subject, message: date, autoEnd: false })
+
+    log.snapshot('before')
+    // ...interact with the element to pick the date...
+
+    return cy.wrap(subject, { log: false }).then(() => {
+      log.snapshot('after').end()
+    })
+  }
+)
+```
+
+</TabItem>
+</Tabs>
 
 Beyond letting UI Coverage credit the interaction, logging a snapshot that references the subject is what renders element highlights for the command in Cypress open mode and [Test Replay](/cloud/features/test-replay). See [Custom Commands](/api/cypress-api/custom-commands) for the full API.
 

--- a/docs/ui-coverage/configuration/additionalinteractioncommands.mdx
+++ b/docs/ui-coverage/configuration/additionalinteractioncommands.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'additionalInteractionCommands'
-description: 'Use additionalInteractionCommands to extend the default set of interaction command types recognized by UI Coverage.'
+title: 'additionalInteractionCommands: count custom commands as coverage in UI Coverage'
+description: 'Make Cypress UI Coverage count your custom Cypress commands and third-party commands, such as cypress-real-events realClick and realType, as interactions so the elements they touch are marked as tested.'
 sidebar_label: 'Track custom commands'
 sidebar_position: 90
 ---
@@ -9,64 +9,105 @@ sidebar_position: 90
 
 # Track custom commands (`additionalInteractionCommands`)
 
-UI Coverage automatically tracks how elements are used in tests using a predefined set of [Cypress interaction commands](/ui-coverage/core-concepts/interactivity#Interaction-Commands) such as `click`, `type`, `dblclick`, and more.
+The `additionalInteractionCommands` configuration tells UI Coverage that your own Cypress commands, or commands from a third-party plugin, count as interactions. Commands you list are added to the built-in set, so the elements they touch are marked as tested and contribute to your coverage score.
 
-The `additionalInteractionCommands` configuration allows you to extend this default set. You can specify custom command types that should also be recognized as interactions, which can increase the range of actions that are counted towards UI Coverage
+UI Coverage marks an [interactive element](/ui-coverage/core-concepts/interactivity) as tested when a recognized [interaction command](/ui-coverage/core-concepts/interactivity#Interaction-Commands) targets it. Out of the box it recognizes a fixed set of built-in Cypress commands such as `click`, `type`, and `check`. A command it doesn't recognize doesn't count, so an element that your tests only ever exercise through a custom command like `selectDate()`, or a third-party command like [`cypress-real-events`](#Track-cypress-real-events-commands)' `realClick()`, is reported as untested even though your suite interacts with it on every run. Listing those command names in `additionalInteractionCommands` closes that gap, so your coverage score reflects what your tests actually do.
 
 ## Why use additionalInteractionCommands?
 
-- **Custom command support**: Track interactions from custom Cypress commands that aren't included in the default set.
-- **Third-party library support**: Ensure interactions from third-party testing libraries (such as [`cypress-real-events`](#Adding-third-party-library-commands)) are properly recognized and tracked.
-- **Enhanced reporting**: Improve the accuracy of your UI Coverage reports by including all relevant interaction types.
+- **Get credit for custom commands**: If your team wraps interactions in [custom commands](/api/cypress-api/custom-commands), such as a `login()` helper that types and clicks, list them so the elements they touch count as tested.
+- **Support third-party interaction plugins**: Plugins like [`cypress-real-events`](#Track-cypress-real-events-commands) add commands (`realClick`, `realType`, `realHover`) that fire native browser events. These aren't built-in Cypress commands, so UI Coverage doesn't recognize them until you list them.
+- **Keep your score accurate**: Every command your tests rely on that UI Coverage doesn't recognize leaves real coverage unreported. Declaring them removes false gaps from your reports.
+
+## Scope
+
+:::info
+
+**Note:** `additionalInteractionCommands` applies to UI Coverage only and must be nested under the `uiCoverage` key. Unlike properties such as `significantAttributes`, it has no root-level or Cypress Accessibility equivalent, so it never affects Accessibility reports.
+
+:::
+
+## Setting additionalInteractionCommands
+
+To add or edit `additionalInteractionCommands`, open the **App Quality** tab in your project settings in Cypress Cloud. See [Setting configuration](/ui-coverage/configuration/overview#Setting-configuration) for details, including how to regenerate past reports with a new configuration without rerunning your tests.
+
+<DocsImage
+  src="/img/ui-coverage/configuration/cypress-ui-coverage-configuration-editor.png"
+  alt="The App Quality tab of a project's settings in Cypress Cloud, showing the configuration editor with JSON configuration"
+/>
 
 ## Syntax
 
-```json
+```json title="App Quality Config"
 {
   "uiCoverage": {
-    "additionalInteractionCommands": [
-      string
-    ]
+    "additionalInteractionCommands": [string]
   }
 }
 ```
+
+Each entry is the name of a Cypress command, such as `"realClick"` or `"selectDate"`, written exactly as it appears in your test code. Entries are command names only: not CSS selectors and not the `cy.` prefix.
 
 ### Options
 
-The `additionalInteractionCommands` property accepts an array of strings, where each string represents a command name that should be treated as an interaction command by UI Coverage.
-
 | Option                          | Required | Default | Description                                                                                                        |
 | ------------------------------- | -------- | ------- | ------------------------------------------------------------------------------------------------------------------ |
-| `additionalInteractionCommands` | Optional | `[]`    | An array of command names (strings) that should be recognized as interaction commands in addition to the defaults. |
+| `additionalInteractionCommands` | Optional | `[]`    | An array of command names (strings) recognized as interaction commands in addition to the [built-in set](/ui-coverage/core-concepts/interactivity#Interaction-Commands). |
+
+## How additional interaction commands are applied
+
+For each command your test runs, UI Coverage decides whether it counts as an interaction:
+
+1. **The command must reference the element it acts on.** UI Coverage attributes an interaction to an element only when the command logs a [snapshot](/ui-coverage/core-concepts/element-identification#Snapshots) that highlights the subject element. Built-in commands do this automatically. A custom command must do it explicitly (see [Requirements for a custom command](#Requirements-for-a-custom-command)). A command with no subject-referencing snapshot is ignored even when it's listed here.
+2. **The command name must match.** If the command is one of the [built-in interaction commands](/ui-coverage/core-concepts/interactivity#Interaction-Commands), it counts automatically. Otherwise it counts only if its name appears in `additionalInteractionCommands` (or in [`allowedInteractionCommands`](#Relationship-to-allowedInteractionCommands)).
+
+Keep these behaviors in mind:
+
+- **Your list is added to the defaults, not a replacement for them.** The built-in commands keep counting; you're extending the set, not overriding it. To _limit_ which commands count for specific elements, use [`allowedInteractionCommands`](/ui-coverage/configuration/allowedinteractioncommands).
+- **Custom command names are matched case-sensitively.** `"realClick"` matches `realClick` but not `realclick`. Copy the name exactly as you registered it with `Cypress.Commands.add`. (The built-in commands are matched case-insensitively; this exact-match rule applies to the names you add here.)
+- **Duplicate names are rejected.** Each command name may appear once; a repeated entry fails configuration validation.
+
+### Requirements for a custom command
+
+Listing a command name isn't enough on its own. For UI Coverage to attribute the interaction to an element, the custom command must give UI Coverage an element to attribute it to, by logging a snapshot that references the subject element. In practice that means the command should:
+
+1. Receive the element as its subject, by registering with [`prevSubject`](/api/cypress-api/custom-commands#Arguments).
+2. Log the interaction against that element with [`Cypress.log`](/api/cypress-api/cypress-log), passing the subject as `$el`.
+3. Capture at least one snapshot on that log entry.
+
+```javascript
+// A custom command that UI Coverage can track
+Cypress.Commands.add(
+  'selectDate',
+  { prevSubject: ['element'] },
+  (subject, date) => {
+    const log = Cypress.log({ $el: subject, message: date, autoEnd: false })
+
+    log.snapshot('before')
+    // ...interact with the element to pick the date...
+
+    return cy.wrap(subject, { log: false }).then(() => {
+      log.snapshot('after').end()
+    })
+  }
+)
+```
+
+Beyond letting UI Coverage attribute the interaction, logging a snapshot that references the subject is what renders element highlights for the command in Cypress open mode and [Test Replay](/cloud/features/test-replay). See [Custom Commands](/api/cypress-api/custom-commands) for the full API.
+
+### Relationship to allowedInteractionCommands
+
+Any command name you list in [`allowedInteractionCommands`](/ui-coverage/configuration/allowedinteractioncommands) is automatically recognized as an interaction command as well. You don't need to declare the same custom command in both places: use `additionalInteractionCommands` to count a command everywhere it's used, and `allowedInteractionCommands` when a command should count only for elements matching a specific selector.
 
 ## Examples
 
-### Adding custom interaction commands
+### Track `cypress-real-events` commands
+
+[`cypress-real-events`](https://github.com/dmtrKovalenko/cypress-real-events) fires native browser events through commands like `realClick`, `realType`, and `realHover`. Because these aren't built-in Cypress commands, UI Coverage doesn't count them until you list them.
 
 #### Config
 
-```json
-{
-  "uiCoverage": {
-    "additionalInteractionCommands": ["customClick", "dragAndDrop", "swipeLeft"]
-  }
-}
-```
-
-#### Usage in tests
-
-```javascript
-// These custom commands will now be tracked as interactions
-cy.get('[data-testid="submit-button"]').customClick()
-cy.get('[data-testid="draggable"]').dragAndDrop()
-cy.get('[data-testid="carousel"]').swipeLeft()
-```
-
-### Adding third-party library commands
-
-#### Config
-
-```json
+```json title="App Quality Config"
 {
   "uiCoverage": {
     "additionalInteractionCommands": ["realClick", "realType", "realHover"]
@@ -77,15 +118,37 @@ cy.get('[data-testid="carousel"]').swipeLeft()
 #### Usage in tests
 
 ```javascript
-// Commands from cypress-real-events plugin will be tracked
+// Now these commands mark their target elements as tested
 cy.get('[data-cy="button"]').realClick()
-cy.get('[data-cy="input"]).realType('Hello World')
+cy.get('[data-cy="input"]').realType('Hello World')
 cy.get('[data-cy="tooltip-trigger"]').realHover()
+```
+
+### Track your own custom commands
+
+List the custom commands your team defines with `Cypress.Commands.add`. Make sure each one meets the [requirements for a custom command](#Requirements-for-a-custom-command) so UI Coverage can attribute the interaction to an element.
+
+#### Config
+
+```json title="App Quality Config"
+{
+  "uiCoverage": {
+    "additionalInteractionCommands": ["selectDate", "dragAndDrop"]
+  }
+}
+```
+
+#### Usage in tests
+
+```javascript
+// Custom commands that log a snapshot referencing their subject element
+cy.get('[data-testid="due-date"]').selectDate('2026-01-01')
+cy.get('[data-testid="card"]').dragAndDrop('[data-testid="done-column"]')
 ```
 
 ## Notes
 
 - Command names are case-sensitive and must match exactly as they appear in your test code.
-- The additional commands are merged with the default interaction commands, the default commands are not replaced.
-- Only commands that actually interact with DOM elements should be included in this configuration.
-- Custom commands must log a snapshot that references the subject element. This ensures that the command renders element highlights in Cypress open mode/Test Replay, and also ensures that UI Coverage can properly attribute the interaction to the expected element. More information regarding Custom Commands can be found [here](/api/cypress-api/custom-commands).
+- The additional commands are merged with the built-in interaction commands; the defaults are not replaced.
+- Only commands that actually interact with a DOM element should be listed here.
+- A listed command is still ignored unless it logs a snapshot that references the subject element. See [Requirements for a custom command](#Requirements-for-a-custom-command) and [Custom Commands](/api/cypress-api/custom-commands).

--- a/docs/ui-coverage/faq.mdx
+++ b/docs/ui-coverage/faq.mdx
@@ -151,6 +151,24 @@ The most common causes are:
 - The rule targets a tag name or sibling position. Only attributes and individual `class` tokens can be filtered, not an element's tag name or `nth-child` position.
 - The report was processed before you saved the configuration. Regenerate the run to apply the current configuration.
 
+## Interaction commands
+
+### <Icon name="angle-right" /> Which Cypress commands count as interactions by default?
+
+UI Coverage marks an interactive element as tested when a recognized command targets it. The built-in set includes `click`, `dblclick`, `rightclick`, `type`, `clear`, `check`, `uncheck`, `select`, `selectFile`, `trigger`, `focus`, `blur`, `scrollTo`, `scrollIntoView`, and `submit`. See [Interaction Commands](/ui-coverage/core-concepts/interactivity#Interaction-Commands) for the full list. To count commands beyond these, such as your own custom commands or third-party ones, use [`additionalInteractionCommands`](/ui-coverage/configuration/additionalinteractioncommands).
+
+### <Icon name="angle-right" /> How do I make UI Coverage count cypress-real-events commands like realClick and realType?
+
+[`cypress-real-events`](https://github.com/dmtrKovalenko/cypress-real-events) commands (`realClick`, `realType`, `realHover`) aren't built-in Cypress commands, so UI Coverage doesn't count them until you list them in [`additionalInteractionCommands`](/ui-coverage/configuration/additionalinteractioncommands), nested under the `uiCoverage` key. Once listed, the elements they target are marked as tested.
+
+### <Icon name="angle-right" /> Why isn't my custom command counted as an interaction in UI Coverage?
+
+Two conditions must both hold. First, the command name must be listed in [`additionalInteractionCommands`](/ui-coverage/configuration/additionalinteractioncommands) (or [`allowedInteractionCommands`](/ui-coverage/configuration/allowedinteractioncommands)), matched case-sensitively and written exactly as you registered it. Second, the command must log a [snapshot](/ui-coverage/core-concepts/element-identification#Snapshots) that references the subject element, so UI Coverage knows which element to credit. In practice, register the command with [`prevSubject`](/api/cypress-api/custom-commands#Arguments), call [`Cypress.log`](/api/cypress-api/cypress-log) with the subject as `$el`, and capture a snapshot. If you added the command after a run was processed, regenerate the run to apply the change.
+
+### <Icon name="angle-right" /> What's the difference between additionalInteractionCommands and allowedInteractionCommands?
+
+[`additionalInteractionCommands`](/ui-coverage/configuration/additionalinteractioncommands) _adds_ command names to the recognized set so they count everywhere they're used. [`allowedInteractionCommands`](/ui-coverage/configuration/allowedinteractioncommands) _restricts_ which commands count for elements matching a selector, and any command it names is also recognized as an interaction. Use the first to count a custom or third-party command across your whole app, and the second to require specific interactions on specific elements.
+
 ## Configuration
 
 ### <Icon name="angle-right" /> Where do I set UI Coverage configuration?


### PR DESCRIPTION
## Summary

Rewrites the UI Coverage `additionalInteractionCommands` configuration page to match the actual implementation, lead with value, and add SEO/AEO coverage. Also adds an "Interaction commands" section to the UI Coverage FAQ.

## Why

The page had several inaccuracies and misconceptions, and buried the one mechanism that actually determines whether a custom command is tracked. Behavior was verified against the `cypress-services` implementation (`discovery/packages/processing/src/processing/interactivity.ts`, `ResolvedAppQualityConfig.ts`, the app-quality config validation schema, and a real trackable custom command in `capture-protocol`).

Key corrections and additions:

- **Lead with value + the real mechanism.** A listed command counts only when it logs a snapshot that references the subject element — this is the #1 reason custom commands silently go untracked, and it now leads the "How additional interaction commands are applied" section instead of being a footnote.
- **Scope.** Documented that `additionalInteractionCommands` is UI Coverage-only and must be nested under `uiCoverage` (no root-level or Accessibility equivalent), matching `ResolvedAppQualityConfig`.
- **Requirements for a custom command.** Concrete recipe grounded in the real implementation: register with `prevSubject`, call `Cypress.log` with the subject as `$el`, and capture a snapshot. Includes a JS/TS tabbed example.
- **Matching rules.** Custom command names are matched case-sensitively (built-ins are case-insensitive); listing a built-in has no effect; a built-in customized with `Cypress.Commands.overwrite` keeps its name and stays recognized without being listed.
- **Relationship to `allowedInteractionCommands`** — commands named there are also recognized as interactions, so they don't need to be declared in both places.
- **Broader examples** — `cypress-real-events`, other plugins (`@4tw/cypress-drag-drop`, `cypress-plugin-tab`), and custom commands. Fixed a broken code sample from the old page.
- **`App Quality Config` title** added to all config examples.
- **SEO/AEO** — new "Interaction commands" section in the UI Coverage FAQ (which emits `FAQPage` structured data).
- Replaced the redundant Notes section with a "See also" section matching the other configuration pages.

## Notes for reviewers

- No product/code changes — documentation only (`docs/ui-coverage/configuration/additionalinteractioncommands.mdx` and `docs/ui-coverage/faq.mdx`).
- The FAQ additions were validated against the repo's `faq-structured-data` plugin (`parseFaq`) to confirm they produce well-formed Q&A pairs.
- A full `yarn build` was not run in this environment (no `node_modules`); worth a local build before merge. All internal cross-links/anchors were checked manually against their target headings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CYd3q1fhogcdEe9Nii1LK9

---
_Generated by [Claude Code](https://claude.ai/code/session_01CYd3q1fhogcdEe9Nii1LK9)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to MDX; no runtime, config schema, or product behavior changes.
> 
> **Overview**
> **Rewrites** the UI Coverage [`additionalInteractionCommands`](/ui-coverage/configuration/additionalinteractioncommands) page so it leads with outcomes, documents UI Coverage–only scope under `uiCoverage`, and explains that listed commands count only when they log a subject-referencing snapshot—the main reason custom commands stay untracked.
> 
> **Adds** matching rules (case-sensitive custom names, built-ins unchanged, `Cypress.Commands.overwrite` behavior), a **Requirements for a custom command** section with JS/TS `selectDate` examples, Cloud **App Quality** setup, relationship to `allowedInteractionCommands`, refreshed examples (`cypress-real-events`, custom commands, other plugins), SEO-oriented front matter, and a **See also** section instead of redundant notes.
> 
> **Extends** [`docs/ui-coverage/faq.mdx`](/ui-coverage/faq.mdx) with an **Interaction commands** subsection: counting `cypress-real-events`, troubleshooting custom commands (listing + snapshot/`prevSubject`/`Cypress.log`), alongside the existing default-commands and `additionalInteractionCommands` vs `allowedInteractionCommands` content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17c34cddfe23064c3881152ed44ef2530091ca49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->