### PR TITLE
docs(ui-coverage): rework guides into followable workflows

### DIFF
--- a/docs/accessibility/guides/production-monitoring.mdx
+++ b/docs/accessibility/guides/production-monitoring.mdx
@@ -17,30 +17,6 @@ Dynamic or externally controlled content, such as A/B tests or user-generated co
 
 Cypress Accessibility enables you to test dynamic content seamlessly. By visiting a production URL within your Cypress tests and performing minimal UI interactions, you can capture the page's accessibility state in reports. This allows teams to detect accessibility issues introduced outside the regular development lifecycle.
 
-## Example: Automated Sitemap-Based Testing
+## Scan every page from a sitemap
 
-If your project lacks existing Cypress tests, a common approach is to generate test coverage from a sitemap or an array of target URLs. These URLs can be used to perform light interactions and capture accessibility reports. Below is an example of how to automate this process by using a sitemap and scrolling to the footer on each page:
-
-```js
-describe('Accessibility Scan', () => {
-  it('Checks accessibility with the sitemap.xml', () => {
-    cy.request('https://<YOUR_WEBSITE>/sitemap.xml').then((response) => {
-      const xmlString = response.body
-      const parser = new DOMParser()
-      const xmlDoc = parser.parseFromString(xmlString, 'application/xml')
-      const URLs = Array.from(xmlDoc.querySelectorAll('loc')).map(
-        (loc) => loc.textContent
-      )
-      Cypress._.each(URLs, (URL) => {
-        cy.visit(URL)
-        cy.contains('<YOUR_FOOTER_CONTENT>').scrollIntoView()
-        // perform some repeatable actions here that influence accessibility, for example:
-        //  - change from light mode to dark mode
-        //  - modify the viewport size to simulate mobile screens and higher zoom levels
-      })
-    })
-  })
-})
-```
-
-The outcome of this is a first-page-load accessibility report for every URL in the site. Any Cypress UI tests for specific workflows will increase the coverage area automatically to include the states and variations reached during the workflows.
+<SitemapScanExample product="accessibility" />

--- a/docs/partials/_sitemap-scan-example.mdx
+++ b/docs/partials/_sitemap-scan-example.mdx
@@ -1,0 +1,63 @@
+import CodeBlock from '@theme/CodeBlock'
+import {
+  copy,
+  singleTestCode,
+  separateTestCode,
+} from '@site/docs/partials/sitemapScanCode'
+
+If your project lacks existing Cypress tests, a common approach is to drive{' '}
+{copy[props.product].name} from a sitemap or an array of target URLs. Visiting
+each URL performs a light interaction that {copy[props.product].name} records,
+giving you a first {copy[props.product].reportKind} report for the pages your
+suite doesn't reach yet.
+
+### Example: Visit every sitemap URL in a single test
+
+The example below fetches your `sitemap.xml` at runtime and visits every URL it
+finds in a single test. This is the quickest way to get started, with no list to
+maintain:
+
+<CodeBlock language="js">{singleTestCode[props.product]}</CodeBlock>
+
+{props.product === 'accessibility' ? (
+
+<p>
+  The <code>scrollIntoView</code> call is optional. Test Replay captures the
+  full page for accessibility analysis on load, so you only need it when content
+  appears through progressive scrolling, such as lazy-loaded images or infinite
+  lists. It can also be worth keeping to exercise scrolling itself, since a page
+  that cannot be scrolled to reach its content is an accessibility problem in
+  its own right.
+</p>
+
+) : null}
+
+### Example: Visit each URL in separate tests
+
+The single-test scan above is quick to set up, but putting each URL in a
+separate test is often the better choice:
+
+- **Tracking**: each page becomes a distinct test in Cypress Cloud, so a page
+  that fails to load shows up as its own failing test with its own
+  [Test Replay](/cloud/features/test-replay), instead of collapsing the whole
+  scan into one pass/fail.
+- **Performance**: a single test that visits every page keeps accumulating DOM
+  snapshots and command history as it runs, which slows it down and makes it
+  harder to debug. Separate tests each start clean, so they stay fast.
+- **Isolation**: [test isolation](/app/core-concepts/writing-and-organizing-tests#Test-Isolation)
+  resets the browser state between pages, so one page's cookies or storage can't
+  leak into the next.
+
+Because Cypress defines tests when the spec loads (before any command runs), the
+list of URLs has to exist before the run starts rather than come from a sitemap
+fetched at runtime. You can hard-code it in the spec, import it from a committed
+file, or generate it in your Cypress config and pass it to the spec. This
+documentation's own test suite takes the last approach: it builds the list of
+pages in `cypress.config` and loops over them to create one test per page.
+
+<CodeBlock language="js">{separateTestCode[props.product]}</CodeBlock>
+
+The result is a first-load {copy[props.product].reportKind} report for every URL
+in your site. Any Cypress tests you write for specific workflows automatically
+expand the {copy[props.product].reportKind} area to include the states and
+variations those workflows reach.

--- a/docs/partials/sitemapScanCode.ts
+++ b/docs/partials/sitemapScanCode.ts
@@ -1,0 +1,73 @@
+// Code samples for the shared sitemap-scan example partial
+// (`_sitemap-scan-example.mdx`). They live in this module rather than inline in
+// the MDX so that Prettier formats them as plain strings and does not reflow the
+// embedded JavaScript.
+
+type Product = 'ui-coverage' | 'accessibility'
+
+export const copy: Record<Product, { name: string; reportKind: string }> = {
+  'ui-coverage': { name: 'UI Coverage', reportKind: 'coverage' },
+  accessibility: { name: 'Cypress Accessibility', reportKind: 'accessibility' },
+}
+
+export const singleTestCode: Record<Product, string> = {
+  'ui-coverage': `describe('UI Coverage Scan', () => {
+  it('Checks UI Coverage against the URLs in sitemap.xml', () => {
+    cy.request('https://<YOUR_WEBSITE>/sitemap.xml').then((response) => {
+      const parser = new DOMParser()
+      const xml = parser.parseFromString(response.body, 'application/xml')
+      const urls = [...xml.querySelectorAll('loc')].map(
+        (loc) => loc.textContent
+      )
+
+      urls.forEach((url) => {
+        // UI Coverage captures the interactive elements on each page you visit
+        cy.visit(url)
+      })
+    })
+  })
+})`,
+  accessibility: `describe('Accessibility Scan', () => {
+  it('Checks accessibility against the URLs in sitemap.xml', () => {
+    cy.request('https://<YOUR_WEBSITE>/sitemap.xml').then((response) => {
+      const parser = new DOMParser()
+      const xml = parser.parseFromString(response.body, 'application/xml')
+      const urls = [...xml.querySelectorAll('loc')].map(
+        (loc) => loc.textContent
+      )
+
+      urls.forEach((url) => {
+        // Cypress Accessibility captures the accessibility state of each page
+        cy.visit(url)
+
+        // Optional: only needed when content appears as you scroll (lazy-loaded
+        // images, infinite lists). Test Replay already captures the full page.
+        cy.contains('<YOUR_FOOTER_CONTENT>').scrollIntoView()
+      })
+    })
+  })
+})`,
+}
+
+export const separateTestCode: Record<Product, string> = {
+  'ui-coverage': `const urls = ['/', '/about-us', '/pricing', '/contact', '/request-trial']
+
+describe('UI Coverage Scan', () => {
+  urls.forEach((url) => {
+    it(\`Visits \${url}\`, () => {
+      // UI Coverage captures the interactive elements on this page
+      cy.visit(url)
+    })
+  })
+})`,
+  accessibility: `const urls = ['/', '/about-us', '/pricing', '/contact', '/request-trial']
+
+describe('Accessibility Scan', () => {
+  urls.forEach((url) => {
+    it(\`Visits \${url}\`, () => {
+      // Cypress Accessibility captures the accessibility state of this page
+      cy.visit(url)
+    })
+  })
+})`,
+}

--- a/docs/ui-coverage/guides/block-pull-requests.mdx
+++ b/docs/ui-coverage/guides/block-pull-requests.mdx
@@ -2,7 +2,7 @@
 title: Block pull requests with UI Coverage policies
 description: "Set policies and block pull requests automatically with Cypress UI Coverage's Results API, enabling custom CI workflows to enforce test coverage standards and prevent regressions."
 sidebar_label: Block pull requests and set policies
-sidebar_position: 40
+sidebar_position: 90
 ---
 
 <ProductHeading product="ui-coverage" />

--- a/docs/ui-coverage/guides/compare-reports.mdx
+++ b/docs/ui-coverage/guides/compare-reports.mdx
@@ -2,7 +2,7 @@
 title: Compare UI Coverage reports across runs
 description: 'Review where coverage has changed in the application between two runs.'
 sidebar_label: Compare reports
-sidebar_position: 40
+sidebar_position: 70
 ---
 
 <ProductHeading product="ui-coverage" />

--- a/docs/ui-coverage/guides/identify-coverage-gaps.mdx
+++ b/docs/ui-coverage/guides/identify-coverage-gaps.mdx
@@ -15,24 +15,7 @@ Understanding your application's test coverage is crucial for ensuring quality a
 
 To identify coverage gaps, you need to first run and record Cypress tests to the Cloud. If you're new to Cypress, refer to the [Cypress documentation](/app/end-to-end-testing/writing-your-first-end-to-end-test) to get started with writing tests.
 
-### Example: Automated Sitemap-Based Testing
-
-If your project lacks existing Cypress tests, a common approach is to understand test coverage from a sitemap or an array of target URLs. These URLs can be used to perform light interactions and capture the initial gaps in testing. Below is an example of how to automate this process by using a sitemap:
-
-```js
-describe('UI Coverage Scan', () => {
-  it('Checks ui coverage with the sitemap.xml', () => {
-    cy.request('https://<YOUR_WEBSITE>/sitemap.xml').then((response) => {
-      const xmlString = response.body
-      const parser = new DOMParser()
-        (loc) => loc.textContent
-    })
-    Cypress._.each(URLs, (URL) => {
-      cy.visit(URL)
-    })
-  })
-})
-```
+<SitemapScanExample product="ui-coverage" />
 
 ## Review Coverage Reports
 

--- a/docs/ui-coverage/guides/ignore-views-and-links.mdx
+++ b/docs/ui-coverage/guides/ignore-views-and-links.mdx
@@ -2,7 +2,7 @@
 title: Ignore views and links in UI Coverage
 description: 'Exclude irrelevant views and links from UI Coverage reports with viewFilters, so coverage scores reflect the parts of your application you test.'
 sidebar_label: Ignore views and links
-sidebar_position: 40
+sidebar_position: 60
 ---
 
 <ProductHeading product="ui-coverage" />

--- a/docs/ui-coverage/guides/monitor-changes.mdx
+++ b/docs/ui-coverage/guides/monitor-changes.mdx
@@ -1,24 +1,107 @@
 ---
 title: Monitor UI Coverage changes over time
-description: 'Learn how to monitor changes to your UI Coverage scores over time to ensure proactive quality assurance.'
+description: 'Set up a repeatable workflow to catch UI Coverage regressions before they merge and track coverage trends across your projects.'
 sidebar_label: Monitor changes
-sidebar_position: 70
+sidebar_position: 80
 ---
 
 <ProductHeading product="ui-coverage" />
 
 # Monitor changes
 
-Monitoring changes to your UI Coverage scores over time ensures that regressions are identified and addressed before they are merged. Cypress UI Coverage provides tools to track these changes, enabling proactive quality assurance in your development workflow.
+A single UI Coverage score tells you where you are today. Monitoring tells you
+which direction you're moving, so a drop in coverage is caught and reviewed
+before it merges, rather than discovered months later. This guide walks through
+a repeatable monitoring workflow, from establishing a cadence of runs to
+reviewing individual changes and tracking long-term trends.
 
-## Automate monitoring with the Results API
+:::note
+This guide assumes UI Coverage is enabled and your tests are recording to
+Cypress Cloud. If you haven't set that up yet, start with the
+[UI Coverage setup guide](/ui-coverage/get-started/setup).
+:::
 
-The UI Coverage [Results API](/ui-coverage/results-api) allows you to programmatically fetch UI Coverage data for integration into your CI/CD pipeline.
+## Step 1: Record runs on a regular cadence
 
-## Deep dive on changes with Branch Review
+Monitoring only works when there is something to compare. Two recording
+patterns give you that:
 
-[Branch Review for UI Coverage](/ui-coverage/guides/compare-reports) allows you to compare any two runs in detail and review new untested elements and links, as well as all new interactive elements added to the application.
+- **On every pull request**: record a run for each PR so you can compare it
+  against your base branch. This is what surfaces coverage regressions while
+  they can still be fixed cheaply.
+- **On a schedule**: add a recurring job to your CI (for example, a nightly
+  cron workflow) that records a run against a stable environment. Scheduled
+  runs give you a consistent point of comparison that isn't affected by which
+  files a particular PR happened to touch.
 
-## Spot trends overtime with cross-project analytics
+When a run is split across parallel machines or multiple `cypress run` calls,
+combine those specs into a single [Cypress run](/cloud/features/recorded-runs)
+with the [`--group` flag](/cloud/features/smart-orchestration/parallelization#Grouping-test-runs)
+so each report reflects your entire suite rather than a slice of it.
 
-In the [Enterprise Reporting](/cloud/features/analytics/enterprise-reporting#UI-Coverage) area of Cypress Cloud, you can view high-level trends across all projects and runs, as well as download reports or retrieve details with an API.
+Once runs are recording, connect [Slack](/cloud/integrations/slack) or
+[Microsoft Teams](/cloud/integrations/microsoft-teams) so your team is alerted
+whenever a run finishes, with Slack surfacing UI Coverage results directly. For
+scheduled runs especially, this is what turns a nightly regression into an alert
+rather than a report no one opens.
+
+## Step 2: Catch regressions on each pull request
+
+With a run recorded for every PR, compare it against the base branch to see the
+exact coverage impact of the change.
+
+- For a **manual review**, open [Branch Review](/ui-coverage/guides/compare-reports)
+  and compare the PR run against your base branch. The report highlights new
+  untested elements and links introduced by the change, so you can decide whether
+  to add a test or ignore the element with configuration.
+- To **enforce a policy automatically**, add a Results API check to CI that
+  fails the build when new gaps appear. See
+  [Block pull requests and set policies](/ui-coverage/guides/block-pull-requests)
+  for a status-check workflow and a baseline-comparison script that fails only
+  on _new_ untested elements.
+- To **surface the change in code review**, connect a version control
+  integration ([GitHub](/cloud/integrations/github#Pull-request-comments),
+  [GitLab](/cloud/integrations/gitlab#Merge-Request-comments), or
+  [Bitbucket](/cloud/integrations/bitbucket#Pull-Request-comments)). Cypress
+  Cloud comments on the pull request with the run summary and a link straight to
+  Branch Review, putting the coverage comparison one click from the reviewer.
+
+## Step 3: Investigate a specific change
+
+When a monitoring run or a PR shows an unexpected shift, use
+[Branch Review](/ui-coverage/guides/compare-reports) to pin down the cause. Its
+dropdowns let you compare any two runs, so you can:
+
+- Compare a nightly run against the previous night's to catch drift in the
+  application.
+- Step back through runs to find the exact commit that introduced a new
+  untested element or link.
+- Confirm that a fix had the intended effect before sharing it with your team.
+
+<DocsImage
+  src="/img/ui-coverage/branch-review/uic-branch-review.png"
+  alt="UI Coverage Branch Review comparing two runs, with sections for new untested elements, resolved coverage gaps, and elements whose coverage status changed"
+/>
+
+When you find a real gap, follow
+[Address coverage gaps](/ui-coverage/guides/address-coverage-gaps) to close it.
+
+## Step 4: Track trends across projects
+
+Individual comparisons answer "what changed between these two runs?" To answer
+"how is coverage trending over weeks and months?", use the
+[Enterprise Reporting](/cloud/features/analytics/enterprise-reporting#UI-Coverage)
+area of Cypress Cloud, available on the Enterprise plan. It rolls trends up
+across every project in your organization, not just one, so you can view
+high-level UI Coverage trends across all projects and runs, download reports, or
+pull the data through the [data extract API](/cloud/integrations/data-extract-api)
+for your own dashboards.
+
+## See also
+
+- [Compare reports](/ui-coverage/guides/compare-reports): the full Branch
+  Review workflow for diffing two runs.
+- [Block pull requests and set policies](/ui-coverage/guides/block-pull-requests):
+  automate the regression gate in CI.
+- [Address coverage gaps](/ui-coverage/guides/address-coverage-gaps): close the
+  gaps your monitoring surfaces.

--- a/docs/ui-coverage/guides/reduce-noise.mdx
+++ b/docs/ui-coverage/guides/reduce-noise.mdx
@@ -1,141 +1,243 @@
 ---
 title: Reduce noise in UI Coverage reports
-description: 'Cut noise from UI Coverage reports by filtering out elements that do not represent real coverage gaps.'
+description: 'A workflow for turning a noisy UI Coverage report into an actionable one: recognize the noise, diagnose its cause, apply the matching fix, and validate.'
 sidebar_label: Reduce noise
-sidebar_position: 60
+sidebar_position: 40
 ---
 
 <ProductHeading product="ui-coverage" />
 
 # Reduce noise
 
-A clean and focused UI Coverage report enables you to make informed decisions about your testing strategy. Cypress UI Coverage provides tools to reduce noise in your reports by properly grouping elements, stabilizing element identities, special attribute handling, and grouping views that share common URL patterns. This guide explains how and why to create a streamlined report.
+When you first record a run, UI Coverage reports every interactive element it
+finds. Some of what appears as an "untested element" isn't a real gap. It might
+be the same button counted many times, one element whose generated ID keeps
+changing, or dozens of near-identical pages listed as separate views. Left
+alone, this noise hides the gaps that actually matter.
 
-## Group views by URL patterns
+This guide recommends a workflow for cleaning that up:
 
-Cypress attempts to group views with similar URL patterns (like when a URL contains a user ID) to provide a more consolidated view of coverage metrics.
+- **Recognize** the noise.
+- **Diagnose** what's causing it.
+- **Apply** the matching configuration.
+- **Validate** the result.
 
-Customizing views with similar URL patterns allows you to consolidate coverage metrics for pages you know are related. To add or modify the configuration for your project, navigate to the **App Quality** tab in your project settings and add a **views** configuration.
+Each fix below is a small piece of configuration, but the value is in knowing
+_which_ one to reach for.
 
-### Example: Grouping user profiles
+:::info
+This guide is about consolidating and stabilizing elements that _should_ be in
+your report. To remove elements or pages entirely (third-party widgets, admin
+pages, error routes), see [Ignore elements](/ui-coverage/guides/ignore-elements)
+and [Ignore views and links](/ui-coverage/guides/ignore-views-and-links).
+:::
 
-```
-https://cypress.io/users/alice
-https://cypress.io/users/alice?foo=bar
-https://cypress.io/users/bob
-https://cypress.io/users/bob#baz
-```
+## Step 1: Recognize the noise
 
-```json
-{
-  "views": [
-    {
-      "pattern": "https://cypress.io/users/*"
-    }
-  ]
-}
-```
+Open the **UI Coverage** tab for a recent run and look for these patterns:
 
-To learn more about the configuration options, refer to the [Views](/ui-coverage/configuration/views) documentation.
+- **One element appears many times.** A control with the same purpose shows up
+  as several separate untested entries, often because its `id` or another
+  attribute is generated fresh on each render.
+- **A group of similar elements each listed separately.** A navigation bar,
+  list, or set of form fields where every item is its own entry, inflating the
+  count without adding insight.
+- **Too many views.** Pages that differ only by a slug
+  (`/products/wireless-mouse`, `/products/usb-c-cable`) appear as distinct views,
+  spreading coverage across pages you think of as one.
+- **Elements identified by unstable attributes.** Selectors in the report are
+  built from stateful or hashed attributes (like a `data-headlessui-state`
+  toggle or a hashed `css-1a2b3c` class) instead of the stable attributes your
+  team recognizes.
 
-## Group similar elements
+## Step 2: Diagnose and apply the matching fix
 
-Grouping elements improves clarity by reducing repetitive entries for elements with the same functionality. This is especially useful for elements like buttons, links, or form fields that appear across multiple views. By grouping similar elements, you can focus on the overall coverage of a specific element type rather than individual instances.
+Each pattern from Step 1 maps to one of the fixes below. Configure them in the
+**App Quality** tab of your project settings, under the `uiCoverage` key.
 
-### Example: Grouping dynamic IDs
+### Many similar elements → group them
 
-In the example below, the UI Coverage report shows multiple buttons that represent the same button due to a dynamically generated ID. By grouping these buttons, you can reduce noise and see the total coverage for the buttons with similar functionality in your application.
+When several elements share the same function and differ only by a generated
+value, group them into a single entry with `elementGroups`. This is the right
+choice for a control that repeats, such as an action button on every row of a
+list.
+
+Given a list of rows that each repeat the same action, where the button's `id`
+is generated from the row's record ID:
 
 ```html
-<nav>
-  <button id="nav-button819230">Page 1</button>
-  <button id="nav-button819231">Page 2</button>
-  <button id="nav-button819232">Page 3</button>
-</nav>
+<ul class="cart">
+  <li>
+    Wireless Mouse
+    <button id="remove-item-8a2f">Remove</button>
+  </li>
+  <li>
+    USB-C Cable
+    <button id="remove-item-3d9b">Remove</button>
+  </li>
+  <li>
+    Laptop Stand
+    <button id="remove-item-c710">Remove</button>
+  </li>
+</ul>
 ```
 
-To add or modify the configuration for your project, navigate to the **App Quality** tab in your project settings and add an **elementGroups** configuration under **uiCoverage**.
+Every **Remove** button does the same thing, so you want to know that
+interaction is covered without tracking each row separately. Group them by their
+stable prefix:
 
-```json
+```json title="App Quality Config"
 {
   "uiCoverage": {
     "elementGroups": [
       {
-        "selector": "nav [id^=nav-button]"
+        "selector": ".cart [id^='remove-item-']"
       }
     ]
   }
 }
 ```
 
-Now instead of 3 separate elements in the UI Coverage report, the report will show a single entry for all buttons with the `nav-button` ID prefix, simplifying the view and providing a clearer picture of the coverage.
+The report now shows a single entry instead of three:
 
 ```
-nav [id^=nav-button] (3 instances)
+.cart [id^='remove-item-'] (3 instances)
 ```
 
-To learn more about the configuration options, refer to the [Element Groups](/ui-coverage/configuration/elementgroups) documentation.
+See the [Element Groups](/ui-coverage/configuration/elementgroups) reference for
+all options.
 
-## Stabilize a single element's identity
+:::caution
+Group only elements that share the same purpose. Grouping controls that do
+different things, or distinct links you want covered separately, hides real gaps
+instead of reducing noise.
+:::
 
-When one element appears as several untested elements because a generated attribute changes between snapshots, an `elements` rule identifies it by a selector you choose and can rename it in the report. To add or modify the configuration for your project, navigate to the **App Quality** tab in your project settings and add an **elements** configuration under **uiCoverage**.
+### One element splitting into many → stabilize its identity
 
-```json
+When a _single_ element appears as several untested entries because a generated
+attribute changes between snapshots, identify it by a selector you choose with
+an `elements` rule, and optionally give it a readable name:
+
+```json title="App Quality Config"
 {
   "uiCoverage": {
     "elements": [
       {
-        "selector": "#search [id^='combobox']",
-        "name": "Search Combobox"
+        "selector": "input[id^='downshift-'][id$='-input']",
+        "name": "Search input"
       }
     ]
   }
 }
 ```
 
-The rule applies only when its selector matches exactly one interactive element in a snapshot. If many elements share the same generated attribute, use [Attribute Filters](/ui-coverage/configuration/attributefilters) instead.
+The rule applies only when its selector matches exactly one interactive element
+in a snapshot. If many elements share the same generated attribute, group them
+with `elementGroups` (above) or filter the attribute (below) instead. See the
+[Elements](/ui-coverage/configuration/elements) reference for details.
 
-To learn more about the configuration options, refer to the [Elements](/ui-coverage/configuration/elements) documentation.
+### Noisy or meaningless attributes → tune identification
 
-## Configure attribute handling
+If elements are being identified by the wrong attributes, steer Cypress toward
+the attributes you care about and away from the ones you don't.
 
-Attribute configuration ensures that Cypress surfaces element attributes that are most meaningful to your project.
+Prioritize your own stable attributes with `significantAttributes`:
 
-### Define significant attributes
-
-Specify which attributes Cypress should prioritize when identifying elements. To add or modify the configuration for your project, navigate to the **App Quality** tab in your project settings and add an **significantAttributes** configuration under **uiCoverage**.
-
-```json
+```json title="App Quality Config"
 {
   "uiCoverage": {
-    "significantAttributes": ["data-custom-id"]
+    "significantAttributes": ["data-testid"]
   }
 }
 ```
 
-To learn more about the configuration options, refer to the [Significant Attributes](/ui-coverage/configuration/significantattributes) documentation.
+Cypress already filters the most common unstable attributes, so use
+`attributeFilters` only for the ones it misses. This example keeps your `data-cy`
+hook while ignoring the `data-*` state attributes component libraries toggle as
+the UI changes:
 
-### Use Attribute Filters
-
-Exclude auto-generated or irrelevant attributes that add unnecessary noise. To add or modify the configuration for your project, navigate to the **App Quality** tab in your project settings and add an **attributeFilters** configuration under **uiCoverage**.
-
-```json
+```json title="App Quality Config"
 {
   "uiCoverage": {
     "attributeFilters": [
       {
-        "attribute": "id",
-        "value": "sizzle.*",
-        "include": false
+        "attribute": "data-cy",
+        "include": true,
+        "comment": "Always identify elements by our test hook"
       },
       {
-        "attribute": "ng-.*",
-        "value": ".*",
-        "include": false
+        "attribute": "data-.*",
+        "include": false,
+        "comment": "Ignore library state attributes like data-state, data-headlessui-state"
       }
     ]
   }
 }
 ```
 
-To learn more about the configuration options, refer to the [Attribute Filters](/ui-coverage/configuration/attributefilters) documentation.
+See the [Significant Attributes](/ui-coverage/configuration/significantattributes)
+and [Attribute Filters](/ui-coverage/configuration/attributefilters) references
+for the full matching rules.
+
+### Too many near-identical pages → group views
+
+Cypress groups URLs that differ only by numeric IDs or UUIDs automatically, but
+not ones that differ by a slug or name. When these product pages share a
+template you want reported as one view, consolidate them with a `views` pattern:
+
+```
+/products/wireless-mouse
+/products/wireless-mouse?ref=email
+/products/usb-c-cable
+/products/laptop-stand#reviews
+```
+
+Collapse them into one view. Leaving the protocol and hostname off the pattern
+lets it match these paths on any environment your tests run against:
+
+```json title="App Quality Config"
+{
+  "uiCoverage": {
+    "views": [
+      {
+        "pattern": "/products/*"
+      }
+    ]
+  }
+}
+```
+
+See the [Views](/ui-coverage/configuration/views) reference for pattern syntax.
+
+## Step 3: Validate the result
+
+Configuration changes are applied when a report is generated, so you don't need
+to rerun your tests to see their effect. After saving your configuration,
+regenerate a recent run from its **Properties** tab.
+
+<DocsImage
+  src="/img/accessibility/configuration/cypress-cloud-properties-tab-application-quality-config.png"
+  alt="The Properties tab for a run, with an Application Quality section where you can regenerate the report with the current configuration"
+/>
+
+Then reopen the UI Coverage report and confirm that:
+
+- The elements you grouped now appear as a single entry.
+- The element you stabilized no longer splits across snapshots.
+- The views you consolidated are reported together.
+- The overall element and view counts have dropped to reflect real coverage
+  rather than duplication.
+
+If new noise appears in future reports as your application grows, repeat this
+loop (recognize, diagnose, apply, validate) to keep the report actionable.
+
+## See also
+
+- [Ignore elements](/ui-coverage/guides/ignore-elements): remove elements from
+  the report entirely instead of grouping them.
+- [Ignore views and links](/ui-coverage/guides/ignore-views-and-links): remove
+  whole pages from the report.
+- [Element Identification](/ui-coverage/core-concepts/element-identification) and
+  [Element Grouping](/ui-coverage/core-concepts/element-grouping): the concepts
+  behind how Cypress identifies and consolidates elements.

--- a/src/theme/MDXComponents.js
+++ b/src/theme/MDXComponents.js
@@ -39,6 +39,7 @@ import ProductHeading from '@site/src/components/product-heading'
 import Profiles from '@site/docs/partials/_profiles.mdx'
 import RecordKeyEnvVar from '@site/docs/partials/_record-key-env-var.mdx'
 import SignificantAttributesValidation from '@site/docs/partials/_significantattributes-validation.mdx'
+import SitemapScanExample from '@site/docs/partials/_sitemap-scan-example.mdx'
 import SourceMaps from '@site/docs/partials/_source-maps.mdx'
 import SupportFileConfiguration from '@site/docs/partials/_support-file-configuration.mdx'
 import Tabs from '@theme/Tabs'
@@ -235,6 +236,7 @@ export default {
   Profiles,
   RecordKeyEnvVar,
   SignificantAttributesValidation,
+  SitemapScanExample,
   SourceMaps,
   SupportFileConfiguration,
   Tabs,


### PR DESCRIPTION
## Summary

Rework the UI Coverage **Guides** section so each guide walks a real, end-to-end workflow instead of restating the configuration reference, fix a few structural issues, and share the sitemap-scan example between UI Coverage and Accessibility through one product-parameterized partial.

## Why

An evaluation of the UI Coverage Guides found that several guides mostly pointed at the configuration reference rather than giving a task a reader could follow. "Monitor changes" was a stub of link-outs and "Reduce noise" was a menu of config options; `identify-coverage-gaps` shipped a syntactically broken sitemap snippet; three guides shared `sidebar_position: 40`; and the sitemap example was duplicated (and diverging) between the UI Coverage and Accessibility docs.

This PR:

- **Monitor changes** — becomes a four-step workflow: record on a cadence (with `--group` and Slack/Teams notifications), catch regressions on pull requests (Branch Review, Results API gate, VCS PR comments), investigate a specific change in Branch Review, and track trends across projects via Enterprise Reporting / the data extract API.
- **Reduce noise** — becomes a recognize → diagnose → apply → validate workflow with realistic, internally consistent examples (grouping repeated action buttons, stabilizing a generated-id search input, keeping `data-cy` while filtering library `data-*` state, grouping product-slug views) and a caution against over-grouping.
- **Identify coverage gaps** — repairs the broken sitemap snippet and adds a single-test and a separate-tests variant.
- **Structure** — renumbers guide `sidebar_position` values to remove the duplicate `40`.
- **Shared partial** — extracts the sitemap example into `docs/partials/_sitemap-scan-example.mdx`, driven by a `product` prop, so UI Coverage and Accessibility render it from one source with the correct product names, capture wording, and (for Accessibility) an optional footer-scroll note.

## Notes for reviewers

- Two commits, split by concern: (1) the workflow rewrites + structural fixes, (2) the shared sitemap partial.
- Verified with a full `npm run build` (Docusaurus is configured to throw on broken links **and** anchors), plus `prettier --check` and the frontmatter linter.
- The sitemap example's `###` sub-headings now live inside the partial, so they no longer appear in the right-hand table of contents — consistent with other heading-containing partials in the repo (e.g. `_views.mdx`).
- The partial's code samples live in `docs/partials/sitemapScanCode.ts` rather than inline in the MDX because Prettier reflows the JavaScript inside template literals embedded directly in `.mdx`, corrupting the samples on every commit. Keeping them in a `.ts` module avoids that.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ws45tCs4KD81aPkT33SK7V)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, auth, or application code impact.
> 
> **Overview**
> Reworks UI Coverage **Guides** into end-to-end workflows instead of config-reference summaries, and **deduplicates** the sitemap-scan documentation across UI Coverage and Accessibility.
> 
> **Monitor changes** is now a four-step flow (cadence recording with `--group` and Slack/Teams, PR regression gates via Branch Review / Results API / VCS comments, investigating a specific change, Enterprise Reporting trends). **Reduce noise** follows recognize → diagnose → apply → validate, with updated examples (`elementGroups`, `elements`, `significantAttributes` / `attributeFilters`, `views`) and a validation step that regenerates reports from the Properties tab.
> 
> **Identify coverage gaps** drops the broken inline sitemap snippet in favor of `<SitemapScanExample product="ui-coverage" />`. The same partial (with product-specific copy and samples in `sitemapScanCode.ts`) replaces the accessibility production-monitoring inline example. Guide **sidebar_position** values are renumbered to remove duplicate `40` entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41f487c924ecfe5c7d514c9c7b3f52082d540890. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->