### PR TITLE
docs(ui-coverage): rework the Interactivity page for accuracy, value, and clarity

### DIFF
--- a/docs/ui-coverage/core-concepts/interactivity.mdx
+++ b/docs/ui-coverage/core-concepts/interactivity.mdx
@@ -1,37 +1,101 @@
 ---
 title: How UI Coverage detects interactive elements
-description: 'UI Coverage uses a set of rules, based on HTML semantics, WHATWG standards, as well as some additional rules defined by Cypress, to determine which elements are interactive.'
+description: 'Understand what drives your UI Coverage score: the interactive elements Cypress tracks, the commands that mark them as tested, and the links to unvisited pages it flags, plus the overrides that make each one match your app.'
 sidebar_label: Interactivity
 sidebar_position: 10
 ---
 
 <ProductHeading product="ui-coverage" />
 
-# Interactivity
+# How UI Coverage measures interactivity
+
+Your UI Coverage score is built from the interactive parts of your app: the buttons, inputs, links, and controls a user can actually touch. To read your report with confidence, it helps to know the three rules that shape it:
+
+1. **An element is counted when it is interactive**, which forms the denominator of your score.
+2. **An interactive element is marked as tested when a recognized Cypress command targets it**, which forms the numerator.
+3. **A link is flagged as untested when its destination is never visited** during your run.
+
+Put simply, your score is the share of interactive elements your tests exercise: **tested ÷ total**, where [grouped elements](/ui-coverage/core-concepts/element-grouping) count once. See [how the score is calculated](/ui-coverage/faq#How-is-the-UI-Coverage-score-calculated) for the details.
+
+This page covers all three, along with the configuration and markup overrides you can use to make each one match your application. All three are computed from [Test Replay](/cloud/features/test-replay) data, so they work automatically with no setup or instrumentation. Reach for the overrides only when the defaults don't fit.
+
+<DocsImage
+  src="/img/ui-coverage/core-concepts/how-ui-coverage-fits-together.svg"
+  alt="Flow diagram: Test Replay captures DOM snapshots, UI Coverage analyzes each one to detect interactive elements (the total) and the interaction commands that mark them tested (the numerator), and flags untested links, all feeding the coverage score and report."
+  caption="How UI Coverage turns a recorded run into a coverage score."
+  noBorder="true"
+/>
 
 ## Interactive Elements
 
-UI Coverage determines interactivity based on a combination of HTML semantics, [WHATWG standards](https://html.spec.whatwg.org/dev/dom.html#interactive-content), and Cypress-specific rules. Interactive elements included in UI Coverage are:
+UI Coverage follows the WHATWG definition of [interactive content](https://html.spec.whatwg.org/dev/dom.html#interactive-content), extended with a few Cypress-specific rules. An element is counted as interactive when it falls into any of these categories:
 
-- **Implicit interactive roles**: Elements with a tag of `a`, `button`, `input`, `select`, `textarea`, etc.
-- **Explicit interactive roles**: Elements with a `role` attribute set to values like `button`, `checkbox`, `radio`, `tab`, `textbox`, etc.
-- **Tab-navigable elements**: Elements with a `tabindex` attribute set to `>= 0`.
+- **Natively interactive elements**: elements the browser already treats as interactive, such as `<a>` links, `<button>`, form controls like `<input>` and `<select>`, and any element that is `contenteditable`.
+- **Elements with an interactive ARIA role**: an explicit `role` such as `button`, `checkbox`, `tab`, or `menuitem`, or an `aria-haspopup` value that opens a menu or dialog.
+- **Tab-navigable elements**: any element made keyboard-focusable with a `tabindex` of `0` or greater.
 
-These elements are tracked for interaction to provide actionable insights into test coverage.
+Contact links are the one deliberate exception: anchors whose `href` uses `tel:`, `mailto:`, or `sms:` are not treated as interactive. See [Untested Links](#Untested-Links) for how the rest of an anchor's `href` is handled.
 
-### Customizing interactive elements
+Because detection is based on semantics rather than event handlers, a real `<button>` is recognized automatically, while a `<div>` wired up with a click handler is not, until you give it interactive semantics.
 
-Custom interactive elements that do not meet the criteria above can also be declared with a `data-cy-ui-interactive="include"` attribute, used as follows:
+<DocsImage
+  src="/img/ui-coverage/guides/cypress-ui-coverage-untested-elements-view-drilldown.png"
+  alt="A UI Coverage report drilldown showing an interactive button highlighted in a snapshot, with its interactions listed alongside"
+  caption="UI Coverage finds each interactive element in a snapshot and tracks whether your tests exercise it."
+/>
+
+### Overriding interactive elements with `data-cy-ui-interactive`
+
+When the automatic rules don't match your app, the `data-cy-ui-interactive` attribute lets you override them directly in your markup. It accepts four values, matched case-insensitively:
+
+| Value         | Effect                                                                           |
+| ------------- | -------------------------------------------------------------------------------- |
+| `include`     | Treats the element as interactive even when it wouldn't be otherwise.            |
+| `exclude`     | Removes the element from UI Coverage, even when it's normally interactive.       |
+| `exclude-all` | Removes the element and every element nested inside it.                          |
+| `reset`       | Re-enables tracking for a subtree nested inside an element marked `exclude-all`. |
+
+**Include a custom control** the browser doesn't recognize:
 
 ```html
-<div data-cy-ui-interactive="include">Custom interactive widget</div>
+<!-- A custom drag handle built from a div -->
+<div role="presentation" data-cy-ui-interactive="include">Reorder</div>
 ```
 
-It most cases we recommend **not** using this override, and instead updating the HTML to be something the browser would already consider to be interactive. This will likely produce better overall behavior, including for accessibility purposes. `data-cy-ui-interactive` is a fallback for situations where that may not be possible.
+**Exclude a whole section** while keeping one control inside it tracked:
 
-## Interaction Commands
+```html
+<section data-cy-ui-interactive="exclude-all">
+  <!-- Nothing in this experimental panel is tracked... -->
+  <button>Beta action</button>
+  <div data-cy-ui-interactive="reset">
+    <!-- ...except controls inside here -->
+    <button>Save feedback</button>
+  </div>
+</section>
+```
 
-Interactive elements are marked as "tested" when they are interacted with using specific Cypress commands. These include:
+Excluding an element removes it from UI Coverage entirely: it no longer counts as an interactive element, and if it's a link, it also stops appearing as an untested link, so neither affects your score.
+
+In most cases we recommend **not** using `include`, and instead updating the HTML to be something the browser already treats as interactive, such as a real `<button>` in place of a clickable `<div>`. That produces better overall behavior, including for accessibility, since the same semantics that let assistive technology operate a control are what UI Coverage reads. `data-cy-ui-interactive` is a fallback for situations where that isn't possible.
+
+To exclude elements without editing your application's markup, [`elementFilters`](/ui-coverage/configuration/elementfilters) does the same job from Cypress Cloud configuration. Prefer it when the team that manages configuration isn't the team that owns the markup:
+
+```json title="App Quality Config"
+{
+  "elementFilters": [
+    {
+      "selector": ".intercom-launcher, .intercom-launcher *",
+      "include": false,
+      "comment": "Third-party chat widget, not owned by our tests"
+    }
+  ]
+}
+```
+
+## How elements get marked tested {#Interaction-Commands}
+
+An interactive element is marked as **tested** when a recognized Cypress command targets it. UI Coverage recognizes this built-in set of commands:
 
 - `blur`
 - `check`
@@ -49,41 +113,133 @@ Interactive elements are marked as "tested" when they are interacted with using 
 - `type`
 - `uncheck`
 
-By ensuring that at least one of these commands is used on every interactive element, UI Coverage accurately reflects your test coverage.
+Using at least one of them on every interactive element is what drives your coverage score, so a test flow naturally marks the elements it exercises as tested:
+
+```js
+// Each command marks its target element as tested
+cy.get('[data-cy="signup-email"]').type('sarah@example.com')
+cy.get('[data-cy="signup-plan-pro"]').check()
+cy.get('[data-cy="signup-submit"]').click()
+```
+
+<DocsImage
+  src="/img/ui-coverage/guides/cypress-ui-coverage-tested-elements-with-high-interactions.png"
+  alt="The Tested elements list in a UI Coverage report, with Interactions and Tests columns counting how often each element was exercised"
+  caption="An element moves to the Tested list once a recognized command interacts with it, with the interaction count shown per element."
+/>
+
+A command only counts when it logs a [snapshot](/ui-coverage/core-concepts/element-identification#Snapshots) that highlights the element it acts on, which is how UI Coverage knows which element to credit. Built-in commands do this automatically; a custom command must do it explicitly (see [Requirements for a custom command](/ui-coverage/configuration/additionalinteractioncommands#Requirements-for-a-custom-command)).
 
 ### Customizing interaction commands
 
-Configuration is available to support adding [additional interaction commands](/ui-coverage/configuration/additionalinteractioncommands), such as custom commands or ones from third-party libraries, to count towards UI Coverage scores.
+Two configuration options let you change which commands count:
 
-It is also possible to adjust the [allowed commands](/ui-coverage/configuration/allowedinteractioncommands) for specific elements, to restrict or expand the commands that are accepted as coverage for specific elements.
+- [`additionalInteractionCommands`](/ui-coverage/configuration/additionalinteractioncommands) **extends** the built-in set everywhere, so custom commands or ones from third-party libraries (such as [`cypress-real-events`](https://github.com/dmtrKovalenko/cypress-real-events)' `realClick`) count as coverage on any element. Custom command names are matched **case-sensitively**, exactly as you register them.
+- [`allowedInteractionCommands`](/ui-coverage/configuration/allowedinteractioncommands) works **per element**: for elements matching a selector, only the commands you list count. This lets you both require a meaningful interaction (a chart that must be hovered, not just clicked) and credit commands the defaults ignore (an `assert` on a read-only badge).
+
+For example, to require a hover rather than a plain click on a chart before it counts as tested:
+
+```json title="App Quality Config"
+{
+  "uiCoverage": {
+    "allowedInteractionCommands": [
+      {
+        "selector": "[data-cy='revenue-chart']",
+        "commands": ["trigger"],
+        "comment": "Only a hover (dispatched via trigger) proves the tooltip works"
+      }
+    ]
+  }
+}
+```
+
+See [Which option do I need?](/ui-coverage/configuration/overview#Which-option-do-I-need) for a side-by-side comparison.
 
 ## Untested Links
 
-UI Coverage tracks links (`<a>` elements) whose destination URLs are never visited during testing.
+UI Coverage tracks links (`<a>` elements) whose destination URLs are never visited during testing. A link to a page no test navigates to is a coverage gap even when no [view](/ui-coverage/core-concepts/views) exists for that page, so untested links surface the flows your suite is missing, not just the elements it skipped.
+
+<DocsImage
+  src="/img/ui-coverage/guides/cypress-ui-coverage-untested-link-view.png"
+  alt="A UI Coverage snapshot with an untested link highlighted in red in the rendered page, showing it had no interactions during the run"
+  caption="An untested link highlighted in the report: its destination was never visited during the run."
+/>
 
 ### Which hrefs count as links
 
-The `href` value determines how UI Coverage treats each anchor:
+The `href` value determines how UI Coverage treats each anchor. At a glance:
 
-- **URLs**: An `href` that resolves to a URL is treated as a link to a destination. This includes relative paths like `/settings`, hash routes like `#/settings`, and absolute URLs, including links to entirely external websites. If the destination is never visited, the link appears as an untested link and counts against your score, unless a [`viewFilters`](/ui-coverage/configuration/viewfilters) rule excludes the destination URL.
-- **Document fragments**: An `href` that points to a fragment on the current page, such as `#pricing`, makes the anchor an ordinary interactive element. It must be interacted with to count as tested, but it never appears as an untested link.
-- **`#` and `javascript:` values**: Anchors with `href="#"` or a `javascript:` value are also treated as ordinary interactive elements rather than links to a destination.
-- **`tel:`, `mailto:`, and `sms:` values**: Contact links are not considered interactive elements. They don't appear in reports and don't count toward your coverage score.
+| `href` example                                             | Interactive element? | Can be an untested link? |
+| ---------------------------------------------------------- | -------------------- | ------------------------ |
+| `/settings`, `#/settings`, `https://external.com`, `blob:` | Yes                  | Yes, if never visited    |
+| `#pricing` (page fragment)                                 | Yes                  | No                       |
+| `#` or `javascript:`                                       | Yes                  | No                       |
+| Empty or missing `href`                                    | Yes                  | No                       |
+| `tel:`, `mailto:`, `sms:`                                  | No                   | No                       |
 
-For each untested link, detailed information is available:
+The three cases in detail:
 
-### Referrers
+#### 1. Counted as untested links and interactive elements
 
-The **Referrers** section identifies views that contain links to the untested destination, helping you:
+An `href` that resolves to a URL is treated as a link to a destination, and the anchor is also an ordinary interactive element. This covers:
 
-- Pinpoint untested areas referenced from these links.
-- Understand navigation paths leading to untested sections.
-- Gain context on where these links appear within your application.
+- **URLs**: relative paths like `/settings`, hash routes like `#/settings`, and absolute URLs, including links to entirely external websites.
+- **Other schemes**: any other scheme, such as `ftp:`, `file:`, `data:`, `blob:`, or a custom app scheme, treated the same as an `http(s)` URL.
 
-### URLs
+The anchor counts as tested once a test either interacts with it or visits its destination. If the destination is never visited, the link appears as an untested link and counts against your score, unless a [`viewFilters`](/ui-coverage/configuration/viewfilters) rule excludes the destination URL.
 
-The **URLs** section groups similar patterns for dynamic routing. For instance, links to `/users/1`, `/users/2`, and `/users/3` are grouped as /users/\*. This grouping aids in:
+#### 2. Counted only as interactive elements
 
-- Understanding the scope of dynamic routes in your application
-- Viewing the count and variations of a URL pattern.
-- Writing configuration rules to handle these patterns effectively.
+These anchors are ordinary interactive elements that must be interacted with to count as tested. They point to no separate destination, so they never appear as untested links:
+
+- **Document fragments**: an `href` pointing to a fragment on the current page, such as `#pricing`.
+- **`#` and `javascript:` values**: anchors with `href="#"` or a `javascript:` value.
+- **Empty or missing `href`**: an anchor with no usable `href` value.
+
+#### 3. Not counted in UI Coverage
+
+- **`tel:`, `mailto:`, and `sms:` values**: contact links are not considered interactive elements. They don't appear in reports and don't count toward your coverage score. To track one anyway, add [`data-cy-ui-interactive="include"`](#Overriding-interactive-elements-with-data-cy-ui-interactive) to the anchor.
+
+### Exclude link destinations from your score
+
+To keep destinations you'll never test, such as external sites, your marketing pages, or a status page, from counting against your score, exclude them by URL:
+
+```json title="App Quality Config"
+{
+  "viewFilters": [
+    {
+      "pattern": "https://status.example.com/*",
+      "include": false,
+      "comment": "External status page, linked from the footer but not owned by our team"
+    }
+  ]
+}
+```
+
+Excluding a destination with `viewFilters` also removes the links that point to it, so they stop appearing as untested links. See [Ignore views and links](/ui-coverage/guides/ignore-views-and-links) for the full workflow. To exclude a single link from your markup instead, add [`data-cy-ui-interactive="exclude"`](#Overriding-interactive-elements-with-data-cy-ui-interactive) to the anchor.
+
+### Untested link details
+
+Expanding an untested link in the report reveals where it came from and which destinations it covers, so you can decide whether to test it or exclude it. That detail is organized into two tabs, **Referrers** and **URLs**.
+
+<DocsImage
+  src="/img/ui-coverage/guides/cypress-ui-coverage-untested-links.png"
+  alt="The Untested links list in Cypress Cloud with one link expanded to show its Referrers and URLs tabs"
+/>
+
+#### Referrers
+
+The **Referrers** tab lists the views that contain a link to the untested destination, so you can trace it back to the pages that link to it and the flows that lead there.
+
+#### URLs
+
+The **URLs** tab groups similar destinations for dynamic routing. For instance, links to `/users/1`, `/users/2`, and `/users/3` are grouped as `/users/*`. Only path segments that are numbers or UUID-like IDs are treated as dynamic, so `/users/alice` and `/users/bob` stay separate. The grouping shows the scope and variations of a dynamic route, and the pattern it surfaces is the one to use when writing [`views`](/ui-coverage/configuration/views) and [`viewFilters`](/ui-coverage/configuration/viewfilters) rules.
+
+## See also
+
+- [Element Identification](/ui-coverage/core-concepts/element-identification): how UI Coverage gives each interactive element a stable identity across snapshots.
+- [`additionalInteractionCommands`](/ui-coverage/configuration/additionalinteractioncommands): count custom or plugin commands as interactions everywhere.
+- [`allowedInteractionCommands`](/ui-coverage/configuration/allowedinteractioncommands): control which commands count for specific elements.
+- [`elementFilters`](/ui-coverage/configuration/elementfilters): remove elements from reports and scores using configuration.
+- [`viewFilters`](/ui-coverage/configuration/viewfilters): exclude views and link destinations from reports.
+- [UI Coverage FAQ](/ui-coverage/faq): common questions about interactive elements, interaction commands, and links.

--- a/docs/ui-coverage/core-concepts/interactivity.mdx
+++ b/docs/ui-coverage/core-concepts/interactivity.mdx
@@ -134,8 +134,8 @@ A command only counts when it logs a [snapshot](/ui-coverage/core-concepts/eleme
 
 Two configuration options let you change which commands count:
 
-- [`additionalInteractionCommands`](/ui-coverage/configuration/additionalinteractioncommands) **extends** the built-in set everywhere, so custom commands or ones from third-party libraries (such as [`cypress-real-events`](https://github.com/dmtrKovalenko/cypress-real-events)' `realClick`) count as coverage on any element.
-- [`allowedInteractionCommands`](/ui-coverage/configuration/allowedinteractioncommands) works **per element**: for elements matching a selector, only the commands you list count. This lets you both require a meaningful interaction (a chart that must be hovered, not just clicked) and credit commands the defaults ignore (an `assert` on a read-only badge).
+- [`additionalInteractionCommands`](/ui-coverage/configuration/additionalinteractioncommands) extends the built-in set everywhere, so custom commands or ones from third-party libraries (such as [`cypress-real-events`](https://github.com/dmtrKovalenko/cypress-real-events)' `realClick`) count as coverage on any element.
+- [`allowedInteractionCommands`](/ui-coverage/configuration/allowedinteractioncommands) works per element: for elements matching a selector, only the commands you list count. This lets you both require a meaningful interaction (a chart that must be hovered, not just clicked) and credit commands the defaults ignore (an `assert` on a read-only badge).
 
 For example, to require a hover rather than a plain click on a chart before it counts as tested:
 

--- a/docs/ui-coverage/core-concepts/interactivity.mdx
+++ b/docs/ui-coverage/core-concepts/interactivity.mdx
@@ -134,7 +134,7 @@ A command only counts when it logs a [snapshot](/ui-coverage/core-concepts/eleme
 
 Two configuration options let you change which commands count:
 
-- [`additionalInteractionCommands`](/ui-coverage/configuration/additionalinteractioncommands) **extends** the built-in set everywhere, so custom commands or ones from third-party libraries (such as [`cypress-real-events`](https://github.com/dmtrKovalenko/cypress-real-events)' `realClick`) count as coverage on any element. Custom command names are matched **case-sensitively**, exactly as you register them.
+- [`additionalInteractionCommands`](/ui-coverage/configuration/additionalinteractioncommands) **extends** the built-in set everywhere, so custom commands or ones from third-party libraries (such as [`cypress-real-events`](https://github.com/dmtrKovalenko/cypress-real-events)' `realClick`) count as coverage on any element.
 - [`allowedInteractionCommands`](/ui-coverage/configuration/allowedinteractioncommands) works **per element**: for elements matching a selector, only the commands you list count. This lets you both require a meaningful interaction (a chart that must be hovered, not just clicked) and credit commands the defaults ignore (an `assert` on a read-only badge).
 
 For example, to require a hover rather than a plain click on a chart before it counts as tested:

--- a/docs/ui-coverage/core-concepts/interactivity.mdx
+++ b/docs/ui-coverage/core-concepts/interactivity.mdx
@@ -171,7 +171,7 @@ The `href` value determines how UI Coverage treats each anchor. At a glance:
 
 | `href` example                                             | Interactive element? | Can be an untested link? |
 | ---------------------------------------------------------- | -------------------- | ------------------------ |
-| `/settings`, `#/settings`, `https://external.com`, `blob:` | Yes                  | Yes, if never visited    |
+| `/settings`, `#/settings`, `https://external.com`, `blob:` | Yes                  | Yes                      |
 | `#pricing` (page fragment)                                 | Yes                  | No                       |
 | `#` or `javascript:`                                       | Yes                  | No                       |
 | Empty or missing `href`                                    | Yes                  | No                       |

--- a/docs/ui-coverage/faq.mdx
+++ b/docs/ui-coverage/faq.mdx
@@ -23,6 +23,20 @@ No. UI Coverage requires no code changes or instrumentation. Reports are generat
 
 The score compares the number of tested interactive elements to the total number of interactive elements in your application. [Grouped elements](/ui-coverage/core-concepts/element-grouping) count as a single unit: the group counts once toward the total, and an interaction with any element in the group marks the whole group as tested.
 
+## Interactive elements
+
+### <Icon name="angle-right" /> What does Cypress UI Coverage count as an interactive element?
+
+UI Coverage follows the WHATWG definition of [interactive content](https://html.spec.whatwg.org/dev/dom.html#interactive-content), plus a few Cypress-specific rules. In short, an element counts when it is natively interactive (like `<a>`, `<button>`, or a form control), when it has an interactive ARIA `role` (such as `button` or `tab`), or when it is keyboard-focusable with `tabindex="0"` or higher. See [Interactive Elements](/ui-coverage/core-concepts/interactivity#Interactive-Elements) for the full rules.
+
+### <Icon name="angle-right" /> Why doesn't Cypress UI Coverage track my custom widget as an interactive element?
+
+UI Coverage detects interactivity from HTML semantics, not from event handlers, so a `<div>` with a click handler isn't recognized as interactive. The best fix is to give the control real semantics, such as using a `<button>` or adding an appropriate `role`, which also improves accessibility. When that isn't possible, add [`data-cy-ui-interactive="include"`](/ui-coverage/core-concepts/interactivity#Overriding-interactive-elements-with-data-cy-ui-interactive) to the element so UI Coverage tracks it.
+
+### <Icon name="angle-right" /> How do I stop Cypress UI Coverage from tracking an element or a whole section?
+
+You have two options. In your markup, add [`data-cy-ui-interactive="exclude"`](/ui-coverage/core-concepts/interactivity#Overriding-interactive-elements-with-data-cy-ui-interactive) to a single element or `data-cy-ui-interactive="exclude-all"` to a container to also exclude everything inside it (and `reset` to re-enable a subtree). To do the same from Cypress Cloud without changing application code, add an [`elementFilters`](/ui-coverage/configuration/elementfilters) rule with `include: false`. Excluded elements are removed from both the report and the score.
+
 ## Views and URLs
 
 ### <Icon name="angle-right" /> Why do similar URLs show up as separate views?
@@ -58,6 +72,22 @@ Yes. List `include: true` rules for the URLs you want, followed by a catch-all r
 ### <Icon name="angle-right" /> Why is a page missing from my report?
 
 Views are created from URLs your tests actually visit, so a page that no test navigates to has no view. Check [untested links](/ui-coverage/core-concepts/interactivity#Untested-Links) in the report, where pages that are linked to but never visited appear. Also confirm that a [`viewFilters`](/ui-coverage/configuration/viewfilters) rule isn't excluding the page unintentionally.
+
+### <Icon name="angle-right" /> What is an untested link in Cypress UI Coverage?
+
+An untested link is an `<a>` element whose destination URL is never visited during your run. Because a link points to a page, an untested link surfaces a flow your suite is missing even when no [view](/ui-coverage/core-concepts/views) exists for that page. Untested links count against your score unless you exclude their destination with [`viewFilters`](/ui-coverage/configuration/viewfilters). See [Untested Links](/ui-coverage/core-concepts/interactivity#Untested-Links).
+
+### <Icon name="angle-right" /> Why don't `mailto:` and `tel:` links appear in Cypress UI Coverage?
+
+Contact links, meaning anchors whose `href` uses `tel:`, `mailto:`, or `sms:`, aren't treated as interactive elements, so they never appear in reports and never count toward your score. If you need one tracked, add [`data-cy-ui-interactive="include"`](/ui-coverage/core-concepts/interactivity#Overriding-interactive-elements-with-data-cy-ui-interactive) to the anchor.
+
+### <Icon name="angle-right" /> Why does Cypress UI Coverage count an external or non-`http` link as an untested link?
+
+Any `href` that resolves to a URL is treated as a link to a destination, including absolute URLs to external sites and schemes like `ftp:`, `file:`, `data:`, `blob:`, or a custom app scheme. If the destination is never visited, it appears as an untested link. Only `#`, `javascript:`, on-page fragments like `#pricing`, and the contact schemes above are excluded. Exclude destinations you don't intend to test with [`viewFilters`](/ui-coverage/configuration/viewfilters). See [Which hrefs count as links](/ui-coverage/core-concepts/interactivity#Which-hrefs-count-as-links).
+
+### <Icon name="angle-right" /> In Cypress UI Coverage, what's the difference between a hash route like `#/settings` and a page anchor like `#pricing` for untested links?
+
+The leading slash. A hash route (`#/settings`) is treated as a URL, so it can be a destination and can appear as an untested link if never visited. A page anchor, or document fragment (`#pricing`), points to a section of the current page, so it's an ordinary interactive element that must be interacted with to count as tested and never appears as an untested link.
 
 ## Element grouping and identification
 

--- a/docs/ui-coverage/guides/ignore-elements.mdx
+++ b/docs/ui-coverage/guides/ignore-elements.mdx
@@ -69,6 +69,10 @@ A few things to keep in mind when writing rules:
 
 For all options and how rules are evaluated, including rule ordering and `documentScope`, see the [`elementFilters` reference](/ui-coverage/configuration/elementfilters).
 
+### Exclude elements from your markup instead
+
+When the team that owns the markup also owns the decision to exclude an element, you can do it in the application code instead of Cloud configuration. Add [`data-cy-ui-interactive="exclude"`](/ui-coverage/core-concepts/interactivity#Overriding-interactive-elements-with-data-cy-ui-interactive) to a single element, or `data-cy-ui-interactive="exclude-all"` to a container to also exclude everything inside it. Prefer `elementFilters` when you want to manage exclusions centrally in Cypress Cloud without changing application code.
+
 ## Validate Ignored Elements
 
 After saving the configuration, regenerate a recent run from its **Properties** tab and review the UI Coverage report. The ignored elements should no longer appear, and your score should reflect only the elements you intend to test. There's no need to rerun your tests to see the effect of a configuration change.

--- a/static/img/ui-coverage/core-concepts/how-ui-coverage-fits-together.svg
+++ b/static/img/ui-coverage/core-concepts/how-ui-coverage-fits-together.svg
@@ -1,0 +1,69 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 520" width="920" height="520" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif" role="img" aria-label="How UI Coverage fits together: Test Replay snapshots are analyzed by UI Coverage, which detects interactive elements (the total), records which interaction commands marked them tested (the numerator), and flags untested links, all feeding the coverage score and report.">
+  <!-- card background so the diagram reads on light or dark site themes -->
+  <rect x="1" y="1" width="918" height="518" rx="16" fill="#ffffff" stroke="#E2E8F0" stroke-width="2"/>
+
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0 0 L10 5 L0 10 z" fill="#94A3B8"/>
+    </marker>
+  </defs>
+
+  <!-- Step A: recorded run -->
+  <rect x="260" y="28" width="400" height="66" rx="10" fill="#EEF2FF" stroke="#6366F1" stroke-width="1.5"/>
+  <text x="460" y="55" text-anchor="middle" font-size="15" font-weight="700" fill="#1E1B4B">Recorded run</text>
+  <text x="460" y="76" text-anchor="middle" font-size="12" fill="#475569">Test Replay captures DOM snapshots as your tests run</text>
+
+  <!-- A -> B -->
+  <line x1="460" y1="94" x2="460" y2="126" stroke="#94A3B8" stroke-width="2" marker-end="url(#arrow)"/>
+
+  <!-- Step B: analysis -->
+  <rect x="260" y="128" width="400" height="66" rx="10" fill="#EEF2FF" stroke="#6366F1" stroke-width="1.5"/>
+  <text x="460" y="155" text-anchor="middle" font-size="15" font-weight="700" fill="#1E1B4B">UI Coverage analyzes each snapshot</text>
+  <text x="460" y="176" text-anchor="middle" font-size="12" fill="#475569">No setup or instrumentation required</text>
+
+  <!-- B -> branch bus -->
+  <line x1="460" y1="194" x2="460" y2="230" stroke="#94A3B8" stroke-width="2"/>
+  <line x1="165" y1="230" x2="755" y2="230" stroke="#94A3B8" stroke-width="2"/>
+  <line x1="165" y1="230" x2="165" y2="256" stroke="#94A3B8" stroke-width="2" marker-end="url(#arrow)"/>
+  <line x1="460" y1="230" x2="460" y2="256" stroke="#94A3B8" stroke-width="2" marker-end="url(#arrow)"/>
+  <line x1="755" y1="230" x2="755" y2="256" stroke="#94A3B8" stroke-width="2" marker-end="url(#arrow)"/>
+
+  <!-- Card 1: interactive elements -->
+  <rect x="30" y="258" width="270" height="150" rx="10" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
+  <text x="52" y="292" font-size="15" font-weight="700" fill="#065F46">&#9312; Interactive elements</text>
+  <text x="52" y="320" font-size="12" fill="#334155">Everything a user can touch:</text>
+  <text x="52" y="338" font-size="12" fill="#334155">buttons, inputs, links, ARIA</text>
+  <text x="52" y="356" font-size="12" fill="#334155">roles, and tab-navigable elements.</text>
+  <rect x="52" y="372" width="112" height="22" rx="11" fill="#10B981"/>
+  <text x="108" y="387" text-anchor="middle" font-size="11" font-weight="700" fill="#ffffff">The total</text>
+
+  <!-- Card 2: interaction commands -->
+  <rect x="325" y="258" width="270" height="150" rx="10" fill="#EFF6FF" stroke="#3B82F6" stroke-width="1.5"/>
+  <text x="347" y="292" font-size="15" font-weight="700" fill="#1E3A8A">&#9313; Interaction commands</text>
+  <text x="347" y="320" font-size="12" fill="#334155">click, type, check, and more</text>
+  <text x="347" y="338" font-size="12" fill="#334155">mark the elements your tests</text>
+  <text x="347" y="356" font-size="12" fill="#334155">actually exercise as tested.</text>
+  <rect x="347" y="372" width="152" height="22" rx="11" fill="#3B82F6"/>
+  <text x="423" y="387" text-anchor="middle" font-size="11" font-weight="700" fill="#ffffff">Tested (the numerator)</text>
+
+  <!-- Card 3: untested links -->
+  <rect x="620" y="258" width="270" height="150" rx="10" fill="#FEF2F2" stroke="#EF4444" stroke-width="1.5"/>
+  <text x="642" y="292" font-size="15" font-weight="700" fill="#991B1B">&#9314; Untested links</text>
+  <text x="642" y="320" font-size="12" fill="#334155">Links to pages your tests</text>
+  <text x="642" y="338" font-size="12" fill="#334155">never visit, surfaced even</text>
+  <text x="642" y="356" font-size="12" fill="#334155">when no view exists for them.</text>
+  <rect x="642" y="372" width="118" height="22" rx="11" fill="#EF4444"/>
+  <text x="701" y="387" text-anchor="middle" font-size="11" font-weight="700" fill="#ffffff">Coverage gaps</text>
+
+  <!-- cards -> report bus -->
+  <line x1="165" y1="408" x2="165" y2="426" stroke="#94A3B8" stroke-width="2"/>
+  <line x1="460" y1="408" x2="460" y2="426" stroke="#94A3B8" stroke-width="2"/>
+  <line x1="755" y1="408" x2="755" y2="426" stroke="#94A3B8" stroke-width="2"/>
+  <line x1="165" y1="426" x2="755" y2="426" stroke="#94A3B8" stroke-width="2"/>
+  <line x1="460" y1="426" x2="460" y2="446" stroke="#94A3B8" stroke-width="2" marker-end="url(#arrow)"/>
+
+  <!-- Step C: score and report -->
+  <rect x="240" y="448" width="440" height="60" rx="10" fill="#1E1B4B" stroke="#1E1B4B"/>
+  <text x="460" y="474" text-anchor="middle" font-size="15" font-weight="700" fill="#ffffff">Coverage score and report</text>
+  <text x="460" y="494" text-anchor="middle" font-size="12" fill="#C7D2FE">score = tested &#247; total, with untested links called out</text>
+</svg>


### PR DESCRIPTION
## Summary

Reworks the UI Coverage **Interactivity** core-concept page so it matches the implementation and leads with value, adds SEO/AEO FAQ entries, and cross-references the markup exclude override in the **Ignore elements** guide.

## Why

The Interactivity page had drifted from the code and read as a bare reference:

- **Inaccurate/incomplete detection rules** — the interactive-element lists omitted native elements (`label`, `details`, media `controls`, `contenteditable`), most interactive ARIA roles, and `aria-haspopup`.
- **Under-documented API** — `data-cy-ui-interactive` was shown only with `include`, when it also supports `exclude`, `exclude-all`, and `reset`.
- **No value framing or visuals**, and thin FAQ coverage of interactive elements and links.

Everything factual here (detection rules, the built-in command set, and href classification) was verified against the discovery `ui-coverage` source (`findInteractiveNodes`, `DEFAULT_INTERACTION_COMMANDS`, `getHrefType`). This continues the UI Coverage docs rework series (accuracy, value, clarity).

## Notes for reviewers

- **Anchors preserved** for inbound links: `#Untested-Links`, `#Which-hrefs-count-as-links`, and `#Interaction-Commands` (the "Interaction Commands" heading was renamed to "How elements get marked tested" but keeps the anchor via an explicit `{#Interaction-Commands}` id). Verified all inbound references still resolve.
- **New asset**: a self-contained `how-ui-coverage-fits-together.svg` flow diagram. It carries its own light card background so it reads in both light and dark site themes; rendered output was checked with a headless-Chromium screenshot.
- **Screenshots** reuse existing images already in the repo.
- All config examples are titled `App Quality Config`. Prettier and the frontmatter linter pass; no em dashes.
- Confirmed against the code that there is **no** App Quality config option to make a non-interactive element interactive (only the `data-cy-ui-interactive="include"` markup attribute), so the relevant FAQ answer points to markup rather than a config path.

Three commits: the page rework (+ diagram), the FAQ additions, and the Ignore elements cross-reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015qzuX3YwuS1Fvfaev5GLUr

---
_Generated by [Claude Code](https://claude.ai/code/session_015qzuX3YwuS1Fvfaev5GLUr)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and a static SVG asset only; no application or runtime behavior changes.
> 
> **Overview**
> **Reworks the UI Coverage Interactivity core-concept page** so it explains how the score is built (interactive total, tested numerator, untested links), ties detection to WHATWG semantics plus Cypress rules, and documents the full `data-cy-ui-interactive` surface (`include`, `exclude`, `exclude-all`, `reset`) with markup and `elementFilters` / `viewFilters` examples. Adds a **how-ui-coverage-fits-together** flow diagram SVG, screenshots, and clearer sections on interaction commands (including snapshot requirements) and href classification (summary table plus detailed cases).
> 
> **Adds an Interactive elements FAQ block** covering what counts as interactive, custom widgets, exclusions, untested links, contact schemes, external/non-http links, and hash routes vs page anchors.
> 
> **Extends the Ignore elements guide** with a short section on excluding via markup (`data-cy-ui-interactive`) when the markup-owning team prefers that over Cloud `elementFilters`. Preserves key inbound anchors such as `#Interaction-Commands` and `#Untested-Links`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09ed6224686841afd6cc52a3f1ca93e120c5b666. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->