### PR TITLE
fix(theme): remove fragile color-mode override in DarkModeSwitch

### DIFF
--- a/src/theme/BackToTopButton/DarkModeSwitch.js
+++ b/src/theme/BackToTopButton/DarkModeSwitch.js
@@ -1,4 +1,4 @@
-import React , {useEffect} from 'react'
+import React from 'react'
 import clsx from 'clsx'
 import {
   IconShapeSunLong,
@@ -7,11 +7,7 @@ import {
 import { useColorMode } from '@docusaurus/theme-common'
 
 export default function DarkModeSwitch() {
-   
-  const { colorMode, setColorMode } = useColorMode(null)
-   useEffect(() => {
-    setColorMode(localStorage.getItem('theme'))
-  }, [])
+  const { colorMode, setColorMode } = useColorMode()
   const isDark = colorMode === 'dark'
   return (
     <button


### PR DESCRIPTION
## Summary

Removes a custom `useEffect` in the dark-mode toggle (`src/theme/BackToTopButton/DarkModeSwitch.js`) that overrode Docusaurus's native color-mode handling, and drops the invalid `null` argument passed to `useColorMode`. The toggle now relies on the framework's native `useColorMode()`.

## Why

Closes #6001

**Root cause:** The component ran, on every mount:

```js
const { colorMode, setColorMode } = useColorMode(null) // hook takes no argument
useEffect(() => {
  setColorMode(localStorage.getItem('theme'))
}, [])
```

Docusaurus already reads the persisted color mode from `localStorage` (key `theme`) and initializes it in a hydration-safe way. This override duplicated that work and introduced a bug: when no explicit preference is stored, `localStorage.getItem('theme')` returns `null`, and Docusaurus's `setColorMode(null)` **resets the color mode to the default and clears the stored choice** — the "theme reverts to light on refresh" behavior reported in the issue.

**Fix:** Remove the `useEffect` and the `null` argument, relying on native `useColorMode()` — matching the pattern already used elsewhere in the codebase (`src/components/copy-prompt`).

```diff
-import React , {useEffect} from 'react'
+import React from 'react'
 ...
-  const { colorMode, setColorMode } = useColorMode(null)
-   useEffect(() => {
-    setColorMode(localStorage.getItem('theme'))
-  }, [])
+  const { colorMode, setColorMode } = useColorMode()
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QvRXsZ7Uqu8tesuBLCTJP2)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single UI component cleanup with no auth or data changes; behavior is intended to match Docusaurus defaults aside from fixing the refresh bug.
> 
> **Overview**
> Fixes dark mode **reverting to light on refresh** by stopping `DarkModeSwitch` from re-applying `localStorage` on mount.
> 
> The toggle no longer runs a mount `useEffect` that called `setColorMode(localStorage.getItem('theme'))` or passes `null` into `useColorMode(null)`. When no saved theme exists, that path could call `setColorMode(null)` and override Docusaurus’s built-in hydration/persistence. The switch now uses plain `useColorMode()` and only changes mode via the existing click handler, consistent with other theme usage in the repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f351091b533559d2d5c7dba8607983af38df8a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->