### PR TITLE
docs(cloud-mcp): fix feedback tool name to submit_mcp_feedback

### DIFF
--- a/docs/cloud/integrations/cloud-mcp.mdx
+++ b/docs/cloud/integrations/cloud-mcp.mdx
@@ -404,7 +404,7 @@ Some tools are relevant for all Cypress Cloud plans (including free), but some o
 | `cypress_get_ui_coverage_report`          | Returns a high-level UI Coverage report for a run: overall coverage score, tested and untested element and link counts, and the top 5 riskiest views sorted by most untested interactive elements. | "Summarize UI Coverage for the latest run on this branch."              |
 | `cypress_get_ui_coverage_views`           | Returns paginated views from a UI Coverage report, sorted by most untested elements and links. Use to browse all views beyond the top 5 in the report summary.                                     | "Which pages have the most untested elements in this run?"              |
 | `cypress_get_ui_coverage_elements`        | Returns paginated interactive elements for a run. Filter by tested or untested, and optionally scope to a specific view by name.                                                                   | "Show me the untested elements on the checkout page in this run."       |
-| `cypress_feedback`                        | Shares feedback with Cypress directly from your agentic environment.                                                                                                                               | "Report a bug or request a new MCP feature."                            |
+| `submit_mcp_feedback`                     | Shares feedback with Cypress directly from your agentic environment.                                                                                                                               | "Report a bug or request a new MCP feature."                            |
 
 ## Writing effective prompts
 


### PR DESCRIPTION
## Summary

Corrects the feedback tool name in the "Available tools" table of `docs/cloud/integrations/cloud-mcp.mdx` from `cypress_feedback` to `submit_mcp_feedback`. The row's capability description and use-case example are unchanged.

## Why

The Cloud MCP server registers this tool as `submit_mcp_feedback` (verified in `cypress-services` at `packages/cloud-mcp/src/tools/feedback/submitFeedback.ts`, and against the live server's tool list). The docs listed it as `cypress_feedback`, so an agent calling it by the documented name would not find the tool.

## Notes for reviewers

- Only the tool-name cell in that one table row changed; column alignment was preserved.
- Grepped the docs for `cypress_feedback` — this was the only occurrence, so no other page references the old name.
- `prettier --check` passes on the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012236iKs8qJA18kjJpj5tmk

---
_Generated by [Claude Code](https://claude.ai/code/session_012236iKs8qJA18kjJpj5tmk)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only correction to a single tool name in one table row; no runtime or API behavior changes.
> 
> **Overview**
> Updates the **Available tools** table in `cloud-mcp.mdx` so the feedback MCP tool is documented as **`submit_mcp_feedback`** instead of **`cypress_feedback`**. The capability and example prompt for that row are unchanged.
> 
> This aligns the docs with the name exposed by the Cloud MCP server, so agents that rely on the table can invoke the feedback tool successfully.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7dab9330fbb0ffb3bb8cfdc098de0110a2a4a0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->