### PR TITLE
docs: document passing nested/complex --env values as JSON strings

### DIFF
--- a/docs/app/guides/environment-variables.mdx
+++ b/docs/app/guides/environment-variables.mdx
@@ -146,6 +146,18 @@ Pass environment variables via the command line. Multiple values must be separat
 cypress run --env host=kevin.dev.local,api_server=http://localhost:8888/api/v1
 ```
 
+To pass a complex value, such as an object with nested fields, provide it as a
+JSON string. This is also the way to include values that contain commas, spaces,
+or quotes, since those characters would otherwise be interpreted by the shell or
+as delimiters.
+
+```shell
+cypress run --env credentials='{"apiKey":"secret-key-12345","auth":{"user":"jane","token":"abc123"}}'
+```
+
+See the [`--env`](/app/references/command-line#cypress-run-env-lt-env-gt) command
+line reference for more details.
+
 ### 5. setupNodeEvents
 
 Set environment variables dynamically in the `setupNodeEvents` function:


### PR DESCRIPTION
## Summary

Adds documentation to the `--env` CLI flag section of the Environment Variables & Secrets guide showing that complex values — including objects with nested fields — can be passed as a JSON string, and that JSON is also how to include values containing commas, spaces, or quotes.

## Why

Issue #5718 reported that the guide's old "Option 4 - --env" section wrongly stated **"No support for nested fields."** The reporter demonstrated (on v13.6.3) that nested fields *do* work by passing a JSON string.

The erroneous wording was already removed when the guide was rewritten for the `cy.env()` / `Cypress.expose()` work in Cypress 15.10.0. However, the rewritten `--env` section only showed simple comma-separated `key=value` pairs and never documented the positive capability the reporter asked for — so the guide was still incomplete. This adds that guidance and cross-links the `--env` command line reference, which already documents JSON usage.

Verified against the CLI implementation: `--env` is parsed by `sanitizeAndConvertNestedArgs()` in `packages/server/lib/util/args.ts`, which `JSON.parse`s a valid JSON string as a whole before any comma-splitting. That is exactly why nested objects are preserved and why string values containing commas/spaces/quotes survive. The shared parser's nested-JSON path is covered by existing `--config` / `--reporterOptions` tests in `packages/server/test/unit/util/args_spec.ts`.

Closes #5718

## Notes for reviewers

- Single-file change: `docs/app/guides/environment-variables.mdx`.
- Wording and the JSON example mirror the existing [`--env` command line reference](https://docs.cypress.io/app/references/command-line#cypress-run-env-lt-env-gt) for consistency.
- Respects the repo's `.prettierrc` (`proseWrap: preserve`), so the manual line wrapping is intentional and won't be reflowed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01ECofhz12P19wkJb11Aev4i)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the environment variables guide; no runtime or test code is modified.
> 
> **Overview**
> The **Environment Variables & Secrets** guide’s `--env` CLI section now documents how to pass **complex values** (including nested objects) as a **JSON string**, and notes that JSON is the right approach when values contain commas, spaces, or quotes that would break simple `key=value` parsing or shell quoting.
> 
> A concrete `cypress run --env credentials='{...}'` example was added, and the section **cross-links** the existing [`--env` command line reference](/app/references/command-line#cypress-run-env-lt-env-gt) for full detail.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cedb6266c923ea66b13345078d10da0bd91ddbb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->