### PR TITLE
docs: fix cy.origin() examples using non-existent pages

### DIFF
--- a/docs/api/commands/origin.mdx
+++ b/docs/api/commands/origin.mdx
@@ -60,18 +60,17 @@ cy.origin(url, options, callbackFn)
 <Icon name="check-circle" color="green" /> **Correct Usage**
 
 ```js
-const hits = getHits() // Defined elsewhere
+const email = getEmail() // Defined elsewhere
 // Run commands in secondary origin, passing in serializable values
-cy.origin('https://example.cypress.io', { args: { hits } }, ({ hits }) => {
+cy.origin('https://example.cypress.io', { args: { email } }, ({ email }) => {
   // Inside callback baseUrl is https://example.cypress.io
-  cy.visit('/history/founder')
+  cy.visit('/commands/actions')
   // Commands are executed in secondary origin
-  cy.get('h1').contains('About our Founder')
+  cy.get('h1').contains('Actions')
   // Passed in values are accessed via callback args
-  cy.get('#hitcounter').contains(hits)
+  cy.get('.action-email').type(email)
 })
-// Even though we're outside the secondary origin block,
-// we're still on cypress.io so return to baseUrl
+// Back outside the block, cy.visit uses the primary origin's baseUrl again
 cy.visit('/')
 // Continue running commands on primary origin
 cy.get('h1').contains('My cool site under test')
@@ -80,19 +79,18 @@ cy.get('h1').contains('My cool site under test')
 <Icon name="exclamation-triangle" color="red" /> **Incorrect Usage**
 
 ```js
-const hits = getHits()
-cy.visit('https://example.cypress.io/history/founder')
+const email = getEmail()
+cy.visit('https://example.cypress.io/commands/actions')
 // To interact with cross-origin content, move this inside cy.origin() callback
-cy.get('h1').contains('Kitchen Sink')
+cy.get('h1').contains('Actions')
 // Origin must be a precise match including scheme, subdomain and port, i.e. https://www.cypress.io
 cy.origin('https://www.cypress.io', () => {
-  cy.visit('/about-us')
-  cy.get('h1').contains('About us')
-  // Fails because downloads is not passed in via args
-  cy.contains(downloads)
+  cy.visit('/')
+  // Fails because email is not passed in via args
+  cy.contains(email)
 })
 // Won't work because still on www.cypress.io
-cy.get('h1').contains('Kitchen Sink')
+cy.get('h1').contains('Actions')
 ```
 
 ### Arguments
@@ -218,27 +216,27 @@ page.
 // Do things in primary origin...
 
 cy.origin('example.cypress.io', () => {
-  // Visit https://example.cypress.io/history/founder
-  cy.visit('/history/founder')
-  cy.get('h1').contains('About our Founder')
+  // Visit https://example.cypress.io/commands/actions
+  cy.visit('/commands/actions')
+  cy.get('h1').contains('Actions')
 })
 ```
 
 Here the `baseUrl` inside the `cy.origin()` callback is set to `example.cypress.io`
 and the protocol defaults to `https`. When `cy.visit()` is called with the path
-`/history/founder`, the three are concatenated to make
-`https://example.cypress.io/history/founder`.
+`/commands/actions`, the three are concatenated to make
+`https://example.cypress.io/commands/actions`.
 
 #### Alternative navigation
 
 ```js
 // Do things in primary origin...
 
-cy.visit('https://example.cypress.io/history/founder')
+cy.visit('https://example.cypress.io/commands/actions')
 
 // The cy.origin block is required to interact with the cross-origin page.
 cy.origin('example.cypress.io', () => {
-  cy.get('h1').contains('About our Founder')
+  cy.get('h1').contains('Actions')
 })
 ```
 
@@ -251,15 +249,15 @@ communicate with the cross-origin page
 ```js
 // Do things in primary origin...
 
-cy.visit('https://www.cypress.io/history/founder')
+cy.visit('https://example.cypress.io/commands/actions')
 
-// This command will fail, it's executed on localhost but the application is at cypress.io
-cy.get('h1').contains('About our Founder, Marvin Acme')
+// This command will fail, it's executed on localhost but the application is at example.cypress.io
+cy.get('h1').contains('Actions')
 ```
 
 Here `cy.get('h1')` fails because we are trying to interact with a cross-origin
 page outside of the cy.origin block, due to 'same-origin' restrictions, the
-'localhost' javascript context can't communicate with 'cypress.io'.
+'localhost' javascript context can't communicate with 'example.cypress.io'.
 
 ### Navigating to secondary origin with UI
 
@@ -272,7 +270,7 @@ cy.contains('button', 'Go').click()
 
 cy.origin('example.cypress.io', () => {
   // No cy.visit is needed as the button brought us here
-  cy.get('h1').contains('CYPRESS')
+  cy.get('h1').contains('Kitchen Sink')
 })
 ```
 


### PR DESCRIPTION
## Summary

Reworks the `cy.origin()` examples in `docs/api/commands/origin.mdx` so they no longer reference the non-existent `https://example.cypress.io/history/founder` page (and its fictional "About our Founder" / `#hitcounter` content), replacing them with real [Kitchen Sink](https://example.cypress.io) pages and elements.

## Why

Issue #6151 reported that the `cy.origin()` documentation — including the snippets labeled **"Correct Usage"** — visited `https://example.cypress.io/history/founder`, which returns **HTTP 404**. Anyone copying those examples would hit a failing test, defeating the purpose of a "correct usage" reference.

The non-existent references were verified against the live site (the page 404s; `example.cypress.io`'s real `h1` is "Kitchen Sink", not "About our Founder", and there is no `#hitcounter` element). The replacements use real, verified pages/elements:

- `/history/founder` → `/commands/actions` (real page, `h1` = "Actions")
- `About our Founder` → `Actions`
- `#hitcounter` + `getHits()` → `.action-email` input + `getEmail()`, so the `args` passing demo is actually runnable
- UI-navigation example's bogus `h1` "CYPRESS" → real "Kitchen Sink"
- Dropped the incoherent bits (e.g. visiting `/history/founder` then asserting `h1` "Kitchen Sink") and the fragile `www.cypress.io/about-us` assertion

Closes #6151

## Notes for reviewers

- The "Yielding a value" examples already used the valid `/` (Kitchen Sink) page and were left unchanged.
- The abstract SSO/login snippets (`supersecurelogons.com`, `/login`, `/home`) are intentionally illustrative placeholders — not claims of real pages — so they were left as-is and are out of scope for this issue.
- The "Incorrect Usage" blocks are anti-patterns by design; they were made internally coherent but are not meant to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BasauQD8Cw1G4BU5bWJGD8

---
_Generated by [Claude Code](https://claude.ai/code/session_01BasauQD8Cw1G4BU5bWJGD8)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to example code in `origin.mdx`; no runtime, API, or test harness changes.
> 
> **Overview**
> Updates **`cy.origin()`** documentation examples in `origin.mdx` so copy-paste snippets target real Kitchen Sink pages instead of the 404 **`/history/founder`** route and fictional content.
> 
> **Correct Usage** now visits **`/commands/actions`**, asserts **`Actions`**, and demonstrates **`args`** with **`getEmail()`** and **`.action-email`**. **Incorrect Usage** and navigation sections use the same real URLs and headings; the UI-navigation example expects **`Kitchen Sink`** instead of **`CYPRESS`**. Cross-origin error text now references **`example.cypress.io`** consistently.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6332eddab7ea955aaa79c568a399a875c533a2af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->