### PR TITLE
docs(ui-coverage): rework the Configuration overview for accuracy, value, and clarity

### DIFF
--- a/docs/ui-coverage/configuration/overview.mdx
+++ b/docs/ui-coverage/configuration/overview.mdx
@@ -79,9 +79,9 @@ A `comment` lives inside the rule and has no effect on behavior. Comments appear
 {
   "elementFilters": [
     {
-      "selector": "[data-testid*='temp']",
+      "selector": ".intercom-launcher",
       "include": false,
-      "comment": "Exclude temporary test elements from coverage"
+      "comment": "Third-party chat widget owned by support, not covered by our tests"
     }
   ]
 }

--- a/docs/ui-coverage/configuration/overview.mdx
+++ b/docs/ui-coverage/configuration/overview.mdx
@@ -180,11 +180,9 @@ Two behaviors govern every rule you write, regardless of which property it belon
 
 Some properties are shared across App Quality products, and some belong to UI Coverage alone.
 
-**Shared properties**: `elementFilters`, `viewFilters`, `attributeFilters`, and `significantAttributes` apply to both UI Coverage and Cypress Accessibility when set at the root of your configuration. To apply one to a single product, nest it under a `uiCoverage` or `accessibility` key. A nested value **completely replaces** the root-level value for that product (the two are not merged), so repeat any shared rules you still want in the nested list.
-
-**Shared, but not nestable**: `views` applies to both UI Coverage and Cypress Accessibility and can only be set at the root.
-
-**UI Coverage only**: `elementGroups`, `elements`, `additionalInteractionCommands`, and `allowedInteractionCommands` are specific to UI Coverage and are always set under the `uiCoverage` key.
+- **Shared properties**: `elementFilters`, `viewFilters`, `attributeFilters`, and `significantAttributes` apply to both UI Coverage and Cypress Accessibility when set at the root of your configuration. To apply one to a single product, nest it under a `uiCoverage` or `accessibility` key. A nested value **completely replaces** the root-level value for that product (the two are not merged), so repeat any shared rules you still want in the nested list.
+- **Shared, but not nestable**: `views` applies to both UI Coverage and Cypress Accessibility and can only be set at the root.
+- **UI Coverage only**: `elementGroups`, `elements`, `additionalInteractionCommands`, and `allowedInteractionCommands` are specific to UI Coverage and are always set under the `uiCoverage` key.
 
 ## Viewing configuration for a run
 

--- a/docs/ui-coverage/configuration/overview.mdx
+++ b/docs/ui-coverage/configuration/overview.mdx
@@ -187,12 +187,41 @@ Some properties are shared across App Quality products, and some belong to UI Co
 
 ## Viewing configuration for a run
 
-Every run permanently records the exact configuration it was processed with, so the runs themselves are the history of how your configuration has changed over time. To review the configuration a specific run used, open its **Properties** tab, as shown below. This displays the configuration as it was applied when the run was processed. When you open a run that was processed with an older configuration than the one currently saved, the report flags it with a "configuration updated" message, and you can [regenerate](#Setting-configuration) the run to reprocess it with the current configuration.
+Every run permanently records the exact configuration it was processed with, so the runs themselves are the history of how your configuration has changed over time. You can review a run's configuration in Cypress Cloud, or read it programmatically with the Results API.
+
+### In Cypress Cloud
+
+To review the configuration a specific run used, open its **Properties** tab, as shown below. This displays the configuration as it was applied when the run was processed. When you open a run that was processed with an older configuration than the one currently saved, the report flags it with a "configuration updated" message, and you can [regenerate](#Setting-configuration) the run to reprocess it with the current configuration.
 
 <DocsImage
   src="/img/accessibility/configuration/cypress-cloud-properties-tab-application-quality-config.png"
   alt="The properties tab for a run, with an Application Quality section at the bottom"
 />
+
+### From the Results API
+
+The [UI Coverage Results API](/ui-coverage/results-api) exposes the applied configuration on the `config` property of its result, so you can read it in a CI workflow:
+
+```js
+const { getUICoverageResults } = require('@cypress/extract-cloud-results')
+
+getUICoverageResults().then((results) => {
+  if (results.config) {
+    // ISO timestamp of when the applied configuration was last saved
+    console.log(results.config.updatedAt)
+
+    // The App Quality configuration that was applied to the run
+    console.log(results.config.value)
+  }
+})
+```
+
+The `config` property has two fields:
+
+- `updatedAt`: an ISO timestamp of when the applied configuration was last saved.
+- `value`: the App Quality configuration applied to the run, in the same shape as the [Full configuration reference](#Full-configuration-reference).
+
+If no configuration was applied to the run, `config` may be absent, so check for it before reading `value`.
 
 ## See also
 

--- a/docs/ui-coverage/configuration/overview.mdx
+++ b/docs/ui-coverage/configuration/overview.mdx
@@ -26,10 +26,13 @@ By default, editing configuration is limited to Admin users. Your Cypress point-
 
 ## Setting configuration
 
-To add or modify the configuration for your project:
+Configuration lives in Cypress Cloud, not in your repository. To view or change it for a project:
 
-1. Navigate to the **App Quality** tab in your project settings on Cypress Cloud.
-2. Use the configuration editor to add or edit configuration in JSON format.
+1. Open your project in Cypress Cloud and go to **Project Settings**.
+2. Select the **App Quality** tab, which holds the configuration editor.
+3. Edit the configuration as JSON, then **Save**. **Discard** reverts unsaved edits back to the last saved version.
+
+Editing is limited to Admin users by default. The editor validates your JSON against the schema when you save, so an invalid configuration can't be saved, and it shows how long ago the configuration was last saved.
 
 After you save configuration changes, you can reprocess any historical run to apply them. You can start a reprocess from two places:
 
@@ -166,6 +169,13 @@ A complete configuration with all available options looks as follows:
 }
 ```
 
+## How rules are applied
+
+Two behaviors govern every rule you write, regardless of which property it belongs to:
+
+- **Order matters.** For [`elementFilters`](/ui-coverage/configuration/elementfilters), [`viewFilters`](/ui-coverage/configuration/viewfilters), and [`elementGroups`](/ui-coverage/configuration/elementgroups), rules are evaluated top to bottom and the **first** rule that matches an element or URL wins; later rules that also match it are ignored. List specific rules before broad, catch-all rules, and place an `include: true` exception above the `include: false` rule it should override. [`elements`](/ui-coverage/configuration/elements) is the exception: when more than one rule matches the same element, the **last** one wins.
+- **Unknown properties are rejected.** When you save, Cypress Cloud validates your configuration against a strict schema and rejects anything it doesn't recognize, such as a misspelled property, a value of the wrong type, or a note on a property that doesn't accept one. Correct the flagged property to save, and keep freeform notes in a [`comment`](#Comments).
+
 ## Configuration scope
 
 Some properties are shared across App Quality products, and some belong to UI Coverage alone.
@@ -178,7 +188,7 @@ Some properties are shared across App Quality products, and some belong to UI Co
 
 ## Viewing configuration for a run
 
-You can review the configuration used during a specific run by checking the **Properties** tab, as shown below. This displays the configuration as it was applied at the start of the run.
+Every run permanently records the exact configuration it was processed with, so the runs themselves are the history of how your configuration has changed over time. To review the configuration a specific run used, open its **Properties** tab, as shown below. This displays the configuration as it was applied when the run was processed. When you open a run that was processed with an older configuration than the one currently saved, the report flags it with a "configuration updated" message, and you can [regenerate](#Setting-configuration) the run to reprocess it with the current configuration.
 
 <DocsImage
   src="/img/accessibility/configuration/cypress-cloud-properties-tab-application-quality-config.png"

--- a/docs/ui-coverage/configuration/overview.mdx
+++ b/docs/ui-coverage/configuration/overview.mdx
@@ -57,14 +57,14 @@ Several options change what appears in reports and how it's organized. Pick the 
 
 | Your goal                                                           | Use                                                                                                         |
 | ------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| Combine repeated or related elements so they count as one           | [`elementGroups`](/ui-coverage/configuration/elementgroups)                                                 |
-| Rename or stabilize the identity of a single element                | [`elements`](/ui-coverage/configuration/elements)                                                           |
-| Remove elements from reports and scores entirely                    | [`elementFilters`](/ui-coverage/configuration/elementfilters)                                               |
-| Define groups in your application's markup instead of configuration | [`data-cy-ui-group` attribute](/ui-coverage/core-concepts/element-grouping#Grouping-with-markup-attributes) |
-| Stop dynamic or generated attributes from identifying elements      | [`attributeFilters`](/ui-coverage/configuration/attributefilters)                                           |
-| Prioritize your own attributes for identifying and naming elements  | [`significantAttributes`](/ui-coverage/configuration/significantattributes)                                 |
 | Control how URLs are grouped into views                             | [`views`](/ui-coverage/configuration/views)                                                                 |
 | Remove entire views from reports                                    | [`viewFilters`](/ui-coverage/configuration/viewfilters)                                                     |
+| Remove elements from reports and scores entirely                    | [`elementFilters`](/ui-coverage/configuration/elementfilters)                                               |
+| Rename or stabilize the identity of a single element                | [`elements`](/ui-coverage/configuration/elements)                                                           |
+| Combine repeated or related elements so they count as one           | [`elementGroups`](/ui-coverage/configuration/elementgroups)                                                 |
+| Define groups in your application's markup instead of configuration | [`data-cy-ui-group` attribute](/ui-coverage/core-concepts/element-grouping#Grouping-with-markup-attributes) |
+| Prioritize your own attributes for identifying and naming elements  | [`significantAttributes`](/ui-coverage/configuration/significantattributes)                                 |
+| Stop dynamic or generated attributes from identifying elements      | [`attributeFilters`](/ui-coverage/configuration/attributefilters)                                           |
 | Count your custom commands as interactions                          | [`additionalInteractionCommands`](/ui-coverage/configuration/additionalinteractioncommands)                 |
 | Limit which interaction commands count for specific elements        | [`allowedInteractionCommands`](/ui-coverage/configuration/allowedinteractioncommands)                       |
 | Apply different configuration to runs based on run tags             | [`profiles`](/ui-coverage/configuration/profiles)                                                           |
@@ -81,7 +81,7 @@ A `comment` lives inside the rule and has no effect on behavior. Comments appear
     {
       "selector": ".intercom-launcher",
       "include": false,
-      "comment": "Third-party chat widget owned by support, not covered by our tests"
+      "comment": "Third-party chat widget, not covered by our tests"
     }
   ]
 }
@@ -97,14 +97,6 @@ A complete configuration with all available options looks as follows:
 
 ```json title="App Quality Config"
 {
-  "elementFilters": [
-    {
-      "selector": string,
-      "include": boolean,
-      "documentScope": [string],
-      "comment": string
-    }
-  ],
   "views": [
     {
       "pattern": string,
@@ -119,20 +111,20 @@ A complete configuration with all available options looks as follows:
       "comment": string
     }
   ],
-  "profiles": [
+  "elementFilters": [
     {
-      "name": string,
-      "config": {
-        // Any App Quality configuration options
-      }
+      "selector": string,
+      "include": boolean,
+      "documentScope": [string],
+      "comment": string
     }
   ],
   "uiCoverage": {
-    "attributeFilters": [
+    "elements": [
       {
-        "attribute": string,
-        "value": string,
-        "include": boolean,
+        "selector": string,
+        "name": string,
+        "documentScope": [string],
         "comment": string
       }
     ],
@@ -144,16 +136,16 @@ A complete configuration with all available options looks as follows:
         "comment": string
       }
     ],
-    "elements": [
-      {
-        "selector": string,
-        "name": string,
-        "documentScope": [string],
-        "comment": string
-      }
-    ],
     "significantAttributes": [
       string
+    ],
+    "attributeFilters": [
+      {
+        "attribute": string,
+        "value": string,
+        "include": boolean,
+        "comment": string
+      }
     ],
     "additionalInteractionCommands": [
       string
@@ -166,7 +158,15 @@ A complete configuration with all available options looks as follows:
         "comment": string
       }
     ]
-  }
+  },
+  "profiles": [
+    {
+      "name": string,
+      "config": {
+        // Any App Quality configuration options
+      }
+    }
+  ]
 }
 ```
 
@@ -196,10 +196,10 @@ Check out the following configuration guides.
 - [Views](/ui-coverage/configuration/views)
 - [View Filters](/ui-coverage/configuration/viewfilters)
 - [Element Filters](/ui-coverage/configuration/elementfilters)
-- [Attribute Filters](/ui-coverage/configuration/attributefilters)
-- [Significant Attributes](/ui-coverage/configuration/significantattributes)
-- [Element Groups](/ui-coverage/configuration/elementgroups)
 - [Elements](/ui-coverage/configuration/elements)
+- [Element Groups](/ui-coverage/configuration/elementgroups)
+- [Significant Attributes](/ui-coverage/configuration/significantattributes)
+- [Attribute Filters](/ui-coverage/configuration/attributefilters)
 - [Additional Interaction Commands](/ui-coverage/configuration/additionalinteractioncommands)
 - [Allowed Interaction Commands](/ui-coverage/configuration/allowedinteractioncommands)
 - [Profiles](/ui-coverage/configuration/profiles)

--- a/docs/ui-coverage/configuration/overview.mdx
+++ b/docs/ui-coverage/configuration/overview.mdx
@@ -48,7 +48,10 @@ Editing is limited to Admin users by default. Your Cypress point-of-contact can 
 
 :::info
 
-<Icon name="book-open-reader" /> For a quick overview of the practical application of the most common UI Coverage configuration properties, you can read [this blog post](https://www.cypress.io/blog/making-the-most-of-ui-coverage).
+<Icon name="book-open-reader" /> For a quick overview of the practical
+application of the most common UI Coverage configuration properties, you can
+read [this blog
+post](https://www.cypress.io/blog/making-the-most-of-ui-coverage).
 
 :::
 

--- a/docs/ui-coverage/configuration/overview.mdx
+++ b/docs/ui-coverage/configuration/overview.mdx
@@ -28,17 +28,17 @@ Configuration lives in Cypress Cloud, not in your repository. To view or change 
 
 The editor validates your JSON against the schema when you save, so an invalid configuration can't be saved, and it shows how long ago the configuration was last saved.
 
+<DocsImage
+  src="/img/ui-coverage/configuration/cypress-ui-coverage-configuration-editor.png"
+  alt="The Cypress Cloud UI showing the configuration editor"
+/>
+
 After you save configuration changes, you can reprocess any historical run to apply them. You can start a reprocess from two places:
 
 - The **Properties** tab, using the "regenerate" button next to the configuration values that were used for that run.
 - The UI Coverage report, using the "configuration updated" message that appears when you view a historical run that was processed with an older configuration.
 
 Regenerating reports in this way allows you to make config changes and see their effects without running your Cypress tests again.
-
-<DocsImage
-  src="/img/ui-coverage/configuration/cypress-ui-coverage-configuration-editor.png"
-  alt="The Cypress Cloud UI showing the configuration editor"
-/>
 
 ### Who can edit configuration
 

--- a/docs/ui-coverage/configuration/overview.mdx
+++ b/docs/ui-coverage/configuration/overview.mdx
@@ -90,9 +90,9 @@ A `comment` lives inside the rule and has no effect on behavior. Comments appear
 }
 ```
 
-### Complete configuration example
+### Full configuration reference
 
-A complete configuration with all available options looks as follows:
+The shape of every available option, with the type each value expects:
 
 ```json title="App Quality Config"
 {

--- a/docs/ui-coverage/configuration/overview.mdx
+++ b/docs/ui-coverage/configuration/overview.mdx
@@ -216,11 +216,6 @@ getUICoverageResults().then((results) => {
 })
 ```
 
-The `config` property has two fields:
-
-- `updatedAt`: an ISO timestamp of when the applied configuration was last saved.
-- `value`: the App Quality configuration applied to the run, in the same shape as the [Full configuration reference](#Full-configuration-reference).
-
 If no configuration was applied to the run, `config` may be absent, so check for it before reading `value`.
 
 ## See also

--- a/docs/ui-coverage/configuration/overview.mdx
+++ b/docs/ui-coverage/configuration/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: Configure UI Coverage in Cypress
-description: 'Configuration allows you to customize and fine-tune UI Coverage in Cypress to suit specific needs and scenarios.'
+description: 'Configure Cypress UI Coverage to get a coverage score you can trust: ignore dynamic attributes, filter out noise, group elements, shape views, and count the interactions that matter. Set it all in the App Quality config editor.'
 sidebar_label: Overview
 sidebar_position: 10
 ---
@@ -9,18 +9,18 @@ sidebar_position: 10
 
 # Configuration overview
 
-Configuration enables you to customize and fine-tune UI Coverage in Cypress to suit the unique needs of your application. While UI Coverage is designed to work seamlessly out of the box, there are scenarios where fine-tuning may be necessary—such as dealing with dynamic attributes, filtering out irrelevant elements, or grouping related components. These guides explain how to configure UI Coverage effectively to improve accuracy and usability.
+UI Coverage works out of the box with no setup—but a few lines of configuration make your reports match your application. Configuration lets you get a coverage score you can trust and act on by:
 
-**Note**: By default, setting configuration is limited to Admin users. At your request, this can be changed to allow setting config by all users. Reach out to your Cypress point-of-contact if you would like to change this.
+- **Reflecting your app, not the framework**: ignore dynamic or auto-generated attributes so the same button is recognized as one element across snapshots instead of many.
+- **Removing noise**: filter out third-party widgets, admin-only pages, and elements your team doesn't own so the report focuses on what matters.
+- **Organizing reports around your product**: group related elements and shape how URLs roll up into [views](/ui-coverage/core-concepts/views) that map to real pages and flows.
+- **Counting the interactions you care about**: recognize custom or plugin commands, require a meaningful interaction on specific elements, and even credit assertions as coverage.
 
-:::success
+You don't need any of this to get started, and you can add it incrementally—reprocess a past run after each change to see the effect immediately, without re-running your tests.
 
-## New configuration options
+:::info
 
-UI Coverage now supports defining custom commands that will count towards coverage scores, restricting which kinds of interactions are allowed for certain elements, and including assertions in the UI Coverage calculations. See the following new properties for more details:
-
-- [`additionalInteractionCommands`](/ui-coverage/configuration/additionalinteractioncommands)
-- [`allowedInteractionCommands`](/ui-coverage/configuration/allowedinteractioncommands)
+By default, editing configuration is limited to Admin users. Your Cypress point-of-contact can enable editing for all users on request.
 
 :::
 
@@ -44,7 +44,7 @@ Regenerating reports in this way allows you to make config changes and see their
 
 :::info
 
-For a quick overview of the practical application of the most common UI Coverage confiuration properties, you can read [this blog post](https://www.cypress.io/blog/making-the-most-of-ui-coverage).
+For a quick overview of the practical application of the most common UI Coverage configuration properties, you can read [this blog post](https://www.cypress.io/blog/making-the-most-of-ui-coverage).
 
 :::
 
@@ -105,9 +105,7 @@ A complete configuration with all available options looks as follows:
   "views": [
     {
       "pattern": string,
-      "groupBy": [
-        string
-      ],
+      "groupBy": string | [string],
       "comment": string
     }
   ],
@@ -171,11 +169,15 @@ A complete configuration with all available options looks as follows:
 
 ## Configuration scope
 
-The root-level properties `elementFilters`, `viewFilters`, `attributeFilters`, and `significantAttributes` apply to both UI Coverage and Accessibility. These properties can also be nested under `uiCoverage` or `accessibility` to apply to only that product, with nested configuration taking precedence over root-level configuration.
+Some properties are shared across App Quality products, and some belong to UI Coverage alone.
 
-The `views` property applies to UI Coverage and Accessibility but cannot be nested.
+**Shared properties** — `elementFilters`, `viewFilters`, `attributeFilters`, and `significantAttributes` apply to both UI Coverage and Cypress Accessibility when set at the root of your configuration. To apply one to a single product, nest it under a `uiCoverage` or `accessibility` key. A nested value **completely replaces** the root-level value for that product—the two are not merged—so repeat any shared rules you still want in the nested list.
 
-## Viewing Configuration for a Run
+**Shared, but not nestable** — `views` applies to both UI Coverage and Cypress Accessibility and can only be set at the root.
+
+**UI Coverage only** — `elementGroups`, `elements`, `additionalInteractionCommands`, and `allowedInteractionCommands` are specific to UI Coverage and are always set under the `uiCoverage` key.
+
+## Viewing configuration for a run
 
 You can review the configuration used during a specific run by checking the **Properties** tab, as shown below. This displays the configuration as it was applied at the start of the run.
 
@@ -198,5 +200,3 @@ Check out the following configuration guides.
 - [Additional Interaction Commands](/ui-coverage/configuration/additionalinteractioncommands)
 - [Allowed Interaction Commands](/ui-coverage/configuration/allowedinteractioncommands)
 - [Profiles](/ui-coverage/configuration/profiles)
-
-UI Coverage now supports defining custom commands that will count towards coverage scores, restricting which kinds of interactions are allowed for certain elements, and including assertions in the UI Coverage calculations. See the following new properties for more details:

--- a/docs/ui-coverage/configuration/overview.mdx
+++ b/docs/ui-coverage/configuration/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: Configure UI Coverage in Cypress
-description: 'Configure Cypress UI Coverage to get a coverage score you can trust: ignore dynamic attributes, filter out noise, group elements, shape views, and count the interactions that matter. Set it all in the App Quality config editor.'
+description: 'Configure Cypress UI Coverage to get a coverage score you can trust: ignore dynamic attributes, filter out noise, group elements, shape views, and count the interactions that matter.'
 sidebar_label: Overview
 sidebar_position: 10
 ---
@@ -9,14 +9,14 @@ sidebar_position: 10
 
 # Configuration overview
 
-UI Coverage works out of the box with no setup—but a few lines of configuration make your reports match your application. Configuration lets you get a coverage score you can trust and act on by:
+UI Coverage works out of the box with no setup, but a few lines of configuration make your reports match your application. Configuration lets you get a coverage score you can trust and act on by:
 
 - **Reflecting your app, not the framework**: ignore dynamic or auto-generated attributes so the same button is recognized as one element across snapshots instead of many.
 - **Removing noise**: filter out third-party widgets, admin-only pages, and elements your team doesn't own so the report focuses on what matters.
 - **Organizing reports around your product**: group related elements and shape how URLs roll up into [views](/ui-coverage/core-concepts/views) that map to real pages and flows.
 - **Counting the interactions you care about**: recognize custom or plugin commands, require a meaningful interaction on specific elements, and even credit assertions as coverage.
 
-You don't need any of this to get started, and you can add it incrementally—reprocess a past run after each change to see the effect immediately, without re-running your tests.
+You don't need any of this to get started, and you can add it incrementally. Reprocess a past run after each change to see the effect immediately, without re-running your tests.
 
 :::info
 
@@ -171,11 +171,11 @@ A complete configuration with all available options looks as follows:
 
 Some properties are shared across App Quality products, and some belong to UI Coverage alone.
 
-**Shared properties** — `elementFilters`, `viewFilters`, `attributeFilters`, and `significantAttributes` apply to both UI Coverage and Cypress Accessibility when set at the root of your configuration. To apply one to a single product, nest it under a `uiCoverage` or `accessibility` key. A nested value **completely replaces** the root-level value for that product—the two are not merged—so repeat any shared rules you still want in the nested list.
+**Shared properties**: `elementFilters`, `viewFilters`, `attributeFilters`, and `significantAttributes` apply to both UI Coverage and Cypress Accessibility when set at the root of your configuration. To apply one to a single product, nest it under a `uiCoverage` or `accessibility` key. A nested value **completely replaces** the root-level value for that product (the two are not merged), so repeat any shared rules you still want in the nested list.
 
-**Shared, but not nestable** — `views` applies to both UI Coverage and Cypress Accessibility and can only be set at the root.
+**Shared, but not nestable**: `views` applies to both UI Coverage and Cypress Accessibility and can only be set at the root.
 
-**UI Coverage only** — `elementGroups`, `elements`, `additionalInteractionCommands`, and `allowedInteractionCommands` are specific to UI Coverage and are always set under the `uiCoverage` key.
+**UI Coverage only**: `elementGroups`, `elements`, `additionalInteractionCommands`, and `allowedInteractionCommands` are specific to UI Coverage and are always set under the `uiCoverage` key.
 
 ## Viewing configuration for a run
 

--- a/docs/ui-coverage/configuration/overview.mdx
+++ b/docs/ui-coverage/configuration/overview.mdx
@@ -48,7 +48,7 @@ Editing is limited to Admin users by default. Your Cypress point-of-contact can 
 
 :::info
 
-For a quick overview of the practical application of the most common UI Coverage configuration properties, you can read [this blog post](https://www.cypress.io/blog/making-the-most-of-ui-coverage).
+<Icon name="book-open-reader" /> For a quick overview of the practical application of the most common UI Coverage configuration properties, you can read [this blog post](https://www.cypress.io/blog/making-the-most-of-ui-coverage).
 
 :::
 

--- a/docs/ui-coverage/configuration/overview.mdx
+++ b/docs/ui-coverage/configuration/overview.mdx
@@ -31,7 +31,10 @@ To add or modify the configuration for your project:
 1. Navigate to the **App Quality** tab in your project settings on Cypress Cloud.
 2. Use the configuration editor to add or edit configuration in JSON format.
 
-After new configuration changes have been saved, you can reprocess any historical run using the "regenerate" button on the properties tab where the configuration values that were used for that run are displayed, or through the UI Coverage report where the "configuration updated" message appears if you are looking at a historical run using an old config.
+After you save configuration changes, you can reprocess any historical run to apply them. You can start a reprocess from two places:
+
+- The **Properties** tab, using the "regenerate" button next to the configuration values that were used for that run.
+- The UI Coverage report, using the "configuration updated" message that appears when you view a historical run that was processed with an older configuration.
 
 Regenerating reports in this way allows you to make config changes and see their effects without running your Cypress tests again.
 
@@ -68,9 +71,9 @@ Several options change what appears in reports and how it's organized. Pick the 
 
 ### Comments
 
-All configuration objects support an optional `comment` property that you can use to provide context and explanations for why certain values are set. This helps make your configuration easier to understand and maintain, especially when working in teams or revisiting configuration after some time.
+Most configuration rules support an optional `comment` property that you can use to record why a value is set. This makes your configuration easier to understand and maintain, especially when working in a team or revisiting configuration after some time. Any rule defined as an object accepts a `comment`; the options that are plain lists of strings, such as [`significantAttributes`](/ui-coverage/configuration/significantattributes) and [`additionalInteractionCommands`](/ui-coverage/configuration/additionalinteractioncommands), do not take a per-entry comment.
 
-Comments have no effect on behavior. They belong inside each rule object; Cypress Cloud validates every rule and rejects properties it doesn't recognize, so `comment` is the supported place for notes.
+A `comment` lives inside the rule and has no effect on behavior. Comments appear only in the configuration itself and are never displayed in reports. Because Cypress Cloud validates every rule and rejects properties it doesn't recognize, `comment` is the supported place to keep notes.
 
 ```json title="App Quality Config"
 {

--- a/docs/ui-coverage/configuration/overview.mdx
+++ b/docs/ui-coverage/configuration/overview.mdx
@@ -18,12 +18,6 @@ UI Coverage works out of the box with no setup, but a few lines of configuration
 
 You don't need any of this to get started, and you can add it incrementally. Reprocess a past run after each change to see the effect immediately, without re-running your tests.
 
-:::info
-
-By default, editing configuration is limited to Admin users. Your Cypress point-of-contact can enable editing for all users on request.
-
-:::
-
 ## Setting configuration
 
 Configuration lives in Cypress Cloud, not in your repository. To view or change it for a project:
@@ -32,7 +26,7 @@ Configuration lives in Cypress Cloud, not in your repository. To view or change 
 2. Select the **App Quality** tab, which holds the configuration editor.
 3. Edit the configuration as JSON, then **Save**. **Discard** reverts unsaved edits back to the last saved version.
 
-Editing is limited to Admin users by default. The editor validates your JSON against the schema when you save, so an invalid configuration can't be saved, and it shows how long ago the configuration was last saved.
+The editor validates your JSON against the schema when you save, so an invalid configuration can't be saved, and it shows how long ago the configuration was last saved.
 
 After you save configuration changes, you can reprocess any historical run to apply them. You can start a reprocess from two places:
 
@@ -45,6 +39,10 @@ Regenerating reports in this way allows you to make config changes and see their
   src="/img/ui-coverage/configuration/cypress-ui-coverage-configuration-editor.png"
   alt="The Cypress Cloud UI showing the configuration editor"
 />
+
+### Who can edit configuration
+
+Editing is limited to Admin users by default. Your Cypress point-of-contact can enable editing for all users on request.
 
 ## Configuration options
 

--- a/docs/ui-coverage/configuration/overview.mdx
+++ b/docs/ui-coverage/configuration/overview.mdx
@@ -87,10 +87,6 @@ A `comment` lives inside the rule and has no effect on behavior. Comments appear
 }
 ```
 
-### Profiles
-
-The `profiles` property allows you to use different configuration settings for different runs based on [run tags](/app/references/command-line#cypress-run-tag-lt-tag-gt). See the [Profiles](/ui-coverage/configuration/profiles) guide for more details.
-
 ### Complete configuration example
 
 A complete configuration with all available options looks as follows:
@@ -189,9 +185,7 @@ You can review the configuration used during a specific run by checking the **Pr
   alt="The properties tab for a run, with an Application Quality section at the bottom"
 />
 
-## Next steps
-
-Check out the following configuration guides.
+## See also
 
 - [Views](/ui-coverage/configuration/views)
 - [View Filters](/ui-coverage/configuration/viewfilters)

--- a/docs/ui-coverage/faq.mdx
+++ b/docs/ui-coverage/faq.mdx
@@ -33,7 +33,7 @@ Automatic grouping only replaces path segments that are numbers or IDs (UUIDs an
 
 No. Query strings are ignored when grouping, so `/dashboard?tab=overview` and `/dashboard?tab=settings` become a single `/dashboard` view. If a query parameter meaningfully changes the page, use a [`views`](/ui-coverage/configuration/views) pattern with `groupBy` on that parameter to split it into separate views.
 
-### <Icon name="angle-right" /> How do I create a separate view for each value of a URL parameter?
+### <Icon name="angle-right" /> How do I create a separate UI Coverage view for each value of a URL parameter?
 
 Write a [`views`](/ui-coverage/configuration/views) pattern that names the parameter, then list that name in `groupBy`. For a pattern like `/analytics/:type/:id`, `groupBy: ["type"]` creates a distinct view for each `type` value (such as `/analytics/performance/:id` and `/analytics/usage/:id`) while still collapsing the dynamic `:id`. `groupBy` accepts a single string or an array of strings, and each name can come from the path, query string, or hash. See [Using groupBy](/ui-coverage/configuration/views#Using-groupBy).
 
@@ -199,11 +199,11 @@ No. UI Coverage works out of the box with no configuration. Every recorded run p
 
 In the **App Quality** tab of your project settings in Cypress Cloud. By default, only Admin users can edit configuration; your Cypress point-of-contact can change this on request. See [Setting configuration](/ui-coverage/configuration/overview#Setting-configuration).
 
-### <Icon name="angle-right" /> How do I document why a configuration rule exists?
+### <Icon name="angle-right" /> How do I document why a UI Coverage configuration rule exists?
 
 Add a `comment` property to any rule. Comments are for humans only and have no effect on behavior, so they're the supported place to explain a rule for teammates or your future self. Because Cypress Cloud rejects properties it doesn't recognize, `comment` is the only field you can use for freeform notes. See [Comments](/ui-coverage/configuration/overview#Comments).
 
-### <Icon name="angle-right" /> Why is my configuration being rejected as invalid?
+### <Icon name="angle-right" /> Why is Cypress Cloud rejecting my UI Coverage configuration as invalid?
 
 Cypress Cloud validates your configuration against a strict schema and rejects any property it doesn't recognize. The usual causes are a misspelled property name, a value of the wrong type (for example, a string where an array is expected), or a note added on an unsupported field. Put explanations in a [`comment`](/ui-coverage/configuration/overview#Comments) instead. The editor reports the offending property so you can correct it before saving.
 

--- a/docs/ui-coverage/faq.mdx
+++ b/docs/ui-coverage/faq.mdx
@@ -33,6 +33,10 @@ Automatic grouping only replaces path segments that are numbers or IDs (UUIDs an
 
 No. Query strings are ignored when grouping, so `/dashboard?tab=overview` and `/dashboard?tab=settings` become a single `/dashboard` view. If a query parameter meaningfully changes the page, use a [`views`](/ui-coverage/configuration/views) pattern with `groupBy` on that parameter to split it into separate views.
 
+### <Icon name="angle-right" /> How do I create a separate view for each value of a URL parameter?
+
+Write a [`views`](/ui-coverage/configuration/views) pattern that names the parameter, then list that name in `groupBy`. For a pattern like `/analytics/:type/:id`, `groupBy: ["type"]` creates a distinct view for each `type` value (such as `/analytics/performance/:id` and `/analytics/usage/:id`) while still collapsing the dynamic `:id`. `groupBy` accepts a single string or an array of strings, and each name can come from the path, query string, or hash. See [Using groupBy](/ui-coverage/configuration/views#Using-groupBy).
+
 ### <Icon name="angle-right" /> How do I exclude URLs from UI Coverage?
 
 Add a [`viewFilters`](/ui-coverage/configuration/viewfilters) rule with `include: false` for a URL pattern. Excluding a URL removes its snapshots from the report and stops links pointing to it from counting against your coverage score. The [Ignore views and links](/ui-coverage/guides/ignore-views-and-links) guide walks through common cases.
@@ -187,9 +191,21 @@ Once an element matches an [`allowedInteractionCommands`](/ui-coverage/configura
 
 ## Configuration
 
+### <Icon name="angle-right" /> Do I need to configure anything to use UI Coverage?
+
+No. UI Coverage works out of the box with no configuration—every recorded run produces a report automatically. Configuration is opt-in and incremental: add a rule only when you want to sharpen the report, such as ignoring a dynamic attribute, filtering out a third-party widget, or grouping related elements. See the [Configuration overview](/ui-coverage/configuration/overview) for what each option does.
+
 ### <Icon name="angle-right" /> Where do I set UI Coverage configuration?
 
 In the **App Quality** tab of your project settings in Cypress Cloud. By default, only Admin users can edit configuration; your Cypress point-of-contact can change this on request. See [Setting configuration](/ui-coverage/configuration/overview#Setting-configuration).
+
+### <Icon name="angle-right" /> How do I document why a configuration rule exists?
+
+Add a `comment` property to any rule. Comments are for humans only and have no effect on behavior, so they're the supported place to explain a rule for teammates or your future self. Because Cypress Cloud rejects properties it doesn't recognize, `comment` is the only field you can use for freeform notes. See [Comments](/ui-coverage/configuration/overview#Comments).
+
+### <Icon name="angle-right" /> Why is my configuration being rejected as invalid?
+
+Cypress Cloud validates your configuration against a strict schema and rejects any property it doesn't recognize. The usual causes are a misspelled property name, a value of the wrong type (for example, a string where an array is expected), or a note added on an unsupported field—put explanations in a [`comment`](/ui-coverage/configuration/overview#Comments) instead. The editor reports the offending property so you can correct it before saving.
 
 ### <Icon name="angle-right" /> Do I need to rerun my tests after changing configuration?
 

--- a/docs/ui-coverage/faq.mdx
+++ b/docs/ui-coverage/faq.mdx
@@ -193,7 +193,7 @@ Once an element matches an [`allowedInteractionCommands`](/ui-coverage/configura
 
 ### <Icon name="angle-right" /> Do I need to configure anything to use UI Coverage?
 
-No. UI Coverage works out of the box with no configuration—every recorded run produces a report automatically. Configuration is opt-in and incremental: add a rule only when you want to sharpen the report, such as ignoring a dynamic attribute, filtering out a third-party widget, or grouping related elements. See the [Configuration overview](/ui-coverage/configuration/overview) for what each option does.
+No. UI Coverage works out of the box with no configuration. Every recorded run produces a report automatically. Configuration is opt-in and incremental: add a rule only when you want to sharpen the report, such as ignoring a dynamic attribute, filtering out a third-party widget, or grouping related elements. See the [Configuration overview](/ui-coverage/configuration/overview) for what each option does.
 
 ### <Icon name="angle-right" /> Where do I set UI Coverage configuration?
 
@@ -205,7 +205,7 @@ Add a `comment` property to any rule. Comments are for humans only and have no e
 
 ### <Icon name="angle-right" /> Why is my configuration being rejected as invalid?
 
-Cypress Cloud validates your configuration against a strict schema and rejects any property it doesn't recognize. The usual causes are a misspelled property name, a value of the wrong type (for example, a string where an array is expected), or a note added on an unsupported field—put explanations in a [`comment`](/ui-coverage/configuration/overview#Comments) instead. The editor reports the offending property so you can correct it before saving.
+Cypress Cloud validates your configuration against a strict schema and rejects any property it doesn't recognize. The usual causes are a misspelled property name, a value of the wrong type (for example, a string where an array is expected), or a note added on an unsupported field. Put explanations in a [`comment`](/ui-coverage/configuration/overview#Comments) instead. The editor reports the offending property so you can correct it before saving.
 
 ### <Icon name="angle-right" /> Do I need to rerun my tests after changing configuration?
 


### PR DESCRIPTION
## Summary

Reworks the UI Coverage **Configuration overview** page (and adds a few FAQ entries) so it accurately reflects the App Quality config implementation, leads with value, and reads as a tight hub page. Touches `docs/ui-coverage/configuration/overview.mdx` and `docs/ui-coverage/faq.mdx`.

Key changes to `overview.mdx`:

- **Lead with value** — replaced the generic intro with a benefit-first summary (trustworthy score, less noise, reports shaped around your app, meaningful interactions) and the fact that config is optional/incremental.
- **Accuracy fixes verified against `cypress-services`:**
  - `views.groupBy` documented as `string | [string]` (was array-only), matching the schema and the views page.
  - Corrected the `comment` claim: object-shaped rules accept `comment`, but the plain string-list options (`significantAttributes`, `additionalInteractionCommands`) do not.
  - Rewrote **Configuration scope** so nested product config **replaces** (not merges with) the root value, `views` is shared-but-not-nestable, and `elementGroups`/`elements`/`additionalInteractionCommands`/`allowedInteractionCommands` are UI-Coverage-only. Now a bulleted list.
  - Removed a stale "New configuration options" callout and a dangling, incomplete paragraph at the end of the page; fixed a "confiuration" typo.
- **New "How rules are applied" section** consolidating two cross-cutting behaviors that were previously only stated per-property: first-match-wins ordering (with the `elements` last-match exception) and strict schema validation.
- **Clearer editing + history coverage** — "Setting configuration" now spells out where the editor lives (Project Settings → App Quality), Save/Discard, admin-only editing, save-time validation, and the last-saved indicator; "Viewing configuration for a run" now frames the per-run config snapshot as how you track configuration over time.
- **One consistent order** for the options across the "Which option do I need?" table, the reference block, and See also (previously four different orders).
- **Renamed** "Complete configuration example" → "Full configuration reference" (it uses type placeholders, not real values), "Next steps" → "See also", and removed a redundant standalone `### Profiles` blurb already covered by the table and its own page.
- Used a realistic `elementFilters` example (a third-party chat widget) and removed em dashes throughout.

Key changes to `faq.mdx`:

- Added answer-first FAQ entries scoped to Cypress + UI Coverage: no config required to start, documenting rules with `comment`, invalid-config troubleshooting, and splitting a view by a URL parameter with `groupBy`.

## Why

The Configuration overview had drifted from the implementation (incorrect `groupBy` type, an over-broad `comment` claim, ambiguous merge semantics) and carried stale/leftover content, an inconsistent option order across four lists, and a couple of mislabeled sections. Everything here was checked against the actual App Quality config schema and resolver in `cypress-services` (`packages/validations/.../discoverySchema_0_1.ts`, `sharedSchemas.ts`, `ResolvedAppQualityConfig.ts`) and the dashboard config editor. The FAQ additions target common, high-intent questions for SEO/AEO.

## Notes for reviewers

- **Scope decision:** the schema also supports a `policies` property (validated and user-editable, but labeled Experimental in Cloud). It was intentionally left undocumented for now.
- **`elements` ordering nuance:** unlike the filter/group properties, `elements` is last-match-wins — confirmed against the elements property page and called out explicitly in the new "How rules are applied" section.
- **History:** there is no dedicated config change-log/audit in the product (confirmed in the data source + GraphQL schema), so the page frames per-run config snapshots as the way to track changes rather than implying an audit trail exists.
- All changes are prose/markdown; Prettier (`lint:markdown`) and the frontmatter linter both pass. No inbound links point to the renamed headings.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VaBrPBBZbGG1EY4jTbLy91)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prose and markdown only; no runtime or product code changes. Heading renames on the overview page could affect deep links if any exist outside this diff.
> 
> **Overview**
> **Documentation-only** update to the UI Coverage **Configuration overview** and **FAQ** so they match App Quality config behavior and read as a clearer hub page.
> 
> The **overview** now opens with **why** configuration matters (trustworthy scores, less noise, product-shaped views) and that setup is optional and incremental. It corrects **`views.groupBy`** as `string | [string]`, narrows **`comment`** to object-shaped rules only, and states that nested **`uiCoverage` / `accessibility`** config **replaces** root values rather than merging. A new **How rules are applied** section documents first-match-wins ordering (with **`elements`** as last-match-wins) and strict schema validation on save. **Setting** and **viewing** configuration sections spell out Cloud editor location, Save/Discard, admin editing, regeneration, per-run config snapshots, and a **Results API** example for reading applied config. Stale callouts and trailing junk are removed; the options table, reference block, and **See also** list share one order; section titles are renamed (**Full configuration reference**, **See also**).
> 
> **FAQ** adds four answer-first entries: no config required to start, documenting rules with **`comment`**, invalid-config troubleshooting, and splitting views by URL parameters via **`groupBy`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6462d9a56d55c740db52ff7b618cca278ef4383b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->