### PR TITLE
Add changelog for cloud cli

### DIFF
--- a/docs/cloud/integrations/cloud-cli.mdx
+++ b/docs/cloud/integrations/cloud-cli.mdx
@@ -1018,6 +1018,47 @@ Usage limits are separate from data availability. What data you can retrieve fol
 
 The Cloud CLI communicates with the Cypress Cloud API at `https://cloud-api.cypress.io`. If you run the CLI from behind a restrictive VPN or firewall, add that host to your allowlist so the CLI can reach Cloud. Sign-in also uses `https://cloud.cypress.io`. See the [Cypress Cloud allowlist URLs](/cloud/faq#Im-working-with-a-restrictive-VPN-Which-subdomains-do-I-have-to-allow-on-my-VPN-for-Cypress-Cloud-to-work-properly) for the full list.
 
+## Changelog
+
+### 0.3.0
+
+_Released July 27, 2026_
+
+- Support Cypress Cloud test URLs via `--testResultUrl` in `test get`, `replay info`, and `replay timeline`
+- Fix an issue in `replay *` commands that caused queries against some tests to fail with a "SQLite3 can only bind numbers, strings, bigints, buffers, and null" error message
+- Redirect some logging so that command output is cleanly output to stdout
+- Improve handling of expired or invalid credentials without discarding OAuth credentials during transient refresh failures
+- Fix test setup to prevent network calls
+
+### 0.2.0
+
+_Released July 23, 2026_
+
+- Improve error logging
+- Convert all positional CLI arguments to flags
+- Update field names used in `test get` after duplicates were removed from API
+- Append additional metadata to API requests to aid troubleshooting
+- Remove unused fields from output of the `status` command
+- Default `replay timeline` to commands around the failure plus XHR/Fetch network events; add `--all` to opt into the full timeline
+- Add check to ensure user is authenticated prior to making API calls
+- Improve validation of arguments when calling `spec list` and `test list`
+- Fix `--schema` flag to not require other arguments, now outputs recursively
+
+### 0.1.1
+
+_Released July 16, 2026_
+
+- Clarify license metadata
+- Fix minor issues in some error messages
+- Fix issue with release process
+- Fix typo in default URL
+
+### 0.1.0
+
+_Released July 16, 2026_
+
+- Initial Release
+
 ## See also
 
 - [Cloud MCP: Agentic debugging](/cloud/integrations/cloud-mcp)


### PR DESCRIPTION
<!--
Fill in every section. This template doubles as the historical record of the
change, so future readers can understand not just what changed but
why. Delete a section only if it is genuinely not applicable, and say so.
-->

## Summary

Adding a changelog section for the Cloud CLI package - at this point just copying over the release notes from each release entry in Github. Also prepping for a 0.3.0 release likely to land Monday

## Why

<!-- The motivation and context. If this originated from an issue, a Slack/
Discord thread, a broken link, an outdated example, or a release, capture it
here so the reasoning survives after the source is gone. -->

Closes #<!-- issue number, or remove this line if none -->

## Notes for reviewers

<!-- Anything a reviewer should focus on: decisions made, alternatives
considered, areas of uncertainty, or follow-ups intentionally left out. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition with no runtime, API, or build changes.
> 
> **Overview**
> Adds a **Changelog** section to the Cloud CLI integration doc (`cloud-cli.mdx`), placed before **See also**, with versioned release notes for **0.3.0**, **0.2.0**, **0.1.1**, and **0.1.0** (dates and bullet lists copied from GitHub releases).
> 
> The entries document CLI behavior changes such as `--testResultUrl`, replay/SQLite fixes, OAuth refresh handling, flag-based arguments, and default `replay timeline` scoping—serving as the in-docs history for `@cypress/cloud` releases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27b0ddffb81469de1803e7736250717645c1a7a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->