### PR TITLE
docs(ui-coverage): rework Element Grouping core concept for accuracy, value, and clarity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,12 @@ Each rule is a hard convention. See the linked section for the how and why.
 - Tag every code block with a language; add `title="file.ext"` for file snippets.
 - Never use em dashes — they read as AI-generated; use commas, periods, or
   parentheses instead.
+- Use **bold** only for real UI controls the reader acts on in a walkthrough
+  (actual buttons, links, tabs, and flows in Cypress Cloud or the Cypress App,
+  e.g. the **App Quality** tab). Put hypothetical UI labels from illustrative
+  examples in `"quotes"` instead (e.g. an `"Add to cart"` button in a sample),
+  so invented examples stay distinct from the real UI a tutorial navigates. See
+  [Writing style](./AGENTS_REFERENCE.md#writing-style).
 - Don't use minimizing words like "simply", "just", "easy", or "obviously" in
   instructions. They undermine a reader who is struggling and add nothing; state
   the step plainly instead.

--- a/AGENTS_REFERENCE.md
+++ b/AGENTS_REFERENCE.md
@@ -133,6 +133,16 @@ To add a plugin to the plugins list, add an entry to `src/data/plugins.json`
   best fit, and rarely more than one per paragraph.
 - Header anchor casing is intentionally preserved via a `patch-package` patch to
   `@docusaurus/mdx-loader` (see `patches/`). This is expected, not a bug.
+- **Bold vs. quotes for UI labels.** Reserve **bold** for real controls the
+  reader acts on in a walkthrough or tutorial, meaning actual buttons, links,
+  tabs, menu items, and flows in the Cypress Cloud or Cypress App UI (for
+  example, "open the **App Quality** tab" or "click **Record run**"). Bolding
+  these makes the clickable target scannable as the reader follows along. When a
+  UI label is only a hypothetical example in an illustrative scenario, not a real
+  control the reader is being told to use, put it in `"double quotes"` instead
+  (for example, an `"Add to cart"` button repeated on every card, or a `"Delete"`
+  button in a sample table). This keeps invented example labels visually distinct
+  from the real UI the tutorial navigates.
 
 ## Code blocks
 

--- a/docs/ui-coverage/core-concepts/element-grouping.mdx
+++ b/docs/ui-coverage/core-concepts/element-grouping.mdx
@@ -1,6 +1,6 @@
 ---
 title: How UI Coverage groups related elements
-description: 'UI Coverage groups elements that are related to one another through structural or behavioral hints, but this is configurable.'
+description: 'UI Coverage automatically groups repeated interactive elements so they count once and a single test can cover the whole set. Learn the automatic grouping rules and how to customize them.'
 sidebar_label: Element Grouping
 sidebar_position: 30
 ---
@@ -9,35 +9,44 @@ sidebar_position: 30
 
 # Element Grouping
 
-Testing every element on a page is not always necessary when multiple elements share the same behavior. UI Coverage simplifies this by grouping related elements, allowing interactions with any element in the group to count as testing the entire group. This reduces redundancy and ensures efficient and accurate coverage. For example, options in a dropdown menu can be grouped if interacting with one option verifies the behavior of the entire set.
+Applications reuse the same control in many places. A product listing renders an "Add to cart" button on every card, and a data table renders the same action button on every row. UI Coverage sees each rendered button as its own interactive element, so without grouping a single page can add hundreds of near-identical elements to your report, each counted on its own. Because these buttons all behave the same way, testing one is enough to verify the rest. Without grouping, though, every button a test doesn't touch still counts as untested and lowers your coverage score.
 
-## How element grouping works
+UI Coverage solves this by grouping elements that behave the same way. A group counts **once** toward your coverage score, and interacting with **any** element in the group marks the whole group as tested. Fifty untested product cards become one clearly named group that a single test can cover.
 
-UI Coverage groups elements using structural and behavioral hints, along with user-defined configurations. When grouped, interacting with one element is considered equivalent to testing all elements in the group.
+## How grouping affects your report and score
 
-## Grouping Rules
+Grouping changes what you see and what you're measured against:
 
-- **User-Defined Groups**: Elements are grouped by [Element Groups](/ui-coverage/configuration/elementgroups) configuration if specified.
-- **Labels and Form Elements**: `label` elements are automatically grouped with the form elements they are associated with.
-- **Table Row Grouping**: Elements within table rows are grouped with elements sharing common attributes or the same position across rows.
-- **Repeated Elements**: Duplicate elements in the DOM with shared attributes are grouped.
-- **Parent-Shared Attributes**: Duplicate elements with parents that share common attributes are grouped.
-- **Dynamic Links**: Links with similar `href` patterns are resolved into [views](/ui-coverage/configuration/views) and grouped by their `href` pattern.
+- **The group counts once.** A group of 50 buttons contributes a single unit to your total element count, not 50.
+- **One interaction covers the group.** Testing any one member marks the entire group as tested, since every member shares the same behavior.
+- **Reports stay readable.** A group appears as one row, labeled by a shared attribute or a name you choose, instead of a long list of machine-generated selectors.
 
-### Example
+## Automatic grouping
 
-Consider a table where each row contains a delete button:
+Out of the box, with no configuration, UI Coverage groups elements it can recognize as variations of the same control. It uses structural and behavioral signals from the DOM:
+
+- **Shared test attributes.** Interactive elements with the same [identifying attribute](/ui-coverage/core-concepts/element-identification#How-an-element-is-identified) value are grouped, such as a `data-cy="favorite"` button repeated on every product card.
+- **Form controls and their labels.** A `<label>` is grouped with the form control it identifies, so the pair counts as one unit instead of two.
+- **Table and grid rows.** Controls in the same position across sibling rows are grouped, in `<table>` elements and ARIA grids (`role="grid"`, `role="table"`, and `role="treegrid"`).
+- **Repeated structures.** Elements that share a tag and class hierarchy up to a common parent are grouped, catching repeated lists and cards that behave alike even without test attributes.
+- **Links to the same view.** Links whose `href` resolves to the same [view](/ui-coverage/core-concepts/views) are represented by that view instead of listed separately.
+
+Automatic grouping requires at least two similar elements. A control that appears only once stays on its own.
+
+### Example: repeated controls in a table
+
+Consider a customer table where each row has a "Delete" button:
 
 ```html
 <table>
   <tr>
-    <td>John Doe</td>
+    <td>Aisha Rahman</td>
     <td>
       <button>Delete</button>
     </td>
   </tr>
   <tr>
-    <td>Jane Smith</td>
+    <td>Mateo Ramirez</td>
     <td>
       <button>Delete</button>
     </td>
@@ -45,11 +54,34 @@ Consider a table where each row contains a delete button:
 </table>
 ```
 
-In this case, UI Coverage groups the delete buttons together in accordance with our grouping rules. Interacting with one delete button is equivalent to testing all delete buttons in the table.
+The "Delete" buttons occupy the same position in sibling rows, so UI Coverage groups them. A test that deletes one customer marks the group as tested, and the report shows a single "Delete" group instead of one element per row.
 
-## Grouping with markup attributes
+## Custom grouping
 
-You can define groups directly in your application's markup with the `data-cy-ui-group` attribute, without any Cypress Cloud configuration. Elements that share the same attribute value are grouped together, and the group appears in reports under a selector formatted with that value, such as `[data-cy-ui-group="pagination"]`.
+Automatic grouping handles most cases, but you can override it when it collapses too much, too little, or names things unhelpfully. You have two ways to take control: centrally in Cypress Cloud, or in your application's markup.
+
+### Grouping with configuration
+
+When you want to manage grouping centrally in Cypress Cloud without changing application code, use the [`elementGroups`](/ui-coverage/configuration/elementgroups) configuration. Each rule matches interactive elements with a CSS selector and collects them into one named group. This is the right tool when the team reading the reports isn't the team that owns the markup, or when you want to correct the automatic grouping without a code change.
+
+```json title="App Quality Config"
+{
+  "uiCoverage": {
+    "elementGroups": [
+      {
+        "selector": "[data-cy^='add-to-cart-']",
+        "name": "Add to Cart Button"
+      }
+    ]
+  }
+}
+```
+
+The [`elementGroups` configuration guide](/ui-coverage/configuration/elementgroups) covers the full syntax, including how to name groups, order rules, and scope them to specific iframes or shadow DOM hosts with `documentScope`.
+
+### Grouping with markup attributes
+
+You can also define groups directly in your application's markup with the `data-cy-ui-group` attribute, without any Cypress Cloud configuration. Elements that share the same attribute value are grouped together, and the group appears in reports under a selector formatted with that value, such as `[data-cy-ui-group="pagination"]`.
 
 ```html
 <button data-cy-ui-group="pagination">1</button>
@@ -57,15 +89,19 @@ You can define groups directly in your application's markup with the `data-cy-ui
 <button data-cy-ui-group="pagination">3</button>
 ```
 
-The attribute follows these rules:
+Where you place the attribute determines what it groups:
 
-- Placing the attribute on an interactive element applies the group to that element only.
-- Placing the attribute on a wrapper or parent element applies the group to all interactive elements inside it.
-- When wrappers with the attribute are nested, each interactive element joins the group of its closest ancestor with the attribute.
-- Groups defined with this attribute take priority over every other grouping mechanism, including [`elementGroups`](/ui-coverage/configuration/elementgroups) configuration rules.
+- **On an interactive element**, it groups that element only.
+- **On a wrapper or parent element**, it groups every interactive element inside it.
+- **On nested wrappers**, each interactive element joins the group of its closest ancestor that has the attribute.
 
-Use the attribute when the team that owns the markup also owns the grouping decisions, and use [`elementGroups`](/ui-coverage/configuration/elementgroups) configuration when you want to manage grouping centrally in Cypress Cloud without changing application code.
+Groups defined this way take priority over every other grouping mechanism, including [`elementGroups`](/ui-coverage/configuration/elementgroups) configuration rules. Reach for the attribute when the team that owns the markup also owns the grouping decisions.
 
-## Customizing element grouping
+## See also
 
-You can customize element grouping to suit your application's structure and behavior. Refer to the [Element Groups](/ui-coverage/configuration/elementgroups) configuration guide to learn how to define custom groups and group elements based on specific attributes or selectors.
+- [`elementGroups`](/ui-coverage/configuration/elementgroups) defines custom groups in Cypress Cloud and overrides the automatic rules.
+- [`significantAttributes`](/ui-coverage/configuration/significantattributes) changes which attributes identify and group elements.
+- [`elementFilters`](/ui-coverage/configuration/elementfilters) removes elements from reports entirely, so they're never grouped or scored.
+- [Element Identification](/ui-coverage/core-concepts/element-identification) explains the significant attributes that drive grouping and how elements are recognized across snapshots.
+- [Guide: Reduce noise in UI Coverage reports](/ui-coverage/guides/reduce-noise) walks through combining grouping and filtering to clean up a report.
+- [UI Coverage FAQ](/ui-coverage/faq) answers common questions about grouping, scores, and configuration.

--- a/docs/ui-coverage/core-concepts/element-grouping.mdx
+++ b/docs/ui-coverage/core-concepts/element-grouping.mdx
@@ -14,6 +14,7 @@ Applications reuse the same control in many places. A product listing renders an
 UI Coverage solves this by grouping elements that behave the same way. A group counts **once** toward your coverage score, and interacting with **any** element in the group marks the whole group as tested. Fifty untested product cards become one clearly named group that a single test can cover.
 
 <DocsImage
+  noBorder
   src="/img/ui-coverage/core-concepts/element-grouping-before-after.svg"
   alt="A before-and-after comparison of element grouping. On the left, without grouping, six identical 'Add to cart' buttons each appear as their own untested element, totaling six elements and six untested. An arrow labeled 'UI Coverage groups them' points to the right. On the right, with grouping, the six buttons collapse into a single 'Add to Cart Button' group that is counted once, where one interaction marks all six of them tested."
 />

--- a/docs/ui-coverage/core-concepts/element-grouping.mdx
+++ b/docs/ui-coverage/core-concepts/element-grouping.mdx
@@ -13,6 +13,11 @@ Applications reuse the same control in many places. A product listing renders an
 
 UI Coverage solves this by grouping elements that behave the same way. A group counts **once** toward your coverage score, and interacting with **any** element in the group marks the whole group as tested. Fifty untested product cards become one clearly named group that a single test can cover.
 
+<DocsImage
+  src="/img/ui-coverage/core-concepts/element-grouping-before-after.svg"
+  alt="A before-and-after comparison of element grouping. On the left, without grouping, six identical 'Add to cart' buttons each appear as their own untested element, totaling six elements and six untested. An arrow labeled 'UI Coverage groups them' points to the right. On the right, with grouping, the six buttons collapse into a single 'Add to Cart Button' group that is counted once, where one interaction marks all six of them tested."
+/>
+
 ## How grouping affects your report and score
 
 Grouping changes what you see and what you're measured against:

--- a/docs/ui-coverage/faq.mdx
+++ b/docs/ui-coverage/faq.mdx
@@ -91,6 +91,22 @@ The leading slash. A hash route (`#/settings`) is treated as a URL, so it can be
 
 ## Element grouping and identification
 
+### <Icon name="angle-right" /> How does UI Coverage group elements automatically?
+
+Out of the box, with no Cypress Cloud configuration, UI Coverage combines elements it recognizes as variations of the same control. It groups interactive elements that share the same [identifying attribute](/ui-coverage/core-concepts/element-identification#How-an-element-is-identified) value (such as a `data-cy="favorite"` button repeated on every card), form controls with their `<label>`, controls in the same position across table and grid rows, repeated structures that share a tag and class hierarchy, and links that resolve to the same [view](/ui-coverage/core-concepts/views). Automatic grouping needs at least two similar elements; a control that appears once stays on its own. See [Element Grouping](/ui-coverage/core-concepts/element-grouping#Automatic-grouping) for the full set of rules.
+
+### <Icon name="angle-right" /> How does grouping affect my UI Coverage score?
+
+A [group](/ui-coverage/core-concepts/element-grouping) counts once toward your total element count in Cypress Cloud, and interacting with any one member marks the whole group as tested. So a list of 50 identical "Remove" buttons contributes a single unit to your score, and one test that removes one item covers all 50. This keeps repeated elements from inflating your total and keeps a single untested set from sinking your score for no real gap in testing.
+
+### <Icon name="angle-right" /> Why does my UI Coverage report show one group instead of every repeated element?
+
+That's grouping working as intended. When UI Coverage detects that many elements are copies of the same control, such as a "Delete" button on every table row, it collapses them into one named group so the report stays readable and the score reflects distinct behaviors rather than raw element counts. If the automatic grouping is combining elements you'd rather see separately, split them apart with an [`elementGroups`](/ui-coverage/configuration/elementgroups) rule in your Cypress Cloud configuration.
+
+### <Icon name="angle-right" /> Which UI Coverage grouping mechanism wins when more than one could apply?
+
+The [`data-cy-ui-group` markup attribute](/ui-coverage/core-concepts/element-grouping#Grouping-with-markup-attributes) takes priority over everything, then [`elementGroups`](/ui-coverage/configuration/elementgroups) configuration rules in Cypress Cloud, and finally the [automatic grouping rules](/ui-coverage/core-concepts/element-grouping#Automatic-grouping) apply to whatever no attribute or rule claimed. Elements removed by [`elementFilters`](/ui-coverage/configuration/elementfilters) are never grouped at all.
+
 ### <Icon name="angle-right" /> What happens if two elementGroups rules match the same element?
 
 The first matching rule in your [`elementGroups`](/ui-coverage/configuration/elementgroups) configuration wins, so list specific rules before broad catch-all rules. A rule that appears after another rule matching the same elements never applies to them.

--- a/static/img/ui-coverage/core-concepts/element-grouping-before-after.svg
+++ b/static/img/ui-coverage/core-concepts/element-grouping-before-after.svg
@@ -1,0 +1,85 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 392" width="920" height="392" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif" role="img" aria-label="Element grouping, before and after. Without grouping, six repeated Add to cart buttons are each counted as their own untested element. UI Coverage groups them into one Add to Cart Button group that is counted once, and a single interaction with any button marks the whole group tested.">
+  <!-- card background so the diagram reads on light or dark site themes -->
+  <rect x="1" y="1" width="918" height="390" rx="16" fill="#ffffff" stroke="#E2E8F0" stroke-width="2"/>
+
+  <defs>
+    <marker id="eg-arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0 0 L10 5 L0 10 z" fill="#94A3B8"/>
+    </marker>
+  </defs>
+
+  <!-- caption -->
+  <text x="460" y="34" text-anchor="middle" font-size="13" fill="#475569">The same six "Add to cart" buttons, before and after grouping</text>
+
+  <!-- ============ LEFT: without grouping ============ -->
+  <text x="204" y="70" text-anchor="middle" font-size="15" font-weight="700" fill="#0F172A">Without grouping</text>
+  <text x="204" y="90" text-anchor="middle" font-size="11" fill="#64748B">Each button is its own untested element</text>
+  <rect x="24" y="104" width="360" height="252" rx="12" fill="#F8FAFC" stroke="#E2E8F0" stroke-width="1.5"/>
+
+  <!-- six repeated product-card buttons -->
+  <!-- row 1 -->
+  <g>
+    <rect x="42" y="120" width="160" height="62" rx="8" fill="#ffffff" stroke="#E2E8F0" stroke-width="1.5"/>
+    <circle cx="184" cy="136" r="5" fill="#F43F5E"/>
+    <rect x="60" y="140" width="110" height="24" rx="12" fill="#FFF1F2" stroke="#F43F5E" stroke-width="1.5"/>
+    <text x="115" y="156" text-anchor="middle" font-size="11" fill="#9F1239">Add to cart</text>
+  </g>
+  <g>
+    <rect x="214" y="120" width="160" height="62" rx="8" fill="#ffffff" stroke="#E2E8F0" stroke-width="1.5"/>
+    <circle cx="356" cy="136" r="5" fill="#F43F5E"/>
+    <rect x="232" y="140" width="110" height="24" rx="12" fill="#FFF1F2" stroke="#F43F5E" stroke-width="1.5"/>
+    <text x="287" y="156" text-anchor="middle" font-size="11" fill="#9F1239">Add to cart</text>
+  </g>
+  <!-- row 2 -->
+  <g>
+    <rect x="42" y="192" width="160" height="62" rx="8" fill="#ffffff" stroke="#E2E8F0" stroke-width="1.5"/>
+    <circle cx="184" cy="208" r="5" fill="#F43F5E"/>
+    <rect x="60" y="212" width="110" height="24" rx="12" fill="#FFF1F2" stroke="#F43F5E" stroke-width="1.5"/>
+    <text x="115" y="228" text-anchor="middle" font-size="11" fill="#9F1239">Add to cart</text>
+  </g>
+  <g>
+    <rect x="214" y="192" width="160" height="62" rx="8" fill="#ffffff" stroke="#E2E8F0" stroke-width="1.5"/>
+    <circle cx="356" cy="208" r="5" fill="#F43F5E"/>
+    <rect x="232" y="212" width="110" height="24" rx="12" fill="#FFF1F2" stroke="#F43F5E" stroke-width="1.5"/>
+    <text x="287" y="228" text-anchor="middle" font-size="11" fill="#9F1239">Add to cart</text>
+  </g>
+  <!-- row 3 -->
+  <g>
+    <rect x="42" y="264" width="160" height="62" rx="8" fill="#ffffff" stroke="#E2E8F0" stroke-width="1.5"/>
+    <circle cx="184" cy="280" r="5" fill="#F43F5E"/>
+    <rect x="60" y="284" width="110" height="24" rx="12" fill="#FFF1F2" stroke="#F43F5E" stroke-width="1.5"/>
+    <text x="115" y="300" text-anchor="middle" font-size="11" fill="#9F1239">Add to cart</text>
+  </g>
+  <g>
+    <rect x="214" y="264" width="160" height="62" rx="8" fill="#ffffff" stroke="#E2E8F0" stroke-width="1.5"/>
+    <circle cx="356" cy="280" r="5" fill="#F43F5E"/>
+    <rect x="232" y="284" width="110" height="24" rx="12" fill="#FFF1F2" stroke="#F43F5E" stroke-width="1.5"/>
+    <text x="287" y="300" text-anchor="middle" font-size="11" fill="#9F1239">Add to cart</text>
+  </g>
+
+  <text x="204" y="344" text-anchor="middle" font-size="11" fill="#9F1239">6 elements &#183; 6 untested</text>
+
+  <!-- ============ MIDDLE: transform ============ -->
+  <text x="460" y="212" text-anchor="middle" font-size="11" font-weight="600" fill="#475569">UI Coverage</text>
+  <text x="460" y="226" text-anchor="middle" font-size="11" font-weight="600" fill="#475569">groups them</text>
+  <line x1="392" y1="244" x2="528" y2="244" stroke="#94A3B8" stroke-width="2" marker-end="url(#eg-arrow)"/>
+
+  <!-- ============ RIGHT: with grouping ============ -->
+  <text x="716" y="70" text-anchor="middle" font-size="15" font-weight="700" fill="#0F172A">With grouping</text>
+  <text x="716" y="90" text-anchor="middle" font-size="11" fill="#64748B">Collapsed into one unit, counted once</text>
+  <rect x="536" y="104" width="360" height="252" rx="12" fill="#F8FAFC" stroke="#E2E8F0" stroke-width="1.5"/>
+
+  <!-- single group -->
+  <rect x="576" y="176" width="280" height="108" rx="12" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
+  <!-- check badge -->
+  <circle cx="606" cy="212" r="11" fill="#10B981"/>
+  <path d="M600.5 212 l4 4 l7 -8" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="626" y="217" font-size="15" font-weight="700" fill="#065F46">Add to Cart Button</text>
+  <!-- count badge -->
+  <rect x="792" y="198" width="44" height="26" rx="13" fill="#10B981"/>
+  <text x="814" y="216" text-anchor="middle" font-size="13" font-weight="700" fill="#ffffff">&#215;6</text>
+  <line x1="596" y1="240" x2="836" y2="240" stroke="#A7F3D0" stroke-width="1.5"/>
+  <text x="716" y="264" text-anchor="middle" font-size="12" fill="#047857">One interaction marks all six tested</text>
+
+  <text x="716" y="344" text-anchor="middle" font-size="11" fill="#047857">1 group &#183; 1 test covers the set</text>
+</svg>

--- a/static/img/ui-coverage/core-concepts/element-grouping-before-after.svg
+++ b/static/img/ui-coverage/core-concepts/element-grouping-before-after.svg
@@ -4,7 +4,7 @@
 
   <defs>
     <marker id="eg-arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
-      <path d="M0 0 L10 5 L0 10 z" fill="#94A3B8"/>
+      <path d="M0 0 L10 5 L0 10 z" fill="#64748B"/>
     </marker>
   </defs>
 
@@ -62,7 +62,7 @@
   <!-- ============ MIDDLE: transform ============ -->
   <text x="460" y="212" text-anchor="middle" font-size="11" font-weight="600" fill="#475569">UI Coverage</text>
   <text x="460" y="226" text-anchor="middle" font-size="11" font-weight="600" fill="#475569">groups them</text>
-  <line x1="392" y1="244" x2="528" y2="244" stroke="#94A3B8" stroke-width="2" marker-end="url(#eg-arrow)"/>
+  <line x1="392" y1="244" x2="528" y2="244" stroke="#64748B" stroke-width="2" marker-end="url(#eg-arrow)"/>
 
   <!-- ============ RIGHT: with grouping ============ -->
   <text x="716" y="70" text-anchor="middle" font-size="15" font-weight="700" fill="#0F172A">With grouping</text>
@@ -70,13 +70,13 @@
   <rect x="536" y="104" width="360" height="252" rx="12" fill="#F8FAFC" stroke="#E2E8F0" stroke-width="1.5"/>
 
   <!-- single group -->
-  <rect x="576" y="176" width="280" height="108" rx="12" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
+  <rect x="576" y="176" width="280" height="108" rx="12" fill="#ECFDF5" stroke="#059669" stroke-width="1.5"/>
   <!-- check badge -->
-  <circle cx="606" cy="212" r="11" fill="#10B981"/>
+  <circle cx="606" cy="212" r="11" fill="#047857"/>
   <path d="M600.5 212 l4 4 l7 -8" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
   <text x="626" y="217" font-size="15" font-weight="700" fill="#065F46">Add to Cart Button</text>
   <!-- count badge -->
-  <rect x="792" y="198" width="44" height="26" rx="13" fill="#10B981"/>
+  <rect x="792" y="198" width="44" height="26" rx="13" fill="#047857"/>
   <text x="814" y="216" text-anchor="middle" font-size="13" font-weight="700" fill="#ffffff">&#215;6</text>
   <line x1="596" y1="240" x2="836" y2="240" stroke="#A7F3D0" stroke-width="1.5"/>
   <text x="716" y="264" text-anchor="middle" font-size="12" fill="#047857">One interaction marks all six tested</text>


### PR DESCRIPTION
## Summary

Reworks the UI Coverage **Element Grouping** core concept page so it matches the actual grouping implementation, leads with the value grouping provides, and reads clearly. Also expands the UI Coverage FAQ with grouping questions and records a bold-vs-quotes convention for UI labels in the agent guides.

## Why

The Element Grouping page had drifted from the implementation in the discovery UI Coverage service (`discovery/packages/ui-coverage/src/render/grouping/`). Most notably, it never documented the **shared test attributes** rule (elements sharing the same identifying attribute value are grouped), described the automatic rules vaguely, and buried the value of the feature. This continues the ongoing UI Coverage docs accuracy pass and improves SEO/AEO by adding branded FAQ entries.

Changes verified against the grouping engine and its e2e rulesets:

- **Lead with value** — repeated controls each count as their own interactive element and inflate the report/score without grouping; testing one representative covers the set.
- **Accurate automatic rules** — shared test attributes (previously missing), form controls with their labels, table/grid rows (including ARIA grid roles), repeated structures, and links resolved to a shared view.
- **Custom grouping** split into configuration (`elementGroups`) and markup (`data-cy-ui-group`), with the config example titled `App Quality Config`.
- **Realistic, diverse examples**, and hypothetical UI labels quoted so they read distinctly from real Cypress Cloud/App controls.
- **FAQ** — four grouping questions (automatic grouping, score impact, expected collapsing, precedence), named for UI Coverage and Cypress Cloud so answer engines match branded queries.
- **Agent guides** — documents when to bold (real controls in a walkthrough) versus quote (hypothetical example labels) UI labels.

## Notes for reviewers

- Two commits: the docs rework + FAQ, and the agent-guide convention.
- The page preserves the `Grouping with markup attributes` heading anchor, which `troubleshooting`, `configuration/overview`, `elementgroups`, `significantattributes`, and `faq` all link to.
- `main` rewrote `element-identification.mdx` and removed its `Significant attributes` heading; the two links that pointed there now target `#How-an-element-is-identified`, so `onBrokenLinks` stays green.
- Verified with `prettier --check` and `lint-frontmatter`; all anchored cross-links in the changed pages were checked against their current targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013A4cheq1DWDW2RyUdRfJPC

---
_Generated by [Claude Code](https://claude.ai/code/session_013A4cheq1DWDW2RyUdRfJPC)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to MDX, agent guides, and a static SVG; no application or product code paths are affected.
> 
> **Overview**
> **Reworks the UI Coverage Element Grouping core concept** so it leads with why grouping matters (repeated controls and score inflation), adds a before/after diagram, and documents automatic rules more precisely—including **shared identifying attributes**, form labels, table/grid rows, repeated structures, and links to the same view—with separate sections for Cloud `elementGroups` config and `data-cy-ui-group` markup. The page gets an updated meta description, an `elementGroups` JSON example titled `App Quality Config`, a **See also** section, and hypothetical UI labels in quotes per the new style rule.
> 
> **Adds four UI Coverage FAQ entries** on automatic grouping, score impact, collapsed reports, and precedence (`data-cy-ui-group` → `elementGroups` → automatic rules).
> 
> **Updates agent authoring guides** (`AGENTS.md`, `AGENTS_REFERENCE.md`) to reserve **bold** for real Cypress Cloud/App controls in walkthroughs and use `"quotes"` for illustrative example labels.
> 
> **Adds** `element-grouping-before-after.svg` for the new `<DocsImage>` on the concept page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54957ed6a2dcbe771400e47412c246409990f618. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->