### PR TITLE
docs: link the Cypress Cloud Savings Calculator from high-intent Cloud pages

### DIFF
--- a/docs/cloud/features/smart-orchestration/load-balancing.mdx
+++ b/docs/cloud/features/smart-orchestration/load-balancing.mdx
@@ -145,7 +145,10 @@ provision multiple machines with your CI provider.
 ## Verifying your time savings
 
 You don't have to estimate the savings yourself. Cypress Cloud measures them for
-you.
+you. (Want a projection before you record your first run? The
+[Cypress Cloud Savings Calculator](https://www.cypress.io/savings-calculator?utm_source=docs.cypress.io&utm_medium=load-balancing&utm_content=Savings+Calculator)
+estimates the time and cost you could save from parallelization and load
+balancing based on your suite size and run frequency.)
 
 ### Run Duration analytics
 

--- a/docs/cloud/features/smart-orchestration/load-balancing.mdx
+++ b/docs/cloud/features/smart-orchestration/load-balancing.mdx
@@ -145,10 +145,16 @@ provision multiple machines with your CI provider.
 ## Verifying your time savings
 
 You don't have to estimate the savings yourself. Cypress Cloud measures them for
-you. (Want a projection before you record your first run? The
+you.
+
+:::success
+
+Want a projection before you record your first run? The
 [Cypress Cloud Savings Calculator](https://www.cypress.io/savings-calculator?utm_source=docs.cypress.io&utm_medium=load-balancing&utm_content=Savings+Calculator)
 estimates the time and cost you could save from parallelization and load
-balancing based on your suite size and run frequency.)
+balancing based on your suite size and run frequency.
+
+:::
 
 ### Run Duration analytics
 

--- a/docs/cloud/features/smart-orchestration/overview.mdx
+++ b/docs/cloud/features/smart-orchestration/overview.mdx
@@ -25,3 +25,7 @@ to speed up test runs, accelerate debugging workflows, and reduce costs:
   Automatically cancel a Cypress run once failures cross a threshold you set, so
   you stop paying for tests you'll never look at and free up CI resources to
   validate the fix.
+
+Curious how much these add up to for your team? The
+[Cypress Cloud Savings Calculator](https://www.cypress.io/savings-calculator?utm_source=docs.cypress.io&utm_medium=smart-orchestration&utm_content=Savings+Calculator)
+estimates the annual time and CI cost you could save by orchestrating your runs.

--- a/docs/cloud/features/smart-orchestration/overview.mdx
+++ b/docs/cloud/features/smart-orchestration/overview.mdx
@@ -26,6 +26,10 @@ to speed up test runs, accelerate debugging workflows, and reduce costs:
   you stop paying for tests you'll never look at and free up CI resources to
   validate the fix.
 
+:::success
+
 Curious how much these add up to for your team? The
 [Cypress Cloud Savings Calculator](https://www.cypress.io/savings-calculator?utm_source=docs.cypress.io&utm_medium=smart-orchestration&utm_content=Savings+Calculator)
 estimates the annual time and CI cost you could save by orchestrating your runs.
+
+:::

--- a/docs/cloud/get-started/free-trial.mdx
+++ b/docs/cloud/get-started/free-trial.mdx
@@ -52,7 +52,13 @@ The [Cypress App](https://www.cypress.io/app#browser_testing) is open source and
 - **Regressions reaching your main branch.** Status checks from the [GitHub](/cloud/integrations/github), [GitLab](/cloud/integrations/gitlab), and [Bitbucket](/cloud/integrations/bitbucket) integrations keep failing code out of your protected branches.
 - **No visibility into quality over time.** [Analytics](/cloud/features/analytics/overview) track test health at the project and organization level, so you can see when speed or reliability starts to slip and act before it becomes a problem.
 
-A trial lets you measure all of this against your own suite, in your own CI, and see real results within days. Curious what that adds up to before you start? The [Cypress Cloud Savings Calculator](https://www.cypress.io/savings-calculator?utm_source=docs.cypress.io&utm_medium=free-trial&utm_content=Savings+Calculator) estimates the annual time and cost savings for a team your size in about a minute.
+A trial lets you measure all of this against your own suite, in your own CI, and see real results within days.
+
+:::success
+
+Curious what that adds up to before you start? The [Cypress Cloud Savings Calculator](https://www.cypress.io/savings-calculator?utm_source=docs.cypress.io&utm_medium=free-trial&utm_content=Savings+Calculator) estimates the annual time and cost savings for a team your size in about a minute.
+
+:::
 
 <DocsVideo
   title="Test Replay Product Demo"

--- a/docs/cloud/get-started/free-trial.mdx
+++ b/docs/cloud/get-started/free-trial.mdx
@@ -52,7 +52,7 @@ The [Cypress App](https://www.cypress.io/app#browser_testing) is open source and
 - **Regressions reaching your main branch.** Status checks from the [GitHub](/cloud/integrations/github), [GitLab](/cloud/integrations/gitlab), and [Bitbucket](/cloud/integrations/bitbucket) integrations keep failing code out of your protected branches.
 - **No visibility into quality over time.** [Analytics](/cloud/features/analytics/overview) track test health at the project and organization level, so you can see when speed or reliability starts to slip and act before it becomes a problem.
 
-A trial lets you measure all of this against your own suite, in your own CI, and see real results within days.
+A trial lets you measure all of this against your own suite, in your own CI, and see real results within days. Curious what that adds up to before you start? The [Cypress Cloud Savings Calculator](https://www.cypress.io/savings-calculator?utm_source=docs.cypress.io&utm_medium=free-trial&utm_content=Savings+Calculator) estimates the annual time and cost savings for a team your size in about a minute.
 
 <DocsVideo
   title="Test Replay Product Demo"

--- a/docs/cloud/get-started/introduction.mdx
+++ b/docs/cloud/get-started/introduction.mdx
@@ -44,7 +44,11 @@ Most of the value of Cypress Cloud is the time, money, and risk it removes from 
 - Regressions reaching your main branch: status checks from the [GitHub](/cloud/integrations/github), [GitLab](/cloud/integrations/gitlab), and [Bitbucket](/cloud/integrations/bitbucket) integrations block failing code from merging.
 - Blind spots in quality over time: [analytics](/cloud/features/analytics/overview) track test health at the project and organization level, so you can see when reliability or speed starts to slip.
 
+:::success
+
 Want a rough dollar figure for your own team? The [Cypress Cloud Savings Calculator](https://www.cypress.io/savings-calculator?utm_source=docs.cypress.io&utm_medium=cloud-intro&utm_content=Savings+Calculator) estimates the annual time and money you could save from Smart Orchestration, Test Replay, flake detection, and more, based on your team size, run frequency, and suite size.
+
+:::
 
 ## Benefits
 

--- a/docs/cloud/get-started/introduction.mdx
+++ b/docs/cloud/get-started/introduction.mdx
@@ -44,6 +44,8 @@ Most of the value of Cypress Cloud is the time, money, and risk it removes from 
 - Regressions reaching your main branch: status checks from the [GitHub](/cloud/integrations/github), [GitLab](/cloud/integrations/gitlab), and [Bitbucket](/cloud/integrations/bitbucket) integrations block failing code from merging.
 - Blind spots in quality over time: [analytics](/cloud/features/analytics/overview) track test health at the project and organization level, so you can see when reliability or speed starts to slip.
 
+Want a rough dollar figure for your own team? The [Cypress Cloud Savings Calculator](https://www.cypress.io/savings-calculator?utm_source=docs.cypress.io&utm_medium=cloud-intro&utm_content=Savings+Calculator) estimates the annual time and money you could save from Smart Orchestration, Test Replay, flake detection, and more, based on your team size, run frequency, and suite size.
+
 ## Benefits
 
 [Cypress Cloud](https://on.cypress.io/about-cypress-cloud?utm_medium=cloud-benefits&utm_source=docs.cypress.io&utm_term=&utm_content=Cypress+Cloud) brings test results, analytics, orchestration, and integrations together in one platform. With it, you can:


### PR DESCRIPTION
## Summary

Adds contextual `:::success` callouts linking to the [Cypress Cloud Savings Calculator](https://www.cypress.io/savings-calculator) on four Cloud docs pages that readers reach with ROI/evaluation intent.

## Why

The Savings Calculator is an evaluation tool — you enter team size, run frequency, and suite size and it estimates annual hours and dollars saved, broken down across Smart Orchestration, Test Replay, Flake Detection, Cloud MCP, and Test Generation. Those value drivers map directly onto specific Cloud feature pages, so a "here's what it's worth for your team" link is most useful exactly where a reader is already weighing adoption. Placements were kept to a curated set (rather than every reference page) so the links stay helpful instead of reading as spam. Each link is where the page's own copy already discusses cost/time savings, and carries UTM parameters matching the existing promotional-link convention for placement-level attribution.

Placements:

| Page | Anchor | Driver |
| --- | --- | --- |
| Cloud Introduction | end of the "Costs and risks Cypress Cloud helps you reduce" section | all drivers |
| Free Trial | alongside "measure this against your own suite" | decision-stage CTA |
| Smart Orchestration Overview | after the four feature bullets | Smart Orchestration (headline driver) |
| Load Balancing → "Verifying your time savings" | top of the section | a pre-adoption projection to complement the post-adoption measurement |

## Notes for reviewers

- All four callouts use `:::success` admonitions, matching existing usage in the repo (e.g. Test Replay's "Get Started" section).
- `prettier --check` passes on all four files.
- Deliberately held back from Test Replay, Flaky Test Management, Cloud MCP, and Billing pages to avoid over-seeding — easy to add if wider coverage is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TAM5gfhZL22d7srSqbueKL

---
_Generated by [Claude Code](https://claude.ai/code/session_01TAM5gfhZL22d7srSqbueKL)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only MDX additions with external marketing links; no application, API, or build logic changes.
> 
> **Overview**
> Adds **`:::success`** callouts on four Cloud docs pages that point readers to the **Cypress Cloud Savings Calculator**, placed next to copy about time/CI savings or trial evaluation.
> 
> **Introduction** and **Free Trial** get pre-adoption ROI prompts after the “costs and risks” / “measure against your suite” sections. **Smart Orchestration overview** adds a team-wide orchestration savings estimate after the feature list. **Load balancing** adds a pre-recording projection at the start of “Verifying your time savings,” before the existing post-adoption analytics guidance.
> 
> Each link uses the same `utm_source=docs.cypress.io` pattern with a distinct **`utm_medium`** (`cloud-intro`, `free-trial`, `smart-orchestration`, `load-balancing`) for attribution. No other pages or product behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14c48aee3ebeae6d51dd4aa3c4517b1701ab8b29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->