### PR TITLE
docs(cloud-mcp): clarify agents can find recorded runs after failed CI

### DIFF
--- a/docs/cloud/integrations/cloud-mcp.mdx
+++ b/docs/cloud/integrations/cloud-mcp.mdx
@@ -492,7 +492,9 @@ Both are available on every Cypress Cloud plan at no additional cost. See the [C
 **Agent can't find your run:**
 
 - Verify the organization has the Cloud MCP integration enabled in Cypress Cloud.
-- Ensure your Git branch name in CI matches the branch name you're telling agent.
+- Ensure your Git branch name in CI matches the branch name you're telling the agent.
+- A failed CI job doesn't mean no run was recorded. A red CI conclusion only reflects the job's exit code. As long as Cypress recorded the run, it's in Cypress Cloud and the agent can query it, so point the agent at the run by branch, commit, run number, or Run URL instead of assuming a failed job left nothing to find.
+- If you pair Cloud MCP with a CI or GitHub MCP that reads job logs, the recorded Run URL prints near the _end_ of the Cypress CLI output. Have the agent read the tail of the log so it doesn't miss the link.
 
 **Connection errors:**
 


### PR DESCRIPTION
## Summary

Adds two troubleshooting bullets to the Cloud MCP page (`docs/cloud/integrations/cloud-mcp.mdx`, under **Agent can't find your run**) clarifying that a failed CI job still records a run in Cypress Cloud, and that when Cloud MCP is paired with a CI/GitHub MCP the recorded Run URL prints near the end of the CLI output. Also fixes a small grammar nit in the adjacent existing bullet ("telling agent" → "telling the agent").

## Why

Feedback about an agent debugging workflow flagged two failure modes when finding a recorded Cypress Cloud run from CI:

1. A GitHub Actions `conclusion: failure` was being read as "Cypress didn't run," so the agent stopped instead of querying Cloud. In reality a red CI conclusion only reflects the job's exit code — the run is still recorded and queryable.
2. The recorded Run URL sits near the end of the CI job log, so an agent that reads only the head of the log misses it.

The specific tools named in the original feedback (`cypress_extract_run_url`, `github_get_workflow_run_logs` with `tail=True`) are not part of Cypress's MCP — the first doesn't exist (`cypress_get_runs` accepts a Run URL directly) and the second belongs to the GitHub MCP server. So rather than document another vendor's tool params, this change captures the product-accurate insight in Cypress's own terms: don't assume a failed CI job means no run, and read the tail of the log when pairing with a CI/GitHub MCP.

## Notes for reviewers

- Scoped to prose in the existing Troubleshooting section; no structural or tooling changes.
- The GitHub-side detail (Run URL near the end of the log) is intentionally kept brief and caveated ("if you pair Cloud MCP with a CI or GitHub MCP"), since that behavior isn't Cypress's to own.
- Prettier wasn't available in the working environment to run a format check, but the new bullets match the file's existing unwrapped single-line style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013aAUtTCmT29Cv3gkWsmvrb

---
_Generated by [Claude Code](https://claude.ai/code/session_013aAUtTCmT29Cv3gkWsmvrb)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only prose in an existing troubleshooting section; no product or security behavior changes.
> 
> **Overview**
> Under **Agent can't find your run** in the Cloud MCP troubleshooting section, the docs now explain that a **failed CI job can still have a recorded Cypress Cloud run** (query by branch, commit, run number, or Run URL) and that when **Cloud MCP is used with a CI/GitHub MCP**, the Run URL appears near the **end** of Cypress CLI output—agents should read the log tail.
> 
> Also fixes grammar in the existing branch-name bullet (“telling **the** agent”).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7516e2764d16b6d44660d94995cb1cd199dd27d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->