### PR TITLE
docs: clarify how the .within() "temporarily escape" example works

### DIFF
--- a/docs/api/commands/within.mdx
+++ b/docs/api/commands/within.mdx
@@ -158,8 +158,11 @@ cy.contains('My first client')
 ### Temporarily escape
 
 You can temporarily escape the `.within` context by starting a new command chain
-with [cy.root](/api/commands/root) followed by [.closest](/api/commands/closest)
-commands.
+with [cy.root](/api/commands/root) followed by [.closest](/api/commands/closest).
+Inside a `.within()` block, `cy.root()` yields the scoped element (here, the
+`<form>`) rather than `<html>`. Chaining [.closest](/api/commands/closest) then
+traverses _up_ from that element to a shared ancestor outside the scope, from
+which you can query elements that live outside the `.within()` context.
 
 ```html
 <section class="example">
@@ -175,7 +178,8 @@ commands.
 
 ```javascript
 cy.get('form').within(($form) => {
-  // temporarily escape the .within context
+  // temporarily escape the .within context: cy.root() is the <form>, and
+  // .closest('.example') walks up to the ancestor outside it
   cy.root().closest('.example').find('#name').type('Joe')
   // continue using the .within context
   cy.get('input[name="email"]').type('john.doe@email.com')


### PR DESCRIPTION
## Summary

Clarifies the "Temporarily escape" example on the [`.within()`](https://docs.cypress.io/api/commands/within#Temporarily-escape) page by explaining *how* the escape works, rather than just presenting it. The prose and inline comment now spell out that inside a `.within()` block `cy.root()` yields the scoped element (the `<form>`) and `.closest()` traverses up to a shared ancestor outside the scope.

## Why

Issue #5525 reported that the "Temporarily escape" example "does not work," citing that the [`cy.root()`](https://docs.cypress.io/api/commands/root#Within) docs state the opposite (that `cy.root()` inside `.within()` yields the scoped element, not `<html>`).

On investigation, the example is actually **correct and functional** — this was verified against the driver source:

- `cy.root()` inside `.within()` yields the `withinSubjectChain`, i.e. the `<form>` (as the `root` docs describe).
- `.closest()` / `.find()` are traversal queries that operate on their piped subject and are *not* re-scoped to the `.within()` root, so `.closest('.example')` walks up from the form to its ancestor `<section class="example">`, and `.find('#name')` reaches the input outside the form.

The escape works precisely *because* `cy.root()` returns the scoped element — there is no contradiction with the `root` docs. The confusion stemmed from the prose reading as if `cy.root()` itself does the escaping; a reader expecting it to yield `<html>` would reasonably conclude the example was broken. This change makes the mechanism explicit so future readers aren't misled.

No behavior/code change — documentation only. `prettier --check` passes on the file.

Closes #5525

## Notes for reviewers

- The code example itself is unchanged (it already worked); only the explanatory prose and the inline comment were edited.
- If you'd prefer to also close #5525 as "not a bug" without this clarification, that's a reasonable alternative — but the wording tweak should prevent the same confusion from recurring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015d8wJTGsH8ZxYxGcxLggvh

---
_Generated by [Claude Code](https://claude.ai/code/session_015d8wJTGsH8ZxYxGcxLggvh)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording changes with no runtime or API behavior impact.
> 
> **Overview**
> Clarifies the **Temporarily escape** section on the `.within()` docs so readers understand *why* `cy.root().closest(...).find(...)` works instead of assuming `cy.root()` should yield `<html>`.
> 
> The prose now states that inside `.within()`, `cy.root()` yields the scoped element (e.g. the `<form>`), and chaining `.closest()` walks up to an ancestor outside that scope so you can reach siblings or other nodes outside the block. The sample’s inline comment was updated to match; the HTML/JS example is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be5e8b297ea65332d64f76fde3f8f21b0ba01475. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->