### PR TITLE
docs(ui-coverage): rework "Work with AI agents" for accuracy, value, and clarity

### DIFF
--- a/docs/ui-coverage/faq.mdx
+++ b/docs/ui-coverage/faq.mdx
@@ -556,6 +556,28 @@ Most often the run was processed before you saved: Cypress UI Coverage reports u
 
 Start by [regenerating the run](/ui-coverage/configuration/overview#Setting-configuration) in Cypress Cloud so it reflects your current configuration, then match your symptom to a cause on the [Troubleshooting](/ui-coverage/troubleshooting) page, which covers duplicate elements, mis-grouped elements, tested elements shown as untested, configuration that has no effect, and unexpected scores. Because you can regenerate any past run, the fastest approach is to make one change, regenerate a recent run, and check the result before making the next.
 
+## Using AI agents with Cypress UI Coverage
+
+### <Icon name="angle-right" /> Which Cypress Cloud MCP tools expose UI Coverage data to AI agents?
+
+Cypress Cloud MCP provides three UI Coverage tools: `cypress_get_ui_coverage_report` returns a run's overall coverage score, tested and untested element and link counts, and the top 5 riskiest views; `cypress_get_ui_coverage_views` pages through all views sorted by most untested elements and links; and `cypress_get_ui_coverage_elements` pages through individual elements, filterable by tested or untested and scopable to a single view. Your AI agent selects them automatically based on your prompt.
+
+### <Icon name="angle-right" /> Can Cypress Cloud MCP update my Cypress tests, configuration, or runs?
+
+No. The Cypress UI Coverage MCP tools are read-only: they retrieve report data and can't edit your test code, update your [App Quality configuration](/ui-coverage/configuration/overview), or delete runs. An AI agent can draft test code locally in your editor, but nothing an agent does through Cypress Cloud MCP writes back to Cypress Cloud. Access is also scoped to the projects your Cypress Cloud user can already see. See [Cloud MCP security](/cloud/integrations/cloud-mcp#Security--Privacy).
+
+### <Icon name="angle-right" /> How do I make Cypress UI Coverage reports easier for an AI agent to use?
+
+Shape your Cypress UI Coverage report the same way you would for human review. [Filter out](/ui-coverage/configuration/elementfilters) third-party widgets you don't own, [promote a stable attribute](/ui-coverage/configuration/significantattributes) so elements have clean, readable names, and [group](/ui-coverage/configuration/elementgroups) repeated controls so they count once. A high-signal report gives the agent accurate context and avoids wasting tokens on noise. See [Tune reports for better agent results](/ui-coverage/work-with-ai-agents#Tune-reports-for-better-agent-results).
+
+### <Icon name="angle-right" /> Can an AI agent write Cypress tests for my untested UI Coverage elements?
+
+Yes, with your review. Because Cypress UI Coverage lists untested elements with the selectors and views that produced them, an AI agent can draft Cypress tests targeting those elements and suggest the existing spec file that's the best home for them. Pair the agent with [Cypress AI Skills](/app/tooling/ai-skills) so the tests it drafts follow Cypress best practices and match your project's conventions. Ask it to show a diff before writing files, and confirm intent and risk yourself before merging. See the [prompts to plan and draft tests](/ui-coverage/work-with-ai-agents#Prompts-to-plan-and-draft-tests).
+
+### <Icon name="angle-right" /> Is my Cypress UI Coverage data used to train AI models?
+
+No. Cypress UI Coverage data returned through Cypress Cloud MCP is used only to fulfill the agent's request and is never used to train or improve any LLM. Cypress also has no visibility into your AI assistant's conversation or outputs. See [Cloud MCP security and privacy](/cloud/integrations/cloud-mcp#Security--Privacy).
+
 ## See also
 
 - [Troubleshooting UI Coverage](/ui-coverage/troubleshooting) maps common report problems to their causes and fixes.

--- a/docs/ui-coverage/guides/compare-reports.mdx
+++ b/docs/ui-coverage/guides/compare-reports.mdx
@@ -334,8 +334,8 @@ coverage is acceptable is a judgment call. A lower score after a deliberate scop
 change is fine; the same drop from a test that quietly stopped interacting with a
 control is not. Treat unexpected coverage movement as a quality gate: let the
 agent narrate the diff and propose tests, and have a reviewer confirm intent and
-risk before merging. See [Governance: when to involve a
-human](/ui-coverage/work-with-ai-agents#Governance-when-to-involve-a-human).
+risk before merging. See [Review and enforce
+coverage](/ui-coverage/work-with-ai-agents#Review-and-enforce-coverage).
 
 ## See also
 

--- a/docs/ui-coverage/work-with-ai-agents.mdx
+++ b/docs/ui-coverage/work-with-ai-agents.mdx
@@ -1,6 +1,6 @@
 ---
 title: Use AI agents with UI Coverage
-description: 'Use AI assistants with UI Coverage and Cypress Cloud MCP: pull coverage scores and untested elements from recorded runs, tune reports for clearer signal, and review coverage deltas alongside passing tests.'
+description: 'Use AI agents with UI Coverage and Cypress Cloud MCP to pull coverage scores and untested elements from recorded runs and turn gaps into drafted tests.'
 sidebar_label: Work with AI agents
 sidebar_position: 110
 ---
@@ -9,44 +9,277 @@ sidebar_position: 110
 
 # Work with AI agents
 
-UI Coverage maps how your Cypress tests use the interface: which [interactive elements and links](/ui-coverage/core-concepts/interactivity) were exercised in each view, how that adds up to a [coverage score](/ui-coverage/get-started/introduction), and the DOM snapshots from [Test Replay](/cloud/features/test-replay) that put each finding in context. That picture is built from what actually ran in the browser, so it is a strong signal for **test completeness** relative to the UI states your suite reaches.
+UI Coverage gives your AI agent the grounded context it needs to improve your tests. For every recorded Cypress run, it reports which interactive elements and links your tests exercised, assigns a coverage score to each view, and names the exact untested controls to go after. It's all built from what really ran in the browser during [Test Replay](/cloud/features/test-replay), and filtered through your configuration to focus on what already matters to you. Working from that report, an agent can find real coverage gaps and write tests that target them, rather than guessing at your app's structure.
 
-AI agents can use that signal to summarize gaps, draft targeted tests, or correlate a drop in coverage with specific specs—while your team keeps ownership of what “enough coverage” means for each area.
+## What an AI agent can do with UI Coverage
 
-## Cypress Cloud MCP
+Connected to your UI Coverage report, an agent can turn coverage gaps into concrete testing work:
 
-[Cypress Cloud MCP](/cloud/integrations/cloud-mcp) lets compatible agents query UI Coverage for a run using structured tools.
+- **Turn "coverage dropped" into a work list**: which views regressed, which elements are newly untested, and where the risk is concentrated.
+- **Prioritize missing scenarios**: comparing missing coverage with your currently-tested user journeys can put the gaps in context.
+- **Draft tests for untested elements**, and suggest the existing spec file that's the best home for them.
+- **Correlate gaps with ownership**: group untested areas by team, feature, or route so the right people get the right list.
+- **Backfill incrementally**: sequence the work from highest-risk to lowest instead of dumping every control on every page.
+- **Configure with intent**: generate the configuration needed to ignore or group elements to remove a gap.
 
-Use it to turn “something changed in coverage” into a concrete next step: which views regressed, which elements are newly untested, and where to add or restore interactions.
+Your team still decides what "enough coverage" means for each area. The agent handles the triage, drafting, and bookkeeping around that judgment.
 
-### Example prompts
+## Quickstart
 
-Here are some example prompts to try out:
+Three steps to your first useful result:
 
-> "Using Cypress Cloud, pull the UI Coverage report for the latest run on this branch. Summarize the overall coverage score, the views with the most untested elements, and list the untested elements on the top view."
+1. **Connect the MCP.** Add Cypress Cloud MCP to your AI client by following [Configuring the Cloud MCP](/cloud/integrations/cloud-mcp#Configuring-the-Cloud-MCP).
+2. **Ask for the riskiest view.** Prompt: _"Using Cypress Cloud, pull the UI Coverage report for the latest run on this branch and list the untested elements on the riskiest view."_
+3. **Act on one gap.** Have the agent [draft a test](#Prompts-to-plan-and-draft-tests) for one of those elements, review the diff, and run it.
 
-> "Get UI Coverage for this run URL. For the view named `/checkout`, list untested interactive elements and suggest which existing spec file is the best place to add a test that exercises them."
+The rest of this page deepens each step: better prompts, report tuning, and how to keep the score honest.
 
-> "Use this CSV of our most-used pages based on Google Analytics data and create a matrix of risk where pages with large amounts of user interactions have relatively low UI Coverage. Create an action plan around this to backfill missing coverage in small increments starting from the most urgent work and working backwards."
+## Query UI Coverage with Cypress Cloud MCP
 
-## Tune UI Coverage for agent-friendly signal
+Prompt your agent in natural language, and it selects the right tool for you.
 
-Agents work best when reports emphasize the surfaces your team cares about. Use [configuration](/ui-coverage/configuration/overview) to shape what appears in Cloud and in MCP responses:
+### UI Coverage MCP tools
 
-- Use config [profiles](/ui-coverage/configuration/profiles) for team or owner-based customization,
-- [Reduce noise](/ui-coverage/guides/reduce-noise) with filters to ignore third-party or out-of-scope ui
-- Create clear [element identification](/ui-coverage/core-concepts/element-identification) and [grouping](/ui-coverage/core-concepts/element-grouping) so your agent can quickly make correct assumptions about an elements purpose.
+An agent connected to Cloud MCP can call these UI Coverage tools, choosing them based on your prompt.
 
-You can also use your agent to help you define and shape your configuration, by referencing the Cypress docs and describing intended changes.
+| Tool                               | What it returns                                                                                                                                              |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `cypress_get_ui_coverage_report`   | A run's high-level report: overall coverage score, tested and untested element and link counts, and the top 5 riskiest views (most untested elements first). |
+| `cypress_get_ui_coverage_views`    | Paginated views for a run, sorted by most untested elements and links. Use it to browse past the top 5 in the report summary.                                |
+| `cypress_get_ui_coverage_elements` | Paginated interactive elements for a run. Filter by tested or untested, and optionally scope to a single view by name.                                       |
 
-The goal is the same as for human review: high-signal lists of views and elements tied to ownership and critical flows, not an undifferentiated dump of every control on every page.
+These tools are read-only: they retrieve data and can't change your configuration, tests, or runs. Access is scoped to the projects your Cypress Cloud user can already see. For availability, limits, and security details, see the [Cloud MCP reference](/cloud/integrations/cloud-mcp).
 
-## Governance: when to involve a human
+### How to prompt effectively
 
-Treat unexpected coverage movement as a **quality gate on the tests and the UI under test**, not noise to ignore by default.
+A few habits make every prompt land better:
 
-- Use [Branch Review](/ui-coverage/guides/compare-reports) to see what changed between runs: new untested elements, new links, or new interactables in the application.
-- Use [monitoring and the Results API](/ui-coverage/guides/monitor-changes) to watch trends and wire checks into CI.
-- Use [policies and blocking flows](/ui-coverage/guides/block-pull-requests) when you need explicit thresholds or baselines before merge.
+- **Say "Cypress Cloud"** so the agent reaches for the MCP tools instead of guessing.
+- **Name the run** with a branch, commit, or run URL, so the agent reads the report you mean.
+- **Start with the riskiest view** and work one view at a time, rather than the whole app at once.
+- **Ask for a plan or a diff** before any file changes, so you review intent before code lands.
+- **Use your own view names and paths.** The examples below are patterns to adapt, not literal values; swap in the views, flows, and folders from your app.
 
-Agents can draft tests, suggest spec placement, or narrate diffs; reviewers should still confirm intent, risk, and whether a drop in coverage is acceptable (for example, after a deliberate scope change). That split keeps velocity while avoiding silent drift in what your suite actually exercises.
+## Prompts to summarize and triage coverage
+
+Point the agent at a run and ask it to summarize where the risk is.
+
+<CopyPrompt
+  title="Summarize coverage for a run"
+  subtext="Pull the UI Coverage report for the latest run and surface the riskiest view."
+  prompt={`Using Cypress Cloud, pull the UI Coverage report for the latest run on this branch. Give me the overall coverage score, the views with the most untested elements, and the specific untested elements on the riskiest view.`}
+>
+
+### Summarize coverage for a run
+
+</CopyPrompt>
+
+<CopyPrompt
+  title="Find where new tests belong"
+  subtext="List the untested elements on a view and suggest which spec should cover them."
+  prompt={`Get UI Coverage report for the latest run on this branch. Pick the riskiest view, list its untested interactive elements, and suggest which existing spec file is the best place to add a test that exercises them.`}
+>
+
+### Find where new tests belong
+
+</CopyPrompt>
+
+<CopyPrompt
+  title="Assess release readiness"
+  subtext="Get a go/no-go on your critical flows, with the exact gaps blocking each one."
+  prompt={`Using Cypress Cloud MCP, get the UI Coverage report for the latest run on this branch. For the views behind our most critical user flows, give me each view's coverage score and its untested interactive elements. Then give me a go/no-go: flag any critical view below our threshold (say 80%) and list the specific gaps blocking it.`}
+>
+
+### Assess release readiness
+
+</CopyPrompt>
+
+<CopyPrompt
+  title="Report coverage progress over a sprint"
+  subtext="Summarize how coverage moved across recent runs into a shareable status update."
+  prompt={`Using Cypress Cloud MCP, compare UI Coverage across the last 10 runs on main. Summarize how coverage moved over the sprint: the net score change, the views that improved the most, and the views that regressed. Format it as a short status update I can share with the team.`}
+>
+
+### Report coverage progress over a sprint
+
+</CopyPrompt>
+
+## Prompts to plan and draft tests
+
+Once the agent can read the report, ask it to produce a plan or a change rather than a summary.
+
+<CopyPrompt
+  title="Plan the coverage backfill"
+  subtext="Turn untested elements into a risk-ordered, incremental test plan."
+  prompt={`Using Cypress Cloud MCP, get UI Coverage for the latest run on our main branch. Build a backfill plan that groups untested elements by view, orders the views from most to least risky, and proposes small, reviewable batches of tests, starting with the views most critical to our users.`}
+>
+
+### Plan the coverage backfill
+
+</CopyPrompt>
+
+<CopyPrompt
+  title="Write a Markdown test plan"
+  defaultCollapsed
+  subtext="Turn untested elements, links, and views into a Markdown test plan, prioritized against your PRD."
+  prompt={`Using Cypress Cloud MCP, get the untested interactive elements, untested links, and riskiest views for the latest run on this branch. Write a Markdown test plan grouped by view: for each untested element or link, add a row with the user action to perform and the expected result. Then cross-reference our product requirements document (PRD) and move the flows it marks as required to the top of the plan.`}
+>
+
+### Write a Markdown test plan
+
+</CopyPrompt>
+
+<CopyPrompt
+  title="Open a ticket for each untested area"
+  defaultCollapsed
+  subtext="Turn each view's gaps into a ready-to-file ticket, grouped by view."
+  prompt={`Using Cypress Cloud MCP, group the untested interactive elements by view for the latest run on main. For each view with meaningful gaps, draft a ticket with a title, the list of untested elements, the user-facing risk, and a suggested test approach. If you have access to our issue tracker, create one ticket per view and link them under an epic; otherwise output them as Markdown I can paste in.`}
+>
+
+### Open a ticket for each untested area
+
+</CopyPrompt>
+
+<CopyPrompt
+  title="Diff coverage between two branches"
+  defaultCollapsed
+  subtext="Compare two branches' coverage scores and diff their untested elements to catch regressions or gains."
+  prompt={`Using Cypress Cloud MCP, get the UI Coverage report for the latest run on this branch and for the latest run on main. Compare the overall coverage scores, then diff the untested interactive elements and links between the two runs: list what became untested on this branch (regressions) and what is now covered (gains), grouped by view. For each regression, point me to the spec or app change most likely responsible.`}
+>
+
+### Diff coverage between two branches
+
+</CopyPrompt>
+
+<CopyPrompt
+  title="Draft tests for untested elements"
+  subtext="Draft focused tests for untested elements on a view, diff-first."
+  prompt={`You are a Cypress test author. Using Cypress Cloud, take the untested elements on the view I'm working on from the latest run. For each, draft a focused test using our existing data-cy selectors and add it to the closest matching spec in our e2e folder. Show me a diff before writing files.`}
+>
+
+### Draft tests for untested elements
+
+</CopyPrompt>
+
+<CopyPrompt
+  title="Author tests in natural language with cy.prompt"
+  defaultCollapsed
+  subtext="Cover untested areas by describing each flow in plain language and letting cy.prompt write the Cypress commands."
+  prompt={`Using Cypress Cloud, list the untested interactive elements on the riskiest view for the latest run. For each, add a test that uses cy.prompt to drive the flow in natural language: describe the user action to take and what to verify in plain English, and let cy.prompt generate the Cypress commands. Use the Cypress Author skill, if available, to create well-formed prompt steps following best practices. Put the tests in our e2e folder and show me a diff before writing files.`}
+>
+
+### Author tests in natural language with cy.prompt
+
+</CopyPrompt>
+
+:::tip
+
+When the agent moves from finding gaps to authoring tests, pair it with [Cypress AI Skills](/app/tooling/ai-skills). The skills teach your AI tool to write Cypress tests the way an experienced Cypress engineer would, following best practices and matching your project's conventions.
+
+:::
+
+To align risk with real-world usage, combine coverage data with your own analytics:
+
+<CopyPrompt
+  title="Prioritize gaps by traffic and risk"
+  subtext="Cross-reference page traffic with coverage to prioritize backfill."
+  prompt={`Here is a CSV of our most-visited pages from analytics. Cross-reference it with the latest UI Coverage report from Cypress Cloud to build a risk matrix where high-traffic pages with low coverage rank highest. Turn the top of that matrix into an incremental backfill plan.`}
+>
+
+### Prioritize gaps by traffic and risk
+
+</CopyPrompt>
+
+Coverage data also points the other way, at tests you can safely trim:
+
+<CopyPrompt
+  title="Trim over-tested UI"
+  defaultCollapsed
+  subtext="Find elements your tests hit far more than needed and suggest redundant tests to cut."
+  prompt={`Using Cypress Cloud MCP, list the tested interactive elements for the latest run on main, sorted by interaction count. Flag elements interacted with far more than their importance warrants (for example a nav link exercised by dozens of tests), and suggest which redundant tests we could consolidate or remove to speed up the suite without losing meaningful coverage.`}
+>
+
+### Trim over-tested UI
+
+</CopyPrompt>
+
+## Tune reports for better agent results
+
+Agents produce better work from reports that already reflect what your team cares about. The same [configuration](/ui-coverage/configuration/overview) that sharpens reports for human review also sharpens the context an agent reads over MCP.
+
+A few high-value changes make the report sharper for both people and agents:
+
+- **Remove noise and stabilize identity** so the agent reads clean element names instead of third-party clutter or the same button counted many ways. Filter out widgets you don't own, [promote a stable attribute](/ui-coverage/configuration/significantattributes) your app already renders, and [group](/ui-coverage/configuration/elementgroups) repeated controls so they count once.
+- **Count the interactions that reflect real usage** so coverage isn't understated where your suite drives the UI through plugin or [custom commands](/ui-coverage/configuration/additionalinteractioncommands).
+- **Scope the report to the runs your agent triages** with [`profiles`](/ui-coverage/configuration/profiles), so a smoke run and a full regression run each read the configuration that fits them.
+
+See the [configuration overview](/ui-coverage/configuration/overview) to get started. The goal is the same as for human review: a high-signal list of views and elements tied to ownership and critical flows, not an exhaustive list of every control on every page.
+
+You can also let the agent draft that configuration for you. It reads the untested elements over MCP, spots the noise, and hands back rules to paste into your App Quality Config. To review the configuration a run actually used before changing it, open the run's **Properties** tab or read the `config` property from the [Results API](/ui-coverage/results-api).
+
+<CopyPrompt
+  title="Draft configuration to cut noise"
+  defaultCollapsed
+  subtext="Have the agent read the untested elements and propose App Quality Config rules that remove noise."
+  prompt={`First read https://docs.cypress.io/llm/markdown/ui-coverage/configuration/overview.md for the App Quality configuration reference. Then use Cypress Cloud MCP to list the untested interactive elements for the latest run on this branch, flag third-party widgets and controls split apart by dynamic attributes, and propose App Quality Config rules (elementFilters, attributeFilters, elementGroups) to remove that noise. Show the JSON I can paste into the App Quality tab.`}
+>
+
+### Draft configuration to cut noise
+
+</CopyPrompt>
+
+## Keep coverage honest
+
+Coverage measures whether your tests _touch_ an element, not whether they confirm the desired behavior. An agent told to raise the score can write tests that click everything and assert nothing, so it's important to ground your coverage in the scenarios and outcomes that matter.
+
+Ensure tests include assertions about the state of the application and the readiness of the DOM for the next step of the test.
+
+:::info
+
+For areas where assertions on non-interactive elements are critical to track, your code can use the [`data-cy-ui-interactive`](/ui-coverage/core-concepts/interactivity#Overriding-interactive-elements-with-data-cy-ui-interactive) attribute to bring those elements into your coverage report.
+
+Combine this with [`allowedInteractionCommands`](/ui-coverage/configuration/allowedinteractioncommands) configuration to allow assertions to count as coverage for those elements. This adds an extra layer of guidance for your agent about what must be included in your tests.
+
+:::
+
+Keep a person in the loop wherever judgment matters:
+
+- **Intent.** Confirm the drafted test verifies the right behavior, not just that an element was interacted with.
+- **What's worth testing.** Agents target trivial controls as eagerly as critical ones. You decide which gaps matter.
+- **Selectors.** When your app lacks stable `data-*` attributes, agent-written selectors can be brittle. Add `data-cy` attributes rather than accept fragile ones, or have the agent author the test with [`cy.prompt`](/api/commands/prompt), whose selectors self-heal as your app changes.
+- **Intentional drops.** A coverage decrease after removing a test is correct. Don't let an agent "fix" it by re-adding the test; instead, filter out the elements you do not intend to cover with tests.
+
+## Review and enforce coverage
+
+Treat unexpected coverage movement as a quality gate, not noise to wave through, and wire that gate into your workflow so regressions surface before they merge:
+
+- Use [Branch Review](/ui-coverage/guides/compare-reports) to see exactly what changed between two runs: new untested elements, new links, and newly interactive parts of the app.
+- Use [monitoring and the Results API](/ui-coverage/guides/monitor-changes) to track trends and wire coverage checks into CI.
+- Use [blocking flows](/ui-coverage/guides/block-pull-requests) when you need explicit thresholds or baselines before a merge.
+
+An agent can draft tests, propose spec placement, and narrate diffs, but these gates keep a human in control of what merges. The signal that it is genuinely helping is your coverage score trending up across runs, which you can watch through [monitoring and analytics](/ui-coverage/guides/monitor-changes).
+
+## Generate tests directly from the report
+
+Prefer not to wire up an agent at all? Cypress Cloud can write the test for you. Select an untested element in a UI Coverage report and click **Generate test code**, and [UI Coverage Test Generation](/ui-coverage/guides/address-coverage-gaps#Generate-tests-from-UI-Coverage-reports) drafts a Cypress test that navigates to the element and interacts with it, following your existing patterns.
+
+<DocsImage
+  src="/img/ui-coverage/guides/cypress-ui-coverage-generate-test.png"
+  alt="Cypress Cloud showing a generated Cypress test after clicking Generate test code for an untested link in a UI Coverage report."
+/>
+
+## Standardize across your team
+
+These workflows pay off most when everyone gets the same results, not just one power user:
+
+- **Save your best prompts.** Once a prompt works, store it as a reusable skill or custom instruction in your AI client so the whole team runs the same play.
+- **Make it a habit in the repo.** Add a project rule to your agent's instructions file, such as "before adding tests, check UI Coverage for the affected view and cover the highest-risk gaps first."
+- **Focus the report.** Cypress Cloud projects share one [App Quality configuration](/ui-coverage/configuration/overview) so every teammate's agent reads the same high-signal report. Use [`profiles`](/ui-coverage/configuration/profiles) to customize the config for different kinds of runs or different team ownership within a large project.
+
+## See also
+
+- [Cloud MCP: Agentic debugging](/cloud/integrations/cloud-mcp): setup, available tools, limits, and security.
+- [UI Coverage FAQ](/ui-coverage/faq#Using-AI-agents-with-Cypress-UI-Coverage): answers to common questions about using agents with UI Coverage.
+- [Configuration overview](/ui-coverage/configuration/overview): every option for shaping your reports.
+- [Cypress AI Skills](/app/tooling/ai-skills): teach your AI tool to author Cypress tests following best practices.
+- [UI Coverage Test Generation](/ui-coverage/guides/address-coverage-gaps#Generate-tests-from-UI-Coverage-reports): generate a Cypress test for an untested element directly from the report.


### PR DESCRIPTION
## Summary

Reworks the UI Coverage **Work with AI agents** page so it matches the actual Cypress Cloud MCP implementation and leads with the value of pairing an AI agent with UI Coverage, and adds a matching FAQ section. Touches two files: `docs/ui-coverage/work-with-ai-agents.mdx` and `docs/ui-coverage/faq.mdx`.

Highlights on the guide page:

- Leads with the grounded-context value; adds **What an AI agent can do with UI Coverage** and a **Quickstart**.
- Documents the real MCP tools (`cypress_get_ui_coverage_report` / `_views` / `_elements`) and a **How to prompt effectively** block.
- Converts example prompts to `CopyPrompt` cards with named H3 headings (so each appears in the table of contents), covering: summarize a run, find where new tests belong, plan a backfill, write a Markdown **test plan** prioritized against a **PRD**, diff coverage between two branches, draft tests, prioritize by traffic/risk, and draft noise-cutting configuration.
- Adds **Tune reports for better agent results**, **Keep coverage honest** (coverage measures touch, not check — require assertions, and use `cy.prompt` for self-healing selectors), **Review and enforce coverage**, a **Generate tests directly from the report** section with a screenshot, and **Standardize across your team**.
- Spells out Model Context Protocol; keeps every configuration example titled `App Quality Config`.

FAQ page:

- Adds a self-contained **Using AI agents with Cypress UI Coverage** section (for SEO/AEO), cross-linked with the guide.

## Why

The existing page didn't reflect how UI Coverage actually works with Cloud MCP (tool names, what each returns, that the tools are read-only and don't expose configuration), and it led with mechanics rather than value. This pass corrects inaccuracies and misconceptions, adds missing concepts and APIs, leads with clear value, and restructures headings for a fuller, more meaningful table of contents. All tool behavior was verified against the `cypress-services` Cloud MCP implementation.

## Notes for reviewers

- **Accuracy call on configuration:** the Cloud MCP tools return report data only — there is **no** tool that returns a run's saved App Quality configuration. The "Draft configuration to cut noise" example therefore has the agent read the untested *elements* and propose config, and the prose notes that the applied config is reviewed via the run's Properties tab or the Results API `config` property. Please sanity-check that framing.
- **Placement of "Generate tests directly from the report":** it sits between the governance and team sections rather than next to the drafting prompts, per a request to give it its own section later on the page. Easy to move up if you'd prefer topical adjacency.
- Prompts use the `CopyPrompt` component with the heading passed as children (same pattern as the Cloud MCP page), which renders the heading as the card title and feeds the TOC.
- No em dashes; `prettier --check` passes on both files; all in-page and cross-page anchors verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ERXBt8CoVVzr8eHbenEGY6

---
_Generated by [Claude Code](https://claude.ai/code/session_01ERXBt8CoVVzr8eHbenEGY6)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, auth, or data-path impact; risk is limited to possible doc inaccuracies or broken cross-links.
> 
> **Overview**
> **Reworks** the UI Coverage **Work with AI agents** guide so it leads with value, matches real Cypress Cloud MCP behavior, and gives copy-paste workflows instead of a short mechanics overview.
> 
> The guide now documents the three read-only MCP tools (`cypress_get_ui_coverage_report`, `_views`, `_elements`), adds a quickstart and prompting tips, and replaces loose example prompts with many **`CopyPrompt`** cards (summarize runs, triage by view, release readiness, sprint progress, backfill plans, PRD-aligned test plans, branch diffs, draft tests, `cy.prompt`, traffic/risk prioritization, trimming over-tested UI, and drafting **App Quality Config** from untested elements). New sections cover tuning reports for agents, keeping coverage honest (assertions vs. “touch” coverage), **Review and enforce coverage** (renamed from the old governance heading), in-report **Generate test code**, and standardizing prompts across the team.
> 
> **Adds** an FAQ block **Using AI agents with Cypress UI Coverage** (tools, read-only scope, tuning reports, drafting tests, no LLM training on MCP data). **Updates** `compare-reports.mdx` to link to the renamed **Review and enforce coverage** anchor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bcbda76fab56ad7710bba517a53cf5f8aeca2e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->