### PR TITLE
docs(ui-coverage): correct and expand the UI Coverage Results API page

### DIFF
--- a/docs/partials/_results-api-env-vars.mdx
+++ b/docs/partials/_results-api-env-vars.mdx
@@ -2,21 +2,6 @@ The `@cypress/extract-cloud-results` helper detects the correct Cloud run by mat
 
 Knowing which variables it looks for helps with more complex setups and with local iteration: set them to match what was present in CI to pull a specific run (recorded within the last 7 days) from your machine.
 
-### Local development example
-
-If you executed a run in GitHub Actions and it was recorded to Cypress Cloud, you would set these 4 environment variables to replicate the context of that run locally and execute your local handler script. This is a great way to iterate on your script and verify everything is working as expected, without having to integrate anything in CI. It's also useful for debugging.
-
-```shell
-CYPRESS_PROJECT_ID=AAA
-CYPRESS_RECORD_KEY=BBB
-GITHUB_ACTIONS=true
-GITHUB_RUN_ID=111
-GITHUB_RUN_ATTEMPT=1
-node verifyResults.js
-```
-
-The Results API will then look for the Cypress Cloud run that matches this run ID. If there is more than one Cypress Cloud run found for that GitHub Actions Run, you can pass run tags to narrow down to one run's report.
-
 ### Prerequisites
 
 Two prerequisites apply to every provider:
@@ -161,4 +146,19 @@ Reference: [Buildkite documentation](https://buildkite.com/docs)
 
 </AccordionBlock>
 
-In order to iterate on your verification script and see everything working without putting code into your CI environment, it can be useful to simulate the CI context for a specific Cypress run locally. This can save a lot of time when getting started.
+### Local development example
+
+To iterate on your verification script and see everything working without putting code into your CI environment, simulate the CI context for a specific Cypress run locally. This can save a lot of time when getting started.
+
+If you executed a run in GitHub Actions and it was recorded to Cypress Cloud, you would set these 4 environment variables to replicate the context of that run locally and execute your local handler script. This is a great way to iterate on your script and verify everything is working as expected, without having to integrate anything in CI. It's also useful for debugging.
+
+```shell
+CYPRESS_PROJECT_ID=AAA
+CYPRESS_RECORD_KEY=BBB
+GITHUB_ACTIONS=true
+GITHUB_RUN_ID=111
+GITHUB_RUN_ATTEMPT=1
+node verifyResults.js
+```
+
+The Results API will then look for the Cypress Cloud run that matches this run ID. If there is more than one Cypress Cloud run found for that GitHub Actions Run, you can pass run tags to narrow down to one run's report.

--- a/docs/partials/_results-api-env-vars.mdx
+++ b/docs/partials/_results-api-env-vars.mdx
@@ -38,7 +38,7 @@ Reference: [Understanding GitHub Actions](https://docs.github.com/en/actions/lea
 - `GITHUB_RUN_ID` - Value uniquely identifies a GitHub Actions workflow instance. Value does not change as jobs in the workflow are re-executed.
 - `GITHUB_RUN_ATTEMPT` - Value identifies the workflow instance's attempt index. Value is incremented each time jobs are re-executed.
 
-Full environment variable reference: [GitHub Actions default environment variables](https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables)
+[GitHub Actions default environment variables](https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables)
 
 </AccordionBlock>
 
@@ -53,7 +53,7 @@ Reference: [GitLab CI/CD pipelines](https://docs.gitlab.com/ee/ci/pipelines/)
 - `CI_JOB_NAME` - Value uniquely identifies a single job name within a pipeline. Ex. `run-e2e`
 - `CI_JOB_ID` - Value uniquely identifies an execution instance of a job. This value will change each time a job is executed/re-executed.
 
-Full environment variable reference: [GitLab predefined variables](https://docs.gitlab.com/ee/ci/variables/predefined_variables.html)
+[GitLab predefined variables](https://docs.gitlab.com/ee/ci/variables/predefined_variables.html)
 
 </AccordionBlock>
 
@@ -70,7 +70,7 @@ We have implemented Jenkins support within this module using the broadest set of
 - `JENKINS_HOME` - Presence identifies the environment as a Jenkins environment
 - `BUILD_URL` - Value uniquely identifies a Jenkins job execution, including name and id characteristics.
 
-Full environment variable reference: [Jenkins environment variables](https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#using-environment-variables)
+[Jenkins environment variables](https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#using-environment-variables)
 
 </AccordionBlock>
 
@@ -87,7 +87,7 @@ Reference: [Azure Pipelines key concepts](https://learn.microsoft.com/en-us/azur
 - `SYSTEM_JOBID` - Value uniquely identifies a job execution. Value changes each time a job is retried from failure, in conjunction with the `SYSTEM_JOBATTEMPT` being incremented.
 - `SYSTEM_JOBATTEMPT` - Value identifies the pipelines shared attempt index. Value is incremented when jobs are retried from failure.
 
-Full environment variable reference: [Azure Pipelines predefined variables](https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml)
+[Azure Pipelines predefined variables](https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml)
 
 </AccordionBlock>
 
@@ -104,7 +104,7 @@ Reference: [About CircleCI](https://circleci.com/docs/about-circleci/)
 - `CIRCLE_WORKFLOW_ID` - Value uniquely identifies an instance of a workflow's execution within a pipeline. This value will be updated upon each workflow execution; in other words, retrying a workflow from failure from the Circle UI will create a new workflow with a new `CIRCLE_WORKFLOW_ID` value available to the jobs executed within it.
 - `CIRCLE_WORKFLOW_JOB_ID` - Value uniquely identifies an execution instance of a named job within a workflow instance.
 
-Full environment variable reference: [CircleCI built-in environment variables](https://circleci.com/docs/variables/#built-in-environment-variables)
+[CircleCI built-in environment variables](https://circleci.com/docs/variables/#built-in-environment-variables)
 
 </AccordionBlock>
 
@@ -116,7 +116,7 @@ Reference: [AWS CodeBuild documentation](https://docs.aws.amazon.com/codebuild/)
 
 - `CODEBUILD_BUILD_ID` - Presence identifies the environment as an AWS CodeBuild environment. Value uniquely identifies a build.
 
-Full environment variable reference: [AWS CodeBuild environment variables](https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-env-vars.html)
+[AWS CodeBuild environment variables](https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-env-vars.html)
 
 </AccordionBlock>
 
@@ -129,7 +129,7 @@ Reference: [Drone pipeline overview](https://docs.drone.io/pipeline/overview/)
 - `DRONE` - Presence identifies the environment as a Drone environment.
 - `DRONE_BUILD_NUMBER` - Value uniquely identifies a Drone build.
 
-Full environment variable reference: [Drone environment reference](https://docs.drone.io/pipeline/environment/reference/)
+[Drone environment reference](https://docs.drone.io/pipeline/environment/reference/)
 
 </AccordionBlock>
 
@@ -142,7 +142,7 @@ Reference: [Bitbucket Cloud documentation](https://support.atlassian.com/bitbuck
 - `BITBUCKET_BUILD_NUMBER` - Presence identifies the environment as a Bitbucket environment. Value uniquely identifies a build.
 - `BITBUCKET_STEP_RUN_NUMBER` - Value indicates a build step execution index and increments when a step is retried. Initial value of 1.
 
-Full environment variable reference: [Bitbucket variables and secrets](https://support.atlassian.com/bitbucket-cloud/docs/variables-and-secrets/)
+[Bitbucket variables and secrets](https://support.atlassian.com/bitbucket-cloud/docs/variables-and-secrets/)
 
 </AccordionBlock>
 
@@ -157,7 +157,7 @@ Reference: [Buildkite documentation](https://buildkite.com/docs)
 - `BUILDKITE_JOB_ID` - Value uniquely identifies a job execution. Each job in a build has a unique job ID.
 - `BUILDKITE_RETRY_COUNT` - Value indicates the retry attempt for a job. Default value of 0.
 
-Full environment variable reference: [Buildkite environment variables](https://buildkite.com/docs/pipelines/environment-variables)
+[Buildkite environment variables](https://buildkite.com/docs/pipelines/environment-variables)
 
 </AccordionBlock>
 

--- a/docs/partials/_results-api-env-vars.mdx
+++ b/docs/partials/_results-api-env-vars.mdx
@@ -21,13 +21,13 @@ The Results API will then look for the Cypress Cloud run that matches this run I
 
 ## Supported CI Provider Overview
 
-Each CI provider has a unique combination of components, patterns, and environment variables that must be interpreted by this module.
+Each CI provider has a unique combination of components, patterns, and environment variables that must be interpreted by this module. Expand a provider below for its essential environment variables and prerequisites.
 
-### GitHub Actions
+<AccordionBlock title="GitHub Actions" icon={<Icon name="github" />}>
 
 Reference: https://docs.github.com/en/actions/learn-github-actions/understanding-github-actions
 
-#### Essential environment variables
+**Essential environment variables**
 
 - `GITHUB_ACTIONS` - Presence identifies the environment as a GitHub Actions environment.
 - `GITHUB_RUN_ID` - Value uniquely identifies a GitHub Actions workflow instance. Value does not change as jobs in the workflow are re-executed.
@@ -35,18 +35,20 @@ Reference: https://docs.github.com/en/actions/learn-github-actions/understanding
 
 Full environment variable reference: https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
 
-#### Prerequisites
+**Prerequisites**
 
 1. The run to validate and this module's validation script are being executed within the same workflow.
 2. The module script is always executed _after_ the run to validate has been created. This can be achieved by either:
    1. Executing the module script in a separate job that is dependent upon the job that records the run (using the `needs: [job-name]` option in the config), or
    2. Executing the module script in serial with the cypress recording in the same job.
 
-### GitLab Pipelines
+</AccordionBlock>
+
+<AccordionBlock title="GitLab" icon={<Icon name="gitlab" />}>
 
 Reference: https://docs.gitlab.com/ee/ci/pipelines/
 
-#### Essential environment variables
+**Essential environment variables**
 
 - `GITLAB_CI` - Presence identifies the environment as a GitLab CI environment
 - `CI_PIPELINE_ID` - Value uniquely identifies a GitLab pipeline workflow. This value does not change as jobs in the pipeline are retried.
@@ -55,7 +57,7 @@ Reference: https://docs.gitlab.com/ee/ci/pipelines/
 
 Full environment variable reference: https://docs.gitlab.com/ee/ci/variables/predefined_variables.html
 
-#### Prerequisites
+**Prerequisites**
 
 1. The run to validate and this module's validation script are being executed within the same pipeline.
 2. The module script is always executed _after_ the run to validate has been created. This can be achieved by:
@@ -63,7 +65,9 @@ Full environment variable reference: https://docs.gitlab.com/ee/ci/variables/pre
    2. Executing the module script in a separate job that is executed in a lower stage than the job that records the Cypress run, or
    3. Executing the module script in serial with the cypress recording in the same job.
 
-### Jenkins
+</AccordionBlock>
+
+<AccordionBlock title="Jenkins" icon={<Icon name="jenkins" />}>
 
 Reference: https://www.jenkins.io/doc/
 
@@ -71,25 +75,27 @@ Jenkins is heavily customizable through the usage of plugins, which limits the a
 
 We have implemented Jenkins support within this module using the broadest set of available default values. For the purposes of this documentation, though, we will discuss terms related to Jenkins Pipeline support: https://www.jenkins.io/doc/book/pipeline/getting-started/
 
-#### Essential environment variables
+**Essential environment variables**
 
 - `JENKINS_HOME` - Presence identifies the environment as a Jenkins environment
 - `BUILD_URL` - Value uniquely identifies a Jenkins job execution, including name and id characteristics.
 
 Full environment variable reference: https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#using-environment-variables
 
-#### Prerequisites
+**Prerequisites**
 
 1. The run to validate and this module's validation script are being executed within the same job.
 2. The module script is always executed _after_ the run to validate has been created. This can be achieved by executing the module script in serial with the cypress recording in the same job.
 
-### Azure
+</AccordionBlock>
+
+<AccordionBlock title="Azure" icon={<Icon name="microsoft" />}>
 
 Reference: https://learn.microsoft.com/en-us/azure/devops/pipelines/get-started/key-pipelines-concepts?view=azure-devops
 
 > Note: Cypress v13.13.1 is the earliest Cypress release that records the environment variables necessary for this module to identify runs in an Azure environment. Previous Cypress versions are not supported in Azure pipelines.
 
-#### Essential environment variables
+**Essential environment variables**
 
 - `TF_BUILD` and `AZURE_HTTP_USER_AGENT` - Combined presence identifies the environment as an Azure pipeline environment.
 - `SYSTEM_PLANID` - Value uniquely identifies a pipeline run. Value does not change as jobs within the pipeline are retried from failure.
@@ -98,20 +104,22 @@ Reference: https://learn.microsoft.com/en-us/azure/devops/pipelines/get-started/
 
 Full environment variable reference: https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml
 
-#### Prerequisites
+**Prerequisites**
 
 1. The run to validate and this module's validation script are being executed within the same pipeline run (i.e. they share a `SYSTEM_PLANID` value).
 2. The module script is always executed _after_ the run to validate has been created. This can be achieved by either:
    1. Executing the module script in a separate job that is dependent upon the job that records the run (using the `dependsOn: [job-name]` option in the config), or
    2. Executing the module script in serial with the Cypress recording in the same job.
 
-### CircleCI
+</AccordionBlock>
+
+<AccordionBlock title="CircleCI" icon={<Icon name="cog" />}>
 
 Reference: https://circleci.com/docs/about-circleci/
 
 > Note: Cypress v13.13.1 is the earliest Cypress release that records the environment variables necessary for this module to identify runs in an CircleCI environment. Previous Cypress versions are not supported in CircleCI pipelines.
 
-#### Essential environment variables
+**Essential environment variables**
 
 - `CIRCLECI` - Presence identifies the environment as a CircleCI environment
 - `CIRCLE_PIPELINE_ID` - Value uniquely identifies a CircleCI pipeline, created on push or manually triggered through the UI. This value does not change as workflows within the pipeline are re-executed.
@@ -120,65 +128,73 @@ Reference: https://circleci.com/docs/about-circleci/
 
 Full environment variable reference: https://circleci.com/docs/variables/#built-in-environment-variables
 
-#### Prerequisites
+**Prerequisites**
 
 1. The run to validate and this module's validation script are being executed within the same pipeline **and** workflow.
 2. The module script is always executed _after_ the run to validate has been created. This can be achieved by:
    1. Executing the module script in a separate job that is dependent upon the job that records the run (using the `requires: [job-name]` option in the config), or
    2. Executing the module script in serial with the cypress recording in the same job.
 
-### AWS CodeBuild
+</AccordionBlock>
+
+<AccordionBlock title="AWS CodeBuild" icon={<Icon name="aws" />}>
 
 Reference: https://docs.aws.amazon.com/codebuild/
 
-#### Essential environment variables
+**Essential environment variables**
 
 - `CODEBUILD_BUILD_ID` - Presence identifies the environment as an AWS CodeBuild environment. Value uniquely identifies a build.
 
 Full environment variable reference: https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-env-vars.html
 
-#### Prerequisites
+**Prerequisites**
 
 1. The run to validate and this module's validation script are being executed within the same build.
 2. The module script is always executed _after_ the run to validate has been created. This can be achieved by executing the module script in serial with the cypress recording in the same build.
 
-### Drone
+</AccordionBlock>
+
+<AccordionBlock title="Drone" icon={<Icon name="cog" />}>
 
 Reference: https://docs.drone.io/pipeline/overview/
 
-#### Essential environment variables
+**Essential environment variables**
 
 - `DRONE` - Presence identifies the environment as a Drone environment.
 - `DRONE_BUILD_NUMBER` - Value uniquely identifies a Drone build.
 
 Full environment variable reference: https://docs.drone.io/pipeline/environment/reference/
 
-#### Prerequisites
+**Prerequisites**
 
 1. The run to validate and this module's validation script are being executed within the same build.
 2. The module script is always executed _after_ the run to validate has been created. This can be achieved by executing the module script in serial with the cypress recording in the same build.
 
-### Bitbucket
+</AccordionBlock>
+
+<AccordionBlock title="Bitbucket" icon={<Icon name="bitbucket" />}>
 
 Reference: https://support.atlassian.com/bitbucket-cloud/docs/
 
-#### Essential environment variables
+**Essential environment variables**
 
 - `BITBUCKET_BUILD_NUMBER` - Presence identifies the environment as a Bitbucket environment. Value uniquely identifies a build.
 - `BITBUCKET_STEP_RUN_NUMBER` - Value indicates a build step execution index and increments when a step is retried. Initial value of 1.
 
 Full environment variable reference: https://support.atlassian.com/bitbucket-cloud/docs/variables-and-secrets/
 
-#### Prerequisites
+**Prerequisites**
 
 1. The run to validate and this module's validation script are being executed within the same build.
 2. The module script is always executed _after_ the run to validate has been created. This can be achieved by executing the module script in serial with the cypress recording in the same build.
 
-### Buildkite
+</AccordionBlock>
+
+<AccordionBlock title="Buildkite" icon={<Icon name="cog" />}>
 
 Reference: https://buildkite.com/docs
 
-#### Essential environment variables
+**Essential environment variables**
 
 - `BUILDKITE` - Presence identifies the environment as a Buildkite environment.
 - `BUILDKITE_BUILD_ID` - Value uniquely identifies a build. This value does not change across different jobs within the same build.
@@ -187,9 +203,11 @@ Reference: https://buildkite.com/docs
 
 Full environment variable reference: https://buildkite.com/docs/pipelines/environment-variables
 
-#### Prerequisites
+**Prerequisites**
 
 1. The run to validate and this module's validation script are being executed within the same build.
 2. The module script is always executed _after_ the run to validate has been created. This can be achieved by executing the module script in serial with the cypress recording in the same build.
+
+</AccordionBlock>
 
 In order to iterate on your verification script and see everything working without putting code into your CI environment, it can be useful to simulate the CI context for a specific Cypress run locally. This can save a lot of time when getting started.

--- a/docs/partials/_results-api-env-vars.mdx
+++ b/docs/partials/_results-api-env-vars.mdx
@@ -13,8 +13,8 @@ CYPRESS_PROJECT_ID=AAA
 CYPRESS_RECORD_KEY=BBB
 GITHUB_ACTIONS=true
 GITHUB_RUN_ID=111
-GITHUB_RUN_ATTEMPT=0
-node verifyAccessibilityResults.js
+GITHUB_RUN_ATTEMPT=1
+node verifyResults.js
 ```
 
 The Results API will then look for the Cypress Cloud run that matches this run ID. If there is more than one Cypress Cloud run found for that GitHub Actions Run, you can pass run tags to narrow down to one run's report.
@@ -71,8 +71,6 @@ Jenkins is heavily customizable through the usage of plugins, which limits the a
 
 We have implemented Jenkins support within this module using the broadest set of available default values. For the purposes of this documentation, though, we will discuss terms related to Jenkins Pipeline support: https://www.jenkins.io/doc/book/pipeline/getting-started/
 
-#### Essential terms
-
 #### Essential environment variables
 
 - `JENKINS_HOME` - Presence identifies the environment as a Jenkins environment
@@ -93,7 +91,7 @@ Reference: https://learn.microsoft.com/en-us/azure/devops/pipelines/get-started/
 
 #### Essential environment variables
 
-- `TF_BUILD` and `AZURE_HTTP_USER_AGENT` - Combined presence identifies the environment as a Azure pipeline environment.
+- `TF_BUILD` and `AZURE_HTTP_USER_AGENT` - Combined presence identifies the environment as an Azure pipeline environment.
 - `SYSTEM_PLANID` - Value uniquely identifies a pipeline run. Value does not change as jobs within the pipeline are retried from failure.
 - `SYSTEM_JOBID` - Value uniquely identifies a job execution. Value changes each time a job is retried from failure, in conjunction with the `SYSTEM_JOBATTEMPT` being incremented.
 - `SYSTEM_JOBATTEMPT` - Value identifies the pipelines shared attempt index. Value is incremented when jobs are retried from failure.
@@ -120,7 +118,7 @@ Reference: https://circleci.com/docs/about-circleci/
 - `CIRCLE_WORKFLOW_ID` - Value uniquely identifies an instance of a workflow's execution within a pipeline. This value will be updated upon each workflow execution; in other words, retrying a workflow from failure from the Circle UI will create a new workflow with a new `CIRCLE_WORKFLOW_ID` value available to the jobs executed within it.
 - `CIRCLE_WORKFLOW_JOB_ID` - Value uniquely identifies an execution instance of a named job within a workflow instance.
 
-Full environment variable reference: https://docs.gitlab.com/ee/ci/variables/predefined_variables.html
+Full environment variable reference: https://circleci.com/docs/variables/#built-in-environment-variables
 
 #### Prerequisites
 
@@ -139,7 +137,7 @@ Reference: https://docs.aws.amazon.com/codebuild/
 
 Full environment variable reference: https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-env-vars.html
 
-Prerequisites
+#### Prerequisites
 
 1. The run to validate and this module's validation script are being executed within the same build.
 2. The module script is always executed _after_ the run to validate has been created. This can be achieved by executing the module script in serial with the cypress recording in the same build.
@@ -150,7 +148,7 @@ Reference: https://docs.drone.io/pipeline/overview/
 
 #### Essential environment variables
 
-- `DRONE` - Presence identifies the environment as an Drone environment.
+- `DRONE` - Presence identifies the environment as a Drone environment.
 - `DRONE_BUILD_NUMBER` - Value uniquely identifies a Drone build.
 
 Full environment variable reference: https://docs.drone.io/pipeline/environment/reference/

--- a/docs/partials/_results-api-env-vars.mdx
+++ b/docs/partials/_results-api-env-vars.mdx
@@ -17,9 +17,16 @@ node verifyResults.js
 
 The Results API will then look for the Cypress Cloud run that matches this run ID. If there is more than one Cypress Cloud run found for that GitHub Actions Run, you can pass run tags to narrow down to one run's report.
 
+## Prerequisites
+
+Two prerequisites apply to every provider:
+
+1. Record the Cypress run and run your validation script within the same CI run (the same build, workflow, or pipeline).
+2. Run the validation script _after_ the run has been recorded — either in a separate job that depends on the recording job (using your provider's dependency option, such as `needs`, `dependsOn`, or `requires`), or serially after the recording step in the same job.
+
 ## Supported CI Provider Overview
 
-Each CI provider has a unique combination of components, patterns, and environment variables that must be interpreted by this module. Expand a provider below for its essential environment variables and prerequisites.
+Each CI provider has a unique combination of components, patterns, and environment variables that must be interpreted by this module. Expand a provider below for its essential environment variables.
 
 <AccordionBlock title="GitHub Actions" icon={<Icon name="github" />}>
 
@@ -32,13 +39,6 @@ Reference: [Understanding GitHub Actions](https://docs.github.com/en/actions/lea
 - `GITHUB_RUN_ATTEMPT` - Value identifies the workflow instance's attempt index. Value is incremented each time jobs are re-executed.
 
 Full environment variable reference: [GitHub Actions default environment variables](https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables)
-
-**Prerequisites**
-
-1. Record the Cypress run and execute this module's validation script within the same workflow.
-2. The module script is always executed _after_ the run to validate has been created. This can be achieved by either:
-   1. Executing the module script in a separate job that is dependent upon the job that records the run (using the `needs: [job-name]` option in the config), or
-   2. Executing the module script in serial with the cypress recording in the same job.
 
 </AccordionBlock>
 
@@ -54,14 +54,6 @@ Reference: [GitLab CI/CD pipelines](https://docs.gitlab.com/ee/ci/pipelines/)
 - `CI_JOB_ID` - Value uniquely identifies an execution instance of a job. This value will change each time a job is executed/re-executed.
 
 Full environment variable reference: [GitLab predefined variables](https://docs.gitlab.com/ee/ci/variables/predefined_variables.html)
-
-**Prerequisites**
-
-1. Record the Cypress run and execute this module's validation script within the same pipeline.
-2. The module script is always executed _after_ the run to validate has been created. This can be achieved by:
-   1. Executing the module script in a separate job that is dependent upon the job that records the run (using the `needs: [job-name]` option in the config), or
-   2. Executing the module script in a separate job that is executed in a lower stage than the job that records the Cypress run, or
-   3. Executing the module script in serial with the cypress recording in the same job.
 
 </AccordionBlock>
 
@@ -80,11 +72,6 @@ We have implemented Jenkins support within this module using the broadest set of
 
 Full environment variable reference: [Jenkins environment variables](https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#using-environment-variables)
 
-**Prerequisites**
-
-1. Record the Cypress run and execute this module's validation script within the same job.
-2. The module script is always executed _after_ the run to validate has been created. This can be achieved by executing the module script in serial with the cypress recording in the same job.
-
 </AccordionBlock>
 
 <AccordionBlock title="Azure" icon={<Icon name="microsoft" />}>
@@ -101,13 +88,6 @@ Reference: [Azure Pipelines key concepts](https://learn.microsoft.com/en-us/azur
 - `SYSTEM_JOBATTEMPT` - Value identifies the pipelines shared attempt index. Value is incremented when jobs are retried from failure.
 
 Full environment variable reference: [Azure Pipelines predefined variables](https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml)
-
-**Prerequisites**
-
-1. Record the Cypress run and execute this module's validation script within the same pipeline run (i.e. they share a `SYSTEM_PLANID` value).
-2. The module script is always executed _after_ the run to validate has been created. This can be achieved by either:
-   1. Executing the module script in a separate job that is dependent upon the job that records the run (using the `dependsOn: [job-name]` option in the config), or
-   2. Executing the module script in serial with the Cypress recording in the same job.
 
 </AccordionBlock>
 
@@ -126,13 +106,6 @@ Reference: [About CircleCI](https://circleci.com/docs/about-circleci/)
 
 Full environment variable reference: [CircleCI built-in environment variables](https://circleci.com/docs/variables/#built-in-environment-variables)
 
-**Prerequisites**
-
-1. Record the Cypress run and execute this module's validation script within the same pipeline **and** workflow.
-2. The module script is always executed _after_ the run to validate has been created. This can be achieved by:
-   1. Executing the module script in a separate job that is dependent upon the job that records the run (using the `requires: [job-name]` option in the config), or
-   2. Executing the module script in serial with the cypress recording in the same job.
-
 </AccordionBlock>
 
 <AccordionBlock title="AWS CodeBuild" icon={<Icon name="aws" />}>
@@ -144,11 +117,6 @@ Reference: [AWS CodeBuild documentation](https://docs.aws.amazon.com/codebuild/)
 - `CODEBUILD_BUILD_ID` - Presence identifies the environment as an AWS CodeBuild environment. Value uniquely identifies a build.
 
 Full environment variable reference: [AWS CodeBuild environment variables](https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-env-vars.html)
-
-**Prerequisites**
-
-1. Record the Cypress run and execute this module's validation script within the same build.
-2. The module script is always executed _after_ the run to validate has been created. This can be achieved by executing the module script in serial with the cypress recording in the same build.
 
 </AccordionBlock>
 
@@ -163,11 +131,6 @@ Reference: [Drone pipeline overview](https://docs.drone.io/pipeline/overview/)
 
 Full environment variable reference: [Drone environment reference](https://docs.drone.io/pipeline/environment/reference/)
 
-**Prerequisites**
-
-1. Record the Cypress run and execute this module's validation script within the same build.
-2. The module script is always executed _after_ the run to validate has been created. This can be achieved by executing the module script in serial with the cypress recording in the same build.
-
 </AccordionBlock>
 
 <AccordionBlock title="Bitbucket" icon={<Icon name="bitbucket" />}>
@@ -180,11 +143,6 @@ Reference: [Bitbucket Cloud documentation](https://support.atlassian.com/bitbuck
 - `BITBUCKET_STEP_RUN_NUMBER` - Value indicates a build step execution index and increments when a step is retried. Initial value of 1.
 
 Full environment variable reference: [Bitbucket variables and secrets](https://support.atlassian.com/bitbucket-cloud/docs/variables-and-secrets/)
-
-**Prerequisites**
-
-1. Record the Cypress run and execute this module's validation script within the same build.
-2. The module script is always executed _after_ the run to validate has been created. This can be achieved by executing the module script in serial with the cypress recording in the same build.
 
 </AccordionBlock>
 
@@ -200,11 +158,6 @@ Reference: [Buildkite documentation](https://buildkite.com/docs)
 - `BUILDKITE_RETRY_COUNT` - Value indicates the retry attempt for a job. Default value of 0.
 
 Full environment variable reference: [Buildkite environment variables](https://buildkite.com/docs/pipelines/environment-variables)
-
-**Prerequisites**
-
-1. Record the Cypress run and execute this module's validation script within the same build.
-2. The module script is always executed _after_ the run to validate has been created. This can be achieved by executing the module script in serial with the cypress recording in the same build.
 
 </AccordionBlock>
 

--- a/docs/partials/_results-api-env-vars.mdx
+++ b/docs/partials/_results-api-env-vars.mdx
@@ -1,8 +1,6 @@
-The `@cypress/extract-cloud-results` helper cross-references some environment variables from where it is executed with ones that were present when a Cypress Cloud run was recorded. This allows for automatically detecting the correct Cloud run when the Results API is invoked from the same CI context as a given run (as is the case in the above examples).
+The `@cypress/extract-cloud-results` helper detects the correct Cloud run by matching environment variables from where it runs against those present when the run was recorded, which is why it works automatically from the same CI context (as in the examples above).
 
-For more complex setups, or for local iteration on your Results API handler code, it can be useful to know what variables Cypress is looking for so that you can make sure they are passed through where they are needed.
-
-Likewise, if you want to use the Results API locally to pull the data for a specific run (within the last 7 days), you can set these variables locally to match what was present in CI.
+Knowing which variables it looks for helps with more complex setups and with local iteration: set them to match what was present in CI to pull a specific run (recorded within the last 7 days) from your machine.
 
 ## Local development example
 

--- a/docs/partials/_results-api-env-vars.mdx
+++ b/docs/partials/_results-api-env-vars.mdx
@@ -8,7 +8,7 @@ Likewise, if you want to use the Results API locally to pull the data for a spec
 
 If you executed a run in GitHub Actions and it was recorded to Cypress Cloud, you would set these 4 environment variables to replicate the context of that run locally and execute your local handler script. This is a great way to iterate on your script and verify everything is working as expected, without having to integrate anything in CI. It's also useful for debugging.
 
-```
+```shell
 CYPRESS_PROJECT_ID=AAA
 CYPRESS_RECORD_KEY=BBB
 GITHUB_ACTIONS=true

--- a/docs/partials/_results-api-env-vars.mdx
+++ b/docs/partials/_results-api-env-vars.mdx
@@ -24,7 +24,7 @@ Two prerequisites apply to every provider:
 1. Record the Cypress run and run your validation script within the same CI run (the same build, workflow, or pipeline).
 2. Run the validation script _after_ the run has been recorded — either in a separate job that depends on the recording job (using your provider's dependency option, such as `needs`, `dependsOn`, or `requires`), or serially after the recording step in the same job.
 
-## Supported CI Provider Overview
+## Environment variables by CI provider
 
 Each CI provider has a unique combination of components, patterns, and environment variables that must be interpreted by this module. Expand a provider below for its essential environment variables.
 

--- a/docs/partials/_results-api-env-vars.mdx
+++ b/docs/partials/_results-api-env-vars.mdx
@@ -7,7 +7,7 @@ Knowing which variables it looks for helps with more complex setups and with loc
 Two prerequisites apply to every provider:
 
 1. Record the Cypress run and run your validation script within the same CI run (the same build, workflow, or pipeline).
-2. Run the validation script _after_ the run has been recorded — either in a separate job that depends on the recording job (using your provider's dependency option, such as `needs`, `dependsOn`, or `requires`), or serially after the recording step in the same job.
+2. Run the validation script _after_ the run has been recorded, either in a separate job that depends on the recording job (using your provider's dependency option, such as `needs`, `dependsOn`, or `requires`), or serially after the recording step in the same job.
 
 ### Environment variables by CI provider
 
@@ -15,7 +15,7 @@ Each CI provider has a unique combination of components, patterns, and environme
 
 <AccordionBlock title="GitHub Actions" icon={<Icon name="github" />}>
 
-Reference: [Understanding GitHub Actions](https://docs.github.com/en/actions/learn-github-actions/understanding-github-actions)
+References: [Understanding GitHub Actions](https://docs.github.com/en/actions/learn-github-actions/understanding-github-actions) | [GitHub Actions default environment variables](https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables)
 
 **Essential environment variables**
 
@@ -23,13 +23,11 @@ Reference: [Understanding GitHub Actions](https://docs.github.com/en/actions/lea
 - `GITHUB_RUN_ID` - Value uniquely identifies a GitHub Actions workflow instance. Value does not change as jobs in the workflow are re-executed.
 - `GITHUB_RUN_ATTEMPT` - Value identifies the workflow instance's attempt index. Value is incremented each time jobs are re-executed.
 
-[GitHub Actions default environment variables](https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables)
-
 </AccordionBlock>
 
 <AccordionBlock title="GitLab" icon={<Icon name="gitlab" />}>
 
-Reference: [GitLab CI/CD pipelines](https://docs.gitlab.com/ee/ci/pipelines/)
+References: [GitLab CI/CD pipelines](https://docs.gitlab.com/ee/ci/pipelines/) | [GitLab predefined variables](https://docs.gitlab.com/ee/ci/variables/predefined_variables.html)
 
 **Essential environment variables**
 
@@ -38,13 +36,11 @@ Reference: [GitLab CI/CD pipelines](https://docs.gitlab.com/ee/ci/pipelines/)
 - `CI_JOB_NAME` - Value uniquely identifies a single job name within a pipeline. Ex. `run-e2e`
 - `CI_JOB_ID` - Value uniquely identifies an execution instance of a job. This value will change each time a job is executed/re-executed.
 
-[GitLab predefined variables](https://docs.gitlab.com/ee/ci/variables/predefined_variables.html)
-
 </AccordionBlock>
 
 <AccordionBlock title="Jenkins" icon={<Icon name="jenkins" />}>
 
-Reference: [Jenkins documentation](https://www.jenkins.io/doc/)
+References: [Jenkins documentation](https://www.jenkins.io/doc/) | [Jenkins environment variables](https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#using-environment-variables)
 
 Jenkins is heavily customizable through the usage of plugins, which limits the amount of assumptions we can make about available environment variables and overall behavior.
 
@@ -55,13 +51,11 @@ We have implemented Jenkins support within this module using the broadest set of
 - `JENKINS_HOME` - Presence identifies the environment as a Jenkins environment
 - `BUILD_URL` - Value uniquely identifies a Jenkins job execution, including name and id characteristics.
 
-[Jenkins environment variables](https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#using-environment-variables)
-
 </AccordionBlock>
 
 <AccordionBlock title="Azure" icon={<Icon name="microsoft" />}>
 
-Reference: [Azure Pipelines key concepts](https://learn.microsoft.com/en-us/azure/devops/pipelines/get-started/key-pipelines-concepts?view=azure-devops)
+References: [Azure Pipelines key concepts](https://learn.microsoft.com/en-us/azure/devops/pipelines/get-started/key-pipelines-concepts?view=azure-devops) | [Azure Pipelines predefined variables](https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml)
 
 > Note: Cypress v13.13.1 is the earliest Cypress release that records the environment variables necessary for this module to identify runs in an Azure environment. Previous Cypress versions are not supported in Azure pipelines.
 
@@ -72,13 +66,11 @@ Reference: [Azure Pipelines key concepts](https://learn.microsoft.com/en-us/azur
 - `SYSTEM_JOBID` - Value uniquely identifies a job execution. Value changes each time a job is retried from failure, in conjunction with the `SYSTEM_JOBATTEMPT` being incremented.
 - `SYSTEM_JOBATTEMPT` - Value identifies the pipelines shared attempt index. Value is incremented when jobs are retried from failure.
 
-[Azure Pipelines predefined variables](https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml)
-
 </AccordionBlock>
 
 <AccordionBlock title="CircleCI" icon={<Icon name="cog" />}>
 
-Reference: [About CircleCI](https://circleci.com/docs/about-circleci/)
+References: [About CircleCI](https://circleci.com/docs/about-circleci/) | [CircleCI built-in environment variables](https://circleci.com/docs/variables/#built-in-environment-variables)
 
 > Note: Cypress v13.13.1 is the earliest Cypress release that records the environment variables necessary for this module to identify runs in an CircleCI environment. Previous Cypress versions are not supported in CircleCI pipelines.
 
@@ -89,51 +81,43 @@ Reference: [About CircleCI](https://circleci.com/docs/about-circleci/)
 - `CIRCLE_WORKFLOW_ID` - Value uniquely identifies an instance of a workflow's execution within a pipeline. This value will be updated upon each workflow execution; in other words, retrying a workflow from failure from the Circle UI will create a new workflow with a new `CIRCLE_WORKFLOW_ID` value available to the jobs executed within it.
 - `CIRCLE_WORKFLOW_JOB_ID` - Value uniquely identifies an execution instance of a named job within a workflow instance.
 
-[CircleCI built-in environment variables](https://circleci.com/docs/variables/#built-in-environment-variables)
-
 </AccordionBlock>
 
 <AccordionBlock title="AWS CodeBuild" icon={<Icon name="aws" />}>
 
-Reference: [AWS CodeBuild documentation](https://docs.aws.amazon.com/codebuild/)
+References: [AWS CodeBuild documentation](https://docs.aws.amazon.com/codebuild/) | [AWS CodeBuild environment variables](https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-env-vars.html)
 
 **Essential environment variables**
 
 - `CODEBUILD_BUILD_ID` - Presence identifies the environment as an AWS CodeBuild environment. Value uniquely identifies a build.
 
-[AWS CodeBuild environment variables](https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-env-vars.html)
-
 </AccordionBlock>
 
 <AccordionBlock title="Drone" icon={<Icon name="cog" />}>
 
-Reference: [Drone pipeline overview](https://docs.drone.io/pipeline/overview/)
+References: [Drone pipeline overview](https://docs.drone.io/pipeline/overview/) | [Drone environment reference](https://docs.drone.io/pipeline/environment/reference/)
 
 **Essential environment variables**
 
 - `DRONE` - Presence identifies the environment as a Drone environment.
 - `DRONE_BUILD_NUMBER` - Value uniquely identifies a Drone build.
 
-[Drone environment reference](https://docs.drone.io/pipeline/environment/reference/)
-
 </AccordionBlock>
 
 <AccordionBlock title="Bitbucket" icon={<Icon name="bitbucket" />}>
 
-Reference: [Bitbucket Cloud documentation](https://support.atlassian.com/bitbucket-cloud/docs/)
+References: [Bitbucket Cloud documentation](https://support.atlassian.com/bitbucket-cloud/docs/) | [Bitbucket variables and secrets](https://support.atlassian.com/bitbucket-cloud/docs/variables-and-secrets/)
 
 **Essential environment variables**
 
 - `BITBUCKET_BUILD_NUMBER` - Presence identifies the environment as a Bitbucket environment. Value uniquely identifies a build.
 - `BITBUCKET_STEP_RUN_NUMBER` - Value indicates a build step execution index and increments when a step is retried. Initial value of 1.
 
-[Bitbucket variables and secrets](https://support.atlassian.com/bitbucket-cloud/docs/variables-and-secrets/)
-
 </AccordionBlock>
 
 <AccordionBlock title="Buildkite" icon={<Icon name="cog" />}>
 
-Reference: [Buildkite documentation](https://buildkite.com/docs)
+References: [Buildkite documentation](https://buildkite.com/docs) | [Buildkite environment variables](https://buildkite.com/docs/pipelines/environment-variables)
 
 **Essential environment variables**
 
@@ -141,8 +125,6 @@ Reference: [Buildkite documentation](https://buildkite.com/docs)
 - `BUILDKITE_BUILD_ID` - Value uniquely identifies a build. This value does not change across different jobs within the same build.
 - `BUILDKITE_JOB_ID` - Value uniquely identifies a job execution. Each job in a build has a unique job ID.
 - `BUILDKITE_RETRY_COUNT` - Value indicates the retry attempt for a job. Default value of 0.
-
-[Buildkite environment variables](https://buildkite.com/docs/pipelines/environment-variables)
 
 </AccordionBlock>
 

--- a/docs/partials/_results-api-env-vars.mdx
+++ b/docs/partials/_results-api-env-vars.mdx
@@ -14,7 +14,7 @@ CYPRESS_RECORD_KEY=BBB
 GITHUB_ACTIONS=true
 GITHUB_RUN_ID=111
 GITHUB_RUN_ATTEMPT=1
-node verifyResults.js
+node verifyAccessibilityResults.js
 ```
 
 The Results API will then look for the Cypress Cloud run that matches this run ID. If there is more than one Cypress Cloud run found for that GitHub Actions Run, you can pass run tags to narrow down to one run's report.

--- a/docs/partials/_results-api-env-vars.mdx
+++ b/docs/partials/_results-api-env-vars.mdx
@@ -25,7 +25,7 @@ Each CI provider has a unique combination of components, patterns, and environme
 
 <AccordionBlock title="GitHub Actions" icon={<Icon name="github" />}>
 
-Reference: https://docs.github.com/en/actions/learn-github-actions/understanding-github-actions
+Reference: [Understanding GitHub Actions](https://docs.github.com/en/actions/learn-github-actions/understanding-github-actions)
 
 **Essential environment variables**
 
@@ -33,7 +33,7 @@ Reference: https://docs.github.com/en/actions/learn-github-actions/understanding
 - `GITHUB_RUN_ID` - Value uniquely identifies a GitHub Actions workflow instance. Value does not change as jobs in the workflow are re-executed.
 - `GITHUB_RUN_ATTEMPT` - Value identifies the workflow instance's attempt index. Value is incremented each time jobs are re-executed.
 
-Full environment variable reference: https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
+Full environment variable reference: [GitHub Actions default environment variables](https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables)
 
 **Prerequisites**
 
@@ -46,7 +46,7 @@ Full environment variable reference: https://docs.github.com/en/actions/learn-gi
 
 <AccordionBlock title="GitLab" icon={<Icon name="gitlab" />}>
 
-Reference: https://docs.gitlab.com/ee/ci/pipelines/
+Reference: [GitLab CI/CD pipelines](https://docs.gitlab.com/ee/ci/pipelines/)
 
 **Essential environment variables**
 
@@ -55,7 +55,7 @@ Reference: https://docs.gitlab.com/ee/ci/pipelines/
 - `CI_JOB_NAME` - Value uniquely identifies a single job name within a pipeline. Ex. `run-e2e`
 - `CI_JOB_ID` - Value uniquely identifies an execution instance of a job. This value will change each time a job is executed/re-executed.
 
-Full environment variable reference: https://docs.gitlab.com/ee/ci/variables/predefined_variables.html
+Full environment variable reference: [GitLab predefined variables](https://docs.gitlab.com/ee/ci/variables/predefined_variables.html)
 
 **Prerequisites**
 
@@ -69,18 +69,18 @@ Full environment variable reference: https://docs.gitlab.com/ee/ci/variables/pre
 
 <AccordionBlock title="Jenkins" icon={<Icon name="jenkins" />}>
 
-Reference: https://www.jenkins.io/doc/
+Reference: [Jenkins documentation](https://www.jenkins.io/doc/)
 
 Jenkins is heavily customizable through the usage of plugins, which limits the amount of assumptions we can make about available environment variables and overall behavior.
 
-We have implemented Jenkins support within this module using the broadest set of available default values. For the purposes of this documentation, though, we will discuss terms related to Jenkins Pipeline support: https://www.jenkins.io/doc/book/pipeline/getting-started/
+We have implemented Jenkins support within this module using the broadest set of available default values. For the purposes of this documentation, though, we will discuss terms related to [Jenkins Pipeline support](https://www.jenkins.io/doc/book/pipeline/getting-started/).
 
 **Essential environment variables**
 
 - `JENKINS_HOME` - Presence identifies the environment as a Jenkins environment
 - `BUILD_URL` - Value uniquely identifies a Jenkins job execution, including name and id characteristics.
 
-Full environment variable reference: https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#using-environment-variables
+Full environment variable reference: [Jenkins environment variables](https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#using-environment-variables)
 
 **Prerequisites**
 
@@ -91,7 +91,7 @@ Full environment variable reference: https://www.jenkins.io/doc/book/pipeline/je
 
 <AccordionBlock title="Azure" icon={<Icon name="microsoft" />}>
 
-Reference: https://learn.microsoft.com/en-us/azure/devops/pipelines/get-started/key-pipelines-concepts?view=azure-devops
+Reference: [Azure Pipelines key concepts](https://learn.microsoft.com/en-us/azure/devops/pipelines/get-started/key-pipelines-concepts?view=azure-devops)
 
 > Note: Cypress v13.13.1 is the earliest Cypress release that records the environment variables necessary for this module to identify runs in an Azure environment. Previous Cypress versions are not supported in Azure pipelines.
 
@@ -102,7 +102,7 @@ Reference: https://learn.microsoft.com/en-us/azure/devops/pipelines/get-started/
 - `SYSTEM_JOBID` - Value uniquely identifies a job execution. Value changes each time a job is retried from failure, in conjunction with the `SYSTEM_JOBATTEMPT` being incremented.
 - `SYSTEM_JOBATTEMPT` - Value identifies the pipelines shared attempt index. Value is incremented when jobs are retried from failure.
 
-Full environment variable reference: https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml
+Full environment variable reference: [Azure Pipelines predefined variables](https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml)
 
 **Prerequisites**
 
@@ -115,7 +115,7 @@ Full environment variable reference: https://learn.microsoft.com/en-us/azure/dev
 
 <AccordionBlock title="CircleCI" icon={<Icon name="cog" />}>
 
-Reference: https://circleci.com/docs/about-circleci/
+Reference: [About CircleCI](https://circleci.com/docs/about-circleci/)
 
 > Note: Cypress v13.13.1 is the earliest Cypress release that records the environment variables necessary for this module to identify runs in an CircleCI environment. Previous Cypress versions are not supported in CircleCI pipelines.
 
@@ -126,7 +126,7 @@ Reference: https://circleci.com/docs/about-circleci/
 - `CIRCLE_WORKFLOW_ID` - Value uniquely identifies an instance of a workflow's execution within a pipeline. This value will be updated upon each workflow execution; in other words, retrying a workflow from failure from the Circle UI will create a new workflow with a new `CIRCLE_WORKFLOW_ID` value available to the jobs executed within it.
 - `CIRCLE_WORKFLOW_JOB_ID` - Value uniquely identifies an execution instance of a named job within a workflow instance.
 
-Full environment variable reference: https://circleci.com/docs/variables/#built-in-environment-variables
+Full environment variable reference: [CircleCI built-in environment variables](https://circleci.com/docs/variables/#built-in-environment-variables)
 
 **Prerequisites**
 
@@ -139,13 +139,13 @@ Full environment variable reference: https://circleci.com/docs/variables/#built-
 
 <AccordionBlock title="AWS CodeBuild" icon={<Icon name="aws" />}>
 
-Reference: https://docs.aws.amazon.com/codebuild/
+Reference: [AWS CodeBuild documentation](https://docs.aws.amazon.com/codebuild/)
 
 **Essential environment variables**
 
 - `CODEBUILD_BUILD_ID` - Presence identifies the environment as an AWS CodeBuild environment. Value uniquely identifies a build.
 
-Full environment variable reference: https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-env-vars.html
+Full environment variable reference: [AWS CodeBuild environment variables](https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-env-vars.html)
 
 **Prerequisites**
 
@@ -156,14 +156,14 @@ Full environment variable reference: https://docs.aws.amazon.com/codebuild/lates
 
 <AccordionBlock title="Drone" icon={<Icon name="cog" />}>
 
-Reference: https://docs.drone.io/pipeline/overview/
+Reference: [Drone pipeline overview](https://docs.drone.io/pipeline/overview/)
 
 **Essential environment variables**
 
 - `DRONE` - Presence identifies the environment as a Drone environment.
 - `DRONE_BUILD_NUMBER` - Value uniquely identifies a Drone build.
 
-Full environment variable reference: https://docs.drone.io/pipeline/environment/reference/
+Full environment variable reference: [Drone environment reference](https://docs.drone.io/pipeline/environment/reference/)
 
 **Prerequisites**
 
@@ -174,14 +174,14 @@ Full environment variable reference: https://docs.drone.io/pipeline/environment/
 
 <AccordionBlock title="Bitbucket" icon={<Icon name="bitbucket" />}>
 
-Reference: https://support.atlassian.com/bitbucket-cloud/docs/
+Reference: [Bitbucket Cloud documentation](https://support.atlassian.com/bitbucket-cloud/docs/)
 
 **Essential environment variables**
 
 - `BITBUCKET_BUILD_NUMBER` - Presence identifies the environment as a Bitbucket environment. Value uniquely identifies a build.
 - `BITBUCKET_STEP_RUN_NUMBER` - Value indicates a build step execution index and increments when a step is retried. Initial value of 1.
 
-Full environment variable reference: https://support.atlassian.com/bitbucket-cloud/docs/variables-and-secrets/
+Full environment variable reference: [Bitbucket variables and secrets](https://support.atlassian.com/bitbucket-cloud/docs/variables-and-secrets/)
 
 **Prerequisites**
 
@@ -192,7 +192,7 @@ Full environment variable reference: https://support.atlassian.com/bitbucket-clo
 
 <AccordionBlock title="Buildkite" icon={<Icon name="cog" />}>
 
-Reference: https://buildkite.com/docs
+Reference: [Buildkite documentation](https://buildkite.com/docs)
 
 **Essential environment variables**
 
@@ -201,7 +201,7 @@ Reference: https://buildkite.com/docs
 - `BUILDKITE_JOB_ID` - Value uniquely identifies a job execution. Each job in a build has a unique job ID.
 - `BUILDKITE_RETRY_COUNT` - Value indicates the retry attempt for a job. Default value of 0.
 
-Full environment variable reference: https://buildkite.com/docs/pipelines/environment-variables
+Full environment variable reference: [Buildkite environment variables](https://buildkite.com/docs/pipelines/environment-variables)
 
 **Prerequisites**
 

--- a/docs/partials/_results-api-env-vars.mdx
+++ b/docs/partials/_results-api-env-vars.mdx
@@ -2,7 +2,7 @@ The `@cypress/extract-cloud-results` helper detects the correct Cloud run by mat
 
 Knowing which variables it looks for helps with more complex setups and with local iteration: set them to match what was present in CI to pull a specific run (recorded within the last 7 days) from your machine.
 
-## Local development example
+### Local development example
 
 If you executed a run in GitHub Actions and it was recorded to Cypress Cloud, you would set these 4 environment variables to replicate the context of that run locally and execute your local handler script. This is a great way to iterate on your script and verify everything is working as expected, without having to integrate anything in CI. It's also useful for debugging.
 
@@ -17,14 +17,14 @@ node verifyResults.js
 
 The Results API will then look for the Cypress Cloud run that matches this run ID. If there is more than one Cypress Cloud run found for that GitHub Actions Run, you can pass run tags to narrow down to one run's report.
 
-## Prerequisites
+### Prerequisites
 
 Two prerequisites apply to every provider:
 
 1. Record the Cypress run and run your validation script within the same CI run (the same build, workflow, or pipeline).
 2. Run the validation script _after_ the run has been recorded — either in a separate job that depends on the recording job (using your provider's dependency option, such as `needs`, `dependsOn`, or `requires`), or serially after the recording step in the same job.
 
-## Environment variables by CI provider
+### Environment variables by CI provider
 
 Each CI provider has a unique combination of components, patterns, and environment variables that must be interpreted by this module. Expand a provider below for its essential environment variables.
 

--- a/docs/partials/_results-api-env-vars.mdx
+++ b/docs/partials/_results-api-env-vars.mdx
@@ -35,7 +35,7 @@ Full environment variable reference: [GitHub Actions default environment variabl
 
 **Prerequisites**
 
-1. The run to validate and this module's validation script are being executed within the same workflow.
+1. Record the Cypress run and execute this module's validation script within the same workflow.
 2. The module script is always executed _after_ the run to validate has been created. This can be achieved by either:
    1. Executing the module script in a separate job that is dependent upon the job that records the run (using the `needs: [job-name]` option in the config), or
    2. Executing the module script in serial with the cypress recording in the same job.
@@ -57,7 +57,7 @@ Full environment variable reference: [GitLab predefined variables](https://docs.
 
 **Prerequisites**
 
-1. The run to validate and this module's validation script are being executed within the same pipeline.
+1. Record the Cypress run and execute this module's validation script within the same pipeline.
 2. The module script is always executed _after_ the run to validate has been created. This can be achieved by:
    1. Executing the module script in a separate job that is dependent upon the job that records the run (using the `needs: [job-name]` option in the config), or
    2. Executing the module script in a separate job that is executed in a lower stage than the job that records the Cypress run, or
@@ -82,7 +82,7 @@ Full environment variable reference: [Jenkins environment variables](https://www
 
 **Prerequisites**
 
-1. The run to validate and this module's validation script are being executed within the same job.
+1. Record the Cypress run and execute this module's validation script within the same job.
 2. The module script is always executed _after_ the run to validate has been created. This can be achieved by executing the module script in serial with the cypress recording in the same job.
 
 </AccordionBlock>
@@ -104,7 +104,7 @@ Full environment variable reference: [Azure Pipelines predefined variables](http
 
 **Prerequisites**
 
-1. The run to validate and this module's validation script are being executed within the same pipeline run (i.e. they share a `SYSTEM_PLANID` value).
+1. Record the Cypress run and execute this module's validation script within the same pipeline run (i.e. they share a `SYSTEM_PLANID` value).
 2. The module script is always executed _after_ the run to validate has been created. This can be achieved by either:
    1. Executing the module script in a separate job that is dependent upon the job that records the run (using the `dependsOn: [job-name]` option in the config), or
    2. Executing the module script in serial with the Cypress recording in the same job.
@@ -128,7 +128,7 @@ Full environment variable reference: [CircleCI built-in environment variables](h
 
 **Prerequisites**
 
-1. The run to validate and this module's validation script are being executed within the same pipeline **and** workflow.
+1. Record the Cypress run and execute this module's validation script within the same pipeline **and** workflow.
 2. The module script is always executed _after_ the run to validate has been created. This can be achieved by:
    1. Executing the module script in a separate job that is dependent upon the job that records the run (using the `requires: [job-name]` option in the config), or
    2. Executing the module script in serial with the cypress recording in the same job.
@@ -147,7 +147,7 @@ Full environment variable reference: [AWS CodeBuild environment variables](https
 
 **Prerequisites**
 
-1. The run to validate and this module's validation script are being executed within the same build.
+1. Record the Cypress run and execute this module's validation script within the same build.
 2. The module script is always executed _after_ the run to validate has been created. This can be achieved by executing the module script in serial with the cypress recording in the same build.
 
 </AccordionBlock>
@@ -165,7 +165,7 @@ Full environment variable reference: [Drone environment reference](https://docs.
 
 **Prerequisites**
 
-1. The run to validate and this module's validation script are being executed within the same build.
+1. Record the Cypress run and execute this module's validation script within the same build.
 2. The module script is always executed _after_ the run to validate has been created. This can be achieved by executing the module script in serial with the cypress recording in the same build.
 
 </AccordionBlock>
@@ -183,7 +183,7 @@ Full environment variable reference: [Bitbucket variables and secrets](https://s
 
 **Prerequisites**
 
-1. The run to validate and this module's validation script are being executed within the same build.
+1. Record the Cypress run and execute this module's validation script within the same build.
 2. The module script is always executed _after_ the run to validate has been created. This can be achieved by executing the module script in serial with the cypress recording in the same build.
 
 </AccordionBlock>
@@ -203,7 +203,7 @@ Full environment variable reference: [Buildkite environment variables](https://b
 
 **Prerequisites**
 
-1. The run to validate and this module's validation script are being executed within the same build.
+1. Record the Cypress run and execute this module's validation script within the same build.
 2. The module script is always executed _after_ the run to validate has been created. This can be achieved by executing the module script in serial with the cypress recording in the same build.
 
 </AccordionBlock>

--- a/docs/partials/_results-api-env-vars.mdx
+++ b/docs/partials/_results-api-env-vars.mdx
@@ -14,7 +14,7 @@ CYPRESS_RECORD_KEY=BBB
 GITHUB_ACTIONS=true
 GITHUB_RUN_ID=111
 GITHUB_RUN_ATTEMPT=1
-node verifyAccessibilityResults.js
+node verifyResults.js
 ```
 
 The Results API will then look for the Cypress Cloud run that matches this run ID. If there is more than one Cypress Cloud run found for that GitHub Actions Run, you can pass run tags to narrow down to one run's report.

--- a/docs/ui-coverage/faq.mdx
+++ b/docs/ui-coverage/faq.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'UI Coverage FAQ'
-description: 'Get answers to common questions about Cypress UI Coverage, including scores, view and URL grouping, element identification, grouping and filtering, iframes and shadow DOM, interaction commands, configuration, and per-run profiles.'
+description: 'Get answers to common questions about Cypress UI Coverage, including scores, view and URL grouping, element identification, grouping and filtering, iframes and shadow DOM, interaction commands, configuration, per-run profiles, and the Results API for CI.'
 sidebar_label: FAQ
 sidebar_position: 160
 ---
@@ -230,8 +230,42 @@ The most common causes are:
 
 There's no dedicated "skip this run" switch in a profile. To suppress a report for certain runs, point a profile at a deliberately narrow configuration (for example, [`viewFilters`](/ui-coverage/configuration/viewfilters) that exclude every view) so Cypress Cloud produces an empty or tightly scoped report for the run instead. See [Why use profiles?](/ui-coverage/configuration/profiles#Why-use-profiles).
 
+## Results API and CI
+
+### <Icon name="angle-right" /> How do I fail a CI build or block a pull request when UI Coverage drops?
+
+Use the [Results API](/ui-coverage/results-api). Add a step to your CI workflow that installs the `@cypress/extract-cloud-results` module and calls `getUICoverageResults()` after your Cypress run. The helper returns the run's coverage summary and per-view breakdown, and your script decides whether to fail — for example, throwing an error when `summary.coverage` is below a threshold. Because the check lives in your CI job, nothing in the Cypress run itself fails; enforcement is entirely opt-in. See [Block pull requests and set policies](/ui-coverage/guides/block-pull-requests) for a complete example.
+
+### <Icon name="angle-right" /> Do I need to install anything to use the Results API?
+
+Only in CI. Install the `@cypress/extract-cloud-results` module in your CI install step with `npm install --force https://cdn.cypress.io/extract-cloud-results/v1/extract-cloud-results.tgz`. Don't add it to your `package.json` dependencies — install it separately with `--force` so you always get the latest version, as documented in the [Results API installation steps](/ui-coverage/results-api#Installation).
+
+### <Icon name="angle-right" /> Why can't the Results API find my run?
+
+`getUICoverageResults` identifies the run from the CI environment variables present when the run was recorded, so the most common causes are:
+
+- The script runs in a **different CI build** than the one that recorded the run, or **before** the `cypress run --record` step. Run it after recording, in the same build.
+- The run was recorded **more than 7 days ago**. Only runs from the last 7 days can be identified from CI context.
+- You record **multiple runs in one CI build** but didn't pass `runTags`. Tag each run with `--tag` and pass the matching tag to `getUICoverageResults`.
+- The run was recorded on an **unsupported Cypress version**. Azure Pipelines and CircleCI require Cypress v13.13.1 or later.
+
+See [Required CI environment variables](/ui-coverage/results-api#Required-CI-environment-variables) for how each provider is matched.
+
+### <Icon name="angle-right" /> Why does the Results API say no UI Coverage report was found for my run?
+
+UI Coverage reports are generated from [Test Replay](/cloud/features/test-replay) data. If Test Replay was disabled for the run, no report is produced and the helper throws. Enable Test Replay in your project settings and record a new run.
+
+### <Icon name="angle-right" /> How do I get UI Coverage results when I record multiple runs in one CI build?
+
+Record each run with a distinct [`--tag`](/app/references/command-line#cypress-run-tag-lt-tag-gt) and pass that same tag to the helper via `runTags`. For example, `cypress run --record --tag staging` is retrieved with `getUICoverageResults({ runTags: ['staging'] })`. Without tags, Cypress can't tell the runs apart and can't return a single run's results.
+
+### <Icon name="angle-right" /> Can I see which configuration or profile produced a report?
+
+Yes. The result object includes a `config` property containing the [App Quality Config](/ui-coverage/configuration/overview) that generated the report, resolved with any [Profile](/ui-coverage/configuration/profiles) that matched the run's tags. Read `config.value` to confirm exactly which rules were in effect and `config.updatedAt` for when that configuration last changed.
+
 ## See also
 
+- [Results API](/ui-coverage/results-api) fetches a run's UI Coverage results in CI so you can enforce coverage standards.
 - [Configuration overview](/ui-coverage/configuration/overview) lists every configuration option and what each one is for.
 - [Profiles](/ui-coverage/configuration/profiles) apply different configuration to runs based on run tags.
 - [Views](/ui-coverage/core-concepts/views) explains how URLs become views and how automatic grouping works.

--- a/docs/ui-coverage/faq.mdx
+++ b/docs/ui-coverage/faq.mdx
@@ -232,6 +232,15 @@ There's no dedicated "skip this run" switch in a profile. To suppress a report f
 
 ## Results API and CI
 
+### <Icon name="angle-right" /> What are the prerequisites for using the Results API?
+
+A few conditions must hold before `getUICoverageResults` can return a report:
+
+- **Test Replay must be enabled** for the run. UI Coverage reports are built from [Test Replay](/cloud/features/test-replay) data, so a run recorded with Test Replay off has no report and the helper throws. Enable it in your project settings.
+- **Record with Cypress v13 or later.** [Azure Pipelines](/app/continuous-integration/overview#Azure-Pipelines) and [CircleCI](/app/continuous-integration/circleci) additionally require **Cypress v13.13.1 or later** to capture the CI metadata needed to identify runs.
+- **The run must have been recorded within the last 7 days.** Older runs can no longer be identified from CI context.
+- **Run the script after recording, in the same CI build**, so the run it should report on already exists.
+
 ### <Icon name="angle-right" /> How do I fail a CI build or block a pull request when UI Coverage drops?
 
 Use the [Results API](/ui-coverage/results-api). Add a step to your CI workflow that installs the `@cypress/extract-cloud-results` module and calls `getUICoverageResults()` after your Cypress run. The helper returns the run's coverage summary and per-view breakdown, and your script decides whether to fail, for example by throwing an error when `summary.coverage` is below a threshold. Because the check lives in your CI job, nothing in the Cypress run itself fails; enforcement is entirely opt-in. See [Block pull requests and set policies](/ui-coverage/guides/block-pull-requests) for a complete example.

--- a/docs/ui-coverage/faq.mdx
+++ b/docs/ui-coverage/faq.mdx
@@ -234,11 +234,11 @@ There's no dedicated "skip this run" switch in a profile. To suppress a report f
 
 ### <Icon name="angle-right" /> How do I fail a CI build or block a pull request when UI Coverage drops?
 
-Use the [Results API](/ui-coverage/results-api). Add a step to your CI workflow that installs the `@cypress/extract-cloud-results` module and calls `getUICoverageResults()` after your Cypress run. The helper returns the run's coverage summary and per-view breakdown, and your script decides whether to fail — for example, throwing an error when `summary.coverage` is below a threshold. Because the check lives in your CI job, nothing in the Cypress run itself fails; enforcement is entirely opt-in. See [Block pull requests and set policies](/ui-coverage/guides/block-pull-requests) for a complete example.
+Use the [Results API](/ui-coverage/results-api). Add a step to your CI workflow that installs the `@cypress/extract-cloud-results` module and calls `getUICoverageResults()` after your Cypress run. The helper returns the run's coverage summary and per-view breakdown, and your script decides whether to fail, for example by throwing an error when `summary.coverage` is below a threshold. Because the check lives in your CI job, nothing in the Cypress run itself fails; enforcement is entirely opt-in. See [Block pull requests and set policies](/ui-coverage/guides/block-pull-requests) for a complete example.
 
 ### <Icon name="angle-right" /> Do I need to install anything to use the Results API?
 
-Only in CI. Install the `@cypress/extract-cloud-results` module in your CI install step with `npm install --force https://cdn.cypress.io/extract-cloud-results/v1/extract-cloud-results.tgz`. Don't add it to your `package.json` dependencies — install it separately with `--force` so you always get the latest version, as documented in the [Results API installation steps](/ui-coverage/results-api#Installation).
+Only in CI. Install the `@cypress/extract-cloud-results` module in your CI install step with `npm install --force https://cdn.cypress.io/extract-cloud-results/v1/extract-cloud-results.tgz`. Don't add it to your `package.json` dependencies; install it separately with `--force` so you always get the latest version, as documented in the [Results API installation steps](/ui-coverage/results-api#Installation).
 
 ### <Icon name="angle-right" /> Why can't the Results API find my run?
 

--- a/docs/ui-coverage/faq.mdx
+++ b/docs/ui-coverage/faq.mdx
@@ -232,7 +232,7 @@ There's no dedicated "skip this run" switch in a profile. To suppress a report f
 
 ## Results API and CI
 
-### <Icon name="angle-right" /> What are the prerequisites for using the Results API?
+### <Icon name="angle-right" /> What are the prerequisites for using the Cypress UI Coverage Results API?
 
 A few conditions must hold before `getUICoverageResults` can return a report:
 
@@ -241,15 +241,15 @@ A few conditions must hold before `getUICoverageResults` can return a report:
 - **The run must have been recorded within the last 7 days.** Older runs can no longer be identified from CI context.
 - **Run the script after recording, in the same CI build**, so the run it should report on already exists.
 
-### <Icon name="angle-right" /> How do I fail a CI build or block a pull request when UI Coverage drops?
+### <Icon name="angle-right" /> How do I fail a CI build or block a pull request when Cypress UI Coverage drops?
 
 Use the [Results API](/ui-coverage/results-api). Add a step to your CI workflow that installs the `@cypress/extract-cloud-results` module and calls `getUICoverageResults()` after your Cypress run. The helper returns the run's coverage summary and per-view breakdown, and your script decides whether to fail, for example by throwing an error when `summary.coverage` is below a threshold. Because the check lives in your CI job, nothing in the Cypress run itself fails; enforcement is entirely opt-in. See [Block pull requests and set policies](/ui-coverage/guides/block-pull-requests) for a complete example.
 
-### <Icon name="angle-right" /> Do I need to install anything to use the Results API?
+### <Icon name="angle-right" /> Do I need to install anything to use the Cypress UI Coverage Results API?
 
 Only in CI. Install the `@cypress/extract-cloud-results` module in your CI install step with `npm install --force https://cdn.cypress.io/extract-cloud-results/v1/extract-cloud-results.tgz`. Don't add it to your `package.json` dependencies; install it separately with `--force` so you always get the latest version, as documented in the [Results API installation steps](/ui-coverage/results-api#Installation).
 
-### <Icon name="angle-right" /> Why can't the Results API find my run?
+### <Icon name="angle-right" /> Why can't the Cypress UI Coverage Results API find my Cypress Cloud run?
 
 `getUICoverageResults` identifies the run from the CI environment variables present when the run was recorded, so the most common causes are:
 
@@ -260,15 +260,15 @@ Only in CI. Install the `@cypress/extract-cloud-results` module in your CI insta
 
 See [Required CI environment variables](/ui-coverage/results-api#Required-CI-environment-variables) for how each provider is matched.
 
-### <Icon name="angle-right" /> Why does the Results API say no UI Coverage report was found for my run?
+### <Icon name="angle-right" /> Why does the Cypress UI Coverage Results API say no report was found for my run?
 
 UI Coverage reports are generated from [Test Replay](/cloud/features/test-replay) data. If Test Replay was disabled for the run, no report is produced and the helper throws. Enable Test Replay in your project settings and record a new run.
 
-### <Icon name="angle-right" /> How do I get UI Coverage results when I record multiple runs in one CI build?
+### <Icon name="angle-right" /> How do I get Cypress UI Coverage results when I record multiple runs in one CI build?
 
 Record each run with a distinct [`--tag`](/app/references/command-line#cypress-run-tag-lt-tag-gt) and pass that same tag to the helper via `runTags`. For example, `cypress run --record --tag staging` is retrieved with `getUICoverageResults({ runTags: ['staging'] })`. Without tags, Cypress can't tell the runs apart and can't return a single run's results.
 
-### <Icon name="angle-right" /> Can I see which configuration or profile produced a report?
+### <Icon name="angle-right" /> Can I see which App Quality configuration or profile produced a Cypress UI Coverage report?
 
 Yes. The result object includes a `config` property containing the [App Quality Config](/ui-coverage/configuration/overview) that generated the report, resolved with any [Profile](/ui-coverage/configuration/profiles) that matched the run's tags. Read `config.value` to confirm exactly which rules were in effect and `config.updatedAt` for when that configuration last changed.
 

--- a/docs/ui-coverage/results-api.mdx
+++ b/docs/ui-coverage/results-api.mdx
@@ -20,7 +20,7 @@ With the `getUICoverageResults` helper from the
 
 - **Fail a build or block a pull request** when overall coverage falls below a
   threshold, or when a critical view regresses.
-- **Enforce different standards per area** of your app — for example, require
+- **Enforce different standards per area** of your app, such as requiring
   higher coverage on `/checkout` than on marketing pages.
 - **Track regressions over time** by comparing a run against a stored baseline.
 - **Read the exact configuration** that produced a report, including any
@@ -28,7 +28,7 @@ With the `getUICoverageResults` helper from the
 
 Because reports are processed server-side from
 [Test Replay](/cloud/features/test-replay) data, using the Results API adds no
-overhead to your Cypress runs — the enforcement step is entirely opt-in and
+overhead to your Cypress runs. The enforcement step is entirely opt-in and
 lives in your CI workflow.
 
 :::info
@@ -38,8 +38,8 @@ lives in your CI workflow.
 </CalloutLabel>
 
 This page describes how the Results API works and what data it returns. For
-worked end-to-end examples — setting a policy, failing a pull request, and
-comparing against a baseline — see the
+worked end-to-end examples, such as setting a policy, failing a pull request, and
+comparing against a baseline, see the
 [Block pull requests and set policies](/ui-coverage/guides/block-pull-requests)
 guide, or [Monitor changes](/ui-coverage/guides/monitor-changes) to track
 coverage over time.
@@ -60,8 +60,8 @@ When you call `getUICoverageResults` inside a CI job, the helper:
 3. **Returns the results** as a structured object you can assert against, or
    **throws a descriptive error** if no matching run or report can be found.
 
-As it runs, the helper logs its progress to the console — the run it matched, the
-report URL, and each polling attempt — so you can follow along in your CI logs.
+As it runs, the helper logs its progress to the console (the run it matched, the
+report URL, and each polling attempt) so you can follow along in your CI logs.
 
 ### Prerequisites
 
@@ -146,7 +146,7 @@ getUICoverageResults().then((results) => {
 #### Enforce coverage thresholds
 
 This example fails the build when overall coverage drops below a baseline, and
-holds critical flows — like login and checkout — to a higher standard:
+holds critical flows like login and checkout to a higher standard:
 
 ```javascript title="scripts/verifyUICoverageResults.js"
 const { getUICoverageResults } = require('@cypress/extract-cloud-results')
@@ -325,7 +325,7 @@ An example of a returned result:
   config: {
     updatedAt: '2026-05-14T18:22:03.000Z',
     value: {
-      /* App Quality Config — see below */
+      /* App Quality Config, see below */
     },
   },
 }
@@ -336,7 +336,7 @@ An example of a returned result:
 The `config` property returns the **App Quality Config** that Cypress Cloud used
 to generate the report, resolved with any [Profile](/ui-coverage/configuration/profiles)
 that matched the run's tags. This lets your script confirm exactly which rules
-were in effect — useful when different runs use different profiles.
+were in effect, which is useful when different runs use different profiles.
 
 ```json title="App Quality Config"
 {
@@ -358,8 +358,9 @@ were in effect — useful when different runs use different profiles.
 #### Handling errors
 
 `getUICoverageResults` returns a promise that **rejects with a descriptive
-`Error`** when it can't return results — for example, when no matching run is
-found for the CI context, when the run was recorded with Test Replay disabled,
+`Error`** when it can't return results. For example, this happens when no
+matching run is found for the CI context, when the run was recorded with Test
+Replay disabled,
 or when the report is still processing after the poll window elapses. Decide
 whether that should fail your build (let the rejection surface, as in the
 examples above) or be tolerated (catch it and exit cleanly), depending on how
@@ -398,7 +399,7 @@ apply different configuration to different runs.
 
 **Example**
 
-- Imagine that within a single CI build you call `cypress run --record` twice —
+- Imagine that within a single CI build you call `cypress run --record` twice,
   once against a `staging` environment and once against `production`.
 - Pass a different `--tag` to each Cypress run:
   - `cypress run --record --tag staging`
@@ -655,7 +656,7 @@ steps:
 
 Once you can read a run's results, a common next step is to compare them against
 a stored baseline so a build fails only when **new** untested elements are
-introduced — letting you pay down existing gaps over time instead of blocking on
+introduced, letting you pay down existing gaps over time instead of blocking on
 them all at once. For complete code, the baseline structure, and best practices,
 see the
 [Block pull requests and set policies](/ui-coverage/guides/block-pull-requests#comparing-against-a-baseline)
@@ -667,7 +668,7 @@ guide.
 
 ## See also
 
-- [Block pull requests and set policies](/ui-coverage/guides/block-pull-requests) — set a coverage policy and fail a pull request when it isn't met.
-- [Monitor changes](/ui-coverage/guides/monitor-changes) — track coverage trends and catch regressions over time.
-- [Results API FAQ](/ui-coverage/faq#Results-API-and-CI) — quick answers to common Results API and CI questions.
-- [Profiles](/ui-coverage/configuration/profiles) — apply different configuration to different runs using run tags.
+- [Block pull requests and set policies](/ui-coverage/guides/block-pull-requests): set a coverage policy and fail a pull request when it isn't met.
+- [Monitor changes](/ui-coverage/guides/monitor-changes): track coverage trends and catch regressions over time.
+- [Results API FAQ](/ui-coverage/faq#Results-API-and-CI): quick answers to common Results API and CI questions.
+- [Profiles](/ui-coverage/configuration/profiles): apply different configuration to different runs using run tags.

--- a/docs/ui-coverage/results-api.mdx
+++ b/docs/ui-coverage/results-api.mdx
@@ -122,16 +122,17 @@ assumes your Project ID and Record Key are set as environment variables. It
 works in any of the supported CI providers out of the box:
 
 ```javascript title="scripts/verifyUICoverageResults.js"
-// Assuming these environment variables are set:
-// CYPRESS_PROJECT_ID=your-id
-// CYPRESS_RECORD_KEY=your-record-key
-
 const { getUICoverageResults } = require('@cypress/extract-cloud-results')
 
-getUICoverageResults().then((results) => {
-  // use `console.dir` instead of `console.log` because the data is nested
-  console.dir(results, { depth: Infinity })
-})
+getUICoverageResults()
+  .then((results) => {
+    // use `console.dir` instead of `console.log` because the data is nested
+    console.dir(results, { depth: Infinity })
+  })
+  .catch((error) => {
+    console.error(error.message)
+    process.exit(1)
+  })
 ```
 
 Once you can read the results, add your own logic to act on them. See

--- a/docs/ui-coverage/results-api.mdx
+++ b/docs/ui-coverage/results-api.mdx
@@ -110,7 +110,7 @@ changing the URL.
 
 ## Usage
 
-### 1. Write your verification script
+### Write your verification script
 
 Write a script to fetch UI Coverage results and assert your coverage criteria.
 This script runs in CI.
@@ -281,8 +281,8 @@ were in effect, which is useful when different runs use different profiles.
 
 #### Handling errors
 
-`getUICoverageResults` returns a promise that **rejects with a descriptive
-`Error`** when it can't return results. For example, this happens when no
+`getUICoverageResults` returns a promise that rejects with a descriptive
+`Error` when it can't return results. For example, this happens when no
 matching run is found for the CI context, when the run was recorded with Test
 Replay disabled,
 or when the report is still processing after the poll window elapses. Decide
@@ -290,7 +290,7 @@ whether that should fail your build (let the rejection surface, as in the
 examples above) or be tolerated (catch it and exit cleanly), depending on how
 strict you want the check to be.
 
-```javascript
+```javascript title="scripts/verifyUICoverageResults.js"
 getUICoverageResults()
   .then((results) => {
     // assert against results
@@ -303,7 +303,7 @@ getUICoverageResults()
   })
 ```
 
-### 2. Add the verification step to CI
+### Add the verification step to CI
 
 In the CI workflow that runs your Cypress tests:
 
@@ -352,7 +352,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: install
         run: npm install
       - name: Run
@@ -389,7 +389,7 @@ run-cypress:
 
 <TabItem value="Jenkins">
 
-```diff
+```diff title="Jenkinsfile"
 pipeline {
   agent {
     docker {
@@ -424,7 +424,7 @@ pipeline {
 
 <TabItem value="Azure">
 
-```diff
+```diff title="azure-pipelines.yml"
 jobs:
   - job: run_tests
     pool:
@@ -458,11 +458,11 @@ jobs:
 
 <TabItem value="CircleCI">
 
-```diff
+```diff title=".circleci/config.yml"
 version: 2.1
 
 jobs:
-  linux-test:
+  run-tests:
     docker:
       - image: cypress/base:22.15.0
 
@@ -478,7 +478,7 @@ workflows:
   version: 2
   tests:
     jobs:
-      - linux-test
+      - run-tests
 ```
 
 </TabItem>
@@ -504,7 +504,6 @@ phases:
   pre_build:
     commands:
       - npm run cypress:verify
-      - npm run cypress:info
   build:
     commands:
       - CYPRESS_PROJECT_ID=[slug] npx cypress run --record --key [KEY]
@@ -579,10 +578,7 @@ steps:
 ## Examples
 
 Each example below assumes you have written a script that calls
-`getUICoverageResults` (see [Usage](#Usage)) and wired it into CI. They throw to
-fail the CI step; in a Node.js script an uncaught rejection already exits with a
-non-zero code, but calling `process.exit(1)` explicitly makes the failure
-unambiguous across CI providers.
+`getUICoverageResults` and wired it into CI.
 
 ### Enforce coverage thresholds
 
@@ -638,7 +634,7 @@ surface a summary where your team reviews code instead of only passing or
 failing. This example writes a Markdown summary that GitHub Actions renders on
 the job:
 
-```javascript
+```javascript title="scripts/reportUICoverage.js"
 const fs = require('fs')
 const { getUICoverageResults } = require('@cypress/extract-cloud-results')
 
@@ -665,7 +661,7 @@ UI Coverage counts links (navigational elements that point at another view)
 separately from interactive elements. Use the link counts to catch pages that
 are linked but never visited:
 
-```javascript
+```javascript title="scripts/checkUntestedLinks.js"
 const { getUICoverageResults } = require('@cypress/extract-cloud-results')
 
 getUICoverageResults().then(({ summary, views }) => {
@@ -695,7 +691,7 @@ getUICoverageResults().then(({ summary, views }) => {
 A baseline compares one run to one prior run. To trend coverage across many runs
 and teams, push each run's numbers to a dashboard or data warehouse:
 
-```javascript
+```javascript title="scripts/trackCoverageTrends.js"
 const { getUICoverageResults } = require('@cypress/extract-cloud-results')
 
 getUICoverageResults().then(({ runNumber, summary }) => {
@@ -722,7 +718,7 @@ A run can be cancelled, time out, or produce a partial report. Check the run
 state first so an incomplete run warns instead of failing the build for the
 wrong reason:
 
-```javascript
+```javascript title="scripts/skipIncompleteRuns.js"
 const { getUICoverageResults } = require('@cypress/extract-cloud-results')
 
 getUICoverageResults().then((results) => {
@@ -751,7 +747,7 @@ resolved with any [Profile](/ui-coverage/configuration/profiles) that matched th
 run's tags. Assert that required rules are in effect so a misconfigured run
 doesn't silently change what's measured:
 
-```javascript
+```javascript title="scripts/assertCoverageConfig.js"
 const { getUICoverageResults } = require('@cypress/extract-cloud-results')
 
 getUICoverageResults().then(({ config }) => {
@@ -778,7 +774,7 @@ Store the last run's coverage and require the next run to meet or beat it, so th
 bar rises automatically as coverage improves. Commit the floor file so it travels
 with your code:
 
-```javascript
+```javascript title="scripts/ratchetCoverage.js"
 const fs = require('fs')
 const { getUICoverageResults } = require('@cypress/extract-cloud-results')
 

--- a/docs/ui-coverage/results-api.mdx
+++ b/docs/ui-coverage/results-api.mdx
@@ -74,23 +74,15 @@ Test Replay being enabled and a supported Cypress version. See the
 
 The Results API supports the following CI providers:
 
-<Icon name="microsoft" inline="true" /> Azure
-<br />
-<Icon name="cog" inline="true" /> CircleCI
-<br />
-<Icon name="github" inline="true" /> GitHub Actions
-<br />
-<Icon name="gitlab" inline="true" /> GitLab
-<br />
-<Icon name="jenkins" inline="true" /> Jenkins
-<br />
-<Icon name="aws" inline="true" /> AWS CodeBuild
-<br />
-<Icon name="cog" inline="true" /> Drone
-<br />
-<Icon name="bitbucket" inline="true" /> Bitbucket
-<br />
-<Icon name="cog" inline="true" /> Buildkite
+- <Icon name="microsoft" inline="true" /> Azure
+- <Icon name="cog" inline="true" /> CircleCI
+- <Icon name="github" inline="true" /> GitHub Actions
+- <Icon name="gitlab" inline="true" /> GitLab
+- <Icon name="jenkins" inline="true" /> Jenkins
+- <Icon name="aws" inline="true" /> AWS CodeBuild
+- <Icon name="cog" inline="true" /> Drone
+- <Icon name="bitbucket" inline="true" /> Bitbucket
+- <Icon name="cog" inline="true" /> Buildkite
 
 For other CI providers, contact Cypress Support at support@cypress.io to request
 support.

--- a/docs/ui-coverage/results-api.mdx
+++ b/docs/ui-coverage/results-api.mdx
@@ -74,15 +74,23 @@ Test Replay being enabled and a supported Cypress version. See the
 
 The Results API supports the following CI providers:
 
-- <Icon name="microsoft" inline="true" /> Azure
-- <Icon name="cog" inline="true" /> CircleCI
-- <Icon name="github" inline="true" /> GitHub Actions
-- <Icon name="gitlab" inline="true" /> GitLab
-- <Icon name="jenkins" inline="true" /> Jenkins
-- <Icon name="aws" inline="true" /> AWS CodeBuild
-- <Icon name="cog" inline="true" /> Drone
-- <Icon name="bitbucket" inline="true" /> Bitbucket
-- <Icon name="cog" inline="true" /> Buildkite
+<Icon name="microsoft" inline="true" /> Azure
+<br />
+<Icon name="cog" inline="true" /> CircleCI
+<br />
+<Icon name="github" inline="true" /> GitHub Actions
+<br />
+<Icon name="gitlab" inline="true" /> GitLab
+<br />
+<Icon name="jenkins" inline="true" /> Jenkins
+<br />
+<Icon name="aws" inline="true" /> AWS CodeBuild
+<br />
+<Icon name="cog" inline="true" /> Drone
+<br />
+<Icon name="bitbucket" inline="true" /> Bitbucket
+<br />
+<Icon name="cog" inline="true" /> Buildkite
 
 For other CI providers, contact Cypress Support at support@cypress.io to request
 support.

--- a/docs/ui-coverage/results-api.mdx
+++ b/docs/ui-coverage/results-api.mdx
@@ -41,7 +41,8 @@ This page describes how the Results API works and what data it returns. For
 worked end-to-end examples — setting a policy, failing a pull request, and
 comparing against a baseline — see the
 [Block pull requests and set policies](/ui-coverage/guides/block-pull-requests)
-guide.
+guide, or [Monitor changes](/ui-coverage/guides/monitor-changes) to track
+coverage over time.
 
 :::
 
@@ -58,6 +59,9 @@ When you call `getUICoverageResults` inside a CI job, the helper:
    30-second intervals, roughly 15 minutes) before returning.
 3. **Returns the results** as a structured object you can assert against, or
    **throws a descriptive error** if no matching run or report can be found.
+
+As it runs, the helper logs its progress to the console — the run it matched, the
+report URL, and each polling attempt — so you can follow along in your CI logs.
 
 ### Prerequisites
 
@@ -107,11 +111,15 @@ get the latest version.
 If you check this in as a dependency, your installation will fail when we update
 the package.
 
+The `v1` in the URL is the major-version line. Installing with `--force` always
+fetches the latest `1.x` release, so you receive fixes and improvements without
+changing the URL.
+
 :::
 
 ## Usage
 
-### **1. Write your verification script**
+### 1. Write your verification script
 
 Write a script to fetch UI Coverage results and assert your coverage criteria.
 This script runs in CI.
@@ -347,14 +355,30 @@ were in effect — useful when different runs use different profiles.
 }
 ```
 
-## Comparing against a baseline
+#### Handling errors
 
-For comprehensive examples of comparing results against a baseline — including
-complete code, baseline structure, and best practices — see the
-[Block pull requests and set policies](/ui-coverage/guides/block-pull-requests#comparing-against-a-baseline)
-guide.
+`getUICoverageResults` returns a promise that **rejects with a descriptive
+`Error`** when it can't return results — for example, when no matching run is
+found for the CI context, when the run was recorded with Test Replay disabled,
+or when the report is still processing after the poll window elapses. Decide
+whether that should fail your build (let the rejection surface, as in the
+examples above) or be tolerated (catch it and exit cleanly), depending on how
+strict you want the check to be.
 
-### **2. Add the verification step to CI**
+```javascript
+getUICoverageResults()
+  .then((results) => {
+    // assert against results
+  })
+  .catch((error) => {
+    console.error(`Could not verify UI Coverage results: ${error.message}`)
+    // Fail the build...
+    process.exit(1)
+    // ...or treat the check as non-blocking by returning without a non-zero exit.
+  })
+```
+
+### 2. Add the verification step to CI
 
 In the CI workflow that runs your Cypress tests:
 
@@ -627,6 +651,23 @@ steps:
 </TabItem>
 </Tabs>
 
+## Comparing against a baseline
+
+Once you can read a run's results, a common next step is to compare them against
+a stored baseline so a build fails only when **new** untested elements are
+introduced — letting you pay down existing gaps over time instead of blocking on
+them all at once. For complete code, the baseline structure, and best practices,
+see the
+[Block pull requests and set policies](/ui-coverage/guides/block-pull-requests#comparing-against-a-baseline)
+guide.
+
 ## Required CI environment variables
 
 <ResultsApiEnvVars />
+
+## See also
+
+- [Block pull requests and set policies](/ui-coverage/guides/block-pull-requests) — set a coverage policy and fail a pull request when it isn't met.
+- [Monitor changes](/ui-coverage/guides/monitor-changes) — track coverage trends and catch regressions over time.
+- [Results API FAQ](/ui-coverage/faq#Results-API-and-CI) — quick answers to common Results API and CI questions.
+- [Profiles](/ui-coverage/configuration/profiles) — apply different configuration to different runs using run tags.

--- a/docs/ui-coverage/results-api.mdx
+++ b/docs/ui-coverage/results-api.mdx
@@ -771,13 +771,13 @@ getUICoverageResults().then(({ config }) => {
 })
 ```
 
-### Ratchet the threshold as coverage improves
+### Raise the threshold as coverage improves
 
 Store the last run's coverage and require the next run to meet or beat it, so the
 bar rises automatically as coverage improves. Commit the floor file so it travels
 with your code:
 
-```javascript title="scripts/ratchetCoverage.js"
+```javascript title="scripts/raiseCoverageFloor.js"
 const fs = require('fs')
 const { getUICoverageResults } = require('@cypress/extract-cloud-results')
 

--- a/docs/ui-coverage/results-api.mdx
+++ b/docs/ui-coverage/results-api.mdx
@@ -70,7 +70,7 @@ A run must also meet a few conditions before a report can be found, including
 Test Replay being enabled and a supported Cypress version. See the
 [Results API FAQ](/ui-coverage/faq#Results-API-and-CI) for the full list.
 
-## Supported CI Providers
+## Supported CI providers at a glance
 
 The Results API supports the following CI providers:
 
@@ -139,7 +139,12 @@ Once you can read the results, add your own logic to act on them. See
 [Examples](#Examples) for a worked script behind each supported use case, from
 enforcing thresholds to reporting on the pull request.
 
-#### `getUICoverageResults` arguments
+### `getUICoverageResults` reference
+
+The arguments the helper accepts, the data it returns, and how it behaves on
+errors.
+
+#### Arguments
 
 `getUICoverageResults` accepts the following arguments:
 

--- a/docs/ui-coverage/results-api.mdx
+++ b/docs/ui-coverage/results-api.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'UI Coverage Results API: enforce coverage in CI'
-description: 'Programmatically fetch UI Coverage results in a CI environment and fail the build if the test coverage is not acceptable.'
+description: 'Programmatically fetch UI Coverage results in CI with @cypress/extract-cloud-results, then block pull requests or fail the build when coverage drops below your thresholds.'
 sidebar_label: Results API
 sidebar_position: 100
 ---
@@ -9,14 +9,77 @@ sidebar_position: 100
 
 # Results API
 
-The `@cypress/extract-cloud-results` module provides the `getUICoverageResults` utility to programmatically fetch UI Coverage results for a run in a CI environment. This allows you to determine if test coverage meets your requirements before merging code changes.
+UI Coverage reports are generated in Cypress Cloud after your run finishes, so
+nothing in your Cypress pipeline fails on its own when coverage drops. The
+**Results API** closes that loop: it lets you pull a run's UI Coverage results
+into your CI job and decide, in code, whether the coverage is good enough to
+merge.
+
+With the `getUICoverageResults` helper from the
+`@cypress/extract-cloud-results` module you can:
+
+- **Fail a build or block a pull request** when overall coverage falls below a
+  threshold, or when a critical view regresses.
+- **Enforce different standards per area** of your app — for example, require
+  higher coverage on `/checkout` than on marketing pages.
+- **Track regressions over time** by comparing a run against a stored baseline.
+- **Read the exact configuration** that produced a report, including any
+  [Profile](/ui-coverage/configuration/profiles) that was applied.
+
+Because reports are processed server-side from
+[Test Replay](/cloud/features/test-replay) data, using the Results API adds no
+overhead to your Cypress runs — the enforcement step is entirely opt-in and
+lives in your CI workflow.
+
+:::info
+
+<CalloutLabel icon="question-circle" color="#0097A8">
+  Examples and use cases
+</CalloutLabel>
+
+This page describes how the Results API works and what data it returns. For
+worked end-to-end examples — setting a policy, failing a pull request, and
+comparing against a baseline — see the
+[Block pull requests and set policies](/ui-coverage/guides/block-pull-requests)
+guide.
+
+:::
+
+## How it works
+
+When you call `getUICoverageResults` inside a CI job, the helper:
+
+1. **Identifies the Cypress run** for the current CI build by cross-referencing
+   the CI environment variables present when the run was recorded. See
+   [Required CI environment variables](#Required-CI-environment-variables) for
+   details.
+2. **Waits for the UI Coverage report to finish processing.** If the report is
+   still processing, the helper polls Cypress Cloud (up to 30 attempts at
+   30-second intervals, roughly 15 minutes) before returning.
+3. **Returns the results** as a structured object you can assert against, or
+   **throws a descriptive error** if no matching run or report can be found.
+
+### Prerequisites
+
+- **Test Replay must be enabled** for the run. UI Coverage reports are built
+  from Test Replay data, so a run recorded with Test Replay off has no report,
+  and the helper throws. Test Replay can be enabled in your project settings.
+- **Record with Cypress v13 or later.** Azure Pipelines and CircleCI
+  additionally require **Cypress v13.13.1 or later** to capture the CI metadata
+  needed to identify runs.
+- **Run the script after recording, within the same CI build.** The helper
+  matches the run using the current CI context, so it must execute after
+  `cypress run --record` in the same workflow.
+- **The run must have been recorded within the last 7 days.** Older runs can no
+  longer be identified from CI context.
 
 ## Supported CI Providers
 
-The utility supports the following CI providers. Refer to the linked guides for setup details:
+The Results API supports the following CI providers. Refer to the linked guides
+for general setup details:
 
 - [Azure](/app/continuous-integration/overview#Azure-Pipelines) (requires Cypress v13.13.1)
-- [CircleCI ](/app/continuous-integration/circleci)
+- [CircleCI](/app/continuous-integration/circleci) (requires Cypress v13.13.1)
 - [GitHub Actions](/app/continuous-integration/github-actions)
 - [GitLab](/app/continuous-integration/gitlab-ci)
 - [Jenkins](/app/continuous-integration/overview#Jenkins)
@@ -37,21 +100,27 @@ npm install --force https://cdn.cypress.io/extract-cloud-results/v1/extract-clou
 
 :::caution
 
-Do not check this module in as a dependency. We recommend you install it separately outside of your normal module installation. Use `--force` to get the latest version.
+Do not check this module in as a dependency. We recommend you install it
+separately, outside of your normal module installation, and use `--force` to
+get the latest version.
 
-If you check this in as a dependency, your installation will fail when we update the package.
+If you check this in as a dependency, your installation will fail when we update
+the package.
 
 :::
 
 ## Usage
 
-### **1. Get the UI Coverage Results**
+### **1. Write your verification script**
 
-Write a script to fetch UI Coverage results and assert test coverage criteria. This script will be executed in CI.
+Write a script to fetch UI Coverage results and assert your coverage criteria.
+This script runs in CI.
 
 #### Basic example
 
-This snippet uses the `getUICoverageResults()` helper to log out the results. It assumes your Project ID and Record Key variable are set. The following should work in any of the supported CI Providers out of the box:
+This snippet uses the `getUICoverageResults()` helper to log out the results. It
+assumes your Project ID and Record Key are set as environment variables. It
+works in any of the supported CI providers out of the box:
 
 ```javascript title="scripts/verifyUICoverageResults.js"
 // Assuming these environment variables are set:
@@ -66,35 +135,36 @@ getUICoverageResults().then((results) => {
 })
 ```
 
-#### How to assert test coverage meets your requirements
+#### Enforce coverage thresholds
 
-The following example demonstrates how to verify that test coverage meets minimum thresholds:
+This example fails the build when overall coverage drops below a baseline, and
+holds critical flows — like login and checkout — to a higher standard:
 
 ```javascript title="scripts/verifyUICoverageResults.js"
 const { getUICoverageResults } = require('@cypress/extract-cloud-results')
 
 getUICoverageResults({
-  projectId: process.env.CYPRESS_PROJECT_ID, // Optional if set from env
-  recordKey: process.env.CYPRESS_RECORD_KEY, // Optional if set from env
-  runTags: [process.env.RUN_TAGS], // Required if recording multiple runs
+  projectId: process.env.CYPRESS_PROJECT_ID, // optional if set from env
+  recordKey: process.env.CYPRESS_RECORD_KEY, // optional if set from env
+  runTags: ['production'], // required if recording multiple runs in one CI build
 }).then((results) => {
   const { runNumber, uiCoverageReportUrl, summary, views } = results
 
   console.log(
-    `Received ${summary.isPartialReport ? 'partial' : ''} results for run #${runNumber}.`
+    `Received ${summary.isPartialReport ? 'partial ' : ''}results for run #${runNumber}.`
   )
-  console.log(`See full report at ${uiCoverageReportUrl}.`)
+  console.log(`See the full report at ${uiCoverageReportUrl}`)
 
-  // Verify overall coverage
+  // Fail the build if overall coverage is below 80%.
   if (summary.coverage < 80) {
     throw new Error(
-      `Project coverage is ${summary.coverage}, below the minimum threshold of 80%.`
+      `Project coverage is ${summary.coverage}%, below the minimum threshold of 80%.`
     )
   }
 
+  // Hold critical flows to a higher standard.
   const criticalViews = [/login/, /checkout/]
 
-  // Verify critical view coverage
   views.forEach((view) => {
     const { displayName, coverage, uiCoverageReportUrl } = view
 
@@ -108,104 +178,215 @@ getUICoverageResults({
     }
   })
 
-  console.log('UI Coverage is above minimum thresholds.')
+  console.log('UI Coverage meets all thresholds.')
 })
 ```
 
+:::tip
+
+The example above throws to fail the CI step. In a Node.js script an uncaught
+rejection already exits with a non-zero code, but calling `process.exit(1)`
+explicitly (as in the [baseline comparison example](/ui-coverage/guides/block-pull-requests#comparing-against-a-baseline))
+makes the failure unambiguous across CI providers.
+
+:::
+
 #### `getUICoverageResults` arguments
 
-`getUICoverageResults` accpets the following arguments:
+`getUICoverageResults` accepts the following arguments:
 
 ```javascript
 getUICoverageResults({
   // The Cypress project ID.
-  // Optional if the CYPRESS_PROJECT_ID env is set
+  // Optional if the CYPRESS_PROJECT_ID env var is set.
   projectId: string
   // The project's record key.
-  // Optional if the CYPRESS_RECORD_KEY env is set
+  // Optional if the CYPRESS_RECORD_KEY env var is set.
   recordKey: string
   // The run tags associated with the run.
-  // Required IF you are recording multiple Cypress runs from a single CI build.
-  // Pass the run tags you used when recording in each run
+  // Required IF you record multiple Cypress runs from a single CI build.
+  // Pass the same tags you used when recording each run.
+  // A single tag can also be provided via the CYPRESS_RUN_TAG env var.
   runTags: string[]
 })
 ```
 
-#### Result Details
+#### Result properties
 
-The `getUICoverageResults` utility returns the following data:
+`getUICoverageResults` resolves with the following data. A **link** is a
+navigational element (such as an anchor) that points at another view;
+**elements** are the interactive controls counted toward coverage.
 
 ```javascript
 {
   // The run number of the identified build.
   runNumber: number
-  // The run url for the identified build.
+  // The run URL for the identified build.
   runUrl: 'https://cloud.cypress.io/projects/:project_id/runs/:run_number'
   // The status of the identified build.
-  runStatus: 'passed' | 'failed' | 'errored' | 'timedOut' | 'cancelled' | 'noTests'
-   // The url that links to UI Coverage report for the identified build.
+  runStatus: 'passed' | 'failed' | 'errored' | 'timedOut' | 'cancelled' | 'noTests' | 'running' | 'overLimit'
+  // The URL that links to the UI Coverage report for the identified build.
   uiCoverageReportUrl: 'https://cloud.cypress.io/[...]'
   summary: {
-    // Indicates whether a complete UI Coverage report was generated.
-    // For example, if a run was cancelled and the report expected to run
-    // for 20 specs, but only 10 ran, this would result in a partial report.
+    // Whether a complete UI Coverage report was generated.
+    // For example, if a run was cancelled and the report was expected to
+    // cover 20 specs but only 10 ran, this would be a partial report.
     isPartialReport: boolean
-    // The report coverage from 0-100 with 2 decimal precision (e.g 92.45).
+    // The report coverage from 0-100 with 2-decimal precision (e.g. 92.45).
     coverage: number
     // The number of views tested and analyzed.
     viewCount: number
     // The number of interactive elements that were tested.
-    testedElementsCount:number
+    testedElementsCount: number
     // The number of interactive elements that were not tested.
     untestedElementsCount: number
+    // The number of links that were tested (visited).
+    testedLinksCount: number
+    // The number of links that were not tested (never visited).
+    untestedLinksCount: number
   }
-  // The list of tested views and the coverage of each page.
+  // The list of tested views and the coverage of each.
   views: [{
-    // The sanatized URL pattern shown in the report.
+    // The sanitized URL pattern shown in the report.
     displayName: string
-    // The view coverage from 0-100 with 2 decimal precision (e.g 92.45).
+    // The view coverage from 0-100 with 2-decimal precision (e.g. 92.45).
     coverage: number
     // The number of interactive elements that were tested on this view.
-    testedElementsCount:number
+    testedElementsCount: number
     // The number of interactive elements that were not tested on this view.
     untestedElementsCount: number
-    // The url that links the report for this view.
+    // The number of links that were tested (visited) on this view.
+    testedLinksCount: number
+    // The number of links that were not tested (never visited) on this view.
+    untestedLinksCount: number
+    // The URL that links to the report for this view.
     uiCoverageReportUrl: 'https://cloud.cypress.io/[...]'
   }]
+  // The App Quality configuration that produced this report.
+  // Present when configuration exists for the project.
+  config: {
+    // ISO 8601 timestamp of when the configuration was last updated.
+    updatedAt: string
+    // The resolved configuration value, including any Profile applied
+    // to this run via run tags. See the example below.
+    value: object
+  }
+}
+```
+
+An example of a returned result:
+
+```javascript
+{
+  runNumber: 68086,
+  runUrl: 'https://cloud.cypress.io/projects/ypt4pf/runs/68086',
+  runStatus: 'passed',
+  uiCoverageReportUrl:
+    'https://cloud.cypress.io/projects/ypt4pf/runs/68086/ui-coverage',
+  summary: {
+    isPartialReport: false,
+    coverage: 87.42,
+    viewCount: 12,
+    testedElementsCount: 145,
+    untestedElementsCount: 21,
+    testedLinksCount: 34,
+    untestedLinksCount: 8,
+  },
+  views: [
+    {
+      displayName: '/checkout',
+      coverage: 94.12,
+      testedElementsCount: 32,
+      untestedElementsCount: 2,
+      testedLinksCount: 5,
+      untestedLinksCount: 0,
+      uiCoverageReportUrl:
+        'https://cloud.cypress.io/projects/ypt4pf/runs/68086/ui-coverage/view/checkout',
+    },
+    {
+      displayName: '/products/*',
+      coverage: 78.95,
+      testedElementsCount: 15,
+      untestedElementsCount: 4,
+      testedLinksCount: 9,
+      untestedLinksCount: 3,
+      uiCoverageReportUrl:
+        'https://cloud.cypress.io/projects/ypt4pf/runs/68086/ui-coverage/view/products',
+    },
+  ],
+  config: {
+    updatedAt: '2026-05-14T18:22:03.000Z',
+    value: {
+      /* App Quality Config — see below */
+    },
+  },
+}
+```
+
+#### Reading the applied configuration
+
+The `config` property returns the **App Quality Config** that Cypress Cloud used
+to generate the report, resolved with any [Profile](/ui-coverage/configuration/profiles)
+that matched the run's tags. This lets your script confirm exactly which rules
+were in effect — useful when different runs use different profiles.
+
+```json title="App Quality Config"
+{
+  "viewFilters": [{ "pattern": "/admin/*", "include": false }],
+  "uiCoverage": {
+    "elementFilters": [{ "selector": ".cookie-banner *", "include": false }]
+  },
+  "profiles": [
+    {
+      "name": "production",
+      "config": {
+        "viewFilters": [{ "pattern": "/internal/*", "include": false }]
+      }
+    }
+  ]
 }
 ```
 
 ## Comparing against a baseline
 
-For comprehensive examples of comparing results against a baseline, including complete code examples, baseline structure, and best practices, see the [Block pull requests and set policies](/ui-coverage/guides/block-pull-requests#comparing-against-a-baseline) guide.
+For comprehensive examples of comparing results against a baseline — including
+complete code, baseline structure, and best practices — see the
+[Block pull requests and set policies](/ui-coverage/guides/block-pull-requests#comparing-against-a-baseline)
+guide.
 
-### **2. Add to CI Workflow**
+### **2. Add the verification step to CI**
 
-In your CI workflow that runs your Cypress tests,
+In the CI workflow that runs your Cypress tests:
 
-1. Update your install job to install the `@cypress/extract-cloud-results` module.
-2. Pass in the necessary arguments to `getUICoverageResults`.
-3. Add a new step to the job that runs your Cypress tests to verify the UI Coverage results.
+1. Update your install step to install the `@cypress/extract-cloud-results` module.
+2. Pass any necessary arguments to `getUICoverageResults`.
+3. Add a step, after your Cypress run, that executes your verification script.
 
 :::info
 
-If you record multiple runs in a single CI build, you must record these runs using the `--tag` parameter and then call `getUICoverageResults` with the `runTags` argument for each run.
+If you record multiple runs in a single CI build, you must record each run with
+the `--tag` parameter and then call `getUICoverageResults` with the matching
+`runTags` argument for each run.
 
-This is necessary to identify each unique run and return a corresponding set of results. The tags are how each run is uniquely identified. Tags can also be used to activate [Profiles](/ui-coverage/configuration/profiles) that apply different configuration settings to your runs.
+This is how each run is uniquely identified so the correct results are returned.
+Tags can also activate [Profiles](/ui-coverage/configuration/profiles) that
+apply different configuration to different runs.
 
 **Example**
 
-- Let's imagine that within a single CI build you call `cypress run --record` multiple times because you're running one set of tests against a `staging` environment, followed by a `production` environment.
-- In this scenario, you pass a different `--tag` to each cypress run
+- Imagine that within a single CI build you call `cypress run --record` twice —
+  once against a `staging` environment and once against `production`.
+- Pass a different `--tag` to each Cypress run:
   - `cypress run --record --tag staging`
   - `cypress run --record --tag production`
-- When calling `getUICoverageResults` you would then pass these same tags to get the unique set of results for each run
-  - `getUICoverageResults({ runTags: ['staging']})`
-  - `getUICoverageResults({ runTags: ['production']})`
+- When calling `getUICoverageResults`, pass the same tags to get the results for
+  each run:
+  - `getUICoverageResults({ runTags: ['staging'] })`
+  - `getUICoverageResults({ runTags: ['production'] })`
 
 :::
 
-#### Example Job Workflow Update:
+#### Example workflow updates
 
 <Tabs groupId="ui-cov-results-api">
 <TabItem value="GitHub Actions" active>
@@ -237,9 +418,7 @@ jobs:
 
 <TabItem value="GitLab">
 
-```diff title=".git-ci.yml"
-name: Run Cypress Tests
-
+```diff title=".gitlab-ci.yml"
 image: node:latest
 
 stages:
@@ -270,7 +449,7 @@ pipeline {
   }
 
   environment {
-    CYPRESS_PROJECT_ID: 'xxxx'
+    CYPRESS_PROJECT_ID = 'xxxx'
     CYPRESS_RECORD_KEY = credentials('cypress-record-key')
   }
 
@@ -342,15 +521,15 @@ jobs:
     steps:
       - checkout
       - run: npm install
-      - run: npx run cypress:run --record
-+     - run: npm install --force https://cdn.cypress.io/extract-cloud-results/beta/v1/extract-cloud-results.tgz
+      - run: npx cypress run --record
++     - run: npm install --force https://cdn.cypress.io/extract-cloud-results/v1/extract-cloud-results.tgz
 +     - run: node ./scripts/verifyUICoverageResults.js
 
 workflows:
   version: 2
   tests:
     jobs:
-      - run-cypress
+      - linux-test
 ```
 
 </TabItem>
@@ -379,11 +558,11 @@ phases:
       - npm run cypress:info
   build:
     commands:
-      - CYPRESS_INTERNAL_ENV=staging CYPRESS_PROJECT_ID=[slug] npx cypress run --record --key [KEY]
+      - CYPRESS_PROJECT_ID=[slug] npx cypress run --record --key [KEY]
 +  post_build:
 +    commands:
 +      - npm install --force https://cdn.cypress.io/extract-cloud-results/v1/extract-cloud-results.tgz
-+      - CYPRESS_INTERNAL_ENV=staging CYPRESS_PROJECT_ID=[slug] CYPRESS_RECORD_KEY=[KEY] node ./scripts/verifyUICoverageResults.js
++      - CYPRESS_PROJECT_ID=[slug] CYPRESS_RECORD_KEY=[KEY] node ./scripts/verifyUICoverageResults.js
 ```
 
 </TabItem>
@@ -451,4 +630,3 @@ steps:
 ## Required CI environment variables
 
 <ResultsApiEnvVars />
-```

--- a/docs/ui-coverage/results-api.mdx
+++ b/docs/ui-coverage/results-api.mdx
@@ -100,7 +100,10 @@ support.
 
 Install the `@cypress/extract-cloud-results` module in your install step in CI.
 
-<PackageManagerTabs install="--force https://cdn.cypress.io/extract-cloud-results/v1/extract-cloud-results.tgz" />
+<PackageManagerTabs
+  install="--force https://cdn.cypress.io/extract-cloud-results/v1/extract-cloud-results.tgz"
+  exclude="bun"
+/>
 
 :::caution
 

--- a/docs/ui-coverage/results-api.mdx
+++ b/docs/ui-coverage/results-api.mdx
@@ -562,15 +562,21 @@ configuration to different runs.
 
 For example, imagine that within a single CI build you call
 `cypress run --record` twice, once against a `staging` environment and once
-against `production`:
+against `production`.
 
-- Pass a different `--tag` to each Cypress run:
-  - `cypress run --record --tag staging`
-  - `cypress run --record --tag production`
-- When calling `getUICoverageResults`, pass the same tags to get the results for
-  each run:
-  - `getUICoverageResults({ runTags: ['staging'] })`
-  - `getUICoverageResults({ runTags: ['production'] })`
+Pass a different `--tag` to each Cypress run:
+
+<CypressCommandTabs
+  command={'run --record --tag staging\nrun --record --tag production'}
+/>
+
+When calling `getUICoverageResults`, pass the same tags to get the results for
+each run:
+
+```javascript
+getUICoverageResults({ runTags: ['staging'] })
+getUICoverageResults({ runTags: ['production'] })
+```
 
 ## Examples
 

--- a/docs/ui-coverage/results-api.mdx
+++ b/docs/ui-coverage/results-api.mdx
@@ -348,16 +348,16 @@ env:
   CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
 
 jobs:
-  run-cypress:
+  run-tests:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v7
       - name: install
         run: npm install
-      - name: Run
+      - name: Run Cypress tests
         run: npx cypress run --record
-+     - name: Verify UI Coverage Results
++     - name: Get Cypress UI Coverage
 +       run: |
 +          npm install --force https://cdn.cypress.io/extract-cloud-results/v1/extract-cloud-results.tgz
 +          node ./scripts/verifyUICoverageResults.js
@@ -373,7 +373,7 @@ image: node:latest
 stages:
   - test
 
-run-cypress:
+run-tests:
   stage: test
   secrets:
     CYPRESS_RECORD_KEY:
@@ -403,14 +403,14 @@ pipeline {
   }
 
   stages {
-    stage('build and test') {
+    stage('Run Cypress tests') {
       steps {
         sh 'npm ci'
         sh 'npx cypress run --record'
       }
     }
 
-+   stage('Verify UI Coverage Results') {
++   stage('Get Cypress UI Coverage') {
 +     steps {
 +       sh 'npm install --force https://cdn.cypress.io/extract-cloud-results/v1/extract-cloud-results.tgz'
 +       sh 'node ./scripts/verifyUICoverageResults.js'
@@ -448,7 +448,7 @@ jobs:
 +     - script: |
 +           npm install --force https://cdn.cypress.io/extract-cloud-results/v1/extract-cloud-results.tgz
 +           node ./scripts/verifyUICoverageResults.js
-+       displayName: 'Verify UI Coverage Results'
++       displayName: 'Get Cypress UI Coverage'
 +       env:
 +         CYPRESS_PROJECT_ID: $(CYPRESS_PROJECT_ID)
 +         CYPRESS_RECORD_KEY: $(CYPRESS_RECORD_KEY)
@@ -527,13 +527,13 @@ from_secret: example_record_key_secret
 
 steps:
 
-- name: test
+- name: Run Cypress tests
   image: node:latest
   commands:
   - npm install
   - npx cypress run --record
 
-* - name: validate
+* - name: Get Cypress UI Coverage
 * image: node:latest
 * commands:
 * - npm install --force https://cdn.cypress.io/extract-cloud-results/v1/extract-cloud-results.tgz

--- a/docs/ui-coverage/results-api.mdx
+++ b/docs/ui-coverage/results-api.mdx
@@ -311,30 +311,6 @@ In the CI workflow that runs your Cypress tests:
 2. Pass any necessary arguments to `getUICoverageResults`.
 3. Add a step, after your Cypress run, that executes your verification script.
 
-:::info
-
-If you record multiple runs in a single CI build, you must record each run with
-the `--tag` parameter and then call `getUICoverageResults` with the matching
-`runTags` argument for each run.
-
-This is how each run is uniquely identified so the correct results are returned.
-Tags can also activate [Profiles](/ui-coverage/configuration/profiles) that
-apply different configuration to different runs.
-
-**Example**
-
-- Imagine that within a single CI build you call `cypress run --record` twice,
-  once against a `staging` environment and once against `production`.
-- Pass a different `--tag` to each Cypress run:
-  - `cypress run --record --tag staging`
-  - `cypress run --record --tag production`
-- When calling `getUICoverageResults`, pass the same tags to get the results for
-  each run:
-  - `getUICoverageResults({ runTags: ['staging'] })`
-  - `getUICoverageResults({ runTags: ['production'] })`
-
-:::
-
 #### Example workflow updates
 
 <Tabs groupId="ui-cov-results-api">
@@ -574,6 +550,27 @@ steps:
 
 </TabItem>
 </Tabs>
+
+### Recording multiple runs in one CI build
+
+If you record multiple runs in a single CI build, you must record each run with
+the `--tag` parameter and then call `getUICoverageResults` with the matching
+`runTags` argument for each run. This is how each run is uniquely identified so
+the correct results are returned. Tags can also activate
+[Profiles](/ui-coverage/configuration/profiles) that apply different
+configuration to different runs.
+
+For example, imagine that within a single CI build you call
+`cypress run --record` twice, once against a `staging` environment and once
+against `production`:
+
+- Pass a different `--tag` to each Cypress run:
+  - `cypress run --record --tag staging`
+  - `cypress run --record --tag production`
+- When calling `getUICoverageResults`, pass the same tags to get the results for
+  each run:
+  - `getUICoverageResults({ runTags: ['staging'] })`
+  - `getUICoverageResults({ runTags: ['production'] })`
 
 ## Examples
 

--- a/docs/ui-coverage/results-api.mdx
+++ b/docs/ui-coverage/results-api.mdx
@@ -38,21 +38,6 @@ Because reports are processed server-side from
 overhead to your Cypress runs. The enforcement step is entirely opt-in and
 lives in your CI workflow.
 
-:::info
-
-<CalloutLabel icon="question-circle" color="#0097A8">
-  Examples and use cases
-</CalloutLabel>
-
-This page describes how the Results API works and what data it returns. For
-worked end-to-end examples, such as setting a policy, failing a pull request, and
-comparing against a baseline, see the
-[Block pull requests and set policies](/ui-coverage/guides/block-pull-requests)
-guide, or [Monitor changes](/ui-coverage/guides/monitor-changes) to track
-coverage over time.
-
-:::
-
 ## How it works
 
 When you call `getUICoverageResults` inside a CI job, the helper:
@@ -67,22 +52,23 @@ When you call `getUICoverageResults` inside a CI job, the helper:
 3. **Returns the results** as a structured object you can assert against, or
    **throws a descriptive error** if no matching run or report can be found.
 
-As it runs, the helper logs its progress to the console (the run it matched, the
-report URL, and each polling attempt) so you can follow along in your CI logs.
+Because the helper matches the run from the current CI context, call it **after
+`cypress run --record` completes within the same CI build**, so the run it should
+report on already exists.
 
-### Prerequisites
+As it runs, the helper logs its progress to the console so you can follow along
+in your CI logs:
 
-- **Test Replay must be enabled** for the run. UI Coverage reports are built
-  from Test Replay data, so a run recorded with Test Replay off has no report,
-  and the helper throws. Test Replay can be enabled in your project settings.
-- **Record with Cypress v13 or later.** Azure Pipelines and CircleCI
-  additionally require **Cypress v13.13.1 or later** to capture the CI metadata
-  needed to identify runs.
-- **Run the script after recording, within the same CI build.** The helper
-  matches the run using the current CI context, so it must execute after
-  `cypress run --record` in the same workflow.
-- **The run must have been recorded within the last 7 days.** Older runs can no
-  longer be identified from CI context.
+```shell
+Cypress found run #68086 (https://cloud.cypress.io/projects/ypt4pf/runs/68086) associated with this CI workflow.
+Cypress is fetching the UI Coverage report for run #68086.
+Cypress found a UI Coverage report for run #68086 that is still processing. 8 of 12 specs have been processed. Cypress will fetch again in 30 seconds [Attempt 1 of 30]
+Cypress found a UI Coverage report for run #68086 (https://cloud.cypress.io/projects/ypt4pf/runs/68086/ui-coverage).
+```
+
+A run must also meet a few conditions before a report can be found, including
+Test Replay being enabled and a supported Cypress version. See the
+[Results API FAQ](/ui-coverage/faq#Results-API-and-CI) for the full list.
 
 ## Supported CI Providers
 
@@ -99,24 +85,20 @@ for general setup details:
 - [Bitbucket](/app/continuous-integration/bitbucket-pipelines)
 - Buildkite
 
-For other CI providers, contact Cypress Support to request support.
+For other CI providers, contact Cypress Support at support@cypress.io to request
+support.
 
 ## Installation
 
 Install the `@cypress/extract-cloud-results` module in your install step in CI.
 
-```shell
-npm install --force https://cdn.cypress.io/extract-cloud-results/v1/extract-cloud-results.tgz
-```
+<PackageManagerTabs install="--force https://cdn.cypress.io/extract-cloud-results/v1/extract-cloud-results.tgz" />
 
 :::caution
 
 Do not check this module in as a dependency. We recommend you install it
 separately, outside of your normal module installation, and use `--force` to
 get the latest version.
-
-If you check this in as a dependency, your installation will fail when we update
-the package.
 
 The `v1` in the URL is the major-version line. Installing with `--force` always
 fetches the latest `1.x` release, so you receive fixes and improvements without

--- a/docs/ui-coverage/results-api.mdx
+++ b/docs/ui-coverage/results-api.mdx
@@ -22,9 +22,16 @@ With the `getUICoverageResults` helper from the
   threshold, or when a critical view regresses.
 - **Enforce different standards per area** of your app, such as requiring
   higher coverage on `/checkout` than on marketing pages.
-- **Track regressions over time** by comparing a run against a stored baseline.
-- **Read the exact configuration** that produced a report, including any
-  [Profile](/ui-coverage/configuration/profiles) that was applied.
+- **Surface results where your team works** by posting the coverage score and a
+  deep link to the report on the pull request or in Slack.
+- **Catch navigation gaps** by flagging pages that are linked but never visited,
+  using the tested and untested link counts.
+- **Track regressions over time** by comparing a run against a stored baseline,
+  or by trending results in a dashboard.
+- **Read and assert the applied configuration**, including any
+  [Profile](/ui-coverage/configuration/profiles) that produced the report.
+
+See [Examples](#Examples) for a worked script behind each of these.
 
 Because reports are processed server-side from
 [Test Replay](/cloud/features/test-replay) data, using the Results API adds no
@@ -143,61 +150,9 @@ getUICoverageResults().then((results) => {
 })
 ```
 
-#### Enforce coverage thresholds
-
-This example fails the build when overall coverage drops below a baseline, and
-holds critical flows like login and checkout to a higher standard:
-
-```javascript title="scripts/verifyUICoverageResults.js"
-const { getUICoverageResults } = require('@cypress/extract-cloud-results')
-
-getUICoverageResults({
-  projectId: process.env.CYPRESS_PROJECT_ID, // optional if set from env
-  recordKey: process.env.CYPRESS_RECORD_KEY, // optional if set from env
-  runTags: ['production'], // required if recording multiple runs in one CI build
-}).then((results) => {
-  const { runNumber, uiCoverageReportUrl, summary, views } = results
-
-  console.log(
-    `Received ${summary.isPartialReport ? 'partial ' : ''}results for run #${runNumber}.`
-  )
-  console.log(`See the full report at ${uiCoverageReportUrl}`)
-
-  // Fail the build if overall coverage is below 80%.
-  if (summary.coverage < 80) {
-    throw new Error(
-      `Project coverage is ${summary.coverage}%, below the minimum threshold of 80%.`
-    )
-  }
-
-  // Hold critical flows to a higher standard.
-  const criticalViews = [/login/, /checkout/]
-
-  views.forEach((view) => {
-    const { displayName, coverage, uiCoverageReportUrl } = view
-
-    if (
-      criticalViews.some((pattern) => pattern.test(displayName)) &&
-      coverage < 95
-    ) {
-      throw new Error(
-        `Critical view "${displayName}" coverage is ${coverage}%, below the required 95%. See: ${uiCoverageReportUrl}`
-      )
-    }
-  })
-
-  console.log('UI Coverage meets all thresholds.')
-})
-```
-
-:::tip
-
-The example above throws to fail the CI step. In a Node.js script an uncaught
-rejection already exits with a non-zero code, but calling `process.exit(1)`
-explicitly (as in the [baseline comparison example](/ui-coverage/guides/block-pull-requests#comparing-against-a-baseline))
-makes the failure unambiguous across CI providers.
-
-:::
+Once you can read the results, add your own logic to act on them. See
+[Examples](#Examples) for a worked script behind each supported use case, from
+enforcing thresholds to reporting on the pull request.
 
 #### `getUICoverageResults` arguments
 
@@ -652,13 +607,234 @@ steps:
 </TabItem>
 </Tabs>
 
-## Comparing against a baseline
+## Examples
 
-Once you can read a run's results, a common next step is to compare them against
-a stored baseline so a build fails only when **new** untested elements are
-introduced, letting you pay down existing gaps over time instead of blocking on
-them all at once. For complete code, the baseline structure, and best practices,
-see the
+Each example below assumes you have written a script that calls
+`getUICoverageResults` (see [Usage](#Usage)) and wired it into CI. They throw to
+fail the CI step; in a Node.js script an uncaught rejection already exits with a
+non-zero code, but calling `process.exit(1)` explicitly makes the failure
+unambiguous across CI providers.
+
+### Enforce coverage thresholds
+
+Fail the build when overall coverage drops below a floor, and hold critical
+flows like login and checkout to a higher standard:
+
+```javascript title="scripts/verifyUICoverageResults.js"
+const { getUICoverageResults } = require('@cypress/extract-cloud-results')
+
+getUICoverageResults({
+  projectId: process.env.CYPRESS_PROJECT_ID, // optional if set from env
+  recordKey: process.env.CYPRESS_RECORD_KEY, // optional if set from env
+  runTags: ['production'], // required if recording multiple runs in one CI build
+}).then((results) => {
+  const { runNumber, uiCoverageReportUrl, summary, views } = results
+
+  console.log(
+    `Received ${summary.isPartialReport ? 'partial ' : ''}results for run #${runNumber}.`
+  )
+  console.log(`See the full report at ${uiCoverageReportUrl}`)
+
+  // Fail the build if overall coverage is below 80%.
+  if (summary.coverage < 80) {
+    throw new Error(
+      `Project coverage is ${summary.coverage}%, below the minimum threshold of 80%.`
+    )
+  }
+
+  // Hold critical flows to a higher standard.
+  const criticalViews = [/login/, /checkout/]
+
+  views.forEach((view) => {
+    const { displayName, coverage, uiCoverageReportUrl } = view
+
+    if (
+      criticalViews.some((pattern) => pattern.test(displayName)) &&
+      coverage < 95
+    ) {
+      throw new Error(
+        `Critical view "${displayName}" coverage is ${coverage}%, below the required 95%. See: ${uiCoverageReportUrl}`
+      )
+    }
+  })
+
+  console.log('UI Coverage meets all thresholds.')
+})
+```
+
+### Report coverage on the pull request
+
+Every result carries the coverage numbers and deep-link report URLs, so you can
+surface a summary where your team reviews code instead of only passing or
+failing. This example writes a Markdown summary that GitHub Actions renders on
+the job:
+
+```javascript
+const fs = require('fs')
+const { getUICoverageResults } = require('@cypress/extract-cloud-results')
+
+getUICoverageResults().then(({ summary, views, uiCoverageReportUrl }) => {
+  const rows = views
+    .map((view) => `| ${view.displayName} | ${view.coverage}% |`)
+    .join('\n')
+
+  const markdown = `## UI Coverage: ${summary.coverage}%
+
+[View the full report](${uiCoverageReportUrl})
+
+| View | Coverage |
+| ---- | -------- |
+${rows}`
+
+  fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, markdown)
+})
+```
+
+### Fail on untested navigation links
+
+UI Coverage counts links (navigational elements that point at another view)
+separately from interactive elements. Use the link counts to catch pages that
+are linked but never visited:
+
+```javascript
+const { getUICoverageResults } = require('@cypress/extract-cloud-results')
+
+getUICoverageResults().then(({ summary, views }) => {
+  if (summary.untestedLinksCount === 0) {
+    return
+  }
+
+  console.log(
+    `${summary.untestedLinksCount} linked page(s) were never visited:`
+  )
+  views
+    .filter((view) => view.untestedLinksCount > 0)
+    .forEach((view) => {
+      console.log(
+        `  ${view.displayName}: ${view.untestedLinksCount} untested link(s)`
+      )
+    })
+
+  throw new Error(
+    'New navigation paths are untested. Add tests that follow them.'
+  )
+})
+```
+
+### Track coverage trends over time
+
+A baseline compares one run to one prior run. To trend coverage across many runs
+and teams, push each run's numbers to a dashboard or data warehouse:
+
+```javascript
+const { getUICoverageResults } = require('@cypress/extract-cloud-results')
+
+getUICoverageResults().then(({ runNumber, summary }) => {
+  const metrics = {
+    runNumber,
+    coverage: summary.coverage,
+    testedElements: summary.testedElementsCount,
+    untestedElements: summary.untestedElementsCount,
+    viewCount: summary.viewCount,
+  }
+
+  // Send to your metrics service, warehouse, or observability tool.
+  return fetch('https://metrics.example.com/ui-coverage', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(metrics),
+  })
+})
+```
+
+### Skip enforcement for partial or non-passing runs
+
+A run can be cancelled, time out, or produce a partial report. Check the run
+state first so an incomplete run warns instead of failing the build for the
+wrong reason:
+
+```javascript
+const { getUICoverageResults } = require('@cypress/extract-cloud-results')
+
+getUICoverageResults().then((results) => {
+  const { runStatus, summary } = results
+
+  if (runStatus !== 'passed' && runStatus !== 'failed') {
+    console.warn(
+      `Run status is "${runStatus}". Skipping UI Coverage enforcement.`
+    )
+    return
+  }
+
+  if (summary.isPartialReport) {
+    console.warn('Report is partial. Skipping UI Coverage enforcement.')
+    return
+  }
+
+  // ...enforce your thresholds here.
+})
+```
+
+### Assert the applied configuration
+
+The `config` property returns the App Quality Config that produced the report,
+resolved with any [Profile](/ui-coverage/configuration/profiles) that matched the
+run's tags. Assert that required rules are in effect so a misconfigured run
+doesn't silently change what's measured:
+
+```javascript
+const { getUICoverageResults } = require('@cypress/extract-cloud-results')
+
+getUICoverageResults().then(({ config }) => {
+  if (!config) {
+    throw new Error('No App Quality Config was applied to this run.')
+  }
+
+  const elementFilters = config.value.uiCoverage?.elementFilters ?? []
+  const hasCookieBannerFilter = elementFilters.some((filter) =>
+    filter.selector?.includes('cookie-banner')
+  )
+
+  if (!hasCookieBannerFilter) {
+    throw new Error('Expected the cookie-banner element filter to be applied.')
+  }
+
+  console.log(`Configuration last updated ${config.updatedAt}.`)
+})
+```
+
+### Ratchet the threshold as coverage improves
+
+Store the last run's coverage and require the next run to meet or beat it, so the
+bar rises automatically as coverage improves. Commit the floor file so it travels
+with your code:
+
+```javascript
+const fs = require('fs')
+const { getUICoverageResults } = require('@cypress/extract-cloud-results')
+
+const FLOOR_FILE = 'ui-coverage-floor.json'
+const floor = fs.existsSync(FLOOR_FILE)
+  ? JSON.parse(fs.readFileSync(FLOOR_FILE, 'utf8')).coverage
+  : 0
+
+getUICoverageResults().then(({ summary }) => {
+  if (summary.coverage < floor) {
+    throw new Error(
+      `Coverage dropped to ${summary.coverage}%, below the previous floor of ${floor}%.`
+    )
+  }
+
+  fs.writeFileSync(FLOOR_FILE, JSON.stringify({ coverage: summary.coverage }))
+})
+```
+
+### Compare against a baseline
+
+Comparing untested-element counts against a stored baseline fails a build only
+when **new** gaps are introduced, letting you pay down existing gaps over time
+instead of blocking on them all at once. For complete code, the baseline
+structure, and best practices, see the
 [Block pull requests and set policies](/ui-coverage/guides/block-pull-requests#comparing-against-a-baseline)
 guide.
 

--- a/docs/ui-coverage/results-api.mdx
+++ b/docs/ui-coverage/results-api.mdx
@@ -72,25 +72,16 @@ Test Replay being enabled and a supported Cypress version. See the
 
 ## Supported CI Providers
 
-The Results API supports the following CI providers. Refer to the linked guides
-for general setup details:
+The Results API supports the following CI providers:
 
-- <Icon name="microsoft" inline="true" />
-  [Azure](/app/continuous-integration/overview#Azure-Pipelines) (requires
-  Cypress v13.13.1)
-- <Icon name="cog" inline="true" />
-  [CircleCI](/app/continuous-integration/circleci) (requires Cypress v13.13.1)
-- <Icon name="github" inline="true" /> [GitHub
-  Actions](/app/continuous-integration/github-actions)
-- <Icon name="gitlab" inline="true" />
-  [GitLab](/app/continuous-integration/gitlab-ci)
-- <Icon name="jenkins" inline="true" />
-  [Jenkins](/app/continuous-integration/overview#Jenkins)
-- <Icon name="aws" inline="true" /> [AWS
-  CodeBuild](/app/continuous-integration/aws-codebuild)
+- <Icon name="microsoft" inline="true" /> Azure
+- <Icon name="cog" inline="true" /> CircleCI
+- <Icon name="github" inline="true" /> GitHub Actions
+- <Icon name="gitlab" inline="true" /> GitLab
+- <Icon name="jenkins" inline="true" /> Jenkins
+- <Icon name="aws" inline="true" /> AWS CodeBuild
 - <Icon name="cog" inline="true" /> Drone
-- <Icon name="bitbucket" inline="true" />
-  [Bitbucket](/app/continuous-integration/bitbucket-pipelines)
+- <Icon name="bitbucket" inline="true" /> Bitbucket
 - <Icon name="cog" inline="true" /> Buildkite
 
 For other CI providers, contact Cypress Support at support@cypress.io to request
@@ -162,7 +153,6 @@ getUICoverageResults({
   // The run tags associated with the run.
   // Required IF you record multiple Cypress runs from a single CI build.
   // Pass the same tags you used when recording each run.
-  // A single tag can also be provided via the CYPRESS_RUN_TAG env var.
   runTags: string[]
 })
 ```
@@ -175,13 +165,9 @@ navigational element (such as an anchor) that points at another view;
 
 ```javascript
 {
-  // The run number of the identified build.
   runNumber: number
-  // The run URL for the identified build.
   runUrl: 'https://cloud.cypress.io/projects/:project_id/runs/:run_number'
-  // The status of the identified build.
   runStatus: 'passed' | 'failed' | 'errored' | 'timedOut' | 'cancelled' | 'noTests' | 'running' | 'overLimit'
-  // The URL that links to the UI Coverage report for the identified build.
   uiCoverageReportUrl: 'https://cloud.cypress.io/[...]'
   summary: {
     // Whether a complete UI Coverage report was generated.
@@ -190,32 +176,21 @@ navigational element (such as an anchor) that points at another view;
     isPartialReport: boolean
     // The report coverage from 0-100 with 2-decimal precision (e.g. 92.45).
     coverage: number
-    // The number of views tested and analyzed.
     viewCount: number
-    // The number of interactive elements that were tested.
     testedElementsCount: number
-    // The number of interactive elements that were not tested.
     untestedElementsCount: number
-    // The number of links that were tested (visited).
     testedLinksCount: number
-    // The number of links that were not tested (never visited).
     untestedLinksCount: number
   }
-  // The list of tested views and the coverage of each.
   views: [{
     // The sanitized URL pattern shown in the report.
     displayName: string
     // The view coverage from 0-100 with 2-decimal precision (e.g. 92.45).
     coverage: number
-    // The number of interactive elements that were tested on this view.
     testedElementsCount: number
-    // The number of interactive elements that were not tested on this view.
     untestedElementsCount: number
-    // The number of links that were tested (visited) on this view.
     testedLinksCount: number
-    // The number of links that were not tested (never visited) on this view.
     untestedLinksCount: number
-    // The URL that links to the report for this view.
     uiCoverageReportUrl: 'https://cloud.cypress.io/[...]'
   }]
   // The App Quality configuration that produced this report.

--- a/docs/ui-coverage/results-api.mdx
+++ b/docs/ui-coverage/results-api.mdx
@@ -492,30 +492,25 @@ phases:
 </TabItem>
 
 <TabItem value="Drone" >
-```diff title=".drone.yaml"
-  kind: pipeline
-  name: default
 
-environment:
-CYPRESS_PROJECT_ID: example_project_slug
-CYPRESS_RECORD_KEY:
-from_secret: example_record_key_secret
+```diff title=".drone.yml"
+kind: pipeline
+name: default
 
 steps:
+  - name: Run Cypress tests
+    image: node:latest
+    commands:
+      - npm install
+      - npx cypress run --record
 
-- name: Run Cypress tests
-  image: node:latest
-  commands:
-  - npm install
-  - npx cypress run --record
++  - name: Get Cypress UI Coverage
++    image: node:latest
++    commands:
++      - npm install --force https://cdn.cypress.io/extract-cloud-results/v1/extract-cloud-results.tgz
++      - node ./scripts/verifyUICoverageResults.js
+```
 
-* - name: Get Cypress UI Coverage
-* image: node:latest
-* commands:
-* - npm install --force https://cdn.cypress.io/extract-cloud-results/v1/extract-cloud-results.tgz
-* - node ./scripts/verifyUICoverageResults.js
-
-````
 </TabItem>
 
 <TabItem value="Bitbucket" >
@@ -532,7 +527,7 @@ pipelines:
           - npx cypress run --record
 +         - npm install --force https://cdn.cypress.io/extract-cloud-results/v1/extract-cloud-results.tgz
 +         - node ./scripts/verifyUICoverageResults.js
-````
+```
 
 </TabItem>
 

--- a/docs/ui-coverage/results-api.mdx
+++ b/docs/ui-coverage/results-api.mdx
@@ -75,15 +75,23 @@ Test Replay being enabled and a supported Cypress version. See the
 The Results API supports the following CI providers. Refer to the linked guides
 for general setup details:
 
-- [Azure](/app/continuous-integration/overview#Azure-Pipelines) (requires Cypress v13.13.1)
-- [CircleCI](/app/continuous-integration/circleci) (requires Cypress v13.13.1)
-- [GitHub Actions](/app/continuous-integration/github-actions)
-- [GitLab](/app/continuous-integration/gitlab-ci)
-- [Jenkins](/app/continuous-integration/overview#Jenkins)
-- [AWS CodeBuild](/app/continuous-integration/aws-codebuild)
-- Drone
-- [Bitbucket](/app/continuous-integration/bitbucket-pipelines)
-- Buildkite
+- <Icon name="microsoft" inline="true" />
+  [Azure](/app/continuous-integration/overview#Azure-Pipelines) (requires
+  Cypress v13.13.1)
+- <Icon name="cog" inline="true" />
+  [CircleCI](/app/continuous-integration/circleci) (requires Cypress v13.13.1)
+- <Icon name="github" inline="true" /> [GitHub
+  Actions](/app/continuous-integration/github-actions)
+- <Icon name="gitlab" inline="true" />
+  [GitLab](/app/continuous-integration/gitlab-ci)
+- <Icon name="jenkins" inline="true" />
+  [Jenkins](/app/continuous-integration/overview#Jenkins)
+- <Icon name="aws" inline="true" /> [AWS
+  CodeBuild](/app/continuous-integration/aws-codebuild)
+- <Icon name="cog" inline="true" /> Drone
+- <Icon name="bitbucket" inline="true" />
+  [Bitbucket](/app/continuous-integration/bitbucket-pipelines)
+- <Icon name="cog" inline="true" /> Buildkite
 
 For other CI providers, contact Cypress Support at support@cypress.io to request
 support.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -302,6 +302,7 @@ const config = {
       prism: {
         theme: darkCodeTheme,
         darkTheme: darkCodeTheme,
+        additionalLanguages: ['diff'],
       },
       zoom: {
         selector: ':not(.mediaImage, .navbar__logo img, .logo, .br-ui)', // don't zoom these images

--- a/src/components/icon/index.tsx
+++ b/src/components/icon/index.tsx
@@ -3,7 +3,16 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import CypressIcon from "@cypress-design/react-icon";
 
 // Names resolved from the Font Awesome brands pack instead of solid
-const BRAND_ICONS = new Set(["github", "claude", "openai"]);
+const BRAND_ICONS = new Set([
+  "github",
+  "claude",
+  "openai",
+  "gitlab",
+  "jenkins",
+  "aws",
+  "bitbucket",
+  "microsoft",
+]);
 
 interface IconProps {
   useCypressIcon?: boolean;

--- a/src/components/package-manager-tabs/index.tsx
+++ b/src/components/package-manager-tabs/index.tsx
@@ -33,6 +33,11 @@ interface PackageManagerTabsProps {
    * command, e.g. `CYPRESS_RECORD_KEY=abc123`.
    */
   env?: string
+  /**
+   * Comma-separated package-manager values to omit from the tabs, e.g.
+   * `"bun"`. Use when a command isn't portable to a given manager.
+   */
+  exclude?: string
 }
 
 /**
@@ -99,6 +104,7 @@ const PackageManagerTabs: React.FC<PackageManagerTabsProps> = ({
   exec,
   dev = false,
   env,
+  exclude,
 }) => {
   const provided = [install, run, exec].filter(
     (value) => value !== undefined
@@ -111,10 +117,19 @@ const PackageManagerTabs: React.FC<PackageManagerTabsProps> = ({
 
   const envPrefix = env ? `${env} ` : ''
   const lines = toLines(install ?? run ?? exec ?? '')
+  const excluded = new Set(
+    (exclude ?? '')
+      .split(',')
+      .map((value) => value.trim())
+      .filter(Boolean)
+  )
+  const visibleManagers = managers.filter(
+    (manager) => !excluded.has(manager.value)
+  )
 
   return (
     <Tabs groupId="package-manager">
-      {managers.map((manager) => {
+      {visibleManagers.map((manager) => {
         const commands = install
           ? [manager.install(lines.join(' '), dev)]
           : lines.map((line) => `${run ? manager.run : manager.exec} ${line}`)


### PR DESCRIPTION
## Summary

Corrects and substantially expands the **UI Coverage Results API** documentation (`docs/ui-coverage/results-api.mdx`) so it matches the shipped `@cypress/extract-cloud-results` implementation, leads with value, and adds a worked example for every supported use case. Also updates the UI Coverage FAQ and the shared Results API env-vars partial.

## Why

The page had several inaccuracies and gaps versus the actual module (verified against `packages/extract-cloud-results`, the `/ui-coverage-results` API route, and the `@packages/validations` response schema in `cypress-services`), and read as a dry API dump rather than leading with what the API is for.

**Accuracy fixes (verified against the implementation):**

- Documented the missing `testedLinksCount` / `untestedLinksCount` fields on `summary` and each view.
- Documented the `config` field (the **App Quality Config** applied to the report, with `updatedAt` and resolved `value`, including any matching Profile).
- Corrected `runStatus` to include `running` and `overLimit`.
- Removed `CYPRESS_INTERNAL_ENV=staging` from the AWS CodeBuild example (it points customers at Cypress's staging API).
- Fixed the CircleCI tab (beta install URL → `v1`, invalid `npx run cypress:run` → `npx cypress run`, non-existent job reference).
- Fixed the GitLab filename (`.git-ci.yml` → `.gitlab-ci.yml`) and typos ("accpets", "sanatized").
- Corrected the CircleCI env-vars reference link (pointed at GitLab docs) in the shared partial.

**Clarity / value:**

- New value-led intro, a "How it works" section (run identification, server-side polling, prerequisites), a console-output sample, an Examples section with a runnable script per use case (thresholds, PR reporting, navigation-link coverage, trend analytics, state-aware enforcement, config assertion, ratcheting, baseline), and a "Handling errors" note.
- Standardized CI job/step naming to **Run Cypress tests** / **Get Cypress UI Coverage** across every provider tab; bumped `actions/checkout` to v7; collapsed the CI provider env-var reference into per-provider accordions with brand icons.

**SEO/AEO:**

- Added a "Results API and CI" section to the UI Coverage FAQ, with each question phrased to name **Cypress UI Coverage** explicitly so entries match web and AI-agent queries when surfaced in isolation.

Closes #<!-- none -->

## Notes for reviewers

- **Shared component changes** (used site-wide, defaults unchanged): extended the `Icon` brand-icon whitelist (`gitlab`, `jenkins`, `aws`, `bitbucket`, `microsoft`) so CI provider icons render, and added an optional `exclude` prop to `PackageManagerTabs` (used as `exclude="bun"` on the install command, since `bun add` has no `--force` flag).
- **`actions/checkout@v7`** was bumped in this file only; the rest of the repo still uses `@v6` (11 other places). Happy to bump those repo-wide in a follow-up if desired.
- The **env-vars partial is shared** with the Accessibility Results API page, so its changes (accordions, `verifyResults.js`, link fixes) affect both pages.
- **Verification:** the CI environment here had no `node_modules`, so I could not run a full Docusaurus build. Validated via `prettier --check`, the frontmatter linter, and source inspection against the implementation. A CI preview build is the real confirmation for the new `Icon`/`AccordionBlock`/`PackageManagerTabs` usage rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Mk9DwxyiKkmh9o2QW52t4

---
_Generated by [Claude Code](https://claude.ai/code/session_011Mk9DwxyiKkmh9o2QW52t4)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and backward-compatible doc-site component defaults; no runtime product or auth changes.
> 
> **Overview**
> **Substantially rewrites** the UI Coverage **Results API** page so it leads with CI enforcement use cases, documents **How it works** (run matching, polling, logging), and adds an **Examples** section with runnable scripts (thresholds, PR summaries, link coverage, trends, partial-run skips, config assertion, ratcheting, baseline pointer).
> 
> **Aligns documentation with the shipped `@cypress/extract-cloud-results` shape**: link counts on `summary`/`views`, the **`config`** (App Quality Config + profiles), expanded **`runStatus`** values, clearer error-handling, and **`PackageManagerTabs`** for install (with **`exclude="bun"`**). **CI workflow tabs** are corrected and normalized (e.g. CircleCI `v1` URL and `npx cypress run`, GitLab filename, removal of staging env from AWS CodeBuild, **`actions/checkout@v7`** in that example only).
> 
> The shared **`_results-api-env-vars`** partial now uses **global prerequisites**, per-provider **`AccordionBlock`** sections with **brand icons**, and a consolidated local-dev example (also affects Accessibility Results API). The UI Coverage **FAQ** gains a **Results API and CI** section for discoverability.
> 
> **Site components**: **`Icon`** adds CI brand names to the Font Awesome brands set; **`PackageManagerTabs`** gains optional **`exclude`**; Prism adds **`diff`** for workflow diffs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41f2515c69f4492ebf51accecf35d2625d92eb54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->