### PR TITLE
Replace parentheses with dash in UI Coverage / a11y config H1 headings

### DIFF
--- a/docs/accessibility/configuration/attributefilters.mdx
+++ b/docs/accessibility/configuration/attributefilters.mdx
@@ -7,7 +7,7 @@ sidebar_position: 80
 
 <ProductHeading product="accessibility" />
 
-# Ignore attributes for identification (`attributeFilters`)
+# Ignore attributes for identification - `attributeFilters`
 
 Cypress Accessibility [identifies elements](/ui-coverage/core-concepts/element-identification) from a combination of their attributes and the surrounding DOM structure. Use `attributeFilters` to keep unstable attributes out of that process so violations are grouped against stable targets.
 

--- a/docs/accessibility/configuration/components.mdx
+++ b/docs/accessibility/configuration/components.mdx
@@ -7,7 +7,7 @@ sidebar_position: 90
 
 <ProductHeading product="accessibility" />
 
-# Define components (`components`)
+# Define components - `components`
 
 The `accessibility.components` options provide a small but powerful set of controls for how elements are identified in Cypress Accessibility. This helps provide guaranteed "breadcrumbs" to place accessibility findings in context quickly and easily, for fast review by developers and testers, and when using AI agents to triage reports through Cypress Cloud MCP.
 

--- a/docs/accessibility/configuration/elementfilters.mdx
+++ b/docs/accessibility/configuration/elementfilters.mdx
@@ -7,7 +7,7 @@ sidebar_position: 40
 
 <ProductHeading product="accessibility" />
 
-# Exclude elements (`elementFilters`)
+# Exclude elements - `elementFilters`
 
 The `elementFilters` configuration ignores elements in your Cypress Accessibility report. An ignored element's failed and incomplete checks stop counting against your views and your [accessibility score](/accessibility/core-concepts/accessibility-score), and the element appears under an **Ignored** status instead, so you can always audit what your configuration ignores.
 

--- a/docs/accessibility/configuration/ignoring-rules-per-element.mdx
+++ b/docs/accessibility/configuration/ignoring-rules-per-element.mdx
@@ -7,7 +7,7 @@ sidebar_position: 60
 
 <ProductHeading product="accessibility" />
 
-# Ignore rules per element (`data-a11y-ignore`)
+# Ignore rules per element - `data-a11y-ignore`
 
 Cypress Accessibility configuration allows you to exclude [elements](/accessibility/configuration/elementfilters) or whole [pages](/accessibility/configuration/viewfilters) from the accessibility report, but sometimes there are situations where you may want to keep an element in your accessibility report, but ignore some accessibility rules for that element.
 

--- a/docs/accessibility/configuration/profiles.mdx
+++ b/docs/accessibility/configuration/profiles.mdx
@@ -7,6 +7,6 @@ sidebar_position: 100
 
 <ProductHeading product="accessibility" />
 
-# Override config by run tag (`profiles`)
+# Override config by run tag - `profiles`
 
 <Profiles />

--- a/docs/accessibility/configuration/significantattributes.mdx
+++ b/docs/accessibility/configuration/significantattributes.mdx
@@ -7,7 +7,7 @@ sidebar_position: 70
 
 <ProductHeading product="accessibility" />
 
-# Prioritize identifying attributes (`significantAttributes`)
+# Prioritize identifying attributes - `significantAttributes`
 
 The `significantAttributes` configuration adds your own HTML attributes to the priority list Cypress Accessibility uses to identify elements. Attributes you list are checked before the default test attributes, in the order you list them.
 

--- a/docs/accessibility/configuration/viewfilters.mdx
+++ b/docs/accessibility/configuration/viewfilters.mdx
@@ -7,7 +7,7 @@ sidebar_position: 30
 
 <ProductHeading product="accessibility" />
 
-# Exclude views (`viewFilters`)
+# Exclude views - `viewFilters`
 
 The `viewFilters` configuration excludes URLs from Cypress Accessibility. By default, every URL your tests visit is included. A `viewFilters` rule with `include: false` removes matching URLs before any analysis happens: their snapshots are not scanned for accessibility violations and don't appear in your report. The result is a report and [accessibility score](/accessibility/core-concepts/accessibility-score) that reflect the parts of your application you own and can remediate.
 

--- a/docs/accessibility/configuration/views.mdx
+++ b/docs/accessibility/configuration/views.mdx
@@ -7,7 +7,7 @@ sidebar_position: 20
 
 <ProductHeading product="accessibility" />
 
-# Group & name views (`views`)
+# Group & name views - `views`
 
 Views work the same way in Cypress Accessibility and UI Coverage. To learn how views are created by default, see [Views in UI Coverage](/ui-coverage/core-concepts/views).
 

--- a/docs/ui-coverage/configuration/additionalinteractioncommands.mdx
+++ b/docs/ui-coverage/configuration/additionalinteractioncommands.mdx
@@ -7,7 +7,7 @@ sidebar_position: 90
 
 <ProductHeading product="ui-coverage" />
 
-# Track custom commands (`additionalInteractionCommands`)
+# Track custom commands - `additionalInteractionCommands`
 
 The `additionalInteractionCommands` configuration tells UI Coverage that your own Cypress commands, or commands from a third-party plugin, count as interactions. Commands you list are added to the built-in set, so the elements they touch are marked as tested and contribute to your coverage score.
 

--- a/docs/ui-coverage/configuration/allowedinteractioncommands.mdx
+++ b/docs/ui-coverage/configuration/allowedinteractioncommands.mdx
@@ -7,7 +7,7 @@ sidebar_position: 100
 
 <ProductHeading product="ui-coverage" />
 
-# Limit tracked commands (`allowedInteractionCommands`)
+# Limit tracked commands - `allowedInteractionCommands`
 
 By default, UI Coverage marks an element as tested when it's targeted by one of a [default set of Cypress interaction commands](/ui-coverage/core-concepts/interactivity#Interaction-Commands), such as `click`, `type`, and `select`. That default is right for most elements, but not all: a chart is really tested by a hover, not the plain `click` that happens to count, and a status banner you only ever assert against is never "interacted with" at all, so it never counts.
 

--- a/docs/ui-coverage/configuration/attributefilters.mdx
+++ b/docs/ui-coverage/configuration/attributefilters.mdx
@@ -7,7 +7,7 @@ sidebar_position: 80
 
 <ProductHeading product="ui-coverage" />
 
-# Ignore attributes for identification (`attributeFilters`)
+# Ignore attributes for identification - `attributeFilters`
 
 UI Coverage [identifies](/ui-coverage/core-concepts/element-identification) and [groups](/ui-coverage/core-concepts/element-grouping) elements from their attributes and their position in the DOM. Use `attributeFilters` to keep unstable attributes out of that process so your reports stay accurate.
 

--- a/docs/ui-coverage/configuration/elementfilters.mdx
+++ b/docs/ui-coverage/configuration/elementfilters.mdx
@@ -7,7 +7,7 @@ sidebar_position: 40
 
 <ProductHeading product="ui-coverage" />
 
-# Exclude elements (`elementFilters`)
+# Exclude elements - `elementFilters`
 
 The `elementFilters` configuration removes elements from your UI Coverage report. An excluded element doesn't appear in the report and doesn't count toward your coverage score, whether it was tested or not.
 

--- a/docs/ui-coverage/configuration/elementgroups.mdx
+++ b/docs/ui-coverage/configuration/elementgroups.mdx
@@ -7,7 +7,7 @@ sidebar_position: 60
 
 <ProductHeading product="ui-coverage" />
 
-# Group related elements (`elementGroups`)
+# Group related elements - `elementGroups`
 
 The `elementGroups` configuration combines related elements into a single unit in your UI Coverage report. A group counts once toward your coverage score, and an interaction with any element in the group marks the whole group as tested. This means a list of 50 untested product cards no longer appears as 50 untested elements dragging down your score. Instead, it appears as one clearly named group that a single test can cover.
 

--- a/docs/ui-coverage/configuration/elements.mdx
+++ b/docs/ui-coverage/configuration/elements.mdx
@@ -7,7 +7,7 @@ sidebar_position: 50
 
 <ProductHeading product="ui-coverage" />
 
-# Stabilize element identity (`elements`)
+# Stabilize element identity - `elements`
 
 The `elements` configuration assigns a stable identity and a display name to a single element in your UI Coverage report.
 

--- a/docs/ui-coverage/configuration/profiles.mdx
+++ b/docs/ui-coverage/configuration/profiles.mdx
@@ -7,6 +7,6 @@ sidebar_position: 110
 
 <ProductHeading product="ui-coverage" />
 
-# Override config by run tag (`profiles`)
+# Override config by run tag - `profiles`
 
 <Profiles />

--- a/docs/ui-coverage/configuration/significantattributes.mdx
+++ b/docs/ui-coverage/configuration/significantattributes.mdx
@@ -7,7 +7,7 @@ sidebar_position: 70
 
 <ProductHeading product="ui-coverage" />
 
-# Prioritize identifying attributes (`significantAttributes`)
+# Prioritize identifying attributes - `significantAttributes`
 
 The `significantAttributes` configuration adds your own HTML attributes to the priority list UI Coverage uses to identify elements. Attributes you list are checked before the default test attributes, in the order you list them.
 

--- a/docs/ui-coverage/configuration/viewfilters.mdx
+++ b/docs/ui-coverage/configuration/viewfilters.mdx
@@ -7,7 +7,7 @@ sidebar_position: 30
 
 <ProductHeading product="ui-coverage" />
 
-# Exclude views (`viewFilters`)
+# Exclude views - `viewFilters`
 
 The `viewFilters` configuration excludes URLs from UI Coverage. By default, every URL your tests visit is included. A `viewFilters` rule with `include: false` removes matching URLs before any analysis happens: their snapshots don't appear in your report, and no view is created for them. Links are filtered too: any link whose destination URL matches an excluded pattern is removed from the report and the coverage score, and excluded URLs never appear as [untested links](/ui-coverage/core-concepts/interactivity#Untested-Links). The result is a report and score that reflect the parts of your application you own and intend to test.
 

--- a/docs/ui-coverage/configuration/views.mdx
+++ b/docs/ui-coverage/configuration/views.mdx
@@ -7,7 +7,7 @@ sidebar_position: 20
 
 <ProductHeading product="ui-coverage" />
 
-# Group & name views (`views`)
+# Group & name views - `views`
 
 This page is the configuration reference for the `views` property. To learn how UI Coverage creates views by default, and when you'd reach for this property, see the [Views core concept](/ui-coverage/core-concepts/views).
 


### PR DESCRIPTION
## Summary

Updates the H1 heading on all UI Coverage and Accessibility configuration pages so the config-option name is set off with a dash instead of parentheses — e.g. `# Exclude views (`viewFilters`)` becomes `# Exclude views - `viewFilters``.

## Why

Requested change to the heading style on these config reference pages for consistency and readability.

## Notes for reviewers

Applies to 18 pages total:

- **UI Coverage** (10): views, elements, elementGroups, profiles, allowedInteractionCommands, viewFilters, elementFilters, attributeFilters, significantAttributes, additionalInteractionCommands
- **Accessibility** (8): components, views, profiles, viewFilters, data-a11y-ignore, elementFilters, attributeFilters, significantAttributes

Each change is limited to the H1 line; the inline `code` config name is preserved unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JHRR4zKJ9USWGkjBC2UvNy

---
_Generated by [Claude Code](https://claude.ai/code/session_01JHRR4zKJ9USWGkjBC2UvNy)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only heading formatting with no runtime, API, or configuration behavior changes.
> 
> **Overview**
> Updates the **H1 heading style** on 18 UI Coverage and Cypress Accessibility configuration reference pages so the config option name is separated with a dash instead of parentheses (e.g. `# Exclude views - \`viewFilters\`` instead of `# Exclude views (\`viewFilters\`)`).
> 
> Each edit is **only the top-level heading line**; body copy, sidebar labels, and inline `` `code` `` option names are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c989eff663b57280cd560f26b3de459d80fc311. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->