### PR TITLE
docs(ui-coverage): rework Ignore views and links into a followable workflow

### DIFF
--- a/docs/ui-coverage/faq.mdx
+++ b/docs/ui-coverage/faq.mdx
@@ -103,6 +103,18 @@ Write a [`views`](/ui-coverage/configuration/views) pattern that names the param
 
 Add a [`viewFilters`](/ui-coverage/configuration/viewfilters) rule with `include: false` for a URL pattern. Excluding a URL removes its snapshots from the report and stops links pointing to it from counting against your coverage score. The [Ignore views and links](/ui-coverage/guides/ignore-views-and-links) guide walks through common cases.
 
+### <Icon name="angle-right" /> In Cypress UI Coverage, what's the difference between viewFilters and views?
+
+They do opposite things. [`viewFilters`](/ui-coverage/configuration/viewfilters) _removes_ URLs from your report and score, so excluded pages and the links pointing to them stop counting. [`views`](/ui-coverage/configuration/views) _keeps_ URLs but changes how they're grouped and named, so related pages collapse into a single view or a dynamic route splits into several. Use `viewFilters` for pages you don't own or intend to test, and `views` to organize the pages you do. See [Which option do I need?](/ui-coverage/configuration/overview#Which-option-do-I-need).
+
+### <Icon name="angle-right" /> How do I exclude a third-party login or OAuth page from UI Coverage?
+
+Add a [`viewFilters`](/ui-coverage/configuration/viewfilters) rule with `include: false` for the provider's URL, such as `{ "pattern": "https://acme.okta.com/*", "include": false }`. Tests that sign in through an external identity provider (Okta, Auth0, and similar) capture snapshots of its pages, and your links to it count as untested elements. One rule removes both, while every other URL stays included by default. See [Ignore views and links](/ui-coverage/guides/ignore-views-and-links).
+
+### <Icon name="angle-right" /> Can I exclude a URL from UI Coverage without affecting Cypress Accessibility?
+
+Yes. A [`viewFilters`](/ui-coverage/configuration/viewfilters) list at the root of your configuration applies to both products, but nesting it under a `uiCoverage` key applies it to UI Coverage only, so Cypress Accessibility keeps scanning the URL. A nested list completely replaces the root-level one for UI Coverage; the two are not merged, so include every rule UI Coverage needs. See [Scope](/ui-coverage/configuration/viewfilters#Scope).
+
 ### <Icon name="angle-right" /> Why is a URL still in my UI Coverage report after I excluded it with viewFilters?
 
 The most common causes are:

--- a/docs/ui-coverage/guides/ignore-views-and-links.mdx
+++ b/docs/ui-coverage/guides/ignore-views-and-links.mdx
@@ -1,6 +1,6 @@
 ---
 title: Ignore views and links in UI Coverage
-description: 'Exclude irrelevant views and links from UI Coverage reports with viewFilters, so coverage scores reflect the parts of your application you test.'
+description: 'Exclude third-party pages, error redirects, and links you never plan to test from UI Coverage with viewFilters, so your coverage score reflects only the parts of your app you own and intend to test.'
 sidebar_label: Ignore views and links
 sidebar_position: 60
 ---
@@ -9,68 +9,151 @@ sidebar_position: 60
 
 # Ignore views and links
 
-UI Coverage includes every URL your tests visit, but not every URL is relevant to your testing goals. This guide walks through finding irrelevant views and links in your report and excluding them with [`viewFilters`](/ui-coverage/configuration/viewfilters), so your coverage score reflects the parts of your application you own and intend to test.
+UI Coverage measures every URL your tests visit and every link they could
+follow. That's usually what you want, but it means pages you don't own get
+counted as untested and quietly drag your score down. A third-party login screen
+captured mid-sign-in, an error page a test hit by accident, a marketing site
+linked from your footer: none of these are yours to test. When that noise is
+mixed in, a low score no longer tells you where the _real_ gaps are.
 
-## Why ignore views and links?
+This guide walks you through removing that noise with
+[`viewFilters`](/ui-coverage/configuration/viewfilters). Excluding a URL keeps
+its pages out of your report and stops the [untested
+links](/ui-coverage/core-concepts/interactivity#Untested-Links) that point to it
+from counting against your score, so what's left is coverage of the application
+you actually intend to test:
 
-Ignoring views and links helps in the following scenarios:
+1. [Find the views and links worth ignoring](#Step-1-Find-the-views-and-links-worth-ignoring) in your report.
+2. [Add a viewFilters rule](#Step-2-Add-a-viewFilters-rule) in your App Quality configuration.
+3. [Regenerate a run and confirm](#Step-3-Regenerate-a-run-and-confirm) the noise is gone.
+4. [Keep your filters current](#Step-4-Keep-your-filters-current) as your app grows.
 
-- **Third-party pages**: Exclude external URLs, such as OAuth login pages or embedded content, that you don't control or need to test.
-- **Non-critical pages**: Remove views that aren't part of your testing goals, such as informational pages or admin-only sections.
-- **Error pages and redirects**: URLs that tests visit incidentally don't represent meaningful user flows.
-- **Links you never plan to test**: Links pointing to excluded URLs are removed from reports and scores, so they stop appearing as untested elements.
+## When to ignore views and links
 
-By ignoring unnecessary views and links, you maintain clear and actionable coverage metrics.
+Reach for `viewFilters` when a URL is counted against you but isn't something
+your team is responsible for testing:
 
-## Identify views and links to ignore
+- **Third-party pages**: Sign-in flows on an external identity provider (Okta,
+  Auth0), a payment processor's hosted checkout, or embedded content you don't
+  control. Your tests pass through them, but their UI isn't yours to cover.
+- **Links to destinations you'll never test**: Your marketing site, a help
+  center, a status page, or a social profile linked from your app. No test
+  visits them, so no [view](/ui-coverage/core-concepts/views) exists. The link
+  is the only thing UI Coverage sees, and it counts as an [untested
+  link](/ui-coverage/core-concepts/interactivity#Untested-Links). Excluding the
+  destination URL is the way to remove it.
+- **Redirects and intermediate URLs**: A `/redirect` step or an OAuth callback
+  that tests pass through on the way to somewhere else, rather than a page users
+  land on and interact with.
+- **Sections outside your goals**: Admin-only tools or informational pages that
+  aren't part of what you set out to test.
 
-After recording your tests to Cypress Cloud, review the UI Coverage report:
+If your goal is instead to _organize_ URLs into named views rather than remove
+them, use [`views`](/ui-coverage/configuration/views); to remove individual
+elements rather than whole pages, use
+[`elementFilters`](/ui-coverage/configuration/elementfilters). See [Which option
+do I need?](/ui-coverage/configuration/overview#Which-option-do-I-need) for the
+full comparison.
 
-1. Navigate to the **UI Coverage** tab in your test run.
-1. Look for views that consistently appear but don't require testing.
-1. Review [untested links](/ui-coverage/core-concepts/interactivity#Untested-Links) for destinations no test should ever visit.
-1. Note the URLs, paths, or patterns for these views and links.
+## Step 1: Find the views and links worth ignoring
 
-### Common candidates for exclusion
+Start by finding the URLs that are counted against you but sit outside your
+testing goals. You can do this in the Cloud UI or from your editor with an AI
+agent.
 
-- Third-party authentication pages (for example, `https://auth.example.com`)
-- Redirects or intermediate URLs (for example, `/redirect`)
-- Informational pages with few or no interactive elements (for example, `/terms` or `/privacy`)
+### In the Cloud UI
 
-## Configure ignored views and links
+Open the **UI Coverage** tab of a recorded run and work through two sections:
 
-[`viewFilters`](/ui-coverage/configuration/viewfilters) rules in the **App Quality** configuration exclude views and links based on their URLs. To add or modify the configuration for your project, navigate to the **App Quality** tab in your project settings and add a `viewFilters` configuration.
+- **Views**: Scan for pages that appear in your report but you don't own or
+  intend to test, such as a third-party auth screen, an embedded checkout, or an
+  error page tests hit by accident. Note their URLs.
+- **Untested links**: Review the destinations your tests never visited. Each one
+  is a page with no view, so it can only ever surface here. Links to your own
+  marketing site, a help center, a status page, or an external partner are the
+  usual candidates to exclude.
 
-Rules apply in order, and the first rule whose pattern matches a URL decides whether it's included or excluded. URLs that match no rule are included by default. Some common view filter configurations are shown below:
+<DocsImage
+  src="/img/ui-coverage/guides/cypress-ui-coverage-untested-links.png"
+  alt="Cypress Cloud screenshot of the untested links section listing links whose destinations were never visited during the run"
+/>
 
-### Exclude a third-party page
+Expanding an untested link shows a **Referrers** tab (the views that link to the
+destination) and a **URLs** tab (the concrete destinations, grouped for dynamic
+routes). Use these to confirm a destination is genuinely out of scope before you
+exclude it, and to capture the exact URL or path you'll match on.
+
+### With an AI agent
+
+If you use an AI coding assistant, [Cypress Cloud
+MCP](/cloud/integrations/cloud-mcp) can pull the same report into your editor, so
+you can find exclusion candidates without opening a browser. The agent queries UI
+Coverage for a run and returns the views and untested links as structured data
+you can scan and act on.
+
+<CopyPrompt
+  title="Find views and links to exclude with your AI assistant"
+  subtext="Pull the UI Coverage report from Cypress Cloud and list the untested links and third-party views you might exclude with viewFilters."
+  prompt={`Using Cypress Cloud, pull the UI Coverage report for the latest run on this branch. List the untested links, and any views that look like third-party or external pages, so I can decide which to exclude with viewFilters.`}
+/>
+
+Review what it returns the same way you would in the Cloud UI: confirm each
+destination is genuinely out of scope before excluding it. See [Work with AI
+agents](/ui-coverage/work-with-ai-agents) for more prompts.
+
+## Step 2: Add a `viewFilters` rule
+
+Open the **App Quality** tab in your project settings in Cypress Cloud and add a
+[`viewFilters`](/ui-coverage/configuration/viewfilters) array. Each rule pairs a
+URL `pattern` with `include: false` to exclude the URLs it matches, plus an
+optional `comment` explaining why the rule exists:
 
 ```json title="App Quality Config"
 {
   "viewFilters": [
     {
-      "pattern": "https://auth.example.com/*",
+      "pattern": "https://acme.okta.com/*",
       "include": false,
-      "comment": "Exclude the external login flow"
+      "comment": "External Okta sign-in flow, not our UI to test"
     }
   ]
 }
 ```
 
+One rule removes both the excluded pages and any links pointing to them. Every
+other URL stays included, because a few rules govern how filters are applied:
+
+- Each URL is matched against your rules **in order**, and the **first** rule
+  whose `pattern` matches decides whether the URL is included or excluded. Place
+  specific rules before broad ones.
+- URLs that match **no** rule are **included by default**.
+- Patterns use [URL Pattern
+  API](https://developer.mozilla.org/en-US/docs/Web/API/URL_Pattern_API) syntax
+  matched against the full URL. A path-only pattern like `/admin/*` matches that
+  path on **any** environment, while a hostname must match exactly unless it
+  contains a wildcard (`https://*.acme.com/*`).
+
+For the complete pattern-matching and validation rules, see the [`viewFilters`
+reference](/ui-coverage/configuration/viewfilters).
+
 ### Include only your application's URLs
 
-The catch-all `*` rule excludes everything the earlier rules don't include, and must come last.
+When your tests pass through many external pages, an allowlist is simpler than
+excluding each one. Include your application, then add a catch-all `*` rule that
+excludes everything else. Because the first match wins, the catch-all must come
+last:
 
 ```json title="App Quality Config"
 {
   "viewFilters": [
     {
-      "pattern": "http://localhost:3000/*",
+      "pattern": "https://app.acme.com/*",
       "include": true
     },
     {
       "pattern": "*",
-      "include": false
+      "include": false,
+      "comment": "Exclude anything that isn't the app itself"
     }
   ]
 }
@@ -78,7 +161,9 @@ The catch-all `*` rule excludes everything the earlier rules don't include, and 
 
 ### Exclude error pages in every environment
 
-Patterns without a protocol and hostname match on any environment your tests run against.
+A pattern without a protocol and hostname matches any environment your tests run
+against, whether that's `localhost`, staging, or production, so one rule covers
+them all:
 
 ```json title="App Quality Config"
 {
@@ -95,19 +180,61 @@ Patterns without a protocol and hostname match on any environment your tests run
 }
 ```
 
-To learn more about the options, pattern matching behavior, and validation rules, refer to the [`viewFilters` configuration reference](/ui-coverage/configuration/viewfilters).
+### Exclude from UI Coverage without affecting Accessibility
 
-## Validate ignored views and links
+A `viewFilters` array at the **root** of your configuration applies to both UI
+Coverage and Cypress Accessibility. To exclude a URL from UI Coverage alone,
+nest `viewFilters` under a `uiCoverage` key. A nested list completely
+**replaces** the root-level one for UI Coverage (the two are not merged), so
+include every rule UI Coverage needs in the nested list:
 
-After saving the configuration, regenerate a recent run from its **Properties** tab to reprocess it with your new filters. You don't need to rerun your tests. See [Setting configuration](/ui-coverage/configuration/overview#Setting-configuration) for how to regenerate a report.
+```json title="App Quality Config"
+{
+  "uiCoverage": {
+    "viewFilters": [
+      {
+        "pattern": "https://docs.acme.com/*",
+        "include": false,
+        "comment": "Embedded docs: keep out of coverage but keep scanning for a11y"
+      }
+    ]
+  }
+}
+```
 
-In the regenerated report, confirm that the ignored views no longer appear and that links to the excluded URLs no longer count as untested elements. If a URL you excluded still appears, see [troubleshooting view filters](/ui-coverage/configuration/viewfilters#A-URL-you-excluded-still-appears-in-the-report).
+## Step 3: Regenerate a run and confirm
 
-If new unnecessary views or links appear in future reports, update your filters accordingly to keep reports clean and actionable.
+After saving, regenerate a recent run from its **Properties** tab to reprocess
+it with your new filters. There's no need to rerun your tests. See [Setting
+configuration](/ui-coverage/configuration/overview#Setting-configuration) for
+the steps.
+
+<DocsImage
+  src="/img/accessibility/configuration/cypress-cloud-properties-tab-application-quality-config.png"
+  alt="The Properties tab for a run, with an Application Quality section at the bottom and a regenerate button to reprocess the run with the current configuration"
+/>
+
+In the regenerated report, confirm the excluded pages no longer appear as views
+and that links to the excluded URLs no longer count as untested. If a URL you
+excluded still shows up, an earlier rule is usually matching it first, or the
+pattern isn't matching the full URL. See [troubleshooting view
+filters](/ui-coverage/configuration/viewfilters#A-URL-you-excluded-still-appears-in-the-report).
+
+## Step 4: Keep your filters current
+
+`viewFilters` is a living part of your configuration. As you add integrations,
+new external links, or new environments, revisit your rules so reports stay
+clean and every remaining gap is one worth a decision. If different runs need
+different exclusions, such as a smoke run versus a full regression run, apply
+them per run with [`profiles`](/ui-coverage/configuration/profiles) instead of
+maintaining one list for everything.
 
 ## See also
 
 - [`viewFilters` configuration](/ui-coverage/configuration/viewfilters) is the full reference for options, pattern matching, and validation.
+- [Identify coverage gaps](/ui-coverage/guides/identify-coverage-gaps) is the workflow for finding untested elements, links, and pages once the noise is gone.
+- [Reduce noise](/ui-coverage/guides/reduce-noise) covers the other adjustments, such as grouping repeated elements and stabilizing dynamic attributes, that sharpen a report.
+- [Ignore elements](/ui-coverage/guides/ignore-elements) removes individual elements from reports rather than whole pages.
 - [`views` configuration](/ui-coverage/configuration/views) groups and names URLs instead of removing them.
-- [Guide: Ignore elements](/ui-coverage/guides/ignore-elements) removes individual elements from reports rather than whole pages.
-- [UI Coverage FAQ](/ui-coverage/faq) answers common questions about excluding URLs.
+- [Untested links](/ui-coverage/core-concepts/interactivity#Untested-Links) explains how a link's destination determines whether it counts against your score.
+- [UI Coverage FAQ](/ui-coverage/faq) answers common questions about excluding URLs and coverage scores.


### PR DESCRIPTION
## Summary

Reworks the UI Coverage **Ignore views and links** guide into a value-led, step-by-step workflow, and aligns it with the actual `viewFilters` implementation in `cypress-services`. Also adds three SEO/AEO questions to the UI Coverage FAQ.

## Why

The guide read as a flat set of sections rather than a followable workflow, led with mechanics instead of value, and was missing a key concept: root-level `viewFilters` also affect Cypress Accessibility, and a nested `uiCoverage` list replaces (not merges) the root list. Accuracy was verified against the implementation (`discovery/packages/common/src/view-filters.ts`, `ViewPattern.ts`, `ResolvedAppQualityConfig.ts`, and the `packages/validations` schema): first match wins, URLs are included by default, links are filtered by their destination URL, and no view is created for excluded URLs.

**Guide** (`docs/ui-coverage/guides/ignore-views-and-links.mdx`)

- Leads with the value (noise from unowned pages hides real gaps) and a numbered 1–4 workflow.
- Reframes "Why" as a decision-oriented **When to ignore views and links** with realistic scenarios (Okta/Auth0 auth, marketing/help/status links, redirects and OAuth callbacks, admin sections).
- Splits **Step 1** into finding candidates in the Cloud UI and with an AI agent, using a copyable `CopyPrompt` card for the MCP flow.
- Adds the missing product-scope concept and an "exclude from UI Coverage only" example.
- Clarifies that excluding a destination URL is how an untested link is removed.
- Documents how rules are applied (first match wins, included by default, path-only patterns, exact hostname matching), links to the reference.
- Uses realistic branded examples, keeps `App Quality Config` titles on every config block, and adds untested-links and regenerate screenshots plus a fuller See also section.

**FAQ** (`docs/ui-coverage/faq.mdx`)

- Adds three questions: `viewFilters` vs `views`, excluding a third-party/OAuth page, and excluding a URL from UI Coverage without affecting Accessibility.

## Notes for reviewers

- No product-code changes; `cypress-services` was used only to verify accuracy.
- Prettier (`prettier --check`), the frontmatter linter, and all internal cross-reference anchors pass. Screenshots reuse existing assets already referenced elsewhere in the docs.
- The guide's slug and `sidebar_label` are unchanged, so the eight inbound links across the docs still resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017hXbi2Qreqoi8ACSHaKYZt

---
_Generated by [Claude Code](https://claude.ai/code/session_017hXbi2Qreqoi8ACSHaKYZt)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to MDX guides and FAQ; no runtime or configuration code changes.
> 
> **Overview**
> Reworks the **Ignore views and links** guide from a flat reference into a value-led, four-step workflow (find candidates → add rules → regenerate → maintain), with clearer framing of when to use `viewFilters` vs `views` / `elementFilters`.
> 
> The guide now covers finding exclusions in Cloud UI and via **Cypress Cloud MCP** (including a `CopyPrompt`), documents rule ordering and pattern behavior inline, adds **UI Coverage–only** `uiCoverage.viewFilters` (replace-not-merge vs root), and expands examples, screenshots, and See also links. The page **meta description** is updated to match.
> 
> The UI Coverage **FAQ** gains three entries: **`viewFilters` vs `views`**, excluding third-party/OAuth pages, and excluding URLs from UI Coverage without affecting Cypress Accessibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78b32bb7534eb16bbe403f470c6c1b3597bd740e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->