### PR TITLE
docs(ui-coverage): rework Identify coverage gaps into a followable workflow

### DIFF
--- a/docs/ui-coverage/configuration/elementfilters.mdx
+++ b/docs/ui-coverage/configuration/elementfilters.mdx
@@ -85,7 +85,7 @@ To apply rules to UI Coverage only, nest the property under the `uiCoverage` key
 - **Excluded elements are removed everywhere.** They don't appear in any view, don't count toward the totals or the coverage score, and aren't considered by [`elementGroups`](/ui-coverage/configuration/elementgroups) or [`elements`](/ui-coverage/configuration/elements) rules. Interactions with them are removed as well.
 - **Rules match in any document unless scoped.** A rule without `documentScope` can match elements in the main document, in iframes, and in shadow DOMs. Add `documentScope` to restrict a rule to one of those documents.
 
-If a rule doesn't seem to take effect, see [Why isn't my elementFilters rule excluding an element?](/ui-coverage/faq#Why-isnt-my-elementFilters-rule-excluding-an-element) in the UI Coverage FAQ.
+If a rule doesn't seem to take effect, see [Why isn't my elementFilters rule excluding an element?](/ui-coverage/faq#Why-isnt-my-UI-Coverage-elementFilters-rule-excluding-an-element) in the UI Coverage FAQ.
 
 ### Validation rules
 

--- a/docs/ui-coverage/configuration/elements.mdx
+++ b/docs/ui-coverage/configuration/elements.mdx
@@ -77,7 +77,7 @@ In each snapshot captured by your tests, every rule is evaluated independently:
 - **Later rules take precedence.** When more than one rule matches the same element, the last matching rule in the list determines its identity and name.
 - **Filtered elements are never matched.** Elements excluded from reports by [`elementFilters`](/ui-coverage/configuration/elementfilters) are not considered, and don't count toward a rule's one-match limit.
 
-If a rule doesn't seem to take effect, see [Why isn't my elements rule applying?](/ui-coverage/faq#Why-isnt-my-elements-rule-applying) in the UI Coverage FAQ.
+If a rule doesn't seem to take effect, see [Why isn't my elements rule applying?](/ui-coverage/faq#Why-isnt-my-UI-Coverage-elements-rule-applying) in the UI Coverage FAQ.
 
 ### Validation rules
 

--- a/docs/ui-coverage/faq.mdx
+++ b/docs/ui-coverage/faq.mdx
@@ -23,6 +23,24 @@ No. UI Coverage requires no code changes or instrumentation. Reports are generat
 
 The score compares the number of tested interactive elements to the total number of interactive elements in your application. [Grouped elements](/ui-coverage/core-concepts/element-grouping) count as a single unit: the group counts once toward the total, and an interaction with any element in the group marks the whole group as tested.
 
+## Finding coverage gaps
+
+### <Icon name="angle-right" /> How do I find which parts of my UI aren't tested?
+
+Record a run to Cypress Cloud with [Test Replay](/cloud/features/test-replay) enabled, then open its **UI Coverage** tab. Every recorded run produces a report automatically, with no code changes. The report ranks your application's [views](/ui-coverage/core-concepts/views) by coverage score, lists the untested interactive elements on each one, and flags the pages your tests never visited as [untested links](/ui-coverage/core-concepts/interactivity#Untested-Links). The [Identify coverage gaps](/ui-coverage/guides/identify-coverage-gaps) guide walks through the full workflow step by step.
+
+### <Icon name="angle-right" /> Where should I start if my UI Coverage score is low?
+
+Start with your lowest-scoring [views](/ui-coverage/core-concepts/views), weighed against how critical each one is to your users, since a checkout or signup view at 40% is more urgent than a settings page at the same score. Before writing tests, rule out noise: third-party widgets counted as untested elements (exclude them with [`elementFilters`](/ui-coverage/configuration/elementfilters)) and links to pages you'll never test (exclude them with [`viewFilters`](/ui-coverage/configuration/viewfilters)) both lower a score without pointing to a real gap. See [Why is my UI Coverage score lower than I expect?](#Why-is-my-UI-Coverage-score-lower-than-I-expect) and [Identify coverage gaps](/ui-coverage/guides/identify-coverage-gaps).
+
+### <Icon name="angle-right" /> In Cypress UI Coverage, what's the difference between an untested element, an untested link, and an untested view?
+
+They describe three different gaps. An **untested element** is an interactive element (a button, input, or control) on a page your tests opened that no recognized command interacted with. An **untested link** is an `<a>` element whose destination URL was never visited during the run. An **untested view** is a page discovered from those untested links that no test ever opened, so it has no coverage at all. Untested elements and untested links both count against your score; untested views surface pages that need a test to reach them. See [Interactivity](/ui-coverage/core-concepts/interactivity#Untested-Links) and [Views](/ui-coverage/core-concepts/views).
+
+### <Icon name="angle-right" /> How do I find pages my tests never visit?
+
+Use the **Untested links** section of the UI Coverage report. It lists links whose destinations your Cypress tests never opened during the run, and expanding one shows a **Referrers** tab (the views that link to the page) and a **URLs** tab (the concrete destinations, grouped for dynamic routes like `/orders/*`). Because a page with no view can still be linked from a tested page, this is how UI Coverage surfaces flows your suite is missing entirely. Add navigation to reach them, as shown in [Address coverage gaps](/ui-coverage/guides/address-coverage-gaps#Add-tests-for-untested-links).
+
 ## Interactive elements
 
 ### <Icon name="angle-right" /> What does Cypress UI Coverage count as an interactive element?
@@ -39,11 +57,11 @@ You have two options. In your markup, add [`data-cy-ui-interactive="exclude"`](/
 
 ## Views and URLs
 
-### <Icon name="angle-right" /> Why do similar URLs show up as separate views?
+### <Icon name="angle-right" /> Why do similar URLs show up as separate views in Cypress UI Coverage?
 
 Automatic grouping only replaces path segments that are numbers or IDs (UUIDs and UUID-like values) with a wildcard. Segments like usernames or slugs are not recognized as dynamic, so `/users/alice` and `/users/bob` remain separate views. Add a [`views`](/ui-coverage/configuration/views) pattern to group them yourself. See [how views are created](/ui-coverage/core-concepts/views#How-views-are-created) for the full set of automatic rules.
 
-### <Icon name="angle-right" /> Do query parameters create separate views?
+### <Icon name="angle-right" /> Do query parameters create separate Cypress UI Coverage views?
 
 No. Query strings are ignored when grouping, so `/dashboard?tab=overview` and `/dashboard?tab=settings` become a single `/dashboard` view. If a query parameter meaningfully changes the page, use a [`views`](/ui-coverage/configuration/views) pattern with `groupBy` on that parameter to split it into separate views.
 
@@ -55,7 +73,7 @@ Write a [`views`](/ui-coverage/configuration/views) pattern that names the param
 
 Add a [`viewFilters`](/ui-coverage/configuration/viewfilters) rule with `include: false` for a URL pattern. Excluding a URL removes its snapshots from the report and stops links pointing to it from counting against your coverage score. The [Ignore views and links](/ui-coverage/guides/ignore-views-and-links) guide walks through common cases.
 
-### <Icon name="angle-right" /> Why is a URL still in my report after I excluded it with viewFilters?
+### <Icon name="angle-right" /> Why is a URL still in my UI Coverage report after I excluded it with viewFilters?
 
 The most common causes are:
 
@@ -69,7 +87,7 @@ See [pattern matching behavior](/ui-coverage/configuration/viewfilters#How-are-v
 
 Yes. List `include: true` rules for the URLs you want, followed by a catch-all rule that excludes everything else: `{ "pattern": "*", "include": false }`. Because the first matching rule wins, the catch-all must come last. See [Include only your application's URLs](/ui-coverage/configuration/viewfilters#Include-only-your-applications-URLs) for a complete example.
 
-### <Icon name="angle-right" /> Why is a page missing from my report?
+### <Icon name="angle-right" /> Why is a page missing from my Cypress UI Coverage report?
 
 Views are created from URLs your tests actually visit, so a page that no test navigates to has no view. Check [untested links](/ui-coverage/core-concepts/interactivity#Untested-Links) in the report, where pages that are linked to but never visited appear. Also confirm that a [`viewFilters`](/ui-coverage/configuration/viewfilters) rule isn't excluding the page unintentionally.
 
@@ -107,19 +125,19 @@ That's grouping working as intended. When UI Coverage detects that many elements
 
 The [`data-cy-ui-group` markup attribute](/ui-coverage/core-concepts/element-grouping#Grouping-with-markup-attributes) takes priority over everything, then [`elementGroups`](/ui-coverage/configuration/elementgroups) configuration rules in Cypress Cloud, and finally the [automatic grouping rules](/ui-coverage/core-concepts/element-grouping#Automatic-grouping) apply to whatever no attribute or rule claimed. Elements removed by [`elementFilters`](/ui-coverage/configuration/elementfilters) are never grouped at all.
 
-### <Icon name="angle-right" /> What happens if two elementGroups rules match the same element?
+### <Icon name="angle-right" /> What happens if two UI Coverage elementGroups rules match the same element?
 
 The first matching rule in your [`elementGroups`](/ui-coverage/configuration/elementgroups) configuration wins, so list specific rules before broad catch-all rules. A rule that appears after another rule matching the same elements never applies to them.
 
-### <Icon name="angle-right" /> Can I group elements in my application code instead of Cypress Cloud configuration?
+### <Icon name="angle-right" /> Can I group UI Coverage elements in my application code instead of Cypress Cloud configuration?
 
 Yes. Add the [`data-cy-ui-group` attribute](/ui-coverage/core-concepts/element-grouping#Grouping-with-markup-attributes) to your markup, and elements sharing the same attribute value are grouped together with no Cloud configuration needed. Placing the attribute on a wrapper element groups every interactive element inside it. Groups defined this way take priority over [`elementGroups`](/ui-coverage/configuration/elementgroups) configuration rules.
 
-### <Icon name="angle-right" /> Can I group or filter elements inside iframes or shadow DOM?
+### <Icon name="angle-right" /> Can I group or filter UI Coverage elements inside iframes or shadow DOM?
 
 Yes. The [`elementGroups`](/ui-coverage/configuration/elementgroups), [`elementFilters`](/ui-coverage/configuration/elementfilters), and [`elements`](/ui-coverage/configuration/elements) configuration options all accept a `documentScope` property that limits a rule to elements inside specific iframes or shadow DOM hosts. List one CSS selector per host, ordered from the outermost document to the innermost.
 
-### <Icon name="angle-right" /> Why isn't my element group showing up in the report?
+### <Icon name="angle-right" /> Why isn't my element group showing up in the UI Coverage report?
 
 The most common causes are:
 
@@ -137,7 +155,7 @@ Add an [`elementFilters`](/ui-coverage/configuration/elementfilters) rule with `
 
 No. An element excluded by [`elementFilters`](/ui-coverage/configuration/elementfilters) doesn't appear in the report and doesn't count toward the score, whether your tests interacted with it or not. It's also not considered by [`elementGroups`](/ui-coverage/configuration/elementgroups) or [`elements`](/ui-coverage/configuration/elements) rules.
 
-### <Icon name="angle-right" /> Why isn't my elementFilters rule excluding an element?
+### <Icon name="angle-right" /> Why isn't my UI Coverage elementFilters rule excluding an element?
 
 The most common causes are:
 
@@ -150,7 +168,7 @@ The most common causes are:
 
 Yes. An `elementFilters` list at the root of your configuration applies to both products, but nesting it under a `uiCoverage` or `accessibility` key applies it to that product only. A nested list completely replaces a root-level one for that product; the two are not merged. See [Exclude elements](/ui-coverage/configuration/elementfilters#Scope).
 
-### <Icon name="angle-right" /> Why does one element appear as multiple elements in the report?
+### <Icon name="angle-right" /> Why does one element appear as multiple elements in my Cypress UI Coverage report?
 
 This usually means the element's identifying attributes change between [snapshots](/ui-coverage/core-concepts/element-identification#Snapshots), for example auto-generated IDs or dynamic class names. Use [`attributeFilters`](/ui-coverage/configuration/attributefilters) to ignore the dynamic attributes, or [`elements`](/ui-coverage/configuration/elements) to define the element's identity explicitly. See [troubleshooting](/ui-coverage/troubleshooting) for more scenarios.
 
@@ -166,15 +184,15 @@ When an element has none of the [identifying attributes](/ui-coverage/core-conce
 
 Add the attribute name to [`significantAttributes`](/ui-coverage/configuration/significantattributes). Attributes you list are checked before the default list, in the order you list them, so an attribute your application already renders, such as `data-component-name`, can identify, name, and group elements in your reports.
 
-### <Icon name="angle-right" /> Does significantAttributes replace the default attribute list?
+### <Icon name="angle-right" /> In UI Coverage, does significantAttributes replace the default attribute list?
 
 No. Your attributes are checked first, and the defaults still apply after them, so an element without any of your attributes is identified exactly as it would be without configuration. Listing a default attribute like `data-qa` promotes it above the other defaults. To stop an attribute from being used at all, use [`attributeFilters`](/ui-coverage/configuration/attributefilters) instead.
 
-### <Icon name="angle-right" /> Can I use a non-`data-` attribute like aria-label as a significant attribute?
+### <Icon name="angle-right" /> Can I use a non-`data-` attribute like aria-label as a UI Coverage significant attribute?
 
 Yes. Any valid HTML attribute qualifies, not only `data-*` attributes. Listing [`aria-label`](/ui-coverage/configuration/significantattributes) identifies elements by their label text, which gives icon-only controls a readable identity. Because UI Coverage lists every interactive element, it also surfaces every label for a person to read and judge for clarity, since automated accessibility tools confirm only that a label exists, not that it is well written.
 
-### <Icon name="angle-right" /> Why isn't my elements rule applying?
+### <Icon name="angle-right" /> Why isn't my UI Coverage elements rule applying?
 
 An [`elements`](/ui-coverage/configuration/elements) rule applies only when its selector matches exactly one interactive element in a snapshot. The most common causes are:
 
@@ -184,19 +202,19 @@ An [`elements`](/ui-coverage/configuration/elements) rule applies only when its 
 - A later `elements` rule matches the same element, and the last matching rule wins.
 - The report was processed before you saved the configuration. Regenerate the run to apply the current configuration.
 
-### <Icon name="angle-right" /> How do I stop dynamic IDs or class names from splitting one element into many?
+### <Icon name="angle-right" /> How do I stop dynamic IDs or class names from splitting one UI Coverage element into many?
 
 Add an [`attributeFilters`](/ui-coverage/configuration/attributefilters) rule with `include: false` that matches the unstable attribute and value, for example an `id` like `:r11:` or a hashed `class`. Once the volatile attribute is ignored, Cypress identifies the element by a stable attribute instead, so the same control is recognized across [snapshots](/ui-coverage/core-concepts/element-identification#Snapshots) and counted once. When you filter a dynamic `id`, also filter the attributes that reference it (`for`, `aria-labelledby`, `aria-describedby`, and similar), or the element can still be identified by those related values.
 
-### <Icon name="angle-right" /> Do I need to configure attributeFilters for auto-generated IDs?
+### <Icon name="angle-right" /> Do I need to configure UI Coverage attributeFilters for auto-generated IDs?
 
 Often not. Cypress already ignores the most common unstable identifiers, including values containing UUIDs or long hexadecimal hashes, digit-only `id`/`name`/`for`/`aria-*` values, and generated `class` patterns like `jss*` and `ng-tns-*`. Add an [`attributeFilters`](/ui-coverage/configuration/attributefilters) rule only when your application produces unstable attributes these built-in filters don't already cover.
 
-### <Icon name="angle-right" /> What's the difference between attributeFilters and significantAttributes?
+### <Icon name="angle-right" /> In UI Coverage, what's the difference between attributeFilters and significantAttributes?
 
 They pull in opposite directions. [`attributeFilters`](/ui-coverage/configuration/attributefilters) _removes_ attributes from consideration so Cypress won't identify elements by them, while [`significantAttributes`](/ui-coverage/configuration/significantattributes) _prioritizes_ attributes so Cypress prefers them when they're available. Use `attributeFilters` to hide noisy or dynamic attributes, and `significantAttributes` to promote a stable attribute such as `data-component-name`.
 
-### <Icon name="angle-right" /> Why isn't my attributeFilters rule working?
+### <Icon name="angle-right" /> Why isn't my UI Coverage attributeFilters rule working?
 
 The most common causes are:
 
@@ -207,7 +225,7 @@ The most common causes are:
 
 ## Interaction commands
 
-### <Icon name="angle-right" /> Which commands count as coverage by default?
+### <Icon name="angle-right" /> Which Cypress commands does UI Coverage count as coverage by default?
 
 UI Coverage marks an element as tested when it's targeted by one of a default set of Cypress interaction commands: `blur`, `check`, `clear`, `click`, `dblclick`, `focus`, `rightclick`, `scrollIntoView`, `scrollTo`, `select`, `selectFile`, `submit`, `trigger`, `type`, and `uncheck`. Commands outside this set, including plugin commands like `realClick` and `realHover` and assertions, don't count until you add them with [`additionalInteractionCommands`](/ui-coverage/configuration/additionalinteractioncommands) or [`allowedInteractionCommands`](/ui-coverage/configuration/allowedinteractioncommands). See [Interaction Commands](/ui-coverage/core-concepts/interactivity#Interaction-Commands).
 
@@ -219,11 +237,11 @@ UI Coverage marks an element as tested when it's targeted by one of a default se
 
 Two conditions must both hold. First, the command name must be listed in [`additionalInteractionCommands`](/ui-coverage/configuration/additionalinteractioncommands) (or [`allowedInteractionCommands`](/ui-coverage/configuration/allowedinteractioncommands)), matched case-sensitively and written exactly as you registered it. Second, the command must log a [snapshot](/ui-coverage/core-concepts/element-identification#Snapshots) that references the subject element, so UI Coverage knows which element to credit. In practice, register the command with [`prevSubject`](/api/cypress-api/custom-commands#Arguments), call [`Cypress.log`](/api/cypress-api/cypress-log) with the subject as `$el`, and capture a snapshot. If you added the command after a run was processed, regenerate the run to apply the change.
 
-### <Icon name="angle-right" /> What's the difference between additionalInteractionCommands and allowedInteractionCommands?
+### <Icon name="angle-right" /> In UI Coverage, what's the difference between additionalInteractionCommands and allowedInteractionCommands?
 
 [`additionalInteractionCommands`](/ui-coverage/configuration/additionalinteractioncommands) _extends_ the set of commands recognized as interactions everywhere, so a custom or plugin command counts as coverage on any element. [`allowedInteractionCommands`](/ui-coverage/configuration/allowedinteractioncommands) works _per element_: for elements matching a selector, only the commands you list count, which lets you both restrict coverage to a meaningful interaction and accept commands that are otherwise ignored. Use `additionalInteractionCommands` to recognize a command globally, and `allowedInteractionCommands` to control which commands matter for specific elements.
 
-### <Icon name="angle-right" /> How do I require a specific interaction, like a hover, to mark an element tested?
+### <Icon name="angle-right" /> How do I require a specific interaction in UI Coverage, like a hover, to mark an element tested?
 
 Add an [`allowedInteractionCommands`](/ui-coverage/configuration/allowedinteractioncommands) rule whose `selector` matches the element and whose `commands` list contains only the interaction you require. Because matching a rule replaces the default commands for that element, interactions you didn't list, including a plain `click`, no longer mark it tested, so the element only counts once the meaningful interaction runs.
 
@@ -231,11 +249,11 @@ Add an [`allowedInteractionCommands`](/ui-coverage/configuration/allowedinteract
 
 Yes. Assertions don't count by default, but an [`allowedInteractionCommands`](/ui-coverage/configuration/allowedinteractioncommands) rule listing `assert` credits assertions against the matching elements. This is useful for read-only elements such as status badges or computed totals that your tests validate but never interact with. Remember that the rule replaces the defaults for those elements, so include any other commands you also want to accept alongside `assert`.
 
-### <Icon name="angle-right" /> Do commands in allowedInteractionCommands also need to be in additionalInteractionCommands?
+### <Icon name="angle-right" /> In UI Coverage, do commands in allowedInteractionCommands also need to be in additionalInteractionCommands?
 
 No. Listing a command in an [`allowedInteractionCommands`](/ui-coverage/configuration/allowedinteractioncommands) rule automatically registers it as a recognized interaction, so a custom or plugin command works without also appearing in [`additionalInteractionCommands`](/ui-coverage/configuration/additionalinteractioncommands). As with any custom command, it only produces coverage if it logs a snapshot that references the subject element.
 
-### <Icon name="angle-right" /> Why did an element stop counting as tested after I added an allowedInteractionCommands rule?
+### <Icon name="angle-right" /> Why did an element stop counting as tested in UI Coverage after I added an allowedInteractionCommands rule?
 
 Once an element matches an [`allowedInteractionCommands`](/ui-coverage/configuration/allowedinteractioncommands) rule, only the commands listed in the matching rules count for it, and the default commands no longer apply. If your tests exercise the element with a command you didn't list, it's now treated as untested. Add that command to the rule, or tighten the `selector` so the rule doesn't match elements you didn't intend to restrict.
 
@@ -257,7 +275,7 @@ Add a `comment` property to any rule. Comments are for humans only and have no e
 
 Cypress Cloud validates your configuration against a strict schema and rejects any property it doesn't recognize. The usual causes are a misspelled property name, a value of the wrong type (for example, a string where an array is expected), or a note added on an unsupported field. Put explanations in a [`comment`](/ui-coverage/configuration/overview#Comments) instead. The editor reports the offending property so you can correct it before saving.
 
-### <Icon name="angle-right" /> Do I need to rerun my tests after changing configuration?
+### <Icon name="angle-right" /> Do I need to rerun my tests after changing UI Coverage configuration?
 
 No. You can regenerate any historical run from its **Properties** tab, and the report is reprocessed with the current configuration. This lets you iterate on configuration and see the effects immediately without running your Cypress tests again.
 
@@ -265,7 +283,7 @@ No. You can regenerate any historical run from its **Properties** tab, and the r
 
 Root-level properties like [`viewFilters`](/ui-coverage/configuration/viewfilters), [`elementFilters`](/ui-coverage/configuration/elementfilters), and [`views`](/ui-coverage/configuration/views) apply to both UI Coverage and Cypress Accessibility. To configure the products separately, nest `viewFilters`, `elementFilters`, `attributeFilters`, or `significantAttributes` under a `uiCoverage` or `accessibility` key; the nested list completely replaces the root-level one for that product. See [Configuration scope](/ui-coverage/configuration/overview#Configuration-scope).
 
-### <Icon name="angle-right" /> Can I use different configuration for different runs?
+### <Icon name="angle-right" /> Can I use different UI Coverage configuration for different runs?
 
 Yes. The [`profiles`](/ui-coverage/configuration/profiles) property applies configuration overrides based on [run tags](/app/references/command-line#cypress-run-tag-lt-tag-gt), so a smoke-test run and a full regression run can each use their own settings.
 
@@ -344,7 +362,7 @@ Yes. The result object includes a `config` property containing the [App Quality 
 
 A few sources of untested elements commonly lower a score without pointing to a real gap in your suite. Third-party widgets, such as chat launchers, cookie banners, and analytics overlays, are interactive elements each counted as untested; exclude them with [`elementFilters`](/ui-coverage/configuration/elementfilters). [Untested links](/ui-coverage/core-concepts/interactivity#Untested-Links) to pages no test visits, including your own help center, marketing pages, and external sites, also count against the score; exclude their destinations with [`viewFilters`](/ui-coverage/configuration/viewfilters). Finally, one control [split into many](/ui-coverage/troubleshooting#One-element-is-reported-as-many) by an unstable attribute adds duplicate untested elements. See [the coverage score looks wrong](/ui-coverage/troubleshooting#The-coverage-score-looks-wrong) for the fixes.
 
-### <Icon name="angle-right" /> Why does an element my test interacts with still show as untested?
+### <Icon name="angle-right" /> Why does an element my test interacts with still show as untested in UI Coverage?
 
 Usually the command your test uses isn't one UI Coverage recognizes. It counts only a [default set of interaction commands](/ui-coverage/core-concepts/interactivity#Interaction-Commands), so custom commands and plugin commands like `cypress-real-events`' `realClick` don't count until you add them with [`additionalInteractionCommands`](/ui-coverage/configuration/additionalinteractioncommands) or [`allowedInteractionCommands`](/ui-coverage/configuration/allowedinteractioncommands). A custom command also has to log a [snapshot](/ui-coverage/core-concepts/element-identification#Snapshots) referencing the element it acts on. And if you added an `allowedInteractionCommands` rule, only the commands you listed count for the matching elements, so a command you left out, even a plain `click`, no longer marks them tested. See [an element you tested is shown as untested](/ui-coverage/troubleshooting#An-element-you-tested-is-shown-as-untested).
 

--- a/docs/ui-coverage/guides/block-pull-requests.mdx
+++ b/docs/ui-coverage/guides/block-pull-requests.mdx
@@ -98,7 +98,7 @@ In our example the baseline is a JSON object that captures the state of untested
 
 #### Why use untested element counts instead of UI Coverage percentage scores?
 
-The [UI Coverage score](/ui-coverage/guides/identify-coverage-gaps#Overall-Score) is expressed as based on a ratio of what was and was not tested over time, within what was rendered in Cypress during the run. Since testing one new element might reveal many more elements that aren't tested yet, the score isn't useful for a fine-grained baseline comparison between runs. Comparing the number of tested elements gives a more accurate sense of whether one run has added or removed coverage when compared to another, and is a better predictor of what information would be in the report.
+The [UI Coverage score](/ui-coverage/guides/identify-coverage-gaps#Step-2-Read-your-overall-coverage-score) is expressed as based on a ratio of what was and was not tested over time, within what was rendered in Cypress during the run. Since testing one new element might reveal many more elements that aren't tested yet, the score isn't useful for a fine-grained baseline comparison between runs. Comparing the number of tested elements gives a more accurate sense of whether one run has added or removed coverage when compared to another, and is a better predictor of what information would be in the report.
 
 ### Complete example
 

--- a/docs/ui-coverage/guides/identify-coverage-gaps.mdx
+++ b/docs/ui-coverage/guides/identify-coverage-gaps.mdx
@@ -87,14 +87,14 @@ are grouped into patterns; for component tests, each spec file is a view. The
 
 - **Snapshots**: how many DOM snapshots were captured for the view.
 - **Tested elements**: how many of the view's interactive elements were tested, out of the total found.
-- **Coverage score**: the percentage of the view's interactive elements that were tested.
+- **Coverage %**: the percentage of the view's interactive elements that were tested.
 
 <DocsImage
   src="/img/ui-coverage/guides/cypress-ui-coverage-list-of-views.png"
   alt="Cypress Cloud screenshot showing the list of views within the UI Coverage tab, with columns for snapshots, tested elements, and coverage score alongside the lefthand navigation and a filter"
 />
 
-Sort by coverage score to bring your lowest-covered views to the top, then
+Sort by **Coverage %** to bring your lowest-covered views to the top, then
 weigh each one against how important it is to your users. A checkout or signup
 view at 40% is a more urgent gap than a settings page at the same score. This
 is where you decide which views deserve the next test.
@@ -104,8 +104,8 @@ is where you decide which views deserve the next test.
 Selecting a view breaks it down into the specific elements your tests did and
 didn't reach, so you can see each gap in context. A view drilldown includes:
 
-- **Untested Elements**: interactive elements that no recognized Cypress command targeted during the run.
-- **Tested Elements**: interactive elements a test exercised, with a count of how many times.
+- **Untested elements**: interactive elements that no recognized Cypress command targeted during the run.
+- **Tested elements**: interactive elements a test exercised, with a count of how many times.
 - **DOM Snapshot**: a full-page, inspectable snapshot of the view as it appeared during the run. Tested elements are highlighted green, untested elements red.
 - **Snapshot Navigation**: move between snapshots to see the view's different states during the run.
 - **Snapshot Coverage Score**: the coverage score for the specific snapshot you're viewing.
@@ -121,7 +121,7 @@ developer tools on it to understand why an element went untested: it may be
 hidden behind a menu, rendered only after login, or shown in a state your tests
 never reach. That context tells you what setup a new test needs.
 
-The **Untested Elements** section at the top level of the tab collects untested
+The **Untested elements** section at the top level of the tab collects untested
 elements across _all_ views, so you can spot a single control that's missed
 everywhere, such as a "Download" button repeated on every report page, and
 cover it in one place.

--- a/docs/ui-coverage/guides/identify-coverage-gaps.mdx
+++ b/docs/ui-coverage/guides/identify-coverage-gaps.mdx
@@ -1,6 +1,6 @@
 ---
 title: Identify coverage gaps with UI Coverage
-description: 'Find untested interactive elements in your app using UI Coverage reports from recorded Cypress runs.'
+description: 'A step-by-step workflow to find the untested buttons, forms, links, and pages in your app using Cypress UI Coverage reports, with no code instrumentation required.'
 sidebar_label: Identify coverage gaps
 sidebar_position: 10
 ---
@@ -9,108 +9,237 @@ sidebar_position: 10
 
 # Identify coverage gaps
 
-Understanding your application's test coverage is crucial for ensuring quality and reliability. Cypress's UI Coverage tool provides insights into which parts of your application are tested and highlights untested areas. This guide will help you get started with UI Coverage to identify and address coverage gaps effectively.
+Most teams can name a few flows they know are well tested. Naming the buttons,
+forms, and pages that _no_ test ever touches is much harder, and those are the
+gaps that let regressions ship. UI Coverage turns every recorded run into a
+ranked map of exactly those gaps: every interactive element your tests
+exercised, every one they missed, and every page they never opened. It reads
+this from [Test Replay](/cloud/features/test-replay) data in Cypress Cloud, so
+there's no code to instrument and nothing to add to your app.
 
-## Run Tests
+This workflow takes you from a recorded run to a prioritized list of gaps to
+close:
 
-To identify coverage gaps, you need to first run and record Cypress tests to the Cloud. If you're new to Cypress, refer to the [Cypress documentation](/app/end-to-end-testing/writing-your-first-end-to-end-test) to get started with writing tests.
+1. [Record a run](#Step-1-Record-a-run-to-Cypress-Cloud) so Cypress Cloud can build a UI Coverage report.
+2. [Read your overall coverage score](#Step-2-Read-your-overall-coverage-score) to see a baseline.
+3. [Start with your lowest-scoring views](#Step-3-Start-with-your-lowest-scoring-views) to find where gaps cluster.
+4. [Drill into a view](#Step-4-Drill-into-a-view-to-see-untested-elements) to see the untested elements in context.
+5. [Find the pages your tests never visit](#Step-5-Find-the-pages-your-tests-never-visit) from untested links.
+6. [Sharpen the signal with configuration](#Step-6-Sharpen-the-signal-with-configuration) so every gap is a real gap.
+7. [Turn gaps into tests](#Step-7-Turn-gaps-into-tests) to close them.
+
+:::tip
+
+<Icon useCypressIcon name="general-sparkle-triple" fillColor="teal-600" /> If
+you use an AI coding assistant, you can run most of this workflow without
+opening a browser tab. [Cypress Cloud MCP](/cloud/integrations/cloud-mcp) lets
+your agent pull the report, rank the riskiest views, and drill into specific
+untested elements from your editor. See [Work with AI
+agents](/ui-coverage/work-with-ai-agents) for prompts.
+
+:::
+
+## Step 1: Record a run to Cypress Cloud
+
+UI Coverage needs a recorded run to analyze. Any run recorded to
+[Cypress Cloud](https://on.cypress.io/cloud) with Test Replay produces a report
+automatically, with no configuration or code changes. If
+you already record your tests, you're ready; open the run and skip to
+[Step 2](#Step-2-Read-your-overall-coverage-score).
+
+If your project has few or no Cypress tests yet, you can still get a first
+report. Drive UI Coverage from your sitemap or a list of URLs: visiting each
+page captures the interactive elements on it, giving you a baseline for the
+pages your suite doesn't reach yet.
 
 <SitemapScanExample product="ui-coverage" />
 
-## Review Coverage Reports
+## Step 2: Read your overall coverage score
 
-Once your tests have recorded to Cypress Cloud, you can analyze the coverage reports to identify gaps. Click on the runs in your project in [Cypress Cloud](https://on.cypress.io/cloud) to access the UI Coverage reports. This report provides a visual representation of your application's test coverage, highlighting tested and untested elements.
-
-:::tip
-If you use an AI coding assistant, you can query UI Coverage data directly from your editor using [Cypress Cloud MCP](/cloud/integrations/cloud-mcp). Ask your agent to pull the report, identify the riskiest views, and drill into specific untested elements — without opening a browser tab.
-:::
-
-### Overall Score
-
-The first metric to review is the **overall coverage score**. This score is calculated by comparing the number of tested elements to the total number of [interactive elements](/ui-coverage/core-concepts/interactivity) in your application. A higher score indicates better coverage, while a lower score indicates areas that need additional testing. The score will display on the runs page and within individual runs.
+Once your run has recorded, start with the **overall coverage score**. It's the
+percentage of your application's interactive elements that your tests
+exercised, so it's the single number that tells you how much of your UI is
+covered and gives you a baseline to improve against. The score appears on the
+runs list and on each individual run.
 
 <DocsImage
   src="/img/ui-coverage/guides/cypress-ui-coverage-runs-list-with-uicov-score.png"
-  alt="Cypress Cloud screenshot cropping to show a list of 4 runs with the details of the run like git commit, committer, branch, and the UI Coverage score of 11%"
+  alt="Cypress Cloud screenshot showing a list of runs with each run's git commit, committer, branch, and UI Coverage score"
 />
 
-### Views
+[Grouped elements](/ui-coverage/core-concepts/element-grouping) count once
+toward the score, so a list of 50 identical "Remove" buttons is a single unit,
+and one test that removes one item covers all of them. This keeps repeated
+elements from inflating or sinking your score. For the exact calculation, see
+[how the score is calculated](/ui-coverage/faq#How-is-the-UI-Coverage-score-calculated).
 
-Within a run's **UI Coverage** tab, you'll find a **Views** section. Views represent different pages or components of your application. Each view in the list displays the URL or component path, the number of snapshots, the number of untested and tested elements in that view, and the coverage score.
+A low score isn't automatically a problem, and a high one isn't automatically
+safe. The goal isn't a perfect number, but to make sure the score reflects
+_real_ coverage of the flows that matter. The next steps show you where the
+untested elements behind the number actually are.
+
+## Step 3: Start with your lowest-scoring views
+
+Open the run's **UI Coverage** tab. A [view](/ui-coverage/core-concepts/views)
+is a distinct page or state of your application. For end-to-end tests, URLs
+are grouped into patterns; for component tests, each spec file is a view. The
+**Views** section lists every view with:
+
+- **Snapshots**: how many DOM snapshots were captured for the view.
+- **Tested elements**: how many of the view's interactive elements were tested, out of the total found.
+- **Coverage score**: the percentage of the view's interactive elements that were tested.
 
 <DocsImage
   src="/img/ui-coverage/guides/cypress-ui-coverage-list-of-views.png"
-  alt="Cypress Cloud screenshot cropping to show a list of views within the UI Coverage tab including a lefthand navigation, a list of views and a filter"
+  alt="Cypress Cloud screenshot showing the list of views within the UI Coverage tab, with columns for snapshots, tested elements, and coverage score alongside the lefthand navigation and a filter"
 />
 
-#### View Drilldown
+Sort by coverage score to bring your lowest-covered views to the top, then
+weigh each one against how important it is to your users. A checkout or signup
+view at 40% is a more urgent gap than a settings page at the same score. This
+is where you decide which views deserve the next test.
 
-Clicking into a view shows a detailed breakdown of the tested and untested elements within that view. You can use this information to inspect the DOM snapshot of the element using your browser's developer tools and understand the context of any coverage gaps. The view includes:
+## Step 4: Drill into a view to see untested elements
 
-- **Untested Elements**: A list of interactive elements that were not interacted with during the test run.
-- **Tested Elements**: A list of interactive elements that were interacted with during the test run.
-- **DOM Snapshot**: A full-page, inspectable DOM snapshot of the view as it appeared during the test run. Tested elements highlight as green, while untested elements highlight as red.
-- **Snapshot Navigation**: Navigate between snapshots to see the state of the view at different points during the test run.
-- **Snapshot Coverage Score**: The coverage score for the specific snapshot based on the number of tested elements.
-- **Test Replay**: A link to the Test Replay for the specific snapshot.
-- **URL** and **Viewport size**: Metadata for the view.
+Selecting a view breaks it down into the specific elements your tests did and
+didn't reach, so you can see each gap in context. A view drilldown includes:
+
+- **Untested Elements**: interactive elements that no recognized Cypress command targeted during the run.
+- **Tested Elements**: interactive elements a test exercised, with a count of how many times.
+- **DOM Snapshot**: a full-page, inspectable snapshot of the view as it appeared during the run. Tested elements are highlighted green, untested elements red.
+- **Snapshot Navigation**: move between snapshots to see the view's different states during the run.
+- **Snapshot Coverage Score**: the coverage score for the specific snapshot you're viewing.
+- **Test Replay**: a link to open [Test Replay](/cloud/features/test-replay) at that snapshot, where you can see the element within the full test run instead of a single captured state.
 
 <DocsImage
   src="/img/ui-coverage/guides/cypress-ui-coverage-view-drilldown.png"
-  alt="Cypress Cloud screenshot cropping a single view within the cypress-documentation project showing the view's URL, the list of tested and untested elements and a DOM snapshot of the view"
+  alt="Cypress Cloud screenshot of a single view showing its URL, the list of tested and untested elements, and a DOM snapshot of the view"
 />
 
-### Untested links
+Because the snapshot is a real, inspectable DOM, you can open your browser's
+developer tools on it to understand why an element went untested: it may be
+hidden behind a menu, rendered only after login, or shown in a state your tests
+never reach. That context tells you what setup a new test needs.
 
-In the **UI Coverage** tab, the **Untested links** section lists all the links not interacted with during the test run. This can help you identify pages of your application that are not being visited and tested. Use this to identify unvisited pages and prioritize testing.
-
-<DocsImage
-  src="/img/ui-coverage/guides/cypress-ui-coverage-untested-links.png"
-  alt="Cypress Cloud screenshot cropping the untested links section with a list of links that were not interacted with during the test run"
-/>
-
-#### Referrer Drilldown
-
-Clicking a referrer link redirects you to the referrer's view, where the untested link is highlighted in red.
-
-<DocsImage
-  src="/img/ui-coverage/guides/cypress-ui-coverage-untested-link-view.png"
-  alt="Cypress Cloud screenshot showing a view with the untested link highlighted in red"
-/>
-
-### Untested elements
-
-The **Untested Elements** section in the **UI Coverage** tab lists all interactive elements not interacted with during the test run. This can help you identify specific elements that are not being tested across views. Use this information to prioritize testing for these elements.
+The **Untested Elements** section at the top level of the tab collects untested
+elements across _all_ views, so you can spot a single control that's missed
+everywhere, such as a "Download" button repeated on every report page, and
+cover it in one place.
 
 <DocsImage
   src="/img/ui-coverage/guides/cypress-ui-coverage-untested-elements-expanded.png"
-  alt="Cypress Cloud screenshot cropping the untested elements section with a list of elements that were not interacted with during the test run"
+  alt="Cypress Cloud screenshot of the untested elements section listing elements that were not interacted with during the run"
 />
 
-#### View Drilldown
-
-Clicking into an untested element's view shows a detailed breakdown of the element, including the element's selector, the number of times the element was interacted with, and the views without interactions. You can use this information to inspect the DOM snapshot of the element using your browser's developer tools and understand the context of any coverage gaps.
+Expanding an untested element shows its selector, how many times it was
+interacted with, and the views where it appears without any interaction, so
+you can trace the same element back to every page it shows up on.
 
 <DocsImage
   src="/img/ui-coverage/guides/cypress-ui-coverage-untested-elements-view-drilldown.png"
-  alt="Cypress Cloud screenshot cropping a single untested element showing the element's selector, the number of times the element was interacted with, the views without interactions, and a full DOM snapshot of the view"
+  alt="Cypress Cloud screenshot of a single untested element showing its selector, interaction count, the views without interactions, and a full DOM snapshot of the view"
 />
 
-## Configure UI Coverage
+## Step 5: Find the pages your tests never visit
 
-While UI Coverage is designed to work seamlessly out of the box, there are instances where custom configuration may be necessary to address unique application structures, testing requirements, or edge cases. Refer to the [Configuration Guide](/ui-coverage/configuration/overview) to learn how to customize UI Coverage to address these common needs:
+Untested elements only exist for pages your tests actually open. To find the
+pages your suite never reaches at all, use the **Untested links** section. It
+lists links (`<a>` elements) whose destination URL was never visited during the
+run. Each one is a flow your tests are missing, even when no view exists for
+that page yet.
 
-- **Filtering**: Exclude specific elements or views from coverage reports.
-  - [Element Filters](/ui-coverage/configuration/elementfilters): Exclude specific elements from coverage reports.
-  - [View Filters](/ui-coverage/configuration/viewfilters): Exclude specific views from coverage reports.
-- **Grouping**: Group similar elements together for easier analysis.
-  - [Elements](/ui-coverage/configuration/elements): Specify selectors to uniquely identify elements, even when they lack stable identifiers across snapshots.
-  - [Element Grouping](/ui-coverage/configuration/elementgroups): Group similar elements together for easier analysis.
-  - [Views](/ui-coverage/configuration/views): Group views together based on defined URL patterns.
-- **Defining Attribute Patterns**: Define patterns for identifying and grouping elements by attributes.
-  - [Attribute Filters](/ui-coverage/configuration/attributefilters): Specify patterns for attributes and their values that should not be used for identifying and grouping elements.
-  - [Significant Attributes](/ui-coverage/configuration/significantattributes): Define selectors to prioritize above the default attributes Cypress uses for the purpose of identification and grouping.
+<DocsImage
+  src="/img/ui-coverage/guides/cypress-ui-coverage-untested-links.png"
+  alt="Cypress Cloud screenshot of the untested links section listing links whose destinations were never visited during the run"
+/>
 
-## Next Steps
+Expanding an untested link organizes its detail into two tabs:
 
-By leveraging these tools and techniques, you can effectively identify test coverage gaps. Next, read our guide on [addressing coverage gaps](/ui-coverage/guides/address-coverage-gaps) to ensure a robust and reliable application.
+- **Referrers**: the tested pages that link to this destination, showing you where in your app the untested page is reachable from.
+- **URLs**: the concrete destinations behind the link, grouped for dynamic routes, so you can see the full scope of a route your tests haven't reached.
+
+Selecting a referrer opens that view with the untested link highlighted in red,
+so you can see where in the page the link lives.
+
+<DocsImage
+  src="/img/ui-coverage/guides/cypress-ui-coverage-untested-link-view.png"
+  alt="Cypress Cloud screenshot of a view with an untested link highlighted in red in the rendered page"
+/>
+
+Untested links count against your coverage score, which is deliberate: a page
+you link to but never test is a real gap. But links to destinations you'll
+never own, such as external sites, a marketing page, or a status page,
+shouldn't drag your score down. That's what the next step addresses.
+
+## Step 6: Sharpen the signal with configuration
+
+Before you invest in writing tests, make sure the gaps you're looking at are
+_real_ gaps. Two kinds of noise commonly lower a score without pointing to
+anything worth testing:
+
+- **Third-party widgets**, such as chat launchers, cookie banners, and ad embeds, are interactive elements you don't own, each counted as untested.
+- **Untested links to pages you'll never test**, such as external sites, marketing pages, and a status page, count against your score even though testing them isn't your job.
+
+UI Coverage is configured from the **App Quality** tab of your project settings
+in Cypress Cloud. Configuration is opt-in: add a rule only to remove noise or
+sharpen the report. After saving, you can regenerate any historical run from its
+**Properties** tab to see the effect immediately, with no need to re-run your tests.
+
+Exclude a third-party widget so it stops counting as an untested element with
+[`elementFilters`](/ui-coverage/configuration/elementfilters):
+
+```json title="App Quality Config"
+{
+  "elementFilters": [
+    {
+      "selector": "#intercom-container, #intercom-container *",
+      "include": false,
+      "comment": "Third-party support chat, not part of our app, shouldn't count as a gap"
+    }
+  ]
+}
+```
+
+Exclude a destination you'll never test so its untested links stop counting
+against your score with [`viewFilters`](/ui-coverage/configuration/viewfilters):
+
+```json title="App Quality Config"
+{
+  "viewFilters": [
+    {
+      "pattern": "https://status.example.com/*",
+      "include": false,
+      "comment": "External status page linked from the footer, not owned by our team"
+    }
+  ]
+}
+```
+
+The [Reduce noise](/ui-coverage/guides/reduce-noise) guide walks through the
+other common adjustments, such as grouping repeated elements and stabilizing
+elements with dynamic attributes. With the noise removed, every remaining gap is
+one worth a decision.
+
+## Step 7: Turn gaps into tests
+
+You now have a prioritized, trustworthy list of gaps: the untested elements on
+your riskiest views and the pages your suite never opens. The last step is to
+close them.
+
+You have a few ways to close them, depending on how you like to work:
+
+- **Prompt an AI agent with [Cypress Cloud MCP](/cloud/integrations/cloud-mcp)**: point your AI coding assistant at the report and have it pull the untested elements for a view, then draft targeted tests in your editor alongside your existing code and custom commands. See [Work with AI agents](/ui-coverage/work-with-ai-agents).
+- **Generate a test from Cypress Cloud**: select an untested element in the report and click **Generate test code**. Cypress writes a test that navigates to the element and interacts with it, following your existing patterns. See [Generate tests from UI Coverage reports](/ui-coverage/guides/address-coverage-gaps#Generate-tests-from-UI-Coverage-reports).
+- **Write the test yourself**: copy the element's selector from the report with the **Copy element selector** action, or inspect it in the DOM snapshot with your browser's developer tools, then write a focused test by hand.
+
+Whichever you choose, the [Address coverage gaps](/ui-coverage/guides/address-coverage-gaps)
+guide covers the details: writing tests for specific elements, adding navigation
+to reach untested pages, revealing hidden or conditionally rendered elements, and
+confirming the score improved on your next run.
+
+## See also
+
+- [Address coverage gaps](/ui-coverage/guides/address-coverage-gaps): close the gaps you found by adding and improving tests.
+- [Monitor changes](/ui-coverage/guides/monitor-changes): track your score over time so new gaps don't slip in.
+- [Block pull requests and set policies](/ui-coverage/guides/block-pull-requests): enforce a coverage threshold in CI with the [Results API](/ui-coverage/results-api).
+- [UI Coverage FAQ](/ui-coverage/faq): answers to common questions about scores, views, links, and configuration.

--- a/docs/ui-coverage/guides/identify-coverage-gaps.mdx
+++ b/docs/ui-coverage/guides/identify-coverage-gaps.mdx
@@ -30,11 +30,11 @@ close:
 
 :::tip
 
-<Icon useCypressIcon name="general-sparkle-triple" fillColor="teal-600" /> If
-you use an AI coding assistant, you can run most of this workflow without
-opening a browser tab. [Cypress Cloud MCP](/cloud/integrations/cloud-mcp) lets
-your agent pull the report, rank the riskiest views, and drill into specific
-untested elements from your editor. See [Work with AI
+<Icon useCypressIcon name="general-sparkle-triple" className="inline" /> If you
+use an AI coding assistant, you can run most of this workflow without opening a
+browser tab. [Cypress Cloud MCP](/cloud/integrations/cloud-mcp) lets your agent
+pull the report, rank the riskiest views, and drill into specific untested
+elements from your editor. See [Work with AI
 agents](/ui-coverage/work-with-ai-agents) for prompts.
 
 :::


### PR DESCRIPTION
## Summary

Rewrites the **Identify coverage gaps** guide as a value-led, step-by-step workflow, corrects several inaccuracies against the current UI Coverage implementation, and enriches the UI Coverage FAQ for search and answer engines.

## Why

The guide read as a flat feature tour rather than a workflow, and a few details had drifted from how UI Coverage actually behaves (checked against the `discovery/packages/ui-coverage` and `read-api` implementation in `cypress-services`):

- It listed a **"Viewport size"** field for a view, which does not exist.
- Its **"Referrer Drilldown"** section predated the current **Referrers / URLs tabs** on an expanded untested link.
- The views-list columns and score wording didn't reflect the grouping model (grouped elements count once).
- **Untested elements**, **untested links**, and **unvisited pages** were blurred together.

Separately, most FAQ questions didn't name the product, so out of context (a search result or an AI citation) they were ambiguous.

### What changed

**`guides/identify-coverage-gaps.mdx`**
- Restructured into a numbered workflow: record → read the overall score → triage the lowest-scoring views → drill into untested elements → find unvisited pages from untested links → sharpen the signal with configuration → turn gaps into tests, with a closing **See also**.
- Fixed the inaccuracies above and clarified the Referrers/URLs tab descriptions.
- Reframed closing the gap as three real options — **Cypress Cloud MCP**, **Cloud Test Generation**, or writing a test by hand using the **Copy element selector** action and the inspectable DOM snapshot.
- Added two realistic examples with the standard `title="App Quality Config"` label (excluding a third-party chat widget; excluding an external status page), plus an AI sparkle icon on the MCP tip.

**`faq.mdx`**
- Added a **Finding coverage gaps** section with four question-shaped entries, captured by the existing `FAQPage` JSON-LD generator (eligible for rich results / answer-engine citations).
- Wove **Cypress** / **UI Coverage** into the generic question headings so each stands alone in search.

**`configuration/elements.mdx`, `configuration/elementfilters.mdx`**
- Updated two anchor links to the FAQ headings whose slugs changed, so the links keep resolving.

## Notes for reviewers

- The guide stays at `/ui-coverage/guides/identify-coverage-gaps` (many pages link to it); it was not moved despite reading like a core concept.
- Two reworded FAQ headings are anchor targets from the config pages above; I updated those references rather than pinning slugs, to keep the JSON-LD question text clean.
- Verified: Prettier, frontmatter lint, all internal anchors resolve, and the FAQ parses to 75 clean JSON-LD entries. No new images were added — all referenced screenshots already exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XWM1T4QmLcp5wMD9DuLw98

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWM1T4QmLcp5wMD9DuLw98)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to MDX guides and FAQ; no runtime or API changes.
> 
> **Overview**
> **Identify coverage gaps** is reframed as a numbered workflow (record → score → triage views → drill into elements → untested links → configuration noise reduction → close gaps), with corrected product behavior (no viewport field, Referrers/URLs tabs, grouped-element scoring) and clearer separation of untested elements, links, and unvisited pages. Closing gaps is spelled out as MCP, Cloud test generation, or hand-written tests with **Copy element selector**.
> 
> The **UI Coverage FAQ** gains a **Finding coverage gaps** section (four new Q&As) and many headings are retitled to include **Cypress** / **UI Coverage** for standalone search. **`elementfilters.mdx`**, **`elements.mdx`**, and **`block-pull-requests.mdx`** update internal links to match new FAQ slugs and the guide’s Step 2 anchor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91a57449eec29e6fcc8b7b0f9d191e74efa540e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->