### PR TITLE
docs(ui-coverage): rework the reduce test duplication guide

### DIFF
--- a/docs/ui-coverage/faq.mdx
+++ b/docs/ui-coverage/faq.mdx
@@ -85,9 +85,9 @@ Open the **Tested elements** section of the UI Coverage report. It lists every i
 
 **Interactions** counts every recognized command against an element across the run, so one test that hits a control in a loop can run the number up on its own. **Tests** counts the distinct tests that interacted with it, so a high number there means many _separate_ tests all touch the same control. The **Tests** column is the better signal for duplication, because shared setup repeated across your suite shows up as one element touched by a large share of your tests.
 
-### <Icon name="angle-right" /> How do I reduce test duplication with UI Coverage?
+### <Icon name="angle-right" /> How do I reduce test duplication?
 
-Find the elements at the top of the **Tested elements** list, confirm with [Test Replay](/cloud/features/test-replay) that the tests are passing _through_ a flow rather than testing it, then replace the repeated UI steps with a single programmatic step: cache authentication with [`cy.session()`](/api/commands/session), set a cookie or storage flag directly, or seed state with [`cy.request()`](/api/commands/request). Keep one test that still drives the flow through the UI so its coverage is preserved. The [Reduce test duplication](/ui-coverage/guides/reduce-test-duplication) guide walks through the full workflow.
+Use UI Coverage to find the elements at the top of the **Tested elements** list, confirm with [Test Replay](/cloud/features/test-replay) that the tests are passing _through_ a flow rather than testing it, then replace the repeated UI steps with a single programmatic step: cache authentication with [`cy.session()`](/api/commands/session), set a cookie or storage flag directly, or seed state with [`cy.request()`](/api/commands/request). Keep one test that still drives the flow through the UI so its coverage is preserved. The [Reduce test duplication](/ui-coverage/guides/reduce-test-duplication) guide walks through the full workflow.
 
 ### <Icon name="angle-right" /> Does reducing test duplication lower my UI Coverage score?
 

--- a/docs/ui-coverage/faq.mdx
+++ b/docs/ui-coverage/faq.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'UI Coverage FAQ'
-description: 'Get answers to common questions about Cypress UI Coverage, including scores, closing coverage gaps with Test Generation, view and URL grouping, element identification, grouping and filtering, iframes and shadow DOM, interaction commands, configuration, per-run profiles, the Results API for CI, and how to troubleshoot unexpected reports.'
+description: 'Get answers to common questions about Cypress UI Coverage, including scores, closing coverage gaps with Test Generation, finding and reducing test duplication, view and URL grouping, element identification, grouping and filtering, iframes and shadow DOM, interaction commands, configuration, per-run profiles, the Results API for CI, and how to troubleshoot unexpected reports.'
 sidebar_label: FAQ
 sidebar_position: 160
 ---
@@ -70,6 +70,32 @@ Prioritize by risk, not by count. Start with the views behind your highest-value
 ### <Icon name="angle-right" /> Why did closing one coverage gap reveal more untested elements?
 
 Because visiting a page or reaching a new state exposes controls UI Coverage had never seen. When a test navigates to a previously [untested link](/ui-coverage/core-concepts/interactivity#Untested-Links), UI Coverage creates a [view](/ui-coverage/core-concepts/views) for that page and lists every interactive element on it, most of which start untested. This is expected, and it's why closing gaps is a loop: each pass surfaces the next set of elements to prioritize.
+
+## Reducing test duplication
+
+### <Icon name="angle-right" /> What is test duplication in Cypress UI Coverage?
+
+Test duplication is when many separate tests exercise the same interactive element to pass _through_ a flow rather than to test it, such as every test clicking a **Log in** or **Continue** button during setup. UI Coverage surfaces it in the **Tested elements** section, where those shared setup steps rise to the top on interaction and test count. It's wasted suite time, not a coverage gap: the element is tested, just redundantly. See [Reduce test duplication](/ui-coverage/guides/reduce-test-duplication).
+
+### <Icon name="angle-right" /> How do I find elements my tests exercise more than they need to?
+
+Open the **Tested elements** section of the UI Coverage report. It lists every interactive element your tests exercised, with an **Interactions** column (how many times a command targeted it) and a **Tests** column (how many separate tests touched it), and it's sorted by interactions with the most-exercised elements first. A control that a large share of your suite interacts with, such as a **Log in** or **Continue** button, is usually shared setup being repeated across tests. Expand a row to break its counts down by view and open [Test Replay](/cloud/features/test-replay) on each occurrence. See [Reduce test duplication](/ui-coverage/guides/reduce-test-duplication).
+
+### <Icon name="angle-right" /> What's the difference between the Interactions and Tests columns in UI Coverage?
+
+**Interactions** counts every recognized command against an element across the run, so one test that hits a control in a loop can run the number up on its own. **Tests** counts the distinct tests that interacted with it, so a high number there means many _separate_ tests all touch the same control. The **Tests** column is the better signal for duplication, because shared setup repeated across your suite shows up as one element touched by a large share of your tests.
+
+### <Icon name="angle-right" /> How do I reduce test duplication with UI Coverage?
+
+Find the elements at the top of the **Tested elements** list, confirm with [Test Replay](/cloud/features/test-replay) that the tests are passing _through_ a flow rather than testing it, then replace the repeated UI steps with a single programmatic step: cache authentication with [`cy.session()`](/api/commands/session), set a cookie or storage flag directly, or seed state with [`cy.request()`](/api/commands/request). Keep one test that still drives the flow through the UI so its coverage is preserved. The [Reduce test duplication](/ui-coverage/guides/reduce-test-duplication) guide walks through the full workflow.
+
+### <Icon name="angle-right" /> Does reducing test duplication lower my UI Coverage score?
+
+No. An element stays tested as long as at least one test still interacts with it, so consolidating redundant setup removes _interactions_, not _coverage_. When you replace a UI login in 200 tests with [`cy.session()`](/api/commands/session) and keep one test that drives the login form, the form's interaction count drops sharply while it remains marked as tested, and your overall score is unchanged.
+
+### <Icon name="angle-right" /> What's the difference between reducing noise and reducing test duplication in UI Coverage?
+
+[Reducing noise](/ui-coverage/guides/reduce-noise) is a report-accuracy problem: the report over-counts because one control is reported as many elements, or unrelated pages are split into separate views, and you fix it with [App Quality configuration](/ui-coverage/configuration/overview). [Reducing test duplication](/ui-coverage/guides/reduce-test-duplication) is a test-effort problem: the report is correct, but your suite repeats the same setup across many tests, and you fix it in your test code by consolidating that setup.
 
 ## Interactive elements
 

--- a/docs/ui-coverage/guides/identify-coverage-gaps.mdx
+++ b/docs/ui-coverage/guides/identify-coverage-gaps.mdx
@@ -240,6 +240,7 @@ confirming the score improved on your next run.
 ## See also
 
 - [Address coverage gaps](/ui-coverage/guides/address-coverage-gaps): close the gaps you found by adding and improving tests.
+- [Reduce test duplication](/ui-coverage/guides/reduce-test-duplication): consolidate over-tested setup to free suite time for the gaps that matter.
 - [Monitor changes](/ui-coverage/guides/monitor-changes): track your score over time so new gaps don't slip in.
 - [Block pull requests and set policies](/ui-coverage/guides/block-pull-requests): enforce a coverage threshold in CI with the [Results API](/ui-coverage/results-api).
 - [UI Coverage FAQ](/ui-coverage/faq): answers to common questions about scores, views, links, and configuration.

--- a/docs/ui-coverage/guides/reduce-noise.mdx
+++ b/docs/ui-coverage/guides/reduce-noise.mdx
@@ -241,3 +241,6 @@ loop (recognize, diagnose, apply, validate) to keep the report actionable.
 - [Element Identification](/ui-coverage/core-concepts/element-identification) and
   [Element Grouping](/ui-coverage/core-concepts/element-grouping): the concepts
   behind how Cypress identifies and consolidates elements.
+- [Reduce test duplication](/ui-coverage/guides/reduce-test-duplication): the
+  test-effort counterpart to this report-accuracy guide, for when the report is
+  right but too many tests exercise the same control.

--- a/docs/ui-coverage/guides/reduce-test-duplication.mdx
+++ b/docs/ui-coverage/guides/reduce-test-duplication.mdx
@@ -274,7 +274,7 @@ marks it tested.
   alt="The Tested elements list after consolidation, with the Continue button showing a much lower interaction and test count"
 />
 
-To see the change directly, [compare the two
+To see the change directly, use [Branch Review to compare the two
 runs](/ui-coverage/guides/compare-reports): the before-and-after makes it easy
 to confirm the element's interactions dropped while your overall coverage score
 held steady.
@@ -309,7 +309,10 @@ gaps](/ui-coverage/guides/identify-coverage-gaps) to find them.
 
 - [Identify coverage gaps](/ui-coverage/guides/identify-coverage-gaps): find the untested elements and pages to spend your reclaimed time on.
 - [Reduce noise](/ui-coverage/guides/reduce-noise): sharpen a report that over-counts elements, the report-accuracy counterpart to this test-effort guide.
-- [Compare reports](/ui-coverage/guides/compare-reports): confirm interactions dropped and coverage held between your before-and-after runs.
+- [Compare reports with Branch Review](/ui-coverage/guides/compare-reports): confirm interactions dropped and coverage held between your before-and-after runs.
 - [Monitor changes](/ui-coverage/guides/monitor-changes): track the report over time so duplication doesn't creep back.
+- [Cypress Cloud MCP](/cloud/integrations/cloud-mcp): query a run's UI Coverage from your editor, as in the prompts above.
+- [Work with AI agents](/ui-coverage/work-with-ai-agents): more prompts and patterns for pointing an agent at UI Coverage data.
+- [Test Replay](/cloud/features/test-replay): the recorded run data UI Coverage is built from, and where you inspect each interaction.
 - [`cy.session()`](/api/commands/session): cache and restore login so authentication runs once instead of in every test.
 - [UI Coverage FAQ](/ui-coverage/faq#Reducing-test-duplication): common questions about over-tested elements and consolidating setup.

--- a/docs/ui-coverage/guides/reduce-test-duplication.mdx
+++ b/docs/ui-coverage/guides/reduce-test-duplication.mdx
@@ -68,9 +68,9 @@ Each element carries a few counts, and two of them tell you what you need:
 />
 
 The **Tests** count is the clearer duplication signal, so look for controls that
-a large share of your suite touches. A **Submit** button covered by a handful of
-form tests is expected. A **Continue** button on a welcome screen, or a
-**Log in** button, that shows up in hundreds of tests is a strong signal those
+a large share of your suite touches. A "Submit" button covered by a handful of
+form tests is expected. A "Continue" button on a welcome screen, or a
+"Log in" button, that shows up in hundreds of tests is a strong signal those
 tests are passing _through_ a flow to reach something else.
 
 <CopyPrompt
@@ -100,12 +100,12 @@ Open [Test Replay](/cloud/features/test-replay) on a few of the tests. Ask:
 - **Is any assertion about this element?** If tests interact with it but never
   assert on its behavior, they're passing through, not testing it.
 - **Do the tests share the same purpose?** Dozens of unrelated tests clicking
-  the same **Continue** button are all paying for setup that belongs somewhere
+  the same "Continue" button are all paying for setup that belongs somewhere
   cheaper.
 - **Does the interaction happen before the test's real work begins?** Setup that
   runs at the start of nearly every test is the prime candidate to consolidate.
 
-In the example above, the **Continue** button on the welcome screen is
+In the example above, the "Continue" button on the welcome screen is
 interacted with by most of the suite, but Test Replay shows almost none of those
 tests care about the welcome screen. They're just getting past it to reach the
 projects page. That's the duplication to remove.

--- a/docs/ui-coverage/guides/reduce-test-duplication.mdx
+++ b/docs/ui-coverage/guides/reduce-test-duplication.mdx
@@ -1,6 +1,6 @@
 ---
 title: Reduce test duplication with UI Coverage
-description: 'Optimize your test suite by identifying and consolidating duplicate tests with Cypress UI Coverage.'
+description: 'A step-by-step workflow for using Cypress UI Coverage to find the elements your suite tests far more than it needs to, then consolidate that repeated setup to cut CI time without losing coverage.'
 sidebar_label: Reduce test duplication
 sidebar_position: 30
 ---
@@ -9,67 +9,194 @@ sidebar_position: 30
 
 # Reduce test duplication
 
-Efficient test suites not only maximize coverage but also avoid redundant tests that slow down development and CI pipelines. Cypress UI Coverage provides insights into areas where elements have been tested multiple times, helping you optimize your test strategy and reduce duplication. This guide explains how to identify and address test duplication for streamlined and effective testing.
+Most test suites spend real time repeating work that no test is actually
+checking. Every test that clicks through the same login, onboarding, or cookie
+banner just to reach what it means to verify repeats that setup on every run,
+and those minutes add up across a suite and across CI.
 
-## Identify & Consolidate Duplicate Tests
+UI Coverage turns each recorded run into a ranked list of the elements your
+tests exercise, with a count of how many times and how many separate tests
+touched each one. The controls at the top of that list are usually shared setup
+steps you can consolidate: collapse them into one programmatic step and you cut
+CI time and make the report easier to read, without losing any coverage.
 
-UI Coverage reports in Cypress Cloud highlight elements that have been tested multiple times across a run. To identify duplication:
+This workflow takes you from a recorded run to a leaner, faster suite:
 
-1. Navigate to the **Tested elements** section within the **UI Coverage** tab in your test run.
-1. Locate tested elements that have a large number of interactions.
-1. Review the Snapshots within the view to identify duplicate tests that interact with the tested element.
+1. [Record a run](#Step-1-Record-a-run-to-Cypress-Cloud) so Cypress Cloud can build a UI Coverage report.
+2. [Find your most-tested elements](#Step-2-Find-your-most-tested-elements) in Cypress Cloud or from your editor.
+3. [Tell intentional coverage from pass-through](#Step-3-Tell-intentional-coverage-from-pass-through) by drilling into an element.
+4. [Consolidate the repeated setup](#Step-4-Consolidate-the-repeated-setup) with a programmatic step instead of UI clicks.
+5. [Confirm the duplication dropped](#Step-5-Confirm-the-duplication-dropped) on your next run.
+6. [Keep duplication from creeping back](#Step-6-Keep-duplication-from-creeping-back).
+
+## Step 1: Record a run to Cypress Cloud
+
+UI Coverage needs a recorded run to analyze. Any run recorded to Cypress Cloud
+with [Test Replay](/cloud/features/test-replay) produces a report automatically,
+with no configuration or code changes. Use a run that reflects your suite as it
+normally executes, such as a full regression run, so the interaction counts are
+representative.
+
+## Step 2: Find your most-tested elements
+
+However you prefer to work, the goal of this step is the same: a list of the
+elements your tests exercise, ranked so the most-tested rise to the top.
+
+- **In Cypress Cloud**, open the run's **UI Coverage** tab and go to the
+  **Tested elements** section. It lists every interactive element your tests
+  exercised, one row per element or
+  [group](/ui-coverage/core-concepts/element-grouping), sorted by
+  **Interactions** with the highest first.
+- **From your editor**, ask an AI agent connected to
+  [Cypress Cloud MCP](/cloud/integrations/cloud-mcp) to pull the tested elements
+  for the run and rank the most-exercised controls. It reads the same data, so
+  you get the same ranked list without opening a browser tab. See
+  [Work with AI agents](/ui-coverage/work-with-ai-agents) for prompts.
+
+Each element carries a few counts, and two of them tell you what you need:
+
+- **Interactions**: how many times a recognized command targeted the element. A
+  high number can come from one test hitting it in a loop, which usually isn't
+  duplication.
+- **Tests**: how many _separate_ tests interacted with it. A high number here
+  means many separate tests all touch the same control, which is the signature
+  of shared setup repeated across your suite.
 
 <DocsImage
   src="/img/ui-coverage/guides/cypress-ui-coverage-tested-elements-with-high-interactions.png"
-  alt="Cypress Cloud screenshot showing the Welcome Screen of the Cypress App with the Continue button highlighted and the number of snapshots it appears in"
+  alt="The Tested elements list in a UI Coverage report, sorted by Interactions, with a Continue button at the top showing a high interaction and test count"
 />
 
-### Common Signs of Duplication
+The **Tests** count is the clearer duplication signal, so look for controls that
+a large share of your suite touches. A **Submit** button covered by a handful of
+form tests is expected. A **Continue** button on a welcome screen, or a
+**Log in** button, that shows up in hundreds of tests is a strong signal those
+tests are passing _through_ a flow to reach something else.
 
-- **Repeated Interactions**: Elements interacted with in multiple snapshots or across different tests.
-- **Overlapping Tests**: Multiple tests cover the same workflows or user journeys.
-- **Excessive Setup Steps**: Repeated setup steps across tests that interact with the same elements.
+<CopyPrompt
+  title="Find duplication candidates with MCP"
+  subtext="Have an agent rank your most-tested elements and flag the ones that look like shared setup."
+  prompt={`Using Cypress Cloud, pull the UI Coverage tested elements for the latest run on this branch. Rank them by how many separate tests interact with each element, then by total interactions, and for the highest-ranked ones tell me which views they appear in. Flag the ones that look like shared setup a test passes through rather than verifies — logging in, onboarding, cookie or consent banners — and give me a shortlist of consolidation candidates with the element name, its test and interaction counts, and where it appears.`}
+>
 
-### Example: Welcome Screen Duplication
+### Find duplication candidates with MCP
 
-In the example below, the launchpad within Cypress App shows that the **Continue** button on the Welcome Screen has been interacted with **184 times** in **327 snapshots**. This indicates that many tests interact with this element. Clicking through to some of the Test Replay's of the snapshots however reveal that most of our tests are not concerned with the behavior of the Welcome Screen - we're just passing through to get to our other tests. This highlights an opportunity to reduce test duplication.
+</CopyPrompt>
+
+## Step 3: Tell intentional coverage from pass-through
+
+A high count isn't automatically a problem. Before changing anything, confirm
+the interactions are incidental rather than the point of the tests. Expand the
+element to break its counts down by view, with a **Test Replay** link for each
+occurrence:
 
 <DocsImage
   src="/img/ui-coverage/guides/cypress-ui-coverage-test-duplication-welcome-screen-example.png"
-  alt="Cypress Cloud screenshot showing the snapshots and interactions of a button with many snapshots and interactions"
+  alt="An expanded tested element in the UI Coverage report showing the views it appears in, its per-view interaction and test counts, and Test Replay links"
 />
 
-Now we can focus on consolidating tests and optimizing our test suite to avoid unnecessary duplication.
+Open [Test Replay](/cloud/features/test-replay) on a few of the tests. Ask:
+
+- **Is any assertion about this element?** If tests interact with it but never
+  assert on its behavior, they're passing through, not testing it.
+- **Do the tests share the same purpose?** Dozens of unrelated tests clicking
+  the same **Continue** button are all paying for setup that belongs somewhere
+  cheaper.
+- **Does the interaction happen before the test's real work begins?** Setup that
+  runs at the start of nearly every test is the prime candidate to consolidate.
+
+In the example above, the **Continue** button on the welcome screen is
+interacted with by most of the suite, but Test Replay shows almost none of those
+tests care about the welcome screen. They're just getting past it to reach the
+projects page. That's the duplication to remove.
+
+## Step 4: Consolidate the repeated setup
+
+Once you've confirmed a control is pass-through setup, replace the repeated UI
+interaction with a single programmatic step. Which technique fits depends on
+what the setup does:
+
+| When the pass-through is…                           | Reach for                                                                                                                          |
+| --------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| Logging in through a form                           | [`cy.session()`](/api/commands/session) to cache and restore the login                                                             |
+| A modal, banner, or onboarding step gated by a flag | Set the cookie or storage value directly with [`cy.setCookie()`](/api/commands/setcookie)                                          |
+| Building up data your test needs to exist first     | Seed it through your API with [`cy.request()`](/api/commands/request), or run backend setup with [`cy.task()`](/api/commands/task) |
+| Waiting on a network response to reach a state      | Stub it with [`cy.intercept()`](/api/commands/intercept)                                                                           |
+
+### Cache authentication with `cy.session()`
+
+Logging in through the UI is the most common pass-through in any suite. Wrap it
+in [`cy.session()`](/api/commands/session) so the login runs once and every
+later test restores the cached session instead of driving the form again:
 
 <Tabs>
-<TabItem value="cypress/support/commands.js">
+<TabItem value="js" label="JavaScript">
 
-```js
-// This example is simplified for demonstration purposes
-// In a real-world scenario, you would change the properties that are checked
-// to hide or display the welcome screen for first-time users
-Cypress.Commands.add('skipWelcome', () => {
-  cy.setCookie('welcome', 'dismissed')
-})
-
-it('shows welcome page', () => {
-  cy.visit('/')
-  cy.contains('Welcome')
-  cy.get('[data-cy="continue"]').click()
-  cy.contains('Projects')
-})
-
-it('shows projects page', () => {
-  cy.skipWelcome()
-  cy.visit('/')
-  cy.contains('Projects')
+```js title="cypress/support/commands.js"
+Cypress.Commands.add('login', (username = 'user@example.com') => {
+  cy.session(username, () => {
+    cy.visit('/login')
+    cy.get('[data-cy="email"]').type(username)
+    cy.get('[data-cy="password"]').type('super-secret')
+    cy.get('[data-cy="submit"]').click()
+    cy.url().should('include', '/projects')
+  })
 })
 ```
 
 </TabItem>
-<TabItem value="cypress/support/commands.ts">
+<TabItem value="ts" label="TypeScript">
 
-```ts
+```ts title="cypress/support/commands.ts"
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      login(username?: string): Chainable<void>
+    }
+  }
+}
+
+Cypress.Commands.add('login', (username = 'user@example.com') => {
+  cy.session(username, () => {
+    cy.visit('/login')
+    cy.get('[data-cy="email"]').type(username)
+    cy.get('[data-cy="password"]').type('super-secret')
+    cy.get('[data-cy="submit"]').click()
+    cy.url().should('include', '/projects')
+  })
+})
+```
+
+</TabItem>
+</Tabs>
+
+Keep one dedicated test that drives the login form through the UI so the flow
+itself stays covered, then call `cy.login()` everywhere else. UI Coverage still
+marks the form as tested from that one test, while the interaction count on it
+drops from hundreds to one. When your login lives on a separate identity
+provider, pair `cy.session()` with [`cy.origin()`](/api/commands/origin) to
+drive the form across the origin boundary.
+
+### Set state directly instead of clicking through it
+
+When the pass-through is a modal, banner, or onboarding step gated by a cookie
+or stored flag, set that state before the page loads rather than dismissing it
+in the UI each time:
+
+<Tabs>
+<TabItem value="js" label="JavaScript">
+
+```js title="cypress/support/commands.js"
+// Skip the first-run welcome screen by pre-setting the flag it checks
+Cypress.Commands.add('skipWelcome', () => {
+  cy.setCookie('welcome-dismissed', 'true')
+})
+```
+
+</TabItem>
+<TabItem value="ts" label="TypeScript">
+
+```ts title="cypress/support/commands.ts"
 declare global {
   namespace Cypress {
     interface Chainable {
@@ -78,27 +205,111 @@ declare global {
   }
 }
 
+// Skip the first-run welcome screen by pre-setting the flag it checks
 Cypress.Commands.add('skipWelcome', () => {
-  cy.setCookie('welcome', 'dismissed')
+  cy.setCookie('welcome-dismissed', 'true')
 })
 ```
 
 </TabItem>
 </Tabs>
 
-After updating our tests and recording a new run, we can visit the **Tested elements** section to see the impact of our changes. The **Continue** button now appears in fewer snapshots and less interactions, indicating that we've successfully reduced duplication.
+Moving the setup into a `beforeEach` hook is what multiplies the interaction
+count in the first place, so it's also where the fix belongs: the projects specs
+skip the welcome screen once per test in setup, while one dedicated test still
+covers the welcome flow on purpose.
+
+```js title="cypress/e2e/projects.cy.js"
+describe('Projects', () => {
+  it('shows the welcome screen to first-time users', () => {
+    cy.visit('/')
+    cy.contains('Welcome')
+    cy.get('[data-cy="continue"]').click()
+    cy.contains('Projects')
+  })
+
+  describe('for returning users', () => {
+    beforeEach(() => {
+      cy.skipWelcome()
+      cy.visit('/')
+    })
+
+    it('lists the current user projects', () => {
+      cy.contains('Projects')
+    })
+
+    // Every other test starts past the welcome screen without clicking Continue
+  })
+})
+```
+
+The same approach works for seeding data with
+[`cy.request()`](/api/commands/request) against your API, or stubbing a
+response with [`cy.intercept()`](/api/commands/intercept), instead of building
+that state by hand through the UI in every test.
+
+An agent can do this consolidation for you, combining the Cloud data about which
+tests touch the control with your local specs and support files:
+
+<CopyPrompt
+  title="Consolidate a pass-through flow with MCP"
+  subtext="Have an agent replace repeated UI setup with a single programmatic step across your specs."
+  prompt={`Take the login flow that most of my suite passes through. Using Cypress Cloud UI Coverage for the latest run on this branch, find the specs that exercise it, then consolidate that setup in my project: add a cy.session() wrapper in my support files (or set the cookie/flag directly, or seed with cy.request()/cy.task() where that fits better), following the patterns already in my codebase. Keep one test that still drives the flow through the UI so its coverage is preserved, and update the other specs to call the new command instead of repeating the UI steps.`}
+>
+
+### Consolidate a pass-through flow with MCP
+
+</CopyPrompt>
+
+## Step 5: Confirm the duplication dropped
+
+Record a new run after consolidating, then reopen the **Tested elements**
+section. The control you consolidated should sit lower in the list: its
+**Interactions** and **Tests** counts fall to reflect the one test that still
+exercises it on purpose, and its coverage is unchanged because that test still
+marks it tested.
 
 <DocsImage
   src="/img/ui-coverage/guides/cypress-ui-coverage-test-duplication-example-after.png"
-  alt="Cypress Cloud screenshot showing the snapshots and interactions of a tested element after reducing test duplication"
+  alt="The Tested elements list after consolidation, with the Continue button showing a much lower interaction and test count"
 />
 
-## Monitor and Prevent Duplication
+To see the change directly, [compare the two
+runs](/ui-coverage/guides/compare-reports): the before-and-after makes it easy
+to confirm the element's interactions dropped while your overall coverage score
+held steady.
 
-### Document Your Testing Strategy
+The time you saved shows up outside UI Coverage, in how long the suite takes to
+run. Watch the run duration on the [runs
+list](/cloud/features/recorded-runs#Latest-Runs) or in
+[Test Replay](/cloud/features/test-replay) fall as the redundant UI steps come
+out, so you can put a number on the payoff.
 
-Maintain a clear testing strategy that outlines:
+## Step 6: Keep duplication from creeping back
 
-- The scope and purpose of each test suite.
-- Which workflows and components each test covers.
-- Guidelines for avoiding overlap in new tests.
+Consolidation sticks only if new tests reuse the shared setup instead of
+re-introducing the UI steps. A few habits keep the list clean:
+
+- **Reach for shared commands first.** Make `cy.login()`, `cy.skipWelcome()`,
+  and similar setup commands the default way to get a test to its starting
+  point, so no one hand-rolls the flow again.
+- **Recheck the top of the list periodically.** Revisit the **Tested elements**
+  section after big changes, or on a
+  [regular cadence](/ui-coverage/guides/monitor-changes), and treat a control
+  climbing back toward the top as a prompt to consolidate again.
+- **Write down the boundary.** Note which flows are covered once on purpose (the
+  login form, the welcome screen) and which should always be reached
+  programmatically, so the intent survives beyond the person who set it up.
+
+Time you get back from a leaner suite is best spent on the flows you _haven't_
+covered yet. See [Identify coverage
+gaps](/ui-coverage/guides/identify-coverage-gaps) to find them.
+
+## See also
+
+- [Identify coverage gaps](/ui-coverage/guides/identify-coverage-gaps): find the untested elements and pages to spend your reclaimed time on.
+- [Reduce noise](/ui-coverage/guides/reduce-noise): sharpen a report that over-counts elements, the report-accuracy counterpart to this test-effort guide.
+- [Compare reports](/ui-coverage/guides/compare-reports): confirm interactions dropped and coverage held between your before-and-after runs.
+- [Monitor changes](/ui-coverage/guides/monitor-changes): track the report over time so duplication doesn't creep back.
+- [`cy.session()`](/api/commands/session): cache and restore login so authentication runs once instead of in every test.
+- [UI Coverage FAQ](/ui-coverage/faq#Reducing-test-duplication): common questions about over-tested elements and consolidating setup.


### PR DESCRIPTION
## Summary

Rewrites the UI Coverage **Reduce test duplication** guide from a thin two-heading page into a value-led, six-step workflow that matches the other UI Coverage guides, corrects it against the discovery service implementation, and adds Cloud MCP copy-prompt cards. Also adds a FAQ section and reciprocal cross-links.

## Why

The page didn't lay out a followable workflow and described the report inaccurately — it never named the actual **Tested elements** columns and leaned on an imprecise "184 times in 327 snapshots" framing. Checking the `discovery` read-API schema and the `TestedElements` component in `cypress-services` confirmed the real model: each tested element exposes **Snapshots**, **Views**, **Interactions** (total interactions), and **Tests** (distinct tests that touched it), default-sorted by Interactions. The **Tests** count — not raw interactions — is the true duplication signal, so the guide now leads with that distinction. The old consolidation example was also broken (it mixed a custom-command definition with `it` blocks), and the guide had no path for the Cloud MCP / AI-agent workflow the sibling guides now feature.

## Notes for reviewers

- **Accuracy** was verified against `cypress-services`: the Tested elements columns, the default Interactions-descending sort, and the meaning of `snapshotCount` (snapshots where the element was *visible*, not interacted). The two MCP prompts are grounded in what `cypress_get_ui_coverage_elements` / `cypress_get_ui_coverage_report` actually return.
- **Scope beyond the main guide:**
  - `faq.mdx`: new "Reducing test duplication" section (definition, finding over-tested elements, Interactions vs Tests, consolidation, score impact, noise vs duplication) + updated page description for SEO.
  - `identify-coverage-gaps.mdx` and `reduce-noise.mdx`: reciprocal **See also** links so the guide isn't a dead end.
- **Distinction drawn on purpose:** reducing *duplication* (a test-effort fix in test code) vs reducing *noise* (a report-accuracy fix in configuration) — kept in the FAQ and the reduce-noise cross-link.
- **CopyPrompt** uses the existing globally-registered component, same as the Cloud MCP page; each card carries a `###` heading so it feeds the table of contents.
- **Left for a human (not in this PR):** the three reused screenshots should be confirmed to show the Interactions/Tests columns and the sort; a real customer before/after metric would strengthen the lead; and the guides' `sidebar_position` order could group duplication + noise together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Co312EubaRKRJ3PUNh6i4k

---
_Generated by [Claude Code](https://claude.ai/code/session_01Co312EubaRKRJ3PUNh6i4k)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to UI Coverage guides and FAQ; no product code or runtime behavior.
> 
> **Overview**
> Expands UI Coverage documentation so teams can find and fix **test duplication** (repeated pass-through setup) using the real **Tested elements** report model.
> 
> The **Reduce test duplication** guide is rewritten as a six-step workflow aligned with other UI Coverage guides. It centers on **Interactions** vs **Tests** (distinct tests as the duplication signal), **Test Replay** to separate pass-through from intentional coverage, consolidation patterns (`cy.session()`, cookies, `cy.request()`, etc.), verification via Branch Review, and habits to keep duplication down. Two **CopyPrompt** cards add Cloud MCP workflows; code examples are fixed and expanded (JS/TS tabs).
> 
> A new **Reducing test duplication** FAQ section covers definitions, how to find over-tested elements, consolidation, score impact, and **noise vs duplication**. The FAQ meta description and **See also** links on **identify coverage gaps** and **reduce noise** point readers to the new guide.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bdf7b0c1b2d73fb265e46ef5478a512dfe7d5c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->