### PR TITLE
docs(ui-coverage): rework the block pull requests guide and FAQ

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,7 +86,9 @@ Each rule is a hard convention. See the linked section for the how and why.
 - For a copyable, reusable AI prompt (or an agent skill/rule), use `<CopyPrompt>`,
   not a code block; keep example-specific prompts, code, commands, and diagrams in
   code blocks. Prompts are expanded by default; add `defaultCollapsed` past 350
-  characters, and never wrap the prompt in quotes.
+  characters, and never wrap the prompt in quotes. Write `subtext` as the outcome
+  the reader gets, not a restatement that the card copies a prompt for an AI
+  assistant.
 - Never use em dashes — they read as AI-generated; use commas, periods, or
   parentheses instead.
 - Use **bold** only for real UI controls the reader acts on in a walkthrough

--- a/AGENTS_REFERENCE.md
+++ b/AGENTS_REFERENCE.md
@@ -197,6 +197,12 @@ and `docs/app/guides/migration/`.
   table of contents, and the card styles it to match. Keep `title` too, for
   analytics. Use `hideTitle` only for a lone card that already sits under its
   own Markdown heading.
+- **Write `subtext` as the outcome, not the mechanism.** Say what the reader gets
+  from running the prompt, like the example below (_"Get a high-level summary of
+  any failures in the latest run on your branch."_). The card's title and **Copy
+  prompt** button already signal that it copies a prompt for an AI assistant, so
+  don't restate that: skip openers like _"Copies a ready-made prompt that has your
+  AI coding assistant…"_, which just repeat the component's own UI.
 - **Expanded by default** (no prop needed); add `defaultCollapsed` for prompts
   over **350 characters** so they sit behind a **Show prompt** toggle.
 - **Format longer prompts** with newlines and bullet/numbered lists in the

--- a/docs/accessibility/guides/results-api.mdx
+++ b/docs/accessibility/guides/results-api.mdx
@@ -308,7 +308,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: install
         run: npm install
       - name: Run

--- a/docs/app/continuous-integration/github-actions.mdx
+++ b/docs/app/continuous-integration/github-actions.mdx
@@ -106,7 +106,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       # Install npm dependencies, cache them correctly
       # and run all Cypress tests
       - name: Cypress run
@@ -198,7 +198,7 @@ jobs:
       options: --user 1001
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Cypress run
         uses: cypress-io/github-action@v7
         with:
@@ -244,7 +244,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Cypress install
         uses: cypress-io/github-action@v7
@@ -265,7 +265,7 @@ jobs:
     needs: install
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Download the build folder
         uses: actions/download-artifact@v7
@@ -340,7 +340,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Cypress install
         uses: cypress-io/github-action@v7
@@ -385,7 +385,7 @@ jobs:
         containers: [1, 2, 3, 4, 5]
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Download the build folder
         uses: actions/download-artifact@v7
@@ -513,7 +513,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Cypress run
         uses: cypress-io/github-action@v7
@@ -540,7 +540,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Cypress run
         uses: cypress-io/github-action@v7

--- a/docs/app/guides/test-performance.mdx
+++ b/docs/app/guides/test-performance.mdx
@@ -1134,7 +1134,7 @@ jobs:
   install:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: cypress-io/github-action@v7
         with:
           runTests: false
@@ -1144,7 +1144,7 @@ jobs:
     runs-on: ubuntu-24.04
     needs: install
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: cypress-io/github-action@v7
         with:
           start: npm start

--- a/docs/ui-coverage/faq.mdx
+++ b/docs/ui-coverage/faq.mdx
@@ -21,7 +21,7 @@ No. UI Coverage requires no code changes or instrumentation. Reports are generat
 
 ### <Icon name="angle-right" /> How is the UI Coverage score calculated?
 
-The score compares the number of tested interactive elements to the total number of interactive elements in your application. [Grouped elements](/ui-coverage/core-concepts/element-grouping) count as a single unit: the group counts once toward the total, and an interaction with any element in the group marks the whole group as tested.
+The Cypress UI Coverage score compares the number of tested interactive elements to the total number of interactive elements in your application. [Grouped elements](/ui-coverage/core-concepts/element-grouping) count as a single unit: the group counts once toward the total, and an interaction with any element in the group marks the whole group as tested.
 
 ## Finding coverage gaps
 
@@ -31,7 +31,7 @@ Record a run to Cypress Cloud with [Test Replay](/cloud/features/test-replay) en
 
 ### <Icon name="angle-right" /> Where should I start if my UI Coverage score is low?
 
-Start with your lowest-scoring [views](/ui-coverage/core-concepts/views), weighed against how critical each one is to your users, since a checkout or signup view at 40% is more urgent than a settings page at the same score. Before writing tests, rule out noise: third-party widgets counted as untested elements (exclude them with [`elementFilters`](/ui-coverage/configuration/elementfilters)) and links to pages you'll never test (exclude them with [`viewFilters`](/ui-coverage/configuration/viewfilters)) both lower a score without pointing to a real gap. See [Why is my UI Coverage score lower than I expect?](#Why-is-my-UI-Coverage-score-lower-than-I-expect) and [Identify coverage gaps](/ui-coverage/guides/identify-coverage-gaps).
+In Cypress Cloud, start with your lowest-scoring [views](/ui-coverage/core-concepts/views), weighed against how critical each one is to your users, since a checkout or signup view at 40% is more urgent than a settings page at the same score. Before writing tests, rule out noise: third-party widgets counted as untested elements (exclude them with [`elementFilters`](/ui-coverage/configuration/elementfilters)) and links to pages you'll never test (exclude them with [`viewFilters`](/ui-coverage/configuration/viewfilters)) both lower a score without pointing to a real gap. See [Why is my UI Coverage score lower than I expect?](#Why-is-my-UI-Coverage-score-lower-than-I-expect) and [Identify coverage gaps](/ui-coverage/guides/identify-coverage-gaps).
 
 ### <Icon name="angle-right" /> In Cypress UI Coverage, what's the difference between an untested element, an untested link, and an untested view?
 
@@ -61,7 +61,7 @@ Add navigation to the page so it renders during a run. Pages your tests link to 
 
 ### <Icon name="angle-right" /> How do I cover an element that only appears after login or a click?
 
-Drive the interaction that puts the UI into that state before interacting with the element. A control inside a collapsed menu, a modal, or a section that only renders after signing in won't be exercised until your test reveals it, so click the toggle or run your `cy.login()` command first, then interact with the now-visible element. Each new state your tests reach adds its snapshot to the report, so previously hidden elements start appearing as tested.
+Drive the interaction that puts the UI into that state before interacting with the element. A control inside a collapsed menu, a modal, or a section that only renders after signing in won't be exercised until your test reveals it, so click the toggle or run your `cy.login()` command first, then interact with the now-visible element. Each new state your tests reach adds its snapshot to the Cypress UI Coverage report, so previously hidden elements start appearing as tested.
 
 ### <Icon name="angle-right" /> Which coverage gaps should I fix first in Cypress UI Coverage?
 
@@ -69,7 +69,7 @@ Prioritize by risk, not by count. Start with the views behind your highest-value
 
 ### <Icon name="angle-right" /> Why did closing one coverage gap reveal more untested elements?
 
-Because visiting a page or reaching a new state exposes controls UI Coverage had never seen. When a test navigates to a previously [untested link](/ui-coverage/core-concepts/interactivity#Untested-Links), UI Coverage creates a [view](/ui-coverage/core-concepts/views) for that page and lists every interactive element on it, most of which start untested. This is expected, and it's why closing gaps is a loop: each pass surfaces the next set of elements to prioritize.
+Because visiting a page or reaching a new state exposes controls Cypress UI Coverage had never seen. When a test navigates to a previously [untested link](/ui-coverage/core-concepts/interactivity#Untested-Links), UI Coverage creates a [view](/ui-coverage/core-concepts/views) for that page and lists every interactive element on it, most of which start untested. This is expected, and it's why closing gaps is a loop: each pass surfaces the next set of elements to prioritize.
 
 ## Reducing test duplication
 
@@ -79,23 +79,23 @@ Test duplication is when many separate tests exercise the same interactive eleme
 
 ### <Icon name="angle-right" /> How do I find elements my tests exercise more than they need to?
 
-Open the **Tested elements** section of the UI Coverage report. It lists every interactive element your tests exercised, with an **Interactions** column (how many times a command targeted it) and a **Tests** column (how many separate tests touched it), and it's sorted by interactions with the most-exercised elements first. A control that a large share of your suite interacts with, such as a **Log in** or **Continue** button, is usually shared setup being repeated across tests. Expand a row to break its counts down by view and open [Test Replay](/cloud/features/test-replay) on each occurrence. See [Reduce test duplication](/ui-coverage/guides/reduce-test-duplication).
+Open the **Tested elements** section of the Cypress UI Coverage report. It lists every interactive element your tests exercised, with an **Interactions** column (how many times a command targeted it) and a **Tests** column (how many separate tests touched it), and it's sorted by interactions with the most-exercised elements first. A control that a large share of your suite interacts with, such as a **Log in** or **Continue** button, is usually shared setup being repeated across tests. Expand a row to break its counts down by view and open [Test Replay](/cloud/features/test-replay) on each occurrence. See [Reduce test duplication](/ui-coverage/guides/reduce-test-duplication).
 
 ### <Icon name="angle-right" /> What's the difference between the Interactions and Tests columns in UI Coverage?
 
-**Interactions** counts every recognized command against an element across the run, so one test that hits a control in a loop can run the number up on its own. **Tests** counts the distinct tests that interacted with it, so a high number there means many _separate_ tests all touch the same control. The **Tests** column is the better signal for duplication, because shared setup repeated across your suite shows up as one element touched by a large share of your tests.
+In Cypress UI Coverage, **Interactions** counts every recognized command against an element across the run, so one test that hits a control in a loop can run the number up on its own. **Tests** counts the distinct tests that interacted with it, so a high number there means many _separate_ tests all touch the same control. The **Tests** column is the better signal for duplication, because shared setup repeated across your suite shows up as one element touched by a large share of your tests.
 
 ### <Icon name="angle-right" /> How do I reduce test duplication?
 
-Use UI Coverage to find the elements at the top of the **Tested elements** list, confirm with [Test Replay](/cloud/features/test-replay) that the tests are passing _through_ a flow rather than testing it, then replace the repeated UI steps with a single programmatic step: cache authentication with [`cy.session()`](/api/commands/session), set a cookie or storage flag directly, or seed state with [`cy.request()`](/api/commands/request). Keep one test that still drives the flow through the UI so its coverage is preserved. The [Reduce test duplication](/ui-coverage/guides/reduce-test-duplication) guide walks through the full workflow.
+Use Cypress UI Coverage to find the elements at the top of the **Tested elements** list, confirm with [Test Replay](/cloud/features/test-replay) that the tests are passing _through_ a flow rather than testing it, then replace the repeated UI steps with a single programmatic step: cache authentication with [`cy.session()`](/api/commands/session), set a cookie or storage flag directly, or seed state with [`cy.request()`](/api/commands/request). Keep one test that still drives the flow through the UI so its coverage is preserved. The [Reduce test duplication](/ui-coverage/guides/reduce-test-duplication) guide walks through the full workflow.
 
 ### <Icon name="angle-right" /> Does reducing test duplication lower my UI Coverage score?
 
-No. An element stays tested as long as at least one test still interacts with it, so consolidating redundant setup removes _interactions_, not _coverage_. When you replace a UI login in 200 tests with [`cy.session()`](/api/commands/session) and keep one test that drives the login form, the form's interaction count drops sharply while it remains marked as tested, and your overall score is unchanged.
+No. In Cypress UI Coverage, an element stays tested as long as at least one test still interacts with it, so consolidating redundant setup removes _interactions_, not _coverage_. When you replace a UI login in 200 tests with [`cy.session()`](/api/commands/session) and keep one test that drives the login form, the form's interaction count drops sharply while it remains marked as tested, and your overall score is unchanged.
 
 ### <Icon name="angle-right" /> What's the difference between reducing noise and reducing test duplication in UI Coverage?
 
-[Reducing noise](/ui-coverage/guides/reduce-noise) is a report-accuracy problem: the report over-counts because one control is reported as many elements, or unrelated pages are split into separate views, and you fix it with [App Quality configuration](/ui-coverage/configuration/overview). [Reducing test duplication](/ui-coverage/guides/reduce-test-duplication) is a test-effort problem: the report is correct, but your suite repeats the same setup across many tests, and you fix it in your test code by consolidating that setup.
+[Reducing noise](/ui-coverage/guides/reduce-noise) is a report-accuracy problem: the report over-counts because one control is reported as many elements, or unrelated pages are split into separate views, and you fix it with [App Quality configuration](/ui-coverage/configuration/overview) in Cypress Cloud. [Reducing test duplication](/ui-coverage/guides/reduce-test-duplication) is a test-effort problem: the report is correct, but your suite repeats the same setup across many tests, and you fix it in your test code by consolidating that setup.
 
 ## Interactive elements
 
@@ -123,15 +123,15 @@ No. Query strings are ignored when grouping, so `/dashboard?tab=overview` and `/
 
 ### <Icon name="angle-right" /> How do I create a separate UI Coverage view for each value of a URL parameter?
 
-Write a [`views`](/ui-coverage/configuration/views) pattern that names the parameter, then list that name in `groupBy`. For a pattern like `/analytics/:type/:id`, `groupBy: ["type"]` creates a distinct view for each `type` value (such as `/analytics/performance/:id` and `/analytics/usage/:id`) while still collapsing the dynamic `:id`. `groupBy` accepts a single string or an array of strings, and each name can come from the path, query string, or hash. See [Using groupBy](/ui-coverage/configuration/views#Using-groupBy).
+In Cypress UI Coverage, write a [`views`](/ui-coverage/configuration/views) pattern that names the parameter, then list that name in `groupBy`. For a pattern like `/analytics/:type/:id`, `groupBy: ["type"]` creates a distinct view for each `type` value (such as `/analytics/performance/:id` and `/analytics/usage/:id`) while still collapsing the dynamic `:id`. `groupBy` accepts a single string or an array of strings, and each name can come from the path, query string, or hash. See [Using groupBy](/ui-coverage/configuration/views#Using-groupBy).
 
 ### <Icon name="angle-right" /> How do I exclude URLs from UI Coverage?
 
-Add a [`viewFilters`](/ui-coverage/configuration/viewfilters) rule with `include: false` for a URL pattern. Excluding a URL removes its snapshots from the report and stops links pointing to it from counting against your coverage score. The [Ignore views and links](/ui-coverage/guides/ignore-views-and-links) guide walks through common cases.
+In Cypress Cloud, add a [`viewFilters`](/ui-coverage/configuration/viewfilters) rule with `include: false` for a URL pattern. Excluding a URL removes its snapshots from the report and stops links pointing to it from counting against your coverage score. The [Ignore views and links](/ui-coverage/guides/ignore-views-and-links) guide walks through common cases.
 
 ### <Icon name="angle-right" /> Why is a URL still in my UI Coverage report after I excluded it with viewFilters?
 
-The most common causes are:
+The most common causes in Cypress UI Coverage are:
 
 - An earlier rule matches the URL first. Rules apply in order and the first match wins, so a broad `include: true` rule listed before your exclusion prevents it from ever applying.
 - The pattern doesn't match the full URL. Hostnames must match exactly (`https://my-app.com/*` doesn't match `www.my-app.com`), or you can use a path-only pattern like `/admin/*` to match any hostname.
@@ -141,7 +141,7 @@ See [pattern matching behavior](/ui-coverage/configuration/viewfilters#How-are-v
 
 ### <Icon name="angle-right" /> Can I include only specific URLs in UI Coverage?
 
-Yes. List `include: true` rules for the URLs you want, followed by a catch-all rule that excludes everything else: `{ "pattern": "*", "include": false }`. Because the first matching rule wins, the catch-all must come last. See [Include only your application's URLs](/ui-coverage/configuration/viewfilters#Include-only-your-applications-URLs) for a complete example.
+Yes. In Cypress Cloud, list `include: true` rules for the URLs you want, followed by a catch-all rule that excludes everything else: `{ "pattern": "*", "include": false }`. Because the first matching rule wins, the catch-all must come last. See [Include only your application's URLs](/ui-coverage/configuration/viewfilters#Include-only-your-applications-URLs) for a complete example.
 
 ### <Icon name="angle-right" /> Why is a page missing from my Cypress UI Coverage report?
 
@@ -183,7 +183,7 @@ The [`data-cy-ui-group` markup attribute](/ui-coverage/core-concepts/element-gro
 
 ### <Icon name="angle-right" /> What happens if two UI Coverage elementGroups rules match the same element?
 
-The first matching rule in your [`elementGroups`](/ui-coverage/configuration/elementgroups) configuration wins, so list specific rules before broad catch-all rules. A rule that appears after another rule matching the same elements never applies to them.
+In Cypress UI Coverage, the first matching rule in your [`elementGroups`](/ui-coverage/configuration/elementgroups) configuration wins, so list specific rules before broad catch-all rules. A rule that appears after another rule matching the same elements never applies to them.
 
 ### <Icon name="angle-right" /> Can I group UI Coverage elements in my application code instead of Cypress Cloud configuration?
 
@@ -191,11 +191,11 @@ Yes. Add the [`data-cy-ui-group` attribute](/ui-coverage/core-concepts/element-g
 
 ### <Icon name="angle-right" /> Can I group or filter UI Coverage elements inside iframes or shadow DOM?
 
-Yes. The [`elementGroups`](/ui-coverage/configuration/elementgroups), [`elementFilters`](/ui-coverage/configuration/elementfilters), and [`elements`](/ui-coverage/configuration/elements) configuration options all accept a `documentScope` property that limits a rule to elements inside specific iframes or shadow DOM hosts. List one CSS selector per host, ordered from the outermost document to the innermost.
+Yes. In Cypress UI Coverage, the [`elementGroups`](/ui-coverage/configuration/elementgroups), [`elementFilters`](/ui-coverage/configuration/elementfilters), and [`elements`](/ui-coverage/configuration/elements) configuration options all accept a `documentScope` property that limits a rule to elements inside specific iframes or shadow DOM hosts. List one CSS selector per host, ordered from the outermost document to the innermost.
 
 ### <Icon name="angle-right" /> Why isn't my element group showing up in the UI Coverage report?
 
-The most common causes are:
+The most common causes in Cypress UI Coverage are:
 
 - An earlier `elementGroups` rule matches the same elements, and the first matching rule wins.
 - The elements are excluded by [`elementFilters`](/ui-coverage/configuration/elementfilters), so they're never considered for grouping.
@@ -205,11 +205,11 @@ The most common causes are:
 
 ### <Icon name="angle-right" /> How do I exclude elements from UI Coverage?
 
-Add an [`elementFilters`](/ui-coverage/configuration/elementfilters) rule with `include: false` for a CSS selector that matches the elements. Excluded elements are removed from the report and don't count toward your coverage score. This is the standard way to remove third-party widgets, such as chat launchers or cookie banners, from your reports. The [Ignore elements](/ui-coverage/guides/ignore-elements) guide walks through common cases.
+In Cypress Cloud, add an [`elementFilters`](/ui-coverage/configuration/elementfilters) rule with `include: false` for a CSS selector that matches the elements. Excluded elements are removed from the report and don't count toward your coverage score. This is the standard way to remove third-party widgets, such as chat launchers or cookie banners, from your reports. The [Ignore elements](/ui-coverage/guides/ignore-elements) guide walks through common cases.
 
 ### <Icon name="angle-right" /> How do I exclude a third-party widget like a chat launcher or cookie banner from UI Coverage?
 
-Add an [`elementFilters`](/ui-coverage/configuration/elementfilters) rule with `include: false` whose selector matches the widget's container _and_ its descendants, so every control inside it is removed rather than just the wrapper. For a support chat like Intercom, that's `{ "selector": "#intercom-container, #intercom-container *", "include": false }`. Widgets rendered inside an iframe or shadow DOM are removed by pairing a `*` selector with [`documentScope`](/ui-coverage/configuration/elementfilters#Options). See [Ignore elements](/ui-coverage/guides/ignore-elements) for the full walkthrough.
+In Cypress Cloud, add an [`elementFilters`](/ui-coverage/configuration/elementfilters) rule with `include: false` whose selector matches the widget's container _and_ its descendants, so every control inside it is removed rather than just the wrapper. For a support chat like Intercom, that's `{ "selector": "#intercom-container, #intercom-container *", "include": false }`. Widgets rendered inside an iframe or shadow DOM are removed by pairing a `*` selector with [`documentScope`](/ui-coverage/configuration/elementfilters#Options). See [Ignore elements](/ui-coverage/guides/ignore-elements) for the full walkthrough.
 
 ### <Icon name="angle-right" /> Should I exclude UI Coverage elements with elementFilters or data-cy-ui-interactive?
 
@@ -217,11 +217,11 @@ Both remove an element from the report and the score; choose by who owns the dec
 
 ### <Icon name="angle-right" /> Do excluded elements count toward my UI Coverage score?
 
-No. An element excluded by [`elementFilters`](/ui-coverage/configuration/elementfilters) doesn't appear in the report and doesn't count toward the score, whether your tests interacted with it or not. It's also not considered by [`elementGroups`](/ui-coverage/configuration/elementgroups) or [`elements`](/ui-coverage/configuration/elements) rules.
+No. In Cypress UI Coverage, an element excluded by [`elementFilters`](/ui-coverage/configuration/elementfilters) doesn't appear in the report and doesn't count toward the score, whether your tests interacted with it or not. It's also not considered by [`elementGroups`](/ui-coverage/configuration/elementgroups) or [`elements`](/ui-coverage/configuration/elements) rules.
 
 ### <Icon name="angle-right" /> Why isn't my UI Coverage elementFilters rule excluding an element?
 
-The most common causes are:
+The most common causes in Cypress UI Coverage are:
 
 - The selector matches a container instead of the element itself. Filters use standard CSS matching against each tracked element, so `footer` matches only the `<footer>` element. Use a descendant selector like `footer *` to exclude everything inside a container.
 - An earlier `elementFilters` rule already matched the element, and the first matching rule wins. An `include: true` rule above your exclude rule protects the elements it matches.
@@ -238,27 +238,27 @@ This usually means the element's identifying attributes change between [snapshot
 
 ### <Icon name="angle-right" /> Which attributes does UI Coverage use to identify elements?
 
-UI Coverage checks a prioritized list of attributes on each element and uses the first one present with a usable value. In order, that's: any attributes you add to [`significantAttributes`](/ui-coverage/configuration/significantattributes), then the default test attributes `data-cy`, `data-test`, `data-testid`, `data-test-id`, `data-qa`, and `row-id`, falling back to `id` and `name` when none of those are present. See [Element Identification](/ui-coverage/core-concepts/element-identification#How-an-element-is-identified) for the full priority list and how identification works across snapshots.
+Cypress UI Coverage checks a prioritized list of attributes on each element and uses the first one present with a usable value. In order, that's: any attributes you add to [`significantAttributes`](/ui-coverage/configuration/significantattributes), then the default test attributes `data-cy`, `data-test`, `data-testid`, `data-test-id`, `data-qa`, and `row-id`, falling back to `id` and `name` when none of those are present. See [Element Identification](/ui-coverage/core-concepts/element-identification#How-an-element-is-identified) for the full priority list and how identification works across snapshots.
 
 ### <Icon name="angle-right" /> How does UI Coverage identify an element that has no test attribute or id?
 
-When an element has none of the [identifying attributes](/ui-coverage/core-concepts/element-identification#How-an-element-is-identified), UI Coverage falls back to identifying it by its structure and position in the DOM. Because that identity is less stable than an attribute you control, adding a stable `data-cy` (or similar) attribute is the reliable fix. See [When an element has no identifying attribute](/ui-coverage/core-concepts/element-identification#When-an-element-has-no-identifying-attribute).
+When an element has none of the [identifying attributes](/ui-coverage/core-concepts/element-identification#How-an-element-is-identified), Cypress UI Coverage falls back to identifying it by its structure and position in the DOM. Because that identity is less stable than an attribute you control, adding a stable `data-cy` (or similar) attribute is the reliable fix. See [When an element has no identifying attribute](/ui-coverage/core-concepts/element-identification#When-an-element-has-no-identifying-attribute).
 
 ### <Icon name="angle-right" /> How do I make UI Coverage use my own attribute to identify elements?
 
-Add the attribute name to [`significantAttributes`](/ui-coverage/configuration/significantattributes). Attributes you list are checked before the default list, in the order you list them, so an attribute your application already renders, such as `data-component-name`, can identify, name, and group elements in your reports.
+Add the attribute name to [`significantAttributes`](/ui-coverage/configuration/significantattributes). In Cypress UI Coverage, attributes you list are checked before the default list, in the order you list them, so an attribute your application already renders, such as `data-component-name`, can identify, name, and group elements in your reports.
 
 ### <Icon name="angle-right" /> In UI Coverage, does significantAttributes replace the default attribute list?
 
-No. Your attributes are checked first, and the defaults still apply after them, so an element without any of your attributes is identified exactly as it would be without configuration. Listing a default attribute like `data-qa` promotes it above the other defaults. To stop an attribute from being used at all, use [`attributeFilters`](/ui-coverage/configuration/attributefilters) instead.
+No. In Cypress UI Coverage, your attributes are checked first, and the defaults still apply after them, so an element without any of your attributes is identified exactly as it would be without configuration. Listing a default attribute like `data-qa` promotes it above the other defaults. To stop an attribute from being used at all, use [`attributeFilters`](/ui-coverage/configuration/attributefilters) instead.
 
 ### <Icon name="angle-right" /> Can I use a non-`data-` attribute like aria-label as a UI Coverage significant attribute?
 
-Yes. Any valid HTML attribute qualifies, not only `data-*` attributes. Listing [`aria-label`](/ui-coverage/configuration/significantattributes) identifies elements by their label text, which gives icon-only controls a readable identity. Because UI Coverage lists every interactive element, it also surfaces every label for a person to read and judge for clarity, since automated accessibility tools confirm only that a label exists, not that it is well written.
+Yes. In Cypress UI Coverage, any valid HTML attribute qualifies, not only `data-*` attributes. Listing [`aria-label`](/ui-coverage/configuration/significantattributes) identifies elements by their label text, which gives icon-only controls a readable identity. Because UI Coverage lists every interactive element, it also surfaces every label for a person to read and judge for clarity, since automated accessibility tools confirm only that a label exists, not that it is well written.
 
 ### <Icon name="angle-right" /> Why isn't my UI Coverage elements rule applying?
 
-An [`elements`](/ui-coverage/configuration/elements) rule applies only when its selector matches exactly one interactive element in a snapshot. The most common causes are:
+In Cypress UI Coverage, an [`elements`](/ui-coverage/configuration/elements) rule applies only when its selector matches exactly one interactive element in a snapshot. The most common causes are:
 
 - The selector matches more than one interactive element in the same snapshot, so the rule is skipped for that snapshot. Add [`documentScope`](/ui-coverage/configuration/elements#Options) or a more specific selector, or use [`elementGroups`](/ui-coverage/configuration/elementgroups) if several elements should share an identity.
 - The selector only matches non-interactive elements, such as a wrapper around the actual button or input.
@@ -280,7 +280,7 @@ They pull in opposite directions. [`attributeFilters`](/ui-coverage/configuratio
 
 ### <Icon name="angle-right" /> Why isn't my UI Coverage attributeFilters rule working?
 
-The most common causes are:
+The most common causes in Cypress UI Coverage are:
 
 - The pattern doesn't match the full value. Patterns are anchored automatically (as if wrapped in `^(...)$`), so `value: "user"` matches only the exact string `user`. Use wildcards for partial matches, such as `value: "user-.*"`.
 - An earlier rule matches the same attribute first, and the first matching rule wins. List specific `include: true` exceptions before broad `include: false` rules.
@@ -303,29 +303,29 @@ Two conditions must both hold. First, the command name must be listed in [`addit
 
 ### <Icon name="angle-right" /> In UI Coverage, what's the difference between additionalInteractionCommands and allowedInteractionCommands?
 
-[`additionalInteractionCommands`](/ui-coverage/configuration/additionalinteractioncommands) _extends_ the set of commands recognized as interactions everywhere, so a custom or plugin command counts as coverage on any element. [`allowedInteractionCommands`](/ui-coverage/configuration/allowedinteractioncommands) works _per element_: for elements matching a selector, only the commands you list count, which lets you both restrict coverage to a meaningful interaction and accept commands that are otherwise ignored. Use `additionalInteractionCommands` to recognize a command globally, and `allowedInteractionCommands` to control which commands matter for specific elements.
+In Cypress UI Coverage, [`additionalInteractionCommands`](/ui-coverage/configuration/additionalinteractioncommands) _extends_ the set of commands recognized as interactions everywhere, so a custom or plugin command counts as coverage on any element. [`allowedInteractionCommands`](/ui-coverage/configuration/allowedinteractioncommands) works _per element_: for elements matching a selector, only the commands you list count, which lets you both restrict coverage to a meaningful interaction and accept commands that are otherwise ignored. Use `additionalInteractionCommands` to recognize a command globally, and `allowedInteractionCommands` to control which commands matter for specific elements.
 
 ### <Icon name="angle-right" /> How do I require a specific interaction in UI Coverage, like a hover, to mark an element tested?
 
-Add an [`allowedInteractionCommands`](/ui-coverage/configuration/allowedinteractioncommands) rule whose `selector` matches the element and whose `commands` list contains only the interaction you require. Because matching a rule replaces the default commands for that element, interactions you didn't list, including a plain `click`, no longer mark it tested, so the element only counts once the meaningful interaction runs.
+In Cypress UI Coverage, add an [`allowedInteractionCommands`](/ui-coverage/configuration/allowedinteractioncommands) rule whose `selector` matches the element and whose `commands` list contains only the interaction you require. Because matching a rule replaces the default commands for that element, interactions you didn't list, including a plain `click`, no longer mark it tested, so the element only counts once the meaningful interaction runs.
 
 ### <Icon name="angle-right" /> Can I count assertions as UI Coverage?
 
-Yes. Assertions don't count by default, but an [`allowedInteractionCommands`](/ui-coverage/configuration/allowedinteractioncommands) rule listing `assert` credits assertions against the matching elements. This is useful for read-only elements such as status badges or computed totals that your tests validate but never interact with. Remember that the rule replaces the defaults for those elements, so include any other commands you also want to accept alongside `assert`.
+Yes. In Cypress UI Coverage, assertions don't count by default, but an [`allowedInteractionCommands`](/ui-coverage/configuration/allowedinteractioncommands) rule listing `assert` credits assertions against the matching elements. This is useful for read-only elements such as status badges or computed totals that your tests validate but never interact with. Remember that the rule replaces the defaults for those elements, so include any other commands you also want to accept alongside `assert`.
 
 ### <Icon name="angle-right" /> In UI Coverage, do commands in allowedInteractionCommands also need to be in additionalInteractionCommands?
 
-No. Listing a command in an [`allowedInteractionCommands`](/ui-coverage/configuration/allowedinteractioncommands) rule automatically registers it as a recognized interaction, so a custom or plugin command works without also appearing in [`additionalInteractionCommands`](/ui-coverage/configuration/additionalinteractioncommands). As with any custom command, it only produces coverage if it logs a snapshot that references the subject element.
+No. In Cypress UI Coverage, listing a command in an [`allowedInteractionCommands`](/ui-coverage/configuration/allowedinteractioncommands) rule automatically registers it as a recognized interaction, so a custom or plugin command works without also appearing in [`additionalInteractionCommands`](/ui-coverage/configuration/additionalinteractioncommands). As with any custom command, it only produces coverage if it logs a snapshot that references the subject element.
 
 ### <Icon name="angle-right" /> Why did an element stop counting as tested in UI Coverage after I added an allowedInteractionCommands rule?
 
-Once an element matches an [`allowedInteractionCommands`](/ui-coverage/configuration/allowedinteractioncommands) rule, only the commands listed in the matching rules count for it, and the default commands no longer apply. If your tests exercise the element with a command you didn't list, it's now treated as untested. Add that command to the rule, or tighten the `selector` so the rule doesn't match elements you didn't intend to restrict.
+In Cypress UI Coverage, once an element matches an [`allowedInteractionCommands`](/ui-coverage/configuration/allowedinteractioncommands) rule, only the commands listed in the matching rules count for it, and the default commands no longer apply. If your tests exercise the element with a command you didn't list, it's now treated as untested. Add that command to the rule, or tighten the `selector` so the rule doesn't match elements you didn't intend to restrict.
 
 ## Configuration
 
 ### <Icon name="angle-right" /> Do I need to configure anything to use UI Coverage?
 
-No. UI Coverage works out of the box with no configuration. Every recorded run produces a report automatically. Configuration is opt-in and incremental: add a rule only when you want to sharpen the report, such as ignoring a dynamic attribute, filtering out a third-party widget, or grouping related elements. See the [Configuration overview](/ui-coverage/configuration/overview) for what each option does.
+No. Cypress UI Coverage works out of the box with no configuration. Every recorded run produces a report automatically. Configuration is opt-in and incremental: add a rule only when you want to sharpen the report, such as ignoring a dynamic attribute, filtering out a third-party widget, or grouping related elements. See the [Configuration overview](/ui-coverage/configuration/overview) for what each option does.
 
 ### <Icon name="angle-right" /> Where do I set UI Coverage configuration?
 
@@ -349,7 +349,7 @@ Root-level properties like [`viewFilters`](/ui-coverage/configuration/viewfilter
 
 ### <Icon name="angle-right" /> Can I use different UI Coverage configuration for different runs?
 
-Yes. The [`profiles`](/ui-coverage/configuration/profiles) property applies configuration overrides based on [run tags](/app/references/command-line#cypress-run-tag-lt-tag-gt), so a smoke-test run and a full regression run can each use their own settings.
+Yes. In Cypress UI Coverage, the [`profiles`](/ui-coverage/configuration/profiles) property applies configuration overrides based on [run tags](/app/references/command-line#cypress-run-tag-lt-tag-gt), so a smoke-test run and a full regression run can each use their own settings.
 
 ## Profiles
 
@@ -420,11 +420,27 @@ Record each run with a distinct [`--tag`](/app/references/command-line#cypress-r
 
 Yes. The result object includes a `config` property containing the [App Quality Config](/ui-coverage/configuration/overview) that generated the report, resolved with any [Profile](/ui-coverage/configuration/profiles) that matched the run's tags. Read `config.value` to confirm exactly which rules were in effect and `config.updatedAt` for when that configuration last changed.
 
+### <Icon name="angle-right" /> Should I block pull requests on a coverage threshold or on new coverage gaps?
+
+Both are valid Cypress UI Coverage policies, and they suit different situations. A **coverage threshold** fails the build when overall or per-view coverage drops below a fixed percentage; it's simple and works well once your coverage is already where you want it, or for holding a critical flow like checkout to a high bar. A **baseline comparison** fails only when a run introduces _new_ untested elements, which is the better fit for an existing app with known coverage debt: it stops gaps from growing without blocking every pull request until all the old debt is paid down. Many teams enforce a threshold on critical views and a baseline everywhere else. See [Block pull requests and set policies](/ui-coverage/guides/block-pull-requests#Choose-a-policy).
+
+### <Icon name="angle-right" /> How do I block a pull request only when new untested elements are introduced?
+
+Compare each run against a stored **baseline** instead of a fixed threshold. Record a known-good run, save each [view's](/ui-coverage/core-concepts/views) `untestedElementsCount` to a small JSON file committed to your repository, then in CI use the [Cypress UI Coverage Results API](/ui-coverage/results-api) to fail the build only when a view's untested-element count rises above its baseline (or a new view arrives carrying untested elements). This lets you pay down existing gaps on your own schedule while preventing new ones from merging. The [Block pull requests and set policies](/ui-coverage/guides/block-pull-requests#comparing-against-a-baseline) guide has the complete script.
+
+### <Icon name="angle-right" /> Why compare untested-element counts instead of the UI Coverage score when gating pull requests?
+
+The [coverage score](/ui-coverage/guides/identify-coverage-gaps#Step-2-Read-your-overall-coverage-score) is the share of your app's interactive elements that your tests exercise (tested ÷ total, with grouped elements counting once), which makes it ideal for tracking direction over time but noisy as a per-run gate: adding a single test can reveal a whole page of previously unseen elements and _lower_ the score even though coverage improved. In Cypress UI Coverage, a view's `untestedElementsCount` is a more direct answer to "did this change add gaps?": if it rises against the baseline, the change introduced untested elements regardless of what the percentage did. Note the two aren't interchangeable, since the score's denominator also counts navigable links while `untestedElementsCount` doesn't. See [Why compare untested-element counts instead of the coverage score?](/ui-coverage/guides/block-pull-requests#Why-compare-untested-element-counts-instead-of-the-coverage-score).
+
+### <Icon name="angle-right" /> Where should I store my UI Coverage baseline?
+
+Commit the Cypress UI Coverage baseline JSON file to version control so it's reviewed and versioned alongside the code that changes your coverage, and is available to every CI run. If you can't commit it, store it as a CI build artifact retrieved on later runs, or in a database when you need richer versioning across many projects. For long-lived branches, keep branch-specific baseline files so a feature branch isn't gated against `main`'s numbers. See [Best practices](/ui-coverage/guides/block-pull-requests#Where-to-store-the-baseline).
+
 ## Troubleshooting
 
 ### <Icon name="angle-right" /> Why is my UI Coverage score lower than I expect?
 
-A few sources of untested elements commonly lower a score without pointing to a real gap in your suite. Third-party widgets, such as chat launchers, cookie banners, and analytics overlays, are interactive elements each counted as untested; exclude them with [`elementFilters`](/ui-coverage/configuration/elementfilters). [Untested links](/ui-coverage/core-concepts/interactivity#Untested-Links) to pages no test visits, including your own help center, marketing pages, and external sites, also count against the score; exclude their destinations with [`viewFilters`](/ui-coverage/configuration/viewfilters). Finally, one control [split into many](/ui-coverage/troubleshooting#One-element-is-reported-as-many) by an unstable attribute adds duplicate untested elements. See [the coverage score looks wrong](/ui-coverage/troubleshooting#The-coverage-score-looks-wrong) for the fixes.
+A few sources of untested elements commonly lower a Cypress UI Coverage score without pointing to a real gap in your suite. Third-party widgets, such as chat launchers, cookie banners, and analytics overlays, are interactive elements each counted as untested; exclude them with [`elementFilters`](/ui-coverage/configuration/elementfilters). [Untested links](/ui-coverage/core-concepts/interactivity#Untested-Links) to pages no test visits, including your own help center, marketing pages, and external sites, also count against the score; exclude their destinations with [`viewFilters`](/ui-coverage/configuration/viewfilters). Finally, one control [split into many](/ui-coverage/troubleshooting#One-element-is-reported-as-many) by an unstable attribute adds duplicate untested elements. See [the coverage score looks wrong](/ui-coverage/troubleshooting#The-coverage-score-looks-wrong) for the fixes.
 
 ### <Icon name="angle-right" /> Why does an element my test interacts with still show as untested in UI Coverage?
 
@@ -432,11 +448,11 @@ Usually the command your test uses isn't one UI Coverage recognizes. It counts o
 
 ### <Icon name="angle-right" /> I changed my UI Coverage configuration but the report didn't change. Why?
 
-Most often the run was processed before you saved: reports use the configuration that was applied when they were generated, so [regenerate](/ui-coverage/configuration/overview#Setting-configuration) the run to apply your current configuration. If it still has no effect, check whether an earlier rule matched first (the first matching rule wins for most properties), whether a [nested list replaced a root one](/ui-coverage/configuration/overview#Configuration-scope) instead of merging with it, or whether the configuration failed to save because a property was misspelled or misplaced. See [a configuration rule has no effect](/ui-coverage/troubleshooting#A-configuration-rule-has-no-effect) for the full checklist.
+Most often the run was processed before you saved: Cypress UI Coverage reports use the configuration that was applied when they were generated, so [regenerate](/ui-coverage/configuration/overview#Setting-configuration) the run to apply your current configuration. If it still has no effect, check whether an earlier rule matched first (the first matching rule wins for most properties), whether a [nested list replaced a root one](/ui-coverage/configuration/overview#Configuration-scope) instead of merging with it, or whether the configuration failed to save because a property was misspelled or misplaced. See [a configuration rule has no effect](/ui-coverage/troubleshooting#A-configuration-rule-has-no-effect) for the full checklist.
 
 ### <Icon name="angle-right" /> How do I debug a UI Coverage report that looks wrong?
 
-Start by [regenerating the run](/ui-coverage/configuration/overview#Setting-configuration) so it reflects your current configuration, then match your symptom to a cause on the [Troubleshooting](/ui-coverage/troubleshooting) page, which covers duplicate elements, mis-grouped elements, tested elements shown as untested, configuration that has no effect, and unexpected scores. Because you can regenerate any past run, the fastest approach is to make one change, regenerate a recent run, and check the result before making the next.
+Start by [regenerating the run](/ui-coverage/configuration/overview#Setting-configuration) in Cypress Cloud so it reflects your current configuration, then match your symptom to a cause on the [Troubleshooting](/ui-coverage/troubleshooting) page, which covers duplicate elements, mis-grouped elements, tested elements shown as untested, configuration that has no effect, and unexpected scores. Because you can regenerate any past run, the fastest approach is to make one change, regenerate a recent run, and check the result before making the next.
 
 ## See also
 

--- a/docs/ui-coverage/guides/block-pull-requests.mdx
+++ b/docs/ui-coverage/guides/block-pull-requests.mdx
@@ -366,7 +366,7 @@ for the equivalent step in GitLab, Jenkins, Azure, CircleCI, and other providers
 
 A pull request check should be fast and focused, while your nightly regression
 run tracks everything. [Profiles](/ui-coverage/configuration/profiles) let you
-apply different [App Quality configuration](/ui-coverage/configuration/overview)
+apply different app quality configuration
 to different runs based on their [run tags](/app/references/command-line#cypress-run-tag-lt-tag-gt),
 so both can share one Cypress Cloud project.
 

--- a/docs/ui-coverage/guides/block-pull-requests.mdx
+++ b/docs/ui-coverage/guides/block-pull-requests.mdx
@@ -49,7 +49,7 @@ This guide assumes you've completed the
 [Results API setup](/ui-coverage/results-api#Installation): your CI install step
 adds the `@cypress/extract-cloud-results` module, and a verification script runs
 **after** `cypress run --record` in the **same** CI build. A run also needs
-[Test Replay](/cloud/features/test-replay) enabled and must have been recorded
+Test Replay enabled and must have been recorded
 within the last 7 days for the helper to find it. See the
 [Results API FAQ](/ui-coverage/faq#Results-API-and-CI) for the full prerequisite
 list.
@@ -130,7 +130,7 @@ compares.
 ### Baseline structure
 
 The baseline is a small JSON file you commit alongside your code. It records, for
-a known-good run, how many untested elements each [view](/ui-coverage/core-concepts/views)
+a known-good run, how many untested elements each view
 had:
 
 - **runNumber**: the run the baseline was captured from, for reference.
@@ -165,7 +165,7 @@ either run the script locally by replaying a recent run's CI context (see
 [Required CI environment variables](/ui-coverage/results-api#Required-CI-environment-variables)),
 or upload `ui-coverage-baseline.next.json` as a build artifact from the CI run.
 
-<AccordionBlock title="View the comparison script">
+<AccordionBlock title="View the comparison script" icon={<Icon name="laptop-code" />}>
 
 This script reads the committed baseline, fails the build when any view has
 _more_ untested elements than its baseline (or when a new view ships untested

--- a/docs/ui-coverage/guides/block-pull-requests.mdx
+++ b/docs/ui-coverage/guides/block-pull-requests.mdx
@@ -1,6 +1,6 @@
 ---
 title: Block pull requests with UI Coverage policies
-description: "Set policies and block pull requests automatically with Cypress UI Coverage's Results API, enabling custom CI workflows to enforce test coverage standards and prevent regressions."
+description: 'Block pull requests with Cypress UI Coverage: use the Results API to fail a build when coverage drops below a threshold or a run introduces new untested elements.'
 sidebar_label: Block pull requests and set policies
 sidebar_position: 90
 ---
@@ -9,399 +9,466 @@ sidebar_position: 90
 
 # Block pull requests and set policies
 
-Cypress UI Coverage reports are generated server-side in Cypress Cloud, based on test artifacts uploaded during execution. This ensures there is no performance impact on your Cypress test runs, but also means that nothing in your Cypress pipeline will fail due to coverage issues that are detected. Failing a build is a fully opt-in step based on your handling of the results in your CI process.
+Once you've used UI Coverage to [find the untested parts of your app](/ui-coverage/guides/identify-coverage-gaps),
+the next step is keeping new gaps from creeping back in. This guide turns your UI
+Coverage report into a **merge gate**, so a pull request that adds an untested
+button, form, or page can't merge without a deliberate decision.
 
-## Using the Results API
+UI Coverage reports are generated server-side in Cypress Cloud from
+[Test Replay](/cloud/features/test-replay) data, so they add no overhead to your
+test runs, and nothing in your Cypress pipeline fails on its own when coverage
+drops. Enforcement is entirely opt-in: you choose a policy and apply it in your
+CI job with the [Results API](/ui-coverage/results-api). With it you can:
 
-The [Cypress UI Coverage Results API](/ui-coverage/results-api) allows you to access UI Coverage results post-test run, enabling workflows like blocking pull requests or triggering alerts based on specific coverage criteria. This involves adding a dedicated UI Coverage verification step to your CI pipeline. With a Cypress helper function, you can automatically fetch the report for the relevant test run within the CI build context.
+- **Fail a build or block a pull request** when overall coverage falls below a
+  threshold, or when a critical view regresses.
+- **Block only on _new_ gaps** by comparing each run against a stored baseline,
+  so you can pay down existing coverage debt over time instead of all at once.
+- **Post the result where reviewers work**, linking straight to the report on
+  the pull request.
 
-## Implementing a status check
+## Choose a policy
 
-The Results API offers full flexibility to analyze results and take tailored actions. It can also integrate with status checks on pull requests, allowing you to block merges when coverage thresholds are not met.
+The Results API gives you the run's coverage numbers; _how_ you gate on them is
+the policy. Two models cover most teams, and you can combine them.
 
-## Defining policies in the verification step
+| Policy                                                   | Blocks when…                                                 | Best for                                                                                          |
+| -------------------------------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------- |
+| [Coverage threshold](#Enforce-a-coverage-threshold)      | Overall or per-view coverage drops below a fixed percentage  | A codebase whose coverage is already where you want it, or a critical flow you hold to a high bar |
+| [New gaps vs. a baseline](#comparing-against-a-baseline) | A run introduces untested elements that weren't there before | An existing app with known coverage debt you want to stop growing                                 |
 
-The [Results API Documentation](/ui-coverage/results-api) provides detailed guidance on the API's capabilities. Here's a simplified example demonstrating how to enforce a minimum coverage threshold:
+A fixed threshold is simple but blunt: if your app sits at 62% coverage, a
+threshold of 80% blocks _every_ pull request until you've paid down all the
+existing debt. A **baseline** compares each run against a known-good state and
+fails only on _newly_ introduced gaps, which lets you hold the line today and
+improve incrementally. Most teams with an established suite start here.
 
-```js
+## Before you begin
+
+This guide assumes you've completed the
+[Results API setup](/ui-coverage/results-api#Installation): your CI install step
+adds the `@cypress/extract-cloud-results` module, and a verification script runs
+**after** `cypress run --record` in the **same** CI build. A run also needs
+[Test Replay](/cloud/features/test-replay) enabled and must have been recorded
+within the last 7 days for the helper to find it. See the
+[Results API FAQ](/ui-coverage/faq#Results-API-and-CI) for the full prerequisite
+list.
+
+Every example below is a script that calls `getUICoverageResults()` and, when
+your policy isn't met, exits with a non-zero status to fail the CI step. See
+[Wire the check into CI](#Wire-the-check-into-CI) for how that failed step
+becomes a required status check that blocks the merge.
+
+## Enforce a coverage threshold
+
+The simplest policy fails the build when overall coverage drops below a floor,
+and holds critical flows like login and checkout to a higher standard:
+
+```javascript title="scripts/verifyUICoverageResults.js"
 const { getUICoverageResults } = require('@cypress/extract-cloud-results')
 
-// Fetch UI Coverage results
-getUICoverageResults().then((results) => {
-  const { summary, views } = results
+getUICoverageResults()
+  .then((results) => {
+    const { summary, views } = results
 
-  // Verify overall coverage
-  if (summary.coverage < 80) {
-    throw new Error(
-      `Project coverage is ${summary.coverage}%, below the minimum threshold of 80%.`
-    )
-  }
-
-  // Verify critical view coverage
-  const criticalViews = [/login/, /checkout/]
-  views.forEach((view) => {
-    if (
-      criticalViews.some((pattern) => pattern.test(view.displayName)) &&
-      view.coverage < 95
-    ) {
+    // Fail the build if overall coverage is below 80%.
+    if (summary.coverage < 80) {
       throw new Error(
-        `Critical view "${view.displayName}" coverage is ${view.coverage}%, below the required 95%.`
+        `Project coverage is ${summary.coverage}%, below the minimum threshold of 80%.`
       )
     }
+
+    // Hold critical flows to a higher standard.
+    const criticalViews = [/login/, /checkout/]
+
+    views.forEach((view) => {
+      if (
+        criticalViews.some((pattern) => pattern.test(view.displayName)) &&
+        view.coverage < 95
+      ) {
+        throw new Error(
+          `Critical view "${view.displayName}" coverage is ${view.coverage}%, below the required 95%. See: ${view.uiCoverageReportUrl}`
+        )
+      }
+    })
+
+    console.log('UI Coverage meets all thresholds.')
   })
-})
+  .catch((error) => {
+    console.error(error.message)
+    process.exit(1)
+  })
 ```
 
-By examining the results and customizing your response, you gain maximum control over how to handle coverage gaps. Leverage CI environment context, such as tags, to fine-tune responses to specific coverage outcomes.
+The [Results API examples](/ui-coverage/results-api#Examples) cover more
+threshold variations, including reporting the score on the pull request, failing
+on untested navigation links, and ratcheting the floor up as coverage improves.
 
-## Using Profiles for PR-specific configuration
+## Block only on new gaps with a baseline {#comparing-against-a-baseline}
 
-You can use [Profiles](/ui-coverage/configuration/profiles) to apply different configuration settings for pull request runs versus regression runs. This allows you to:
+A threshold treats all untested elements the same, whether they've been untested
+for a year or arrived in the pull request under review. Comparing a run against a
+stored **baseline** lets you ignore existing gaps and fail only when a change
+introduces _new_ untested elements. This is what makes UI Coverage enforceable on
+a real codebase: you stop the debt from growing today, and pay it down on your own
+schedule without blocking every merge.
 
-- Use a narrow, focused configuration for PR runs that blocks merges based on critical coverage thresholds
-- Maintain a broader configuration for regression runs that tracks all coverage gaps for long-term monitoring
-- Apply team-specific configurations when multiple teams share the same Cypress Cloud project
+### Why compare untested-element counts instead of the coverage score?
 
-For example, you might configure a profile named `aq-config-pr` that excludes non-critical pages and focuses only on the most important coverage areas, while your base configuration includes all pages for comprehensive regression tracking.
+The coverage score is the share of your app's interactive elements that your
+tests exercise (tested ÷ total). It's the right number for tracking direction
+over time, but a poor signal for a per-run gate: adding a single test can reveal a
+whole page of previously unseen elements and _lower_ the score even though your
+coverage improved.
 
-```shell
-cypress run --record --tag "aq-config-pr"
-```
-
-This approach ensures that PR checks are fast and focused, while still maintaining comprehensive reporting for your full test suite.
-
-## Comparing against a baseline {#comparing-against-a-baseline}
-
-Comparing current results against a stored baseline allows you to detect only new untested elements that have been introduced, while ignoring existing coverage gaps. This approach helps you focus on regressions in test coverage and track improvements over time.
-
-This is particularly useful in CI/CD pipelines where you want to fail builds only when new untested elements are introduced, allowing you to address existing coverage gaps incrementally without blocking deployments.
+The **untested-element count per view** is a more direct signal for "did this
+change add gaps?" If a view's `untestedElementsCount` rises above its baseline,
+or a brand-new view arrives carrying untested elements, the change introduced
+gaps, regardless of what the percentage did. That's the number the script below
+compares.
 
 ### Baseline structure
 
-In our example the baseline is a JSON object that captures the state of untested elements from a specific run. It includes:
+The baseline is a small JSON file you commit alongside your code. It records, for
+a known-good run, how many untested elements each [view](/ui-coverage/core-concepts/views)
+had:
 
-- **runNumber**: The run number used as the baseline reference
-- **views**: An object mapping view display names to arrays of view identifiers and their untested elements counts
-- **runUrl**: The link to the cloud run that generated this report
+- **runNumber**: the run the baseline was captured from, for reference.
+- **runUrl**: a link back to that run in Cypress Cloud.
+- **views**: a map of each view's `displayName` to its `untestedElementsCount`.
 
-```javascript
+```json title="ui-coverage-baseline.json"
 {
   "runNumber": 68086,
   "runUrl": "https://cloud.cypress.io/projects/ypt4pf/runs/68086",
   "views": {
-    "/": { testedElements: 55 },
-    "/login": { testedElements: 3 },
-    "/products/*": { testedElements: 3 },
+    "/": 0,
+    "/login": 2,
+    "/products/*": 4,
+    "/checkout": 1
   }
 }
 ```
 
-#### Why use untested element counts instead of UI Coverage percentage scores?
+### Create your first baseline
 
-The [UI Coverage score](/ui-coverage/guides/identify-coverage-gaps#Step-2-Read-your-overall-coverage-score) is expressed as based on a ratio of what was and was not tested over time, within what was rendered in Cypress during the run. Since testing one new element might reveal many more elements that aren't tested yet, the score isn't useful for a fine-grained baseline comparison between runs. Comparing the number of tested elements gives a more accurate sense of whether one run has added or removed coverage when compared to another, and is a better predictor of what information would be in the report.
+You need a known-good run to anchor the baseline against. Pick a recent run whose
+coverage reflects the state you want to hold the line at, typically a run on your
+base branch, then capture its per-view untested counts one of two ways.
 
-### Complete example
+**From the comparison script.** The script below is the same one you wire into
+CI. Run it once with no committed baseline and it writes the current run's numbers
+to `ui-coverage-baseline.next.json` without failing the build. Review that file,
+then commit it as `ui-coverage-baseline.json` so every later run compares against
+it. A CI runner is discarded after the job, so to capture that first candidate
+either run the script locally by replaying a recent run's CI context (see
+[Required CI environment variables](/ui-coverage/results-api#Required-CI-environment-variables)),
+or upload `ui-coverage-baseline.next.json` as a build artifact from the CI run.
 
-The following example demonstrates how to compare current results against a baseline, detect new views with untested elements, identify views where coverage has improved, and generate a new baseline on every run so that it's easy to copy and update if needed.
+<AccordionBlock title="View the comparison script">
+
+This script reads the committed baseline, fails the build when any view has
+_more_ untested elements than its baseline (or when a new view ships untested
+elements), and writes the current run's numbers to a separate candidate file so
+you can promote them when you're ready to accept a new state. Running it the first
+time with no baseline just writes the candidate for you.
 
 ```javascript title="scripts/compareUICoverageBaseline.js"
-require('dotenv').config()
-
-const { getUICoverageResults } = require('@cypress/extract-cloud-results')
 const fs = require('fs')
+const { getUICoverageResults } = require('@cypress/extract-cloud-results')
 
-// Define your baseline - this should be stored and updated as your application improves
-// Running the script once with no baseline will generate a baseline for you
-const baseline = {
-  runNumber: undefined,
-  runUrl: undefined,
-  views: [],
-}
+const BASELINE_FILE = 'ui-coverage-baseline.json'
+// Written on every run; promote it to BASELINE_FILE when you accept a new state.
+const CANDIDATE_FILE = 'ui-coverage-baseline.next.json'
 
-// Function to compare coverage between current results and baseline
-const compareTestedElementsWithBaseline = (currentResults, baselineData) => {
-  const testedElementsIssues = []
-  const testedElementsImprovements = []
-  const newPages = []
-
-  // Check if current results has views
-  if (!currentResults.views || !Array.isArray(currentResults.views)) {
-    console.log(
-      'Warning: Current results do not contain a valid "views" array. Skipping comparison.'
-    )
-    return {
-      testedElementsIssues,
-      testedElementsImprovements,
-      newPages,
-      hasChanges: false,
-    }
-  }
-
-  const currentViews = currentResults.views
-
-  // Check if baseline data has the expected structure
-  if (!baselineData.views) {
-    console.log(
-      'Warning: Baseline data does not contain "views" property. Skipping comparison.'
-    )
-    console.log('Current baseline structure:', Object.keys(baselineData))
-    return {
-      testedElementsIssues,
-      testedElementsImprovements,
-      newPages,
-      hasChanges: true,
-    }
-  }
-
-  const baselineViews = baselineData.views
-
-  // Ensure baselineViews is an array
-  if (!Array.isArray(baselineViews)) {
-    console.log('Warning: Baseline views is not an array. Skipping comparison.')
-    return {
-      testedElementsIssues,
-      testedElementsImprovements,
-      newPages,
-      hasChanges: true,
-    }
-  }
-
-  // Create a map of baseline testedElementsCount by displayName for quick lookup
-  const baselineTestedElementsMap = {}
-  baselineViews.forEach((view) => {
-    baselineTestedElementsMap[view.displayName] = view.testedElementsCount
-  })
-
-  // Create a map of current views by displayName to check for missing pages
-  const currentViewsMap = {}
-  currentViews.forEach((view) => {
-    currentViewsMap[view.displayName] = view.testedElementsCount
-  })
-
-  // Compare each current view with baseline
-  currentViews.forEach((currentView) => {
-    const pageName = currentView.displayName
-    const currentTestedElements = currentView.testedElementsCount
-    const pageExistsInBaseline = pageName in baselineTestedElementsMap
-
-    if (pageExistsInBaseline) {
-      const baselineTestedElements = baselineTestedElementsMap[pageName]
-      if (currentTestedElements < baselineTestedElements) {
-        testedElementsIssues.push({
-          page: pageName,
-          currentTestedElements: currentTestedElements,
-          baselineTestedElements: baselineTestedElements,
-          difference: baselineTestedElements - currentTestedElements,
-        })
-      } else if (currentTestedElements > baselineTestedElements) {
-        testedElementsImprovements.push({
-          page: pageName,
-          currentTestedElements: currentTestedElements,
-          baselineTestedElements: baselineTestedElements,
-          difference: currentTestedElements - baselineTestedElements,
-        })
-      }
-    } else {
-      // New page not in baseline
-      newPages.push({
-        page: pageName,
-        testedElementsCount: currentTestedElements,
-      })
-    }
-  })
-
-  // Check for pages in baseline that are missing from current results
-  // These are treated as regressions (0 tested elements)
-  baselineViews.forEach((baselineView) => {
-    const pageName = baselineView.displayName
-    if (!(pageName in currentViewsMap)) {
-      testedElementsIssues.push({
-        page: pageName,
-        currentTestedElements: 0,
-        baselineTestedElements: baselineView.testedElementsCount,
-        difference: baselineView.testedElementsCount,
-        isMissing: true,
-      })
-    }
-  })
-
-  const hasChanges =
-    testedElementsIssues.length > 0 ||
-    testedElementsImprovements.length > 0 ||
-    newPages.length > 0
-
-  return {
-    testedElementsIssues,
-    testedElementsImprovements,
-    newPages,
-    hasChanges,
-  }
-}
-
-function generateUICoverageBaseline(results) {
-  try {
-    // Generate simplified baseline with only runNumber, runUrl, and views with displayName and testedElementsCount
-    return {
-      runNumber: results.runNumber,
-      runUrl: results.runUrl,
-      views: results.views.map((view) => ({
-        displayName: view.displayName,
-        testedElementsCount: view.testedElementsCount,
-      })),
-    }
-  } catch (error) {
-    console.error('Error generating UI Coverage baseline:', error)
-    return null
-  }
-}
+const hasBaseline = fs.existsSync(BASELINE_FILE)
+const baseline = hasBaseline
+  ? JSON.parse(fs.readFileSync(BASELINE_FILE, 'utf8'))
+  : { runNumber: null, runUrl: null, views: {} }
 
 getUICoverageResults()
   .then((results) => {
-    // Compare tested elements count with baseline
-    const {
-      testedElementsIssues,
-      testedElementsImprovements,
-      newPages,
-      hasChanges,
-    } = compareTestedElementsWithBaseline(results, baseline)
+    const { runNumber, runUrl, uiCoverageReportUrl, summary, views } = results
 
-    if (hasChanges) {
-      // Generate and log the new baseline values if there has been a change
-      const newBaseline = generateUICoverageBaseline(results)
-      console.log('\nTo use this run as the new baseline, copy these values:')
-      console.log(JSON.stringify(newBaseline, null, 2))
-      fs.writeFileSync(
-        'new-UICbaseline.json',
-        JSON.stringify(newBaseline, null, 2)
-      )
+    // A cancelled or incomplete run can under-report views, which would look
+    // like a regression. Skip enforcement instead of failing for the wrong reason.
+    if (summary.isPartialReport) {
+      console.warn('Report is partial. Skipping baseline comparison.')
+      return
     }
 
-    // Log tested elements regressions
-    if (testedElementsIssues.length > 0) {
-      console.error('\n❌ TESTED ELEMENTS REGRESSION DETECTED!')
-      console.error(
-        'The following pages have fewer tested elements than the baseline:'
-      )
-      console.error('')
+    const newGaps = []
+    const improvements = []
 
-      testedElementsIssues.forEach((issue) => {
-        console.error(`  📄 ${issue.page}`)
-        if (issue.isMissing) {
-          console.error(
-            `     ⚠️  MISSING FROM REPORT (treated as 0 tested elements)`
-          )
-          console.error(
-            `     Current: 0 | Baseline: ${issue.baselineTestedElements} | Difference: -${issue.difference}`
-          )
-        } else {
-          console.error(
-            `     Current: ${issue.currentTestedElements} | Baseline: ${issue.baselineTestedElements} | Difference: -${issue.difference}`
-          )
+    views.forEach((view) => {
+      const current = view.untestedElementsCount
+      const previous = baseline.views[view.displayName]
+
+      if (previous === undefined) {
+        // A view with no baseline entry is new. Only flag it if it ships gaps.
+        if (current > 0) {
+          newGaps.push({
+            view: view.displayName,
+            previous: 0,
+            current,
+            url: view.uiCoverageReportUrl,
+          })
         }
-        console.error('')
-      })
+      } else if (current > previous) {
+        newGaps.push({
+          view: view.displayName,
+          previous,
+          current,
+          url: view.uiCoverageReportUrl,
+        })
+      } else if (current < previous) {
+        improvements.push({ view: view.displayName, previous, current })
+      }
+    })
 
+    // Save the current run's numbers as the next candidate baseline.
+    fs.writeFileSync(
+      CANDIDATE_FILE,
+      JSON.stringify(
+        {
+          runNumber,
+          runUrl,
+          views: Object.fromEntries(
+            views.map((view) => [view.displayName, view.untestedElementsCount])
+          ),
+        },
+        null,
+        2
+      )
+    )
+
+    // On the first run there's no committed baseline to compare against, so seed
+    // the candidate and exit cleanly. Commit it to start gating later runs.
+    if (!hasBaseline) {
+      console.log(
+        `No committed baseline yet. Wrote ${CANDIDATE_FILE}; commit it as ${BASELINE_FILE} to start gating.`
+      )
+      return
+    }
+
+    improvements.forEach(({ view, previous, current }) =>
+      console.log(`✅ ${view}: untested elements ${previous} → ${current}`)
+    )
+
+    if (newGaps.length > 0) {
+      console.error('\n❌ New untested elements were introduced:\n')
+      newGaps.forEach(({ view, previous, current, url }) =>
+        console.error(`   ${view}: ${previous} → ${current} untested (${url})`)
+      )
       console.error(
-        `Total pages with tested elements regression: ${testedElementsIssues.length}`
+        '\nAdd tests for the new elements, or exclude them with App Quality configuration.'
       )
-    }
-
-    // Log tested elements improvements
-    if (testedElementsImprovements.length > 0) {
-      console.log('\n✅ TESTED ELEMENTS IMPROVEMENTS DETECTED!')
-      console.log(
-        'The following pages have more tested elements than the baseline:'
-      )
-      console.log('')
-
-      testedElementsImprovements.forEach((improvement) => {
-        console.log(`  📄 ${improvement.page}`)
-        console.log(
-          `     Current: ${improvement.currentTestedElements} | Baseline: ${improvement.baselineTestedElements} | Difference: +${improvement.difference}`
-        )
-        console.log('')
-      })
-
-      console.log(
-        `Total pages with tested elements improvement: ${testedElementsImprovements.length}`
-      )
-    }
-
-    // Log new pages
-    if (newPages.length > 0) {
-      console.log('\n📝 NEW PAGES DETECTED (not in baseline):')
-      newPages.forEach((page) => {
-        console.log(
-          `  📄 ${page.page} - Tested Elements: ${page.testedElementsCount}`
-        )
-      })
-      console.log(`Total new pages: ${newPages.length}`)
-    }
-
-    // Summary
-    if (!hasChanges) {
-      console.log(
-        '\n✅ All pages meet or exceed baseline tested elements count!'
-      )
-    } else if (testedElementsIssues.length === 0) {
-      console.log('\n✅ No tested elements regressions detected!')
-    }
-
-    // Exit with error code if there are regressions
-    if (testedElementsIssues.length > 0) {
+      console.error(`Full report: ${uiCoverageReportUrl}`)
       process.exit(1)
     }
+
+    console.log('\n✅ No new untested elements against the baseline.')
   })
   .catch((error) => {
-    console.error('Error getting UI coverage results:', error)
+    console.error(`Could not compare UI Coverage results: ${error.message}`)
     process.exit(1)
   })
 ```
+
+</AccordionBlock>
+
+**From your editor with an AI assistant.** If you use an agent that supports
+[Cypress Cloud MCP](/cloud/integrations/cloud-mcp), you can build the baseline
+without wiring up CI first by having it pull the report and write the file:
+
+<CopyPrompt
+  title="Build a UI Coverage baseline with your AI assistant"
+  subtext="Pulls the UI Coverage report from Cypress Cloud and writes a baseline file you can commit."
+  prompt={`Using Cypress Cloud, pull the UI Coverage report for the latest run on main. Write a ui-coverage-baseline.json file with runNumber, runUrl, and a views object that maps each view's display name to its untested element count.`}
+/>
+
+Review the generated file the same way, then commit it. See
+[Work with AI agents](/ui-coverage/work-with-ai-agents) for more on using Cloud
+MCP with UI Coverage.
 
 ### Key concepts
 
 #### New untested elements
 
-A **new untested element** situation occurs when a view has untested elements in the current run but did not have untested elements in the baseline. This represents a regression in test coverage that needs to be addressed. The script will fail the build if any views with new untested elements are detected.
+A view has **new untested elements** when its `untestedElementsCount` is higher
+than the baseline, or when a view absent from the baseline appears with untested
+elements. This is a coverage regression: the change added interactive elements no
+test exercises. The script fails the build so the pull request can't merge until
+you cover them or exclude them.
 
-#### Resolved untested elements
+#### Resolved gaps
 
-A **resolved untested element** situation occurs when a view had untested elements in the baseline but no longer has untested elements in the current run. This represents an improvement in test coverage. The script reports these but does not fail the build, allowing you to track progress.
+A view has **resolved gaps** when its `untestedElementsCount` is lower than the
+baseline. This is an improvement: a change added coverage. The script reports
+these but doesn't fail the build, so progress is visible without blocking anyone.
 
 #### View-level comparison
 
-Untested elements are tracked per view (URL pattern or component), allowing you to see exactly which pages or components have coverage regressions or improvements. This granular tracking makes it easier to identify where new tests are needed or where coverage has improved.
+Untested elements are compared per [view](/ui-coverage/core-concepts/views) (a URL
+pattern for end-to-end tests, or a spec file for component tests), so the failure
+message points at the exact page or component where the new gap appeared, rather
+than a single project-wide number. Views are matched by `displayName`, so renaming
+a route or changing how views are grouped changes the key: an unchanged page can
+then look like a new view and trip the gate. Re-promote the baseline after changes
+like that.
 
-### Best practices
+## Wire the check into CI
 
-#### When to update the baseline
+Add a step to the CI workflow that runs your Cypress tests, after the
+`cypress run --record` step, that installs the Results API module and executes
+your verification script:
 
-Update your baseline when:
+```diff title="test_cypress.yaml"
+name: My Workflow
+on: push
 
-- You've added tests to cover previously untested elements and want to prevent regressions
-- You've accepted certain coverage gaps as known issues that won't block deployments
-- You want to track coverage improvements over time
+jobs:
+  run-tests:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+      - run: npm install
+      - name: Run Cypress tests
+        run: npx cypress run --record
+        env:
+          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
++     - name: Enforce UI Coverage policy
++       run: |
++          npm install --force https://cdn.cypress.io/extract-cloud-results/v1/extract-cloud-results.tgz
++          node ./scripts/compareUICoverageBaseline.js
++       env:
++         CYPRESS_PROJECT_ID: ${{ secrets.CYPRESS_PROJECT_ID }}
++         CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+```
 
-Store the baseline in version control so it's versioned alongside your code and accessible in CI environments.
+This example runs the baseline script. If you chose the
+[threshold policy](#Enforce-a-coverage-threshold) instead, run
+`verifyUICoverageResults.js` in that step, or run whichever script matches the
+policy you settled on.
 
-#### Handling partial reports
+When your script exits non-zero, the CI step fails, which surfaces as a failed
+**status check** on the pull request. To make that check _block_ the merge rather
+than just show red, mark it as required in your version control provider's branch
+protection settings (for example,
+[GitHub's required status checks](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#require-status-checks-before-merging)).
+Because enforcement lives entirely in your CI job, you control exactly when a
+coverage gap is advisory versus blocking.
 
-If a run is cancelled or incomplete, the Results API may return a partial report. Consider checking `summary.isPartialReport` before comparing against the baseline, as partial reports may not include all views and could produce false positives.
+See the [Results API CI setup](/ui-coverage/results-api#Add-the-verification-step-to-CI)
+for the equivalent step in GitLab, Jenkins, Azure, CircleCI, and other providers.
 
-#### Managing baseline across branches
+## Use Profiles for PR-specific configuration
 
-You may want different baselines for different branches (e.g., `main` vs feature branches). Consider storing baselines in branch-specific files or using environment variables to specify which baseline to use.
+A pull request check should be fast and focused, while your nightly regression
+run tracks everything. [Profiles](/ui-coverage/configuration/profiles) let you
+apply different [App Quality configuration](/ui-coverage/configuration/overview)
+to different runs based on their [run tags](/app/references/command-line#cypress-run-tag-lt-tag-gt),
+so both can share one Cypress Cloud project.
 
-#### Storing the baseline
+For example, this configuration defines a `pr-critical` profile that narrows PR
+runs to just the flows you gate merges on, while the base configuration still
+reports on everything for regression tracking:
 
-Common approaches for storing baselines:
+```json title="App Quality Config"
+{
+  "profiles": [
+    {
+      "name": "pr-critical",
+      "comment": "Narrow, fast config for PR runs: only the flows we block merges on",
+      "config": {
+        "viewFilters": [
+          { "pattern": "/checkout/*", "include": true },
+          { "pattern": "/login", "include": true },
+          { "pattern": "*", "include": false }
+        ]
+      }
+    }
+  ]
+}
+```
 
-- **Version control**: Commit the baseline JSON file to your repository
-- **CI artifacts**: Store baselines as build artifacts that can be retrieved in subsequent runs
-- **External storage**: Use cloud storage or a database for baselines if you need more sophisticated versioning
+Record your PR runs with the matching tag, and Cypress Cloud applies the profile
+automatically:
+
+```shell
+cypress run --record --tag pr-critical
+```
+
+When you record more than one run in a single CI build, pass the same tag to the
+helper so it returns the right run's results:
+
+```javascript title="Fetch results for a tagged run"
+getUICoverageResults({ runTags: ['pr-critical'] })
+```
+
+You can confirm which profile produced a report by reading the
+[`config`](/ui-coverage/results-api#Reading-the-applied-configuration) property on
+the result, which is useful for asserting that a PR run actually used the narrow
+configuration you expect.
+
+## Best practices
+
+### When to update the baseline
+
+Promote the candidate baseline (`ui-coverage-baseline.next.json`) to your
+committed `ui-coverage-baseline.json` when you:
+
+- Add tests that cover previously untested elements and want to lock in the gain.
+- Deliberately accept a new gap as known debt that shouldn't block deployments.
+- Want a fresh reference point after a large change to the application.
+
+Commit the baseline to version control so it's versioned alongside your code and
+available to every CI run.
+
+### Skip incomplete or non-passing runs
+
+A run can be cancelled, time out, or produce a partial report. The example
+already skips comparison when `summary.isPartialReport` is `true`; you can also
+check [`runStatus`](/ui-coverage/results-api#Result-properties) and skip
+enforcement for statuses like `cancelled` or `timedOut`, so an incomplete run
+warns instead of failing the build for the wrong reason. See
+[Skip enforcement for partial or non-passing runs](/ui-coverage/results-api#Skip-enforcement-for-partial-or-non-passing-runs).
+
+### Manage baselines across branches
+
+You may want different baselines for different branches. Store branch-specific
+baseline files, or use an environment variable to choose which baseline to load,
+so a long-lived feature branch doesn't fail against `main`'s numbers.
+
+### Where to store the baseline
+
+- **Version control** (recommended): commit the JSON file so it's reviewed and
+  versioned with the code that changed the coverage.
+- **CI artifacts**: store baselines as build artifacts retrieved on later runs.
+- **External storage**: use a database if you need richer versioning across many
+  projects.
 
 :::info
 
-This baseline comparison approach complements the [Branch Review](/ui-coverage/guides/compare-reports) UI feature, which provides visual comparisons between runs. The programmatic approach is ideal for CI/CD automation, while Branch Review is better suited for manual investigation and code review workflows.
+This programmatic baseline complements the
+[Branch Review](/ui-coverage/guides/compare-reports) UI, which visually compares
+two runs. Use the script to gate merges automatically in CI, and Branch Review
+for manual investigation during code review.
 
 :::
+
+## See also
+
+- [Results API](/ui-coverage/results-api): the full `getUICoverageResults`
+  reference and more enforcement examples.
+- [Monitor changes](/ui-coverage/guides/monitor-changes): track coverage trends
+  and catch regressions over time.
+- [Compare reports](/ui-coverage/guides/compare-reports): diff two runs visually
+  with Branch Review.
+- [Profiles](/ui-coverage/configuration/profiles): apply different configuration
+  to runs using run tags.
+- [Identify coverage gaps](/ui-coverage/guides/identify-coverage-gaps) and
+  [Address coverage gaps](/ui-coverage/guides/address-coverage-gaps): find the
+  gaps a policy will block, and close them.
+- [UI Coverage FAQ](/ui-coverage/faq#Results-API-and-CI): quick answers to common
+  Results API, baseline, and CI questions.


### PR DESCRIPTION
## Summary

Rework the UI Coverage **Block pull requests and set policies** guide into a followable, accurate policy workflow; expand and tighten the UI Coverage FAQ; add a `CopyPrompt` authoring guideline; and standardize `actions/checkout` on `@v7` across the docs.

## Why

The existing guide had thin, stubby sections and an internally inconsistent baseline example. Verifying against the actual `@cypress/extract-cloud-results` implementation in `cypress-services` surfaced real inaccuracies:

- The "Baseline structure" used `testedElements`, a property that does not exist (the Results API only exposes `...Count` fields), and it was structurally inconsistent with the script below it.
- The script compared **tested**-element counts while claiming to detect **new untested** elements, which it would actually miss (adding untested controls leaves the tested count unchanged).
- The example failed the build on the very first run, contradicting its own prose.

The rework leads with the merge-gate value, offers a clear threshold-vs-baseline policy choice, and ships a corrected baseline example. The FAQ gains Results API policy entries, and every Q&A pair is now self-contained (references both Cypress and UI Coverage) for search and answer engines.

## Notes for reviewers

Four logical commits:

1. **Rework the guide** — value-first intro, policy-choice table, corrected baseline example (compares `untestedElementsCount`, seeds the baseline cleanly on the first run), comparison script in a collapsed accordion, baseline-build steps incl. a Cloud MCP prompt, a required-status-check mechanism, `App Quality Config` titles, and a See also section. The `#comparing-against-a-baseline` anchor is preserved (Results API and Accessibility docs link to it).
2. **FAQ** — new Results API policy FAQs; every question/answer pair now mentions both Cypress and UI Coverage. Edits are answer-side only, so all question anchors are unchanged.
3. **CopyPrompt authoring guideline** in `AGENTS.md` / `AGENTS_REFERENCE.md`.
4. **`actions/checkout@v7`** — bumps the remaining `@v6` examples (incl. the canonical `github-actions.mdx`) to the current latest for consistency.

Verified: prettier and frontmatter lint pass, all embedded JS/JSON parse, no em dashes.

One follow-up intentionally left out: a screenshot of a blocked PR / failed status check for the guide. Every existing status-check image is Accessibility- or Cypress-Cloud-specific and would misrepresent the custom-CI-step mechanism this guide describes, so a new asset needs to be captured before it can be added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0123Ca7L8wNctdXxtR8LctS9

---
_Generated by [Claude Code](https://claude.ai/code/session_0123Ca7L8wNctdXxtR8LctS9)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes (guides, FAQ, agent conventions, example workflow pins) with no runtime or application code impact.
> 
> **Overview**
> **Reworks the UI Coverage “Block pull requests and set policies” guide** into a merge-gate workflow: policy choice (threshold vs baseline), prerequisites, corrected baseline JSON and comparison script using `untestedElementsCount` (with first-run seeding and partial-report handling), CI wiring, Profiles, and a Cloud MCP `<CopyPrompt>` for baseline creation. Updates meta description and preserves `#comparing-against-a-baseline`.
> 
> **Expands the UI Coverage FAQ** with Results API / PR-gating Q&As (threshold vs baseline, storing baselines, score vs untested counts) and tightens answers so each pair names Cypress and UI Coverage for search.
> 
> **Adds `<CopyPrompt>` authoring guidance** in `AGENTS.md` and `AGENTS_REFERENCE.md`: write `subtext` as the reader outcome, not “copies a prompt for AI.”
> 
> **Standardizes GitHub Actions examples** from `actions/checkout@v6` to `@v7` across CI docs (including `github-actions.mdx`, test-performance, and Accessibility Results API workflow snippet).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d55901b9ff1279149a08b425ed18923b4ec1e4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->