### PR TITLE
Add cypress-mock-latency plugin

### DIFF
--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -649,6 +649,13 @@
           "link": "https://github.com/bahmutov/cypress-network-idle",
           "keywords": ["network", "idle", "wait", "commands"],
           "badge": "community"
+        },
+         {
+          "name": "cypress-mock-latency",
+          "description": "Easily mock real-world flaky network latency and jitter in Cypress tests.",
+          "link": "https://github.com/dhrusoni84/cypress-mock-latency",
+          "keywords": ["network", "latency", "jitter", "mock", "throttle"],
+          "badge": "community"
         }
       ]
     },


### PR DESCRIPTION
## Summary
Adds an entry for `cypress-mock-latency` to the Network & API Testing
section of the plugins list. The plugin adds a `cy.mockLatency()` command
that layers randomized delay ranges, named network presets (e.g.
`3g-poor`, `satellite`), and jitter spikes on top of `cy.intercept()`, plus
a `cy.mockLatencyOffline()` command for simulating a dropped connection.

## Why
`cy.intercept()` supports a fixed response delay, but there's no built-in
way to simulate a realistic, variable network (randomized ranges, jitter
spikes, common named profiles) without writing that logic by hand in every
test suite. This plugin wraps that boilerplate into a single reusable
command so teams can test loading states, timeouts, and retry UX under
realistic flaky-network conditions with one line.

Closes #<!-- remove this line since there's no linked issue -->

## Notes for reviewers
- Published on npm: https://www.npmjs.com/package/cypress-mock-latency
- Source, tests, and CI: https://github.com/dhrusoni84/cypress-mock-latency
- The repo includes Cypress integration tests (fixed delay, named preset,
  custom config, and offline simulation) run via GitHub Actions on every
  push/PR.
- This is my first contribution to the plugins list — happy to adjust
  wording, category placement, or keywords if they don't match your
  conventions.