### PR TITLE
docs(app-quality): correct and expand the profiles configuration docs

### DIFF
--- a/docs/accessibility/configuration/profiles.mdx
+++ b/docs/accessibility/configuration/profiles.mdx
@@ -10,3 +10,10 @@ sidebar_position: 100
 # Override config by run tag (`profiles`)
 
 <Profiles />
+
+## See also
+
+- [Cypress run `--tag`](/app/references/command-line#cypress-run-tag-lt-tag-gt) is the flag that selects which profile a run uses.
+- [Configuration overview](/accessibility/configuration/overview) lists every option a profile's `config` can override and how to regenerate reports after changing configuration.
+- [`viewFilters`](/accessibility/configuration/viewfilters) and [`elementFilters`](/accessibility/configuration/elementfilters) are common properties to scope a profile's report.
+- [Cypress Accessibility FAQ](/accessibility/faq) answers common questions about configuration.

--- a/docs/accessibility/faq.mdx
+++ b/docs/accessibility/faq.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Cypress Accessibility FAQ'
-description: 'Get answers to common questions about Cypress Accessibility, including ignoring elements with elementFilters, excluding URLs with viewFilters, the Ignored status, score impact, element identification, and configuration.'
+description: 'Get answers to common questions about Cypress Accessibility, including ignoring elements with elementFilters, excluding URLs with viewFilters, the Ignored status, score impact, element identification, configuration, and per-run profiles.'
 sidebar_label: FAQ
 sidebar_position: 160
 ---
@@ -91,9 +91,37 @@ In the **App Quality** tab of your project settings in Cypress Cloud. See [Setti
 
 No. You can regenerate any historical run from its **Properties** tab, and the report is reprocessed with the current configuration. This lets you iterate on configuration and see the effects immediately without running your Cypress tests again.
 
+## Profiles
+
+### <Icon name="angle-right" /> How do I apply different Cypress Accessibility settings to different runs?
+
+In your project's App Quality configuration in Cypress Cloud, add a [`profiles`](/accessibility/configuration/profiles) array, give each profile a `name`, and record the run with a matching [`--tag`](/app/references/command-line#cypress-run-tag-lt-tag-gt). When a run's tag matches a profile's `name`, that profile's `config` overrides your base Cypress Accessibility configuration for that run, so a smoke run and a full regression run can each use their own settings without changing your test code. If no tag matches, the base configuration is used unchanged.
+
+### <Icon name="angle-right" /> Does a Cypress Accessibility profile override my base configuration or merge with it?
+
+Cypress Cloud overrides one property at a time with a shallow merge, not a deep merge. Any property the profile lists replaces the root value for that property entirely (arrays are replaced, not concatenated), so if a profile defines [`elementFilters`](/accessibility/configuration/elementfilters), repeat any root rules you still want to keep. Properties the profile doesn't mention are inherited from the root. The `accessibility` and `uiCoverage` objects merge one level deep, so a profile can override `accessibility.viewFilters` while still inheriting `accessibility.attributeFilters`. See [How a profile changes your configuration](/accessibility/configuration/profiles#How-a-profile-changes-your-configuration).
+
+### <Icon name="angle-right" /> If a run has multiple tags that match profiles, which Cypress Accessibility profile is used?
+
+Cypress Cloud uses the first profile in the [`profiles`](/accessibility/configuration/profiles) array whose `name` matches one of the run's tags. The tie is broken by the order of the profiles array, not the order of the tags on the run, so reordering tags on the command line never changes which profile applies.
+
+### <Icon name="angle-right" /> Why isn't my Cypress Accessibility profile applied even though I tagged the run?
+
+The most common causes are:
+
+- The run tag doesn't exactly match the profile `name`. Matching is case-sensitive and exact, so `aq-config-regression` matches only the tag `aq-config-regression`, not `AQ-Config-Regression` or `aq-config-regression-nightly`.
+- The tag never reached Cypress Cloud. Profiles are selected from the tags passed to `cypress run --record --tag`, so a run recorded without `--record`, or without that specific `--tag`, falls back to the base configuration.
+- An earlier profile in the array also matches one of the tags and is used instead, because the first match wins.
+- The report was processed before you saved the configuration. Regenerate the run to apply the current configuration.
+
+### <Icon name="angle-right" /> Can a profile turn off Cypress Accessibility or skip a run entirely?
+
+There's no dedicated "skip this run" switch in a profile. To suppress a report for certain runs, point a profile at a deliberately narrow configuration (for example, [`viewFilters`](/accessibility/configuration/viewfilters) that exclude every view) so Cypress Cloud produces an empty or tightly scoped accessibility report for the run instead. See [Why use profiles?](/accessibility/configuration/profiles#Why-use-profiles).
+
 ## See also
 
 - [Configuration overview](/accessibility/configuration/overview) lists every configuration option and what each one is for.
+- [`profiles`](/accessibility/configuration/profiles) apply different configuration to runs based on run tags.
 - [`elementFilters`](/accessibility/configuration/elementfilters) is the full reference for ignoring elements.
 - [`viewFilters`](/accessibility/configuration/viewfilters) is the full reference for excluding URLs.
 - [Run-level reports](/accessibility/core-concepts/run-level-reports) explains element statuses, including **Ignored**.

--- a/docs/partials/_profiles.mdx
+++ b/docs/partials/_profiles.mdx
@@ -1,28 +1,40 @@
-The `profiles` property allows you to create configuration overrides that are applied based on [run tags](/app/references/command-line#cypress-run-tag-lt-tag-gt). This enables you to use different configuration settings for different types of runs in the same Cypress Cloud project, such as regression tests compared to smoke tests environments, or providing scoped results relevant to specific teams.
+The `profiles` property lets a single Cypress Cloud project serve many kinds of runs. Instead of maintaining separate projects—or living with one configuration that has to compromise between smoke tests, full regression suites, and per-team reporting—you keep one base configuration and layer targeted overrides on top of it. The right override is selected automatically from the [run tags](/app/references/command-line#cypress-run-tag-lt-tag-gt) you already pass to `cypress run`, so a regression run and a pull request run can each get exactly the App Quality configuration that makes their report actionable, with no changes to your test code.
 
 In many cases, the need for different profiles can be avoided completely by having distinct Cypress Cloud projects for different kinds of runs or different team ownership. This is the recommended first choice, because it usually simplifies reporting and tracking. But where distinct projects are not the right answer, profiles will help.
 
 ## Why use profiles?
 
-- **Team specific reporting**: If multiple teams use the same Cypress Cloud project, they may have completely different areas of concern for which pages or DOM elements are included in reports about accessibility or UI Coverage. Profiles allow each team to see and track against only the results that matter to them, and remove all other findings.
-- **Run-type customization**: Use different filters or settings for regression runs versus pull requests. It can be useful to have a narrow config for blocking a merge, optimized for the most critical areas of your app and high "solvability", while still running a wide config on a full regression suite to manage findings on a difference cadence.
-- **Skip runs when needed**: If you know that certain kinds of runs are not going to be valuable for App Quality reporting, you can ignore all view on these runs so that no report is created. In some situations this can improve clarity about when to look at a report and which reports are considered significant.
+- **Team-specific reporting**: If multiple teams use the same Cypress Cloud project, they may care about completely different pages or DOM elements in their accessibility or UI Coverage reports. Profiles let each team tag their runs to see and track only the results that matter to them, filtering out everything else.
+- **Run-type customization**: Use different filters or settings for regression runs versus pull requests. It can be useful to have a narrow config for blocking a merge, optimized for the most critical areas of your app and high "solvability", while still running a wide config on a full regression suite to manage findings on a different cadence.
+- **Scope a report down for specific runs**: When a full report isn't useful for a certain kind of run, point a profile at a deliberately narrow configuration—for example, `viewFilters` that keep only a handful of views, or exclude everything else—so the report stays focused on what matters for that run type. There is no dedicated "skip this run" switch; you scope reporting by supplying a narrower configuration through the profile.
 
 ## How profiles work
 
-Profiles are selected by matching run tags to profile names. When you run Cypress with the [`--tag`](/app/references/command-line#cypress-run-tag-lt-tag-gt) flag, Cypress Cloud looks for a profile whose `name` matches one of the tags. If a match is found, properties defined in profile's `config` properties override the root configuration. Properties defined in the root that are not referenced in the profile will be inherited, meaning you do not need to repeat config values that you want to keep the same.
+### Selecting a profile
 
-If more than one tag provided to a run matches a profile in your App Quality profiles array, the first matching profile in the array will be used. The order in which the tags are passed to the run doesn't matter.
+Profiles are selected by matching run tags to profile names. When you record a run with the [`--tag`](/app/references/command-line#cypress-run-tag-lt-tag-gt) flag, Cypress Cloud walks the `profiles` array in order and applies the **first profile whose `name` exactly matches one of the run's tags**. Matching is an exact, case-sensitive string comparison: the profile name `aq-config-regression` matches only the tag `aq-config-regression`—not `AQ-Config-Regression`, and not `aq-config-regression-nightly`.
+
+If a run carries several tags that each match a profile, the tie is broken by **the order of the `profiles` array, not the order of the tags** on the run. The first matching profile in the array always wins. If no tag matches any profile—or the run has no tags at all—the base (root) configuration is used unchanged.
+
+### How overrides are merged
+
+A matched profile's `config` is layered on top of the root configuration one property at a time. This is a shallow merge, not a deep merge, and understanding it prevents the most common surprises:
+
+- **Each property is replaced as a whole, never concatenated.** If a property such as `viewFilters` or `elementFilters` appears in a profile's `config`, its value completely replaces the root value for that run. Arrays are **not** merged, so a profile that defines `elementFilters` overrides the root `elementFilters` entirely—repeat any root rules you still want to keep.
+- **Properties you don't override are inherited.** Any root property the profile doesn't mention is used as-is, so a profile only needs to specify what changes.
+- **`uiCoverage` and `accessibility` merge one level deep.** Within these product-specific objects, each key (for example `elementGroups` or `attributeFilters`) is inherited from the root unless the profile provides its own value for that key, in which case that one key is replaced. This lets a profile override `uiCoverage.elementGroups` without disturbing `uiCoverage.attributeFilters`.
+
+Profiles are never nested. The `profiles` array exists only at the root of your configuration, and a profile's `config` accepts every other App Quality option except another `profiles` array.
 
 ## Best practices
 
 Use a naming convention like `aq-config-x` (e.g., `aq-config-regression`, `aq-config-staging`) to make it clear that a tag is used for configuration lookup purposes.
 
-While relying on existing tags works just fine, being explicit will help avoid unintentionally changing or removing a tag which is depended on for a profile.
+While relying on existing tags works just fine, being explicit will help avoid unintentionally changing or removing a tag which is depended on for a profile. Because names are matched exactly against run tags, keep them stable—renaming a profile or changing a tag silently falls back to the base configuration for those runs.
 
 ## Syntax
 
-```json
+```json title="App Quality Config"
 {
   "profiles": [
     {
@@ -38,11 +50,11 @@ While relying on existing tags works just fine, being explicit will help avoid u
 
 ### Options
 
-| Option    | Required | Description                                                                                               |
-| --------- | -------- | --------------------------------------------------------------------------------------------------------- |
-| `name`    | Required | The profile name that must match a run tag to activate this profile.                                      |
-| `config`  | Required | An object containing any App Quality configuration options. These values override the root configuration. |
-| `comment` | Optional | A comment describing the purpose of this profile.                                                         |
+| Option    | Required | Description                                                                                                                                 |
+| --------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`    | Required | The profile name. A run activates this profile when one of its tags exactly matches this value (case-sensitive).                            |
+| `config`  | Required | An object containing any App Quality configuration options, except a nested `profiles` array. These values override the root configuration. |
+| `comment` | Optional | A comment describing the purpose of this profile.                                                                                           |
 
 ## Examples
 
@@ -50,7 +62,7 @@ While relying on existing tags works just fine, being explicit will help avoid u
 
 #### Config
 
-```json
+```json title="App Quality Config"
 {
   "elementFilters": [
     {
@@ -89,7 +101,7 @@ To use this profile, run Cypress with a matching tag:
 cypress run --record --tag "aq-config-regression"
 ```
 
-When this tag is used, the profile's `elementFilters` configuration will override the base `elementFilters`, excluding both temporary test elements and debug elements.
+When this tag is used, the profile's `elementFilters` replaces the base `elementFilters` entirely, so both rules are repeated to exclude temporary test elements and debug elements. Because arrays are replaced rather than merged, dropping the first rule here would stop excluding temporary test elements on regression runs.
 
 ---
 
@@ -99,7 +111,7 @@ You can define multiple profiles for different scenarios:
 
 #### Config
 
-```json
+```json title="App Quality Config"
 {
   "elementFilters": [
     {
@@ -156,11 +168,11 @@ cypress run --record --tag "aq-config-staging"
 
 ### Profile with nested configuration
 
-Profiles can override configuration at any level, including nested configuration specific to Cypress Accessibility or UI Coverage, if your project has both projects enabled. For example:
+Profiles can override configuration at any level, including nested configuration specific to Cypress Accessibility or UI Coverage, if your project has both products enabled. Because `uiCoverage` and `accessibility` merge one level deep, a profile can add or replace a single nested property while inheriting the rest from the root. For example:
 
 #### Config
 
-```json
+```json title="App Quality Config"
 {
   "elementFilters": [
     {
@@ -203,17 +215,17 @@ Profiles can override configuration at any level, including nested configuration
 cypress run --record --tag "aq-config-feature-branch"
 ```
 
-This profile adds element grouping for the new checkout flow while keeping the base configuration for element filters and attribute filters.
+This profile adds element grouping for the new checkout flow. The root `elementFilters` is inherited because the profile doesn't mention it, and inside `uiCoverage`, the profile supplies `elementGroups` while the root's `attributeFilters` is inherited—only the keys the profile names are replaced.
 
 ---
 
 ### Profile selection with multiple matching tags
 
-If you pass multiple tags and more than one matches a profile name, the first matching profile in the `profiles` array is used:
+If you pass multiple tags and more than one matches a profile name, the first matching profile in the `profiles` array is used—regardless of the order the tags appear on the run:
 
 #### Config
 
-```json
+```json title="App Quality Config"
 {
   "profiles": [
     {
@@ -245,7 +257,7 @@ If you pass multiple tags and more than one matches a profile name, the first ma
 #### Usage
 
 ```shell
-cypress run --record --tag "aq-config-regression,aq-config-staging"
+cypress run --record --tag "aq-config-staging,aq-config-regression"
 ```
 
-In this case, the `aq-config-regression` profile will be used because it appears first in the `profiles` array, even though both tags match profile names.
+In this case, the `aq-config-regression` profile is used because it appears first in the `profiles` array, even though `aq-config-staging` is listed first among the tags. Only profile-array order decides the winner.

--- a/docs/partials/_profiles.mdx
+++ b/docs/partials/_profiles.mdx
@@ -58,7 +58,9 @@ While relying on existing tags works just fine, being explicit will help avoid u
 
 ### Basic profile structure
 
-You record runs from more than one environment to the same project. Every environment shows the cookie-consent banner, which you exclude from all reports. Runs against your preview environment (tagged `aq-config-preview`) also render an internal feature-flag panel and a "preview build" banner that never ship to production, and you want those out of preview reports too.
+Your base configuration excludes a third-party support-chat widget, since it isn't your code and just adds noise to most reports. But one suite exists specifically to test the support-chat flow, and it records under the `aq-config-support-chat` tag. For that run, and only that run, the widget should count toward coverage.
+
+This is the kind of difference that genuinely needs a profile: the same widget can't be both excluded and included in a single base configuration, so the conflicting value has to live under a tag.
 
 #### Config
 
@@ -66,30 +68,20 @@ You record runs from more than one environment to the same project. Every enviro
 {
   "elementFilters": [
     {
-      "selector": "#cookie-consent-banner",
+      "selector": "#support-chat-widget",
       "include": false,
-      "comment": "Exclude the cookie-consent banner from all reports"
+      "comment": "Exclude the third-party support-chat widget from most reports"
     }
   ],
   "profiles": [
     {
-      "name": "aq-config-preview",
+      "name": "aq-config-support-chat",
       "config": {
         "elementFilters": [
           {
-            "selector": "#cookie-consent-banner",
-            "include": false,
-            "comment": "Still exclude the cookie-consent banner"
-          },
-          {
-            "selector": "[data-testid='feature-flag-panel']",
-            "include": false,
-            "comment": "Exclude the internal feature-flag panel, which only renders in preview"
-          },
-          {
-            "selector": "[data-testid='preview-build-banner']",
-            "include": false,
-            "comment": "Exclude the preview-build banner that never ships to production"
+            "selector": "#support-chat-widget",
+            "include": true,
+            "comment": "The support-chat suite tests this widget, so count it here"
           }
         ]
       }
@@ -100,13 +92,13 @@ You record runs from more than one environment to the same project. Every enviro
 
 #### Usage
 
-Record the preview environment's runs with a matching tag:
+Record the support-chat suite with a matching tag:
 
 ```shell
-cypress run --record --tag "aq-config-preview"
+cypress run --record --tag "aq-config-support-chat"
 ```
 
-Preview runs use this profile's `elementFilters` in place of the base list. Because a profile's list replaces the base list rather than adding to it, the cookie-banner rule is repeated here alongside the preview-only exclusions; dropping it would let the banner back into your preview reports.
+On every other run the widget stays excluded. On the tagged run, the profile's `elementFilters` replaces the base list, so the `include: true` rule wins and the widget counts toward coverage. Because a profile's list replaces the base list rather than adding to it, list every rule the run needs, not only the one that changed.
 
 ---
 

--- a/docs/partials/_profiles.mdx
+++ b/docs/partials/_profiles.mdx
@@ -104,44 +104,33 @@ On every other run the widget stays excluded. On the tagged run, the profile's `
 
 ### Multiple profiles
 
-Different kinds of runs need different scoping. Pull request runs that gate merges should stay focused on the core application, while staging runs need to ignore an internal admin area that only exists in that environment. Both still inherit the base cookie-banner exclusion because neither profile redefines `elementFilters`.
+You can define several profiles, each for a different kind of run. Here, two focused audit suites want the same routes broken down into separate [views](/ui-coverage/core-concepts/views) so they can see coverage per value: a reporting audit splits `/reports/:type` by report type, and a localization audit splits `/:locale/account` by locale. You wouldn't want either split applied to every run, since it would fragment your normal reports into many low-traffic views, so each `views` rule is scoped to its own tag.
 
 #### Config
 
 ```json title="App Quality Config"
 {
-  "elementFilters": [
-    {
-      "selector": "#cookie-consent-banner",
-      "include": false,
-      "comment": "Exclude the cookie-consent banner from all reports"
-    }
-  ],
   "profiles": [
     {
-      "name": "aq-config-pull-request",
+      "name": "aq-config-reporting-audit",
       "config": {
-        "viewFilters": [
+        "views": [
           {
-            "pattern": "/blog/*",
-            "include": false,
-            "comment": "Keep merge-blocking reports on the app, not marketing pages"
-          },
-          {
-            "pattern": "/docs/*",
-            "include": false
+            "pattern": "/reports/:type",
+            "groupBy": ["type"],
+            "comment": "One view per report type for the reporting audit"
           }
         ]
       }
     },
     {
-      "name": "aq-config-staging",
+      "name": "aq-config-localization-audit",
       "config": {
-        "viewFilters": [
+        "views": [
           {
-            "pattern": "/admin/*",
-            "include": false,
-            "comment": "Exclude the internal admin area that only exists in staging"
+            "pattern": "/:locale/account",
+            "groupBy": ["locale"],
+            "comment": "One view per locale for the localization audit"
           }
         ]
       }
@@ -155,11 +144,11 @@ Different kinds of runs need different scoping. Pull request runs that gate merg
 Use different tags to activate different profiles:
 
 ```shell
-# Pull request runs that gate merges
-cypress run --record --tag "aq-config-pull-request"
+# Reporting audit runs
+cypress run --record --tag "aq-config-reporting-audit"
 
-# Staging runs
-cypress run --record --tag "aq-config-staging"
+# Localization audit runs
+cypress run --record --tag "aq-config-localization-audit"
 ```
 
 ---
@@ -168,19 +157,12 @@ cypress run --record --tag "aq-config-staging"
 
 Profiles can override configuration at any level, including configuration specific to Cypress Accessibility or UI Coverage when your project has both products enabled. Because `uiCoverage` and `accessibility` merge one level deep, a profile can add or replace a single nested property while inheriting the rest.
 
-Here the base configuration ignores React's auto-generated IDs, so a control isn't counted as a brand-new element on every render. A profile for the branch building a checkout redesign groups those new controls together so they're tracked as a single unit.
+Here the base configuration groups every product card into one [element group](/ui-coverage/configuration/elementgroups) so the repeated cards count once and don't dominate the score. A suite that specifically exercises each card variant, tagged `aq-config-card-variants`, needs the opposite: the same cards split into separate groups so featured and standard cards are tracked independently. The two groupings can't both be the base configuration, so the difference lives in a profile.
 
 #### Config
 
 ```json title="App Quality Config"
 {
-  "elementFilters": [
-    {
-      "selector": "#cookie-consent-banner",
-      "include": false,
-      "comment": "Exclude the cookie-consent banner from all reports"
-    }
-  ],
   "uiCoverage": {
     "attributeFilters": [
       {
@@ -189,18 +171,28 @@ Here the base configuration ignores React's auto-generated IDs, so a control isn
         "include": false,
         "comment": "Ignore React auto-generated IDs so elements stay stable across renders"
       }
+    ],
+    "elementGroups": [
+      {
+        "selector": "[data-cy='product-card']",
+        "name": "Product card",
+        "comment": "Count the repeated product cards as one group"
+      }
     ]
   },
   "profiles": [
     {
-      "name": "aq-config-checkout-redesign",
+      "name": "aq-config-card-variants",
       "config": {
         "uiCoverage": {
           "elementGroups": [
             {
-              "selector": "[data-cy^='checkout-']",
-              "name": "Checkout redesign",
-              "comment": "Track the new checkout controls as a single group"
+              "selector": "[data-cy='product-card'][data-variant='featured']",
+              "name": "Featured product card"
+            },
+            {
+              "selector": "[data-cy='product-card'][data-variant='standard']",
+              "name": "Standard product card"
             }
           ]
         }
@@ -213,10 +205,10 @@ Here the base configuration ignores React's auto-generated IDs, so a control isn
 #### Usage
 
 ```shell
-cypress run --record --tag "aq-config-checkout-redesign"
+cypress run --record --tag "aq-config-card-variants"
 ```
 
-The root `elementFilters` is inherited because the profile doesn't mention it. Inside `uiCoverage`, the profile supplies `elementGroups` while the root's `attributeFilters` is inherited; only the keys the profile names are replaced.
+Inside `uiCoverage`, the profile replaces `elementGroups` with its own two groups while the sibling `attributeFilters` is inherited; only the keys the profile names are replaced. On every other run, the single "Product card" group still applies.
 
 ---
 

--- a/docs/partials/_profiles.mdx
+++ b/docs/partials/_profiles.mdx
@@ -58,15 +58,17 @@ While relying on existing tags works just fine, being explicit will help avoid u
 
 ### Basic profile structure
 
+Your base configuration hides the cookie-consent banner from every report. On nightly regression runs, an internal QA debug toolbar is also rendered, and you want it out of those reports too.
+
 #### Config
 
 ```json title="App Quality Config"
 {
   "elementFilters": [
     {
-      "selector": "[data-testid*='temp']",
+      "selector": "#onetrust-banner-sdk",
       "include": false,
-      "comment": "Exclude temporary test elements"
+      "comment": "Exclude the cookie-consent banner from all reports"
     }
   ],
   "profiles": [
@@ -75,14 +77,14 @@ While relying on existing tags works just fine, being explicit will help avoid u
       "config": {
         "elementFilters": [
           {
-            "selector": "[data-testid*='temp']",
+            "selector": "#onetrust-banner-sdk",
             "include": false,
-            "comment": "Exclude temporary test elements in regression runs"
+            "comment": "Still exclude the cookie-consent banner"
           },
           {
-            "selector": "[data-role='debug']",
+            "selector": "[data-testid='debug-toolbar']",
             "include": false,
-            "comment": "Exclude debug elements in regression runs"
+            "comment": "Exclude the internal QA debug toolbar shown on regression runs"
           }
         ]
       }
@@ -99,13 +101,13 @@ To use this profile, run Cypress with a matching tag:
 cypress run --record --tag "aq-config-regression"
 ```
 
-When this tag is used, the profile's `elementFilters` replaces the base `elementFilters` entirely, so both rules are repeated to exclude temporary test elements and debug elements. Because arrays are replaced rather than merged, dropping the first rule here would stop excluding temporary test elements on regression runs.
+On regression runs, the profile's `elementFilters` replaces the base `elementFilters` entirely, so the cookie-banner rule is repeated alongside the new debug-toolbar rule. Because arrays are replaced rather than merged, dropping the repeated rule would let the cookie banner back into your regression reports.
 
 ---
 
 ### Multiple profiles
 
-You can define multiple profiles for different scenarios:
+Different kinds of runs need different scoping. Pull request runs that gate merges should stay focused on the core application, while staging runs need to ignore an internal admin area that only exists in that environment. Both still inherit the base cookie-banner exclusion because neither profile redefines `elementFilters`.
 
 #### Config
 
@@ -113,23 +115,24 @@ You can define multiple profiles for different scenarios:
 {
   "elementFilters": [
     {
-      "selector": "[data-testid*='temp']",
-      "include": false
+      "selector": "#onetrust-banner-sdk",
+      "include": false,
+      "comment": "Exclude the cookie-consent banner from all reports"
     }
   ],
   "profiles": [
     {
-      "name": "aq-config-regression",
+      "name": "aq-config-pull-request",
       "config": {
-        "elementFilters": [
+        "viewFilters": [
           {
-            "selector": "[data-testid*='temp']",
-            "include": false
+            "pattern": "/blog/*",
+            "include": false,
+            "comment": "Keep merge-blocking reports on the app, not marketing pages"
           },
           {
-            "selector": "[data-role='debug']",
-            "include": false,
-            "comment": "Exclude debug elements in regression runs"
+            "pattern": "/docs/*",
+            "include": false
           }
         ]
       }
@@ -139,9 +142,9 @@ You can define multiple profiles for different scenarios:
       "config": {
         "viewFilters": [
           {
-            "pattern": "https://staging.example.com/admin/*",
+            "pattern": "/admin/*",
             "include": false,
-            "comment": "Exclude admin pages in staging runs"
+            "comment": "Exclude the internal admin area that only exists in staging"
           }
         ]
       }
@@ -155,10 +158,10 @@ You can define multiple profiles for different scenarios:
 Use different tags to activate different profiles:
 
 ```shell
-# For regression runs
-cypress run --record --tag "aq-config-regression"
+# Pull request runs that gate merges
+cypress run --record --tag "aq-config-pull-request"
 
-# For staging runs
+# Staging runs
 cypress run --record --tag "aq-config-staging"
 ```
 
@@ -166,7 +169,9 @@ cypress run --record --tag "aq-config-staging"
 
 ### Profile with nested configuration
 
-Profiles can override configuration at any level, including nested configuration specific to Cypress Accessibility or UI Coverage, if your project has both products enabled. Because `uiCoverage` and `accessibility` merge one level deep, a profile can add or replace a single nested property while inheriting the rest from the root. For example:
+Profiles can override configuration at any level, including configuration specific to Cypress Accessibility or UI Coverage when your project has both products enabled. Because `uiCoverage` and `accessibility` merge one level deep, a profile can add or replace a single nested property while inheriting the rest.
+
+Here the base configuration ignores React's auto-generated IDs, so a control isn't counted as a brand-new element on every render. A profile for the branch building a checkout redesign groups those new controls together so they're tracked as a single unit.
 
 #### Config
 
@@ -174,8 +179,9 @@ Profiles can override configuration at any level, including nested configuration
 {
   "elementFilters": [
     {
-      "selector": "[data-testid*='temp']",
-      "include": false
+      "selector": "#onetrust-banner-sdk",
+      "include": false,
+      "comment": "Exclude the cookie-consent banner from all reports"
     }
   ],
   "uiCoverage": {
@@ -184,20 +190,20 @@ Profiles can override configuration at any level, including nested configuration
         "attribute": "id",
         "value": ":r.*:",
         "include": false,
-        "comment": "Filter out React auto-generated IDs"
+        "comment": "Ignore React auto-generated IDs so elements stay stable across renders"
       }
     ]
   },
   "profiles": [
     {
-      "name": "aq-config-feature-branch",
+      "name": "aq-config-checkout-redesign",
       "config": {
         "uiCoverage": {
           "elementGroups": [
             {
-              "selector": "[data-feature='new-checkout']",
-              "name": "New Checkout Flow",
-              "comment": "Group new checkout elements for feature branch testing"
+              "selector": "[data-cy^='checkout-']",
+              "name": "Checkout redesign",
+              "comment": "Track the new checkout controls as a single group"
             }
           ]
         }
@@ -210,16 +216,16 @@ Profiles can override configuration at any level, including nested configuration
 #### Usage
 
 ```shell
-cypress run --record --tag "aq-config-feature-branch"
+cypress run --record --tag "aq-config-checkout-redesign"
 ```
 
-This profile adds element grouping for the new checkout flow. The root `elementFilters` is inherited because the profile doesn't mention it, and inside `uiCoverage`, the profile supplies `elementGroups` while the root's `attributeFilters` is inherited; only the keys the profile names are replaced.
+The root `elementFilters` is inherited because the profile doesn't mention it. Inside `uiCoverage`, the profile supplies `elementGroups` while the root's `attributeFilters` is inherited; only the keys the profile names are replaced.
 
 ---
 
 ### Profile selection with multiple matching tags
 
-If you pass multiple tags and more than one matches a profile name, the first matching profile in the `profiles` array is used, regardless of the order the tags appear on the run:
+Two teams share one Cypress Cloud project, and each has a profile that scopes the report to the views they own. A shared nightly job is tagged for both teams. When more than one tag matches a profile name, Cypress Cloud uses the first matching profile in the `profiles` array, regardless of the order the tags appear on the run.
 
 #### Config
 
@@ -227,23 +233,33 @@ If you pass multiple tags and more than one matches a profile name, the first ma
 {
   "profiles": [
     {
-      "name": "aq-config-regression",
+      "name": "aq-config-team-checkout",
       "config": {
-        "elementFilters": [
+        "viewFilters": [
           {
-            "selector": "[data-role='debug']",
-            "include": false
+            "pattern": "/checkout/*",
+            "include": true
+          },
+          {
+            "pattern": "*",
+            "include": false,
+            "comment": "Checkout team: report only on checkout views"
           }
         ]
       }
     },
     {
-      "name": "aq-config-staging",
+      "name": "aq-config-team-account",
       "config": {
         "viewFilters": [
           {
-            "pattern": "https://staging.example.com/admin/*",
-            "include": false
+            "pattern": "/account/*",
+            "include": true
+          },
+          {
+            "pattern": "*",
+            "include": false,
+            "comment": "Account team: report only on account views"
           }
         ]
       }
@@ -255,7 +271,7 @@ If you pass multiple tags and more than one matches a profile name, the first ma
 #### Usage
 
 ```shell
-cypress run --record --tag "aq-config-staging,aq-config-regression"
+cypress run --record --tag "aq-config-team-account,aq-config-team-checkout"
 ```
 
-In this case, the `aq-config-regression` profile is used because it appears first in the `profiles` array, even though `aq-config-staging` is listed first among the tags. Only profile-array order decides the winner.
+Both tags match a profile, but Cypress Cloud applies `aq-config-team-checkout` because it appears first in the `profiles` array, even though `aq-config-team-account` is listed first among the tags. The checkout team's report is produced; tag order on the command line doesn't change the outcome.

--- a/docs/partials/_profiles.mdx
+++ b/docs/partials/_profiles.mdx
@@ -58,9 +58,7 @@ While relying on existing tags works just fine, being explicit will help avoid u
 
 ### Basic profile structure
 
-Your base configuration excludes a third-party support-chat widget, since it isn't your code and just adds noise to most reports. But one suite exists specifically to test the support-chat flow, and it records under the `aq-config-support-chat` tag. For that run, and only that run, the widget should count toward coverage.
-
-This is the kind of difference that genuinely needs a profile: the same widget can't be both excluded and included in a single base configuration, so the conflicting value has to live under a tag.
+Your base configuration excludes the support-chat widget, since another team owns it and it just adds noise to most reports. But one suite exists specifically to test the support-chat flow, and it records under the `aq-config-support-chat` tag. For that run, and only that run, the widget should count toward coverage.
 
 #### Config
 
@@ -70,7 +68,7 @@ This is the kind of difference that genuinely needs a profile: the same widget c
     {
       "selector": "#support-chat-widget",
       "include": false,
-      "comment": "Exclude the third-party support-chat widget from most reports"
+      "comment": "Exclude the support-chat widget from most reports"
     }
   ],
   "profiles": [

--- a/docs/partials/_profiles.mdx
+++ b/docs/partials/_profiles.mdx
@@ -14,17 +14,15 @@ In many cases, the need for different profiles can be avoided completely by havi
 
 Profiles are selected by matching run tags to profile names. When you record a run with the [`--tag`](/app/references/command-line#cypress-run-tag-lt-tag-gt) flag, Cypress Cloud walks the `profiles` array in order and applies the **first profile whose `name` exactly matches one of the run's tags**. Matching is an exact, case-sensitive string comparison: the profile name `aq-config-regression` matches only the tag `aq-config-regression`, not `AQ-Config-Regression`, and not `aq-config-regression-nightly`.
 
-If a run carries several tags that each match a profile, the tie is broken by **the order of the `profiles` array, not the order of the tags** on the run. The first matching profile in the array always wins. If no tag matches any profile, or the run has no tags at all, the base (root) configuration is used unchanged.
+### How a profile changes your configuration
 
-### How overrides are merged
+When a profile applies, its `config` is laid over your base configuration one setting at a time. Only the settings you include in the profile change; everything else stays exactly as it is in your base configuration. A few things are worth knowing so the result matches what you expect:
 
-A matched profile's `config` is layered on top of the root configuration one property at a time. This is a shallow merge, not a deep merge, and understanding it prevents the most common surprises:
+- **A setting in a profile fully replaces the base version of that setting.** Lists are not combined. If your base configuration has three `elementFilters` rules and a profile defines its own `elementFilters`, the profile's rules are used on their own, so copy over any base rules you still want to apply.
+- **Anything you leave out of a profile stays the same.** You only need to list what's different for that kind of run; the rest is inherited from your base configuration.
+- **`uiCoverage` and `accessibility` settings are handled one by one.** Overriding a single setting inside `uiCoverage` (say, `elementGroups`) leaves the other `uiCoverage` settings (like `attributeFilters`) untouched, so you can adjust one product-specific setting without restating the rest.
 
-- **Each property is replaced as a whole, never concatenated.** If a property such as `viewFilters` or `elementFilters` appears in a profile's `config`, its value completely replaces the root value for that run. Arrays are **not** merged, so a profile that defines `elementFilters` overrides the root `elementFilters` entirely, so repeat any root rules you still want to keep.
-- **Properties you don't override are inherited.** Any root property the profile doesn't mention is used as-is, so a profile only needs to specify what changes.
-- **`uiCoverage` and `accessibility` merge one level deep.** Within these product-specific objects, each key (for example `elementGroups` or `attributeFilters`) is inherited from the root unless the profile provides its own value for that key, in which case that one key is replaced. This lets a profile override `uiCoverage.elementGroups` without disturbing `uiCoverage.attributeFilters`.
-
-Profiles are never nested. The `profiles` array exists only at the root of your configuration, and a profile's `config` accepts every other App Quality option except another `profiles` array.
+You can't put a `profiles` list inside a profile. Profiles live only at the top level of your configuration; a profile's `config` can use any other App Quality setting.
 
 ## Best practices
 
@@ -50,11 +48,11 @@ While relying on existing tags works just fine, being explicit will help avoid u
 
 ### Options
 
-| Option    | Required | Description                                                                                                                                 |
-| --------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`    | Required | The profile name. A run activates this profile when one of its tags exactly matches this value (case-sensitive).                            |
-| `config`  | Required | An object containing any App Quality configuration options, except a nested `profiles` array. These values override the root configuration. |
-| `comment` | Optional | A comment describing the purpose of this profile.                                                                                           |
+| Option    | Required | Description                                                                                                                                                                                                                    |
+| --------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `name`    | Required | Identifies the profile so a run can select it. Its only purpose is matching: the profile applies when one of the run's tags is an exact, case-sensitive match for this value. It isn't shown in reports or used anywhere else. |
+| `config`  | Required | An object containing any App Quality configuration options, except a nested `profiles` array. These values override the root configuration.                                                                                    |
+| `comment` | Optional | A note about why this profile exists, for your team's benefit. Comments appear only in the configuration itself. They have no effect on behavior and are not displayed in reports.                                             |
 
 ## Examples
 

--- a/docs/partials/_profiles.mdx
+++ b/docs/partials/_profiles.mdx
@@ -66,7 +66,7 @@ You record runs from more than one environment to the same project. Every enviro
 {
   "elementFilters": [
     {
-      "selector": "#onetrust-banner-sdk",
+      "selector": "#cookie-consent-banner",
       "include": false,
       "comment": "Exclude the cookie-consent banner from all reports"
     }
@@ -77,7 +77,7 @@ You record runs from more than one environment to the same project. Every enviro
       "config": {
         "elementFilters": [
           {
-            "selector": "#onetrust-banner-sdk",
+            "selector": "#cookie-consent-banner",
             "include": false,
             "comment": "Still exclude the cookie-consent banner"
           },
@@ -120,7 +120,7 @@ Different kinds of runs need different scoping. Pull request runs that gate merg
 {
   "elementFilters": [
     {
-      "selector": "#onetrust-banner-sdk",
+      "selector": "#cookie-consent-banner",
       "include": false,
       "comment": "Exclude the cookie-consent banner from all reports"
     }
@@ -184,7 +184,7 @@ Here the base configuration ignores React's auto-generated IDs, so a control isn
 {
   "elementFilters": [
     {
-      "selector": "#onetrust-banner-sdk",
+      "selector": "#cookie-consent-banner",
       "include": false,
       "comment": "Exclude the cookie-consent banner from all reports"
     }

--- a/docs/partials/_profiles.mdx
+++ b/docs/partials/_profiles.mdx
@@ -1,4 +1,4 @@
-The `profiles` property lets a single Cypress Cloud project serve many kinds of runs. Instead of maintaining separate projects—or living with one configuration that has to compromise between smoke tests, full regression suites, and per-team reporting—you keep one base configuration and layer targeted overrides on top of it. The right override is selected automatically from the [run tags](/app/references/command-line#cypress-run-tag-lt-tag-gt) you already pass to `cypress run`, so a regression run and a pull request run can each get exactly the App Quality configuration that makes their report actionable, with no changes to your test code.
+The `profiles` property lets a single Cypress Cloud project serve many kinds of runs. Instead of maintaining separate projects (or living with one configuration that has to compromise between smoke tests, full regression suites, and per-team reporting), you keep one base configuration and layer targeted overrides on top of it. The right override is selected automatically from the [run tags](/app/references/command-line#cypress-run-tag-lt-tag-gt) you already pass to `cypress run`, so a regression run and a pull request run can each get exactly the App Quality configuration that makes their report actionable, with no changes to your test code.
 
 In many cases, the need for different profiles can be avoided completely by having distinct Cypress Cloud projects for different kinds of runs or different team ownership. This is the recommended first choice, because it usually simplifies reporting and tracking. But where distinct projects are not the right answer, profiles will help.
 
@@ -6,21 +6,21 @@ In many cases, the need for different profiles can be avoided completely by havi
 
 - **Team-specific reporting**: If multiple teams use the same Cypress Cloud project, they may care about completely different pages or DOM elements in their accessibility or UI Coverage reports. Profiles let each team tag their runs to see and track only the results that matter to them, filtering out everything else.
 - **Run-type customization**: Use different filters or settings for regression runs versus pull requests. It can be useful to have a narrow config for blocking a merge, optimized for the most critical areas of your app and high "solvability", while still running a wide config on a full regression suite to manage findings on a different cadence.
-- **Scope a report down for specific runs**: When a full report isn't useful for a certain kind of run, point a profile at a deliberately narrow configuration—for example, `viewFilters` that keep only a handful of views, or exclude everything else—so the report stays focused on what matters for that run type. There is no dedicated "skip this run" switch; you scope reporting by supplying a narrower configuration through the profile.
+- **Scope a report down for specific runs**: When a full report isn't useful for a certain kind of run, point a profile at a deliberately narrow configuration (for example, `viewFilters` that keep only a handful of views, or exclude everything else) so the report stays focused on what matters for that run type. There is no dedicated "skip this run" switch; you scope reporting by supplying a narrower configuration through the profile.
 
 ## How profiles work
 
 ### Selecting a profile
 
-Profiles are selected by matching run tags to profile names. When you record a run with the [`--tag`](/app/references/command-line#cypress-run-tag-lt-tag-gt) flag, Cypress Cloud walks the `profiles` array in order and applies the **first profile whose `name` exactly matches one of the run's tags**. Matching is an exact, case-sensitive string comparison: the profile name `aq-config-regression` matches only the tag `aq-config-regression`—not `AQ-Config-Regression`, and not `aq-config-regression-nightly`.
+Profiles are selected by matching run tags to profile names. When you record a run with the [`--tag`](/app/references/command-line#cypress-run-tag-lt-tag-gt) flag, Cypress Cloud walks the `profiles` array in order and applies the **first profile whose `name` exactly matches one of the run's tags**. Matching is an exact, case-sensitive string comparison: the profile name `aq-config-regression` matches only the tag `aq-config-regression`, not `AQ-Config-Regression`, and not `aq-config-regression-nightly`.
 
-If a run carries several tags that each match a profile, the tie is broken by **the order of the `profiles` array, not the order of the tags** on the run. The first matching profile in the array always wins. If no tag matches any profile—or the run has no tags at all—the base (root) configuration is used unchanged.
+If a run carries several tags that each match a profile, the tie is broken by **the order of the `profiles` array, not the order of the tags** on the run. The first matching profile in the array always wins. If no tag matches any profile, or the run has no tags at all, the base (root) configuration is used unchanged.
 
 ### How overrides are merged
 
 A matched profile's `config` is layered on top of the root configuration one property at a time. This is a shallow merge, not a deep merge, and understanding it prevents the most common surprises:
 
-- **Each property is replaced as a whole, never concatenated.** If a property such as `viewFilters` or `elementFilters` appears in a profile's `config`, its value completely replaces the root value for that run. Arrays are **not** merged, so a profile that defines `elementFilters` overrides the root `elementFilters` entirely—repeat any root rules you still want to keep.
+- **Each property is replaced as a whole, never concatenated.** If a property such as `viewFilters` or `elementFilters` appears in a profile's `config`, its value completely replaces the root value for that run. Arrays are **not** merged, so a profile that defines `elementFilters` overrides the root `elementFilters` entirely, so repeat any root rules you still want to keep.
 - **Properties you don't override are inherited.** Any root property the profile doesn't mention is used as-is, so a profile only needs to specify what changes.
 - **`uiCoverage` and `accessibility` merge one level deep.** Within these product-specific objects, each key (for example `elementGroups` or `attributeFilters`) is inherited from the root unless the profile provides its own value for that key, in which case that one key is replaced. This lets a profile override `uiCoverage.elementGroups` without disturbing `uiCoverage.attributeFilters`.
 
@@ -30,7 +30,7 @@ Profiles are never nested. The `profiles` array exists only at the root of your 
 
 Use a naming convention like `aq-config-x` (e.g., `aq-config-regression`, `aq-config-staging`) to make it clear that a tag is used for configuration lookup purposes.
 
-While relying on existing tags works just fine, being explicit will help avoid unintentionally changing or removing a tag which is depended on for a profile. Because names are matched exactly against run tags, keep them stable—renaming a profile or changing a tag silently falls back to the base configuration for those runs.
+While relying on existing tags works just fine, being explicit will help avoid unintentionally changing or removing a tag which is depended on for a profile. Because names are matched exactly against run tags, keep them stable; renaming a profile or changing a tag silently falls back to the base configuration for those runs.
 
 ## Syntax
 
@@ -215,13 +215,13 @@ Profiles can override configuration at any level, including nested configuration
 cypress run --record --tag "aq-config-feature-branch"
 ```
 
-This profile adds element grouping for the new checkout flow. The root `elementFilters` is inherited because the profile doesn't mention it, and inside `uiCoverage`, the profile supplies `elementGroups` while the root's `attributeFilters` is inherited—only the keys the profile names are replaced.
+This profile adds element grouping for the new checkout flow. The root `elementFilters` is inherited because the profile doesn't mention it, and inside `uiCoverage`, the profile supplies `elementGroups` while the root's `attributeFilters` is inherited; only the keys the profile names are replaced.
 
 ---
 
 ### Profile selection with multiple matching tags
 
-If you pass multiple tags and more than one matches a profile name, the first matching profile in the `profiles` array is used—regardless of the order the tags appear on the run:
+If you pass multiple tags and more than one matches a profile name, the first matching profile in the `profiles` array is used, regardless of the order the tags appear on the run:
 
 #### Config
 

--- a/docs/partials/_profiles.mdx
+++ b/docs/partials/_profiles.mdx
@@ -58,7 +58,7 @@ While relying on existing tags works just fine, being explicit will help avoid u
 
 ### Basic profile structure
 
-Your base configuration hides the cookie-consent banner from every report. On nightly regression runs, an internal QA debug toolbar is also rendered, and you want it out of those reports too.
+You record runs from more than one environment to the same project. Every environment shows the cookie-consent banner, which you exclude from all reports. Runs against your preview environment (tagged `aq-config-preview`) also render an internal feature-flag panel and a "preview build" banner that never ship to production, and you want those out of preview reports too.
 
 #### Config
 
@@ -73,7 +73,7 @@ Your base configuration hides the cookie-consent banner from every report. On ni
   ],
   "profiles": [
     {
-      "name": "aq-config-regression",
+      "name": "aq-config-preview",
       "config": {
         "elementFilters": [
           {
@@ -82,9 +82,14 @@ Your base configuration hides the cookie-consent banner from every report. On ni
             "comment": "Still exclude the cookie-consent banner"
           },
           {
-            "selector": "[data-testid='debug-toolbar']",
+            "selector": "[data-testid='feature-flag-panel']",
             "include": false,
-            "comment": "Exclude the internal QA debug toolbar shown on regression runs"
+            "comment": "Exclude the internal feature-flag panel, which only renders in preview"
+          },
+          {
+            "selector": "[data-testid='preview-build-banner']",
+            "include": false,
+            "comment": "Exclude the preview-build banner that never ships to production"
           }
         ]
       }
@@ -95,13 +100,13 @@ Your base configuration hides the cookie-consent banner from every report. On ni
 
 #### Usage
 
-To use this profile, run Cypress with a matching tag:
+Record the preview environment's runs with a matching tag:
 
 ```shell
-cypress run --record --tag "aq-config-regression"
+cypress run --record --tag "aq-config-preview"
 ```
 
-On regression runs, the profile's `elementFilters` replaces the base `elementFilters` entirely, so the cookie-banner rule is repeated alongside the new debug-toolbar rule. Because arrays are replaced rather than merged, dropping the repeated rule would let the cookie banner back into your regression reports.
+Preview runs use this profile's `elementFilters` in place of the base list. Because a profile's list replaces the base list rather than adding to it, the cookie-banner rule is repeated here alongside the preview-only exclusions; dropping it would let the banner back into your preview reports.
 
 ---
 

--- a/docs/ui-coverage/configuration/profiles.mdx
+++ b/docs/ui-coverage/configuration/profiles.mdx
@@ -10,3 +10,10 @@ sidebar_position: 110
 # Override config by run tag (`profiles`)
 
 <Profiles />
+
+## See also
+
+- [Cypress run `--tag`](/app/references/command-line#cypress-run-tag-lt-tag-gt) is the flag that selects which profile a run uses.
+- [Configuration overview](/ui-coverage/configuration/overview) lists every option a profile's `config` can override and how to regenerate reports after changing configuration.
+- [`viewFilters`](/ui-coverage/configuration/viewfilters) and [`elementFilters`](/ui-coverage/configuration/elementfilters) are common properties to scope a profile's report.
+- [UI Coverage FAQ](/ui-coverage/faq#Profiles) answers common questions about profiles, including merge behavior and tag matching.

--- a/docs/ui-coverage/faq.mdx
+++ b/docs/ui-coverage/faq.mdx
@@ -225,4 +225,8 @@ There's no dedicated "skip this run" switch in a profile. To suppress a report f
 ## See also
 
 - [Configuration overview](/ui-coverage/configuration/overview) lists every configuration option and what each one is for.
+- [Profiles](/ui-coverage/configuration/profiles) apply different configuration to runs based on run tags.
+- [Views](/ui-coverage/core-concepts/views) explains how URLs become views and how automatic grouping works.
+- [Element Identification](/ui-coverage/core-concepts/element-identification) covers how elements are identified and grouped across snapshots.
+- [Interactivity](/ui-coverage/core-concepts/interactivity) describes which commands count as coverage.
 - [Troubleshooting UI Coverage](/ui-coverage/troubleshooting) covers common report problems and their solutions.

--- a/docs/ui-coverage/faq.mdx
+++ b/docs/ui-coverage/faq.mdx
@@ -201,11 +201,11 @@ Yes. The [`profiles`](/ui-coverage/configuration/profiles) property applies conf
 
 Add a [`profiles`](/ui-coverage/configuration/profiles) array to your configuration, give each profile a `name`, and record the run with a matching [`--tag`](/app/references/command-line#cypress-run-tag-lt-tag-gt). When a run's tag matches a profile's `name`, that profile's `config` overrides your base configuration for that run, so a smoke run and a full regression run can each use their own settings without changing your test code. If no tag matches, the base configuration is used unchanged.
 
-### <Icon name="angle-right" /> Does a profile merge with my base configuration or replace it?
+### <Icon name="angle-right" /> Does a UI Coverage profile override my base configuration or merge with it?
 
 A profile overrides one property at a time with a shallow merge, not a deep merge. Any property the profile lists replaces the root value for that property entirely (arrays are replaced, not concatenated), so if a profile defines [`elementFilters`](/ui-coverage/configuration/elementfilters), repeat any root rules you still want to keep. Properties the profile doesn't mention are inherited from the root. The `uiCoverage` and `accessibility` objects merge one level deep, so a profile can override `uiCoverage.elementGroups` while still inheriting `uiCoverage.attributeFilters`. See [How a profile changes your configuration](/ui-coverage/configuration/profiles#How-a-profile-changes-your-configuration).
 
-### <Icon name="angle-right" /> Which profile wins when a run has multiple matching tags?
+### <Icon name="angle-right" /> If a run has multiple tags that match profiles, which UI Coverage profile is used?
 
 The first profile in the [`profiles`](/ui-coverage/configuration/profiles) array whose `name` matches one of the run's tags is used. The tie is broken by the order of the profiles array, not the order of the tags on the run, so reordering tags on the command line never changes which profile applies.
 

--- a/docs/ui-coverage/faq.mdx
+++ b/docs/ui-coverage/faq.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'UI Coverage FAQ'
-description: 'Get answers to common questions about Cypress UI Coverage, including scores, view and URL grouping, element identification, grouping and filtering, iframes and shadow DOM, interaction commands, and configuration.'
+description: 'Get answers to common questions about Cypress UI Coverage, including scores, view and URL grouping, element identification, grouping and filtering, iframes and shadow DOM, interaction commands, configuration, and per-run profiles.'
 sidebar_label: FAQ
 sidebar_position: 160
 ---
@@ -194,6 +194,33 @@ Root-level properties like [`viewFilters`](/ui-coverage/configuration/viewfilter
 ### <Icon name="angle-right" /> Can I use different configuration for different runs?
 
 Yes. The [`profiles`](/ui-coverage/configuration/profiles) property applies configuration overrides based on [run tags](/app/references/command-line#cypress-run-tag-lt-tag-gt), so a smoke-test run and a full regression run can each use their own settings.
+
+## Profiles
+
+### <Icon name="angle-right" /> How do I apply different UI Coverage settings to different runs?
+
+Add a [`profiles`](/ui-coverage/configuration/profiles) array to your configuration, give each profile a `name`, and record the run with a matching [`--tag`](/app/references/command-line#cypress-run-tag-lt-tag-gt). When a run's tag matches a profile's `name`, that profile's `config` overrides your base configuration for that run, so a smoke run and a full regression run can each use their own settings without changing your test code. If no tag matches, the base configuration is used unchanged.
+
+### <Icon name="angle-right" /> Does a profile merge with my base configuration or replace it?
+
+A profile overrides one property at a time with a shallow merge, not a deep merge. Any property the profile lists replaces the root value for that property entirely—arrays are replaced, not concatenated—so if a profile defines [`elementFilters`](/ui-coverage/configuration/elementfilters), repeat any root rules you still want to keep. Properties the profile doesn't mention are inherited from the root. The `uiCoverage` and `accessibility` objects merge one level deep, so a profile can override `uiCoverage.elementGroups` while still inheriting `uiCoverage.attributeFilters`. See [How overrides are merged](/ui-coverage/configuration/profiles#How-overrides-are-merged).
+
+### <Icon name="angle-right" /> Which profile wins when a run has multiple matching tags?
+
+The first profile in the [`profiles`](/ui-coverage/configuration/profiles) array whose `name` matches one of the run's tags is used. The tie is broken by the order of the profiles array, not the order of the tags on the run, so reordering tags on the command line never changes which profile applies.
+
+### <Icon name="angle-right" /> Why isn't my profile being applied?
+
+The most common causes are:
+
+- The run tag doesn't exactly match the profile `name`. Matching is case-sensitive and exact, so `aq-config-regression` matches only the tag `aq-config-regression`, not `AQ-Config-Regression` or `aq-config-regression-nightly`.
+- The run wasn't recorded with the tag. Profiles are selected from the tags passed to `cypress run --record --tag`, so a run without that tag falls back to the base configuration.
+- An earlier profile in the array also matches one of the tags and is used instead, because the first match wins.
+- The report was processed before you saved the configuration. Regenerate the run to apply the current configuration.
+
+### <Icon name="angle-right" /> Can a profile turn off UI Coverage or skip a run entirely?
+
+There's no dedicated "skip this run" switch in a profile. To suppress a report for certain runs, point a profile at a deliberately narrow configuration—for example [`viewFilters`](/ui-coverage/configuration/viewfilters) that exclude every view—so the run produces an empty or tightly scoped report instead. See [Why use profiles?](/ui-coverage/configuration/profiles#Why-use-profiles).
 
 ## See also
 

--- a/docs/ui-coverage/faq.mdx
+++ b/docs/ui-coverage/faq.mdx
@@ -209,12 +209,12 @@ A profile overrides one property at a time with a shallow merge, not a deep merg
 
 The first profile in the [`profiles`](/ui-coverage/configuration/profiles) array whose `name` matches one of the run's tags is used. The tie is broken by the order of the profiles array, not the order of the tags on the run, so reordering tags on the command line never changes which profile applies.
 
-### <Icon name="angle-right" /> Why isn't my profile being applied?
+### <Icon name="angle-right" /> Why isn't my UI Coverage profile applied even though I tagged the run?
 
 The most common causes are:
 
 - The run tag doesn't exactly match the profile `name`. Matching is case-sensitive and exact, so `aq-config-regression` matches only the tag `aq-config-regression`, not `AQ-Config-Regression` or `aq-config-regression-nightly`.
-- The run wasn't recorded with the tag. Profiles are selected from the tags passed to `cypress run --record --tag`, so a run without that tag falls back to the base configuration.
+- The tag never reached Cypress Cloud. Profiles are selected from the tags passed to `cypress run --record --tag`, so a run recorded without `--record`, or without that specific `--tag`, falls back to the base configuration.
 - An earlier profile in the array also matches one of the tags and is used instead, because the first match wins.
 - The report was processed before you saved the configuration. Regenerate the run to apply the current configuration.
 

--- a/docs/ui-coverage/faq.mdx
+++ b/docs/ui-coverage/faq.mdx
@@ -199,7 +199,7 @@ Yes. The [`profiles`](/ui-coverage/configuration/profiles) property applies conf
 
 ### <Icon name="angle-right" /> How do I apply different UI Coverage settings to different runs?
 
-Add a [`profiles`](/ui-coverage/configuration/profiles) array to your configuration, give each profile a `name`, and record the run with a matching [`--tag`](/app/references/command-line#cypress-run-tag-lt-tag-gt). When a run's tag matches a profile's `name`, that profile's `config` overrides your base configuration for that run, so a smoke run and a full regression run can each use their own settings without changing your test code. If no tag matches, the base configuration is used unchanged.
+In your project's App Quality configuration in Cypress Cloud, add a [`profiles`](/ui-coverage/configuration/profiles) array, give each profile a `name`, and record the run with a matching [`--tag`](/app/references/command-line#cypress-run-tag-lt-tag-gt). When a run's tag matches a profile's `name`, that profile's `config` overrides your base configuration for that run, so a smoke run and a full regression run can each use their own settings without changing your test code. If no tag matches, the base configuration is used unchanged.
 
 ### <Icon name="angle-right" /> Does a UI Coverage profile override my base configuration or merge with it?
 

--- a/docs/ui-coverage/faq.mdx
+++ b/docs/ui-coverage/faq.mdx
@@ -203,7 +203,7 @@ Add a [`profiles`](/ui-coverage/configuration/profiles) array to your configurat
 
 ### <Icon name="angle-right" /> Does a profile merge with my base configuration or replace it?
 
-A profile overrides one property at a time with a shallow merge, not a deep merge. Any property the profile lists replaces the root value for that property entirely (arrays are replaced, not concatenated), so if a profile defines [`elementFilters`](/ui-coverage/configuration/elementfilters), repeat any root rules you still want to keep. Properties the profile doesn't mention are inherited from the root. The `uiCoverage` and `accessibility` objects merge one level deep, so a profile can override `uiCoverage.elementGroups` while still inheriting `uiCoverage.attributeFilters`. See [How overrides are merged](/ui-coverage/configuration/profiles#How-overrides-are-merged).
+A profile overrides one property at a time with a shallow merge, not a deep merge. Any property the profile lists replaces the root value for that property entirely (arrays are replaced, not concatenated), so if a profile defines [`elementFilters`](/ui-coverage/configuration/elementfilters), repeat any root rules you still want to keep. Properties the profile doesn't mention are inherited from the root. The `uiCoverage` and `accessibility` objects merge one level deep, so a profile can override `uiCoverage.elementGroups` while still inheriting `uiCoverage.attributeFilters`. See [How a profile changes your configuration](/ui-coverage/configuration/profiles#How-a-profile-changes-your-configuration).
 
 ### <Icon name="angle-right" /> Which profile wins when a run has multiple matching tags?
 

--- a/docs/ui-coverage/faq.mdx
+++ b/docs/ui-coverage/faq.mdx
@@ -53,7 +53,7 @@ Yes. List `include: true` rules for the URLs you want, followed by a catch-all r
 
 ### <Icon name="angle-right" /> Why is a page missing from my report?
 
-Views are created from URLs your tests actually visit, so a page that no test navigates to has no view. Check [untested links](/ui-coverage/core-concepts/interactivity#Untested-Links) in the report — pages that are linked to but never visited appear there. Also confirm that a [`viewFilters`](/ui-coverage/configuration/viewfilters) rule isn't excluding the page unintentionally.
+Views are created from URLs your tests actually visit, so a page that no test navigates to has no view. Check [untested links](/ui-coverage/core-concepts/interactivity#Untested-Links) in the report, where pages that are linked to but never visited appear. Also confirm that a [`viewFilters`](/ui-coverage/configuration/viewfilters) rule isn't excluding the page unintentionally.
 
 ## Element grouping and identification
 
@@ -203,7 +203,7 @@ Add a [`profiles`](/ui-coverage/configuration/profiles) array to your configurat
 
 ### <Icon name="angle-right" /> Does a profile merge with my base configuration or replace it?
 
-A profile overrides one property at a time with a shallow merge, not a deep merge. Any property the profile lists replaces the root value for that property entirely—arrays are replaced, not concatenated—so if a profile defines [`elementFilters`](/ui-coverage/configuration/elementfilters), repeat any root rules you still want to keep. Properties the profile doesn't mention are inherited from the root. The `uiCoverage` and `accessibility` objects merge one level deep, so a profile can override `uiCoverage.elementGroups` while still inheriting `uiCoverage.attributeFilters`. See [How overrides are merged](/ui-coverage/configuration/profiles#How-overrides-are-merged).
+A profile overrides one property at a time with a shallow merge, not a deep merge. Any property the profile lists replaces the root value for that property entirely (arrays are replaced, not concatenated), so if a profile defines [`elementFilters`](/ui-coverage/configuration/elementfilters), repeat any root rules you still want to keep. Properties the profile doesn't mention are inherited from the root. The `uiCoverage` and `accessibility` objects merge one level deep, so a profile can override `uiCoverage.elementGroups` while still inheriting `uiCoverage.attributeFilters`. See [How overrides are merged](/ui-coverage/configuration/profiles#How-overrides-are-merged).
 
 ### <Icon name="angle-right" /> Which profile wins when a run has multiple matching tags?
 
@@ -220,7 +220,7 @@ The most common causes are:
 
 ### <Icon name="angle-right" /> Can a profile turn off UI Coverage or skip a run entirely?
 
-There's no dedicated "skip this run" switch in a profile. To suppress a report for certain runs, point a profile at a deliberately narrow configuration—for example [`viewFilters`](/ui-coverage/configuration/viewfilters) that exclude every view—so the run produces an empty or tightly scoped report instead. See [Why use profiles?](/ui-coverage/configuration/profiles#Why-use-profiles).
+There's no dedicated "skip this run" switch in a profile. To suppress a report for certain runs, point a profile at a deliberately narrow configuration (for example, [`viewFilters`](/ui-coverage/configuration/viewfilters) that exclude every view) so the run produces an empty or tightly scoped report instead. See [Why use profiles?](/ui-coverage/configuration/profiles#Why-use-profiles).
 
 ## See also
 

--- a/docs/ui-coverage/faq.mdx
+++ b/docs/ui-coverage/faq.mdx
@@ -203,11 +203,11 @@ In your project's App Quality configuration in Cypress Cloud, add a [`profiles`]
 
 ### <Icon name="angle-right" /> Does a UI Coverage profile override my base configuration or merge with it?
 
-A profile overrides one property at a time with a shallow merge, not a deep merge. Any property the profile lists replaces the root value for that property entirely (arrays are replaced, not concatenated), so if a profile defines [`elementFilters`](/ui-coverage/configuration/elementfilters), repeat any root rules you still want to keep. Properties the profile doesn't mention are inherited from the root. The `uiCoverage` and `accessibility` objects merge one level deep, so a profile can override `uiCoverage.elementGroups` while still inheriting `uiCoverage.attributeFilters`. See [How a profile changes your configuration](/ui-coverage/configuration/profiles#How-a-profile-changes-your-configuration).
+Cypress Cloud overrides one property at a time with a shallow merge, not a deep merge. Any property the profile lists replaces the root value for that property entirely (arrays are replaced, not concatenated), so if a profile defines [`elementFilters`](/ui-coverage/configuration/elementfilters), repeat any root rules you still want to keep. Properties the profile doesn't mention are inherited from the root. The `uiCoverage` and `accessibility` objects merge one level deep, so a profile can override `uiCoverage.elementGroups` while still inheriting `uiCoverage.attributeFilters`. See [How a profile changes your configuration](/ui-coverage/configuration/profiles#How-a-profile-changes-your-configuration).
 
 ### <Icon name="angle-right" /> If a run has multiple tags that match profiles, which UI Coverage profile is used?
 
-The first profile in the [`profiles`](/ui-coverage/configuration/profiles) array whose `name` matches one of the run's tags is used. The tie is broken by the order of the profiles array, not the order of the tags on the run, so reordering tags on the command line never changes which profile applies.
+Cypress Cloud uses the first profile in the [`profiles`](/ui-coverage/configuration/profiles) array whose `name` matches one of the run's tags. The tie is broken by the order of the profiles array, not the order of the tags on the run, so reordering tags on the command line never changes which profile applies.
 
 ### <Icon name="angle-right" /> Why isn't my UI Coverage profile applied even though I tagged the run?
 
@@ -220,7 +220,7 @@ The most common causes are:
 
 ### <Icon name="angle-right" /> Can a profile turn off UI Coverage or skip a run entirely?
 
-There's no dedicated "skip this run" switch in a profile. To suppress a report for certain runs, point a profile at a deliberately narrow configuration (for example, [`viewFilters`](/ui-coverage/configuration/viewfilters) that exclude every view) so the run produces an empty or tightly scoped report instead. See [Why use profiles?](/ui-coverage/configuration/profiles#Why-use-profiles).
+There's no dedicated "skip this run" switch in a profile. To suppress a report for certain runs, point a profile at a deliberately narrow configuration (for example, [`viewFilters`](/ui-coverage/configuration/viewfilters) that exclude every view) so Cypress Cloud produces an empty or tightly scoped report for the run instead. See [Why use profiles?](/ui-coverage/configuration/profiles#Why-use-profiles).
 
 ## See also
 


### PR DESCRIPTION
## Summary

Rewrites the shared App Quality `profiles` documentation (used by both the UI Coverage and Cypress Accessibility configuration pages) for accuracy and value, and adds parallel profiles FAQ sections to both product FAQs. The behavioral descriptions were verified against the implementation in `cypress-services` (`AppQualityConfigDataSource.resolveConfigToProfile` and the `discoverySchema_0_1` / `configProfile` schemas).

## Why

The profiles page had several inaccuracies and gaps that could mislead users:

- **Merge behavior was never explained.** The resolver does a shallow, property-level replace: arrays are replaced wholesale (not concatenated), and the `uiCoverage` / `accessibility` objects merge exactly one level deep. The page now states this explicitly, which is the single most common source of surprises.
- **Matching semantics were vague.** Tag→`name` matching is exact and case-sensitive, and when multiple tags match, the winner is decided by **profile-array order, not tag order**. Documented, with a dedicated example.
- **An inaccurate "skip runs" claim** implied a dedicated switch to suppress a report exists; it doesn't. Reframed around scoping the config down.
- The examples were abstract and, in some cases, would have worked just as well in the base config (no genuine need for a profile). They now each demonstrate a **different** config property with a genuine, non-hoistable per-run conflict: `elementFilters`, `views`/`groupBy`, `elementGroups` (nested), and `viewFilters`.

Alongside accuracy, the page now leads with the value proposition, every config example carries the `title="App Quality Config"` label, and the prose avoids em dashes and developer jargon.

For discoverability (SEO/AEO), both product FAQs gain a Profiles section whose questions are self-contained and keyword-rich (each names its product — "UI Coverage" or "Cypress Accessibility" — and the answers name Cypress Cloud), plus expanded "See also" lists on the FAQ and config pages.

## Notes for reviewers

- `docs/partials/_profiles.mdx` is shared by both `docs/ui-coverage/configuration/profiles.mdx` and `docs/accessibility/configuration/profiles.mdx`, so its content is product-neutral ("App Quality"). Changes there intentionally improve both product pages.
- Score-threshold gating (`policies`) was deliberately **not** used in examples: the docs teach PR blocking through the Results API, not an App Quality config property, so a `policies` example would introduce an unsupported concept.
- All example JSON blocks were validated as parseable and schema-valid (selectors, `views` named params referenced by `groupBy`, the `*` catch-all view pattern). Prettier and the frontmatter lint both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PwF1hjPSqbjiWXjRA8cuq2

---
_Generated by [Claude Code](https://claude.ai/code/session_01PwF1hjPSqbjiWXjRA8cuq2)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, auth, or data-handling impact.
> 
> **Overview**
> Rewrites the shared **App Quality `profiles`** partial (`_profiles.mdx`) used by both UI Coverage and Cypress Accessibility config pages. The update documents **shallow merge behavior** (arrays replace wholesale; `uiCoverage` / `accessibility` merge one level deep), **exact case-sensitive tag→`name` matching**, and **first matching profile in array order** (not tag order). It reframes the old “skip runs” idea as **scoping via narrow config** (no dedicated skip switch) and replaces abstract examples with scenarios for `elementFilters`, `views`/`groupBy`, nested `uiCoverage.elementGroups`, and team `viewFilters`.
> 
> **Discoverability:** both product FAQs gain a **Profiles** Q&A section; profile and FAQ pages get expanded **See also** links and meta descriptions mentioning per-run profiles. One minor punctuation tweak in the UI Coverage FAQ.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f69cc175ac6e1ae4f2cbdb112f6093647d4fa73a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->