### PR TITLE
docs(accessibility): lead Group & name views with value, add view-grouping FAQs

### DIFF
--- a/docs/accessibility/configuration/views.mdx
+++ b/docs/accessibility/configuration/views.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Views: URLs and components in Accessibility'
-description: 'Cypress Accessibility automatically groups certain URL patterns to create views. For URLs that are not automatically grouped, the views property allows you to specify your own URL patterns that represent views.'
+title: 'views: group URLs with URL patterns in Cypress Accessibility'
+description: 'The views configuration groups related URLs into a single view in Cypress Accessibility using URL patterns, so accessibility reports and scores are organized around the real pages of your application instead of the shape of your test data.'
 sidebar_label: 'Group & name views'
 sidebar_position: 20
 ---
@@ -9,11 +9,17 @@ sidebar_position: 20
 
 # Group & name views - `views`
 
-Views work the same way in Cypress Accessibility and UI Coverage. To learn how views are created by default, see [Views in UI Coverage](/ui-coverage/core-concepts/views).
+Cypress Accessibility organizes every report around **views**, the distinct pages and components of your application. Each view collects the [snapshots](/accessibility/guides/run-level-reports#Snapshots) captured on that page and reports the accessibility violations found there, so you review, score, and track each part of your app as a unit.
+
+The `views` configuration controls that grouping. Without it, URLs that differ only by a username, slug, or other non-numeric value each become their own view, so a single violation on a shared page template is reported once per URL and one issue is split across many rows. A `views` pattern rolls those URLs into one view, so you triage the violation once for the whole page and your report reflects the structure of your application, not the shape of your test data.
+
+The reference below covers the full `views` syntax, including how URLs are matched, the `groupBy` option, and worked examples.
 
 <Views />
 
 ## See also
 
-- [`viewFilters` configuration](/accessibility/configuration/viewfilters): exclude URLs from your reports
+- [Views in accessibility reports](/accessibility/guides/run-level-reports#Views): how views organize your report and per-view score
+- [`viewFilters` configuration](/accessibility/configuration/viewfilters): exclude URLs from your reports instead of grouping them
 - [Configuration overview](/accessibility/configuration/overview): how to set configuration for your project
+- [Cypress Accessibility FAQ](/accessibility/faq#Grouping-and-naming-views): common questions about grouping and naming views

--- a/docs/accessibility/faq.mdx
+++ b/docs/accessibility/faq.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Cypress Accessibility FAQ'
-description: 'Get answers to common questions about Cypress Accessibility, including ignoring elements with elementFilters, excluding URLs with viewFilters, the Ignored status, score impact, element identification, configuration, and per-run profiles.'
+description: 'Get answers to common questions about Cypress Accessibility, including grouping and naming views, ignoring elements with elementFilters, excluding URLs with viewFilters, the Ignored status, score impact, element identification, configuration, and per-run profiles.'
 sidebar_label: FAQ
 sidebar_position: 160
 ---
@@ -42,6 +42,32 @@ Yes. An `elementFilters` list at the root of your configuration applies to both 
 ### <Icon name="angle-right" /> Does include: true do anything in Cypress Accessibility?
 
 Not on its own. Every element is included unless an exclude rule matches it, and an include rule can't protect an element from exclusion. The value matters in root-level `elementFilters` lists shared with UI Coverage, where include rules do protect their elements. See [When to use include: true](/accessibility/configuration/elementfilters#When-to-use-include-true).
+
+## Grouping and naming views
+
+### <Icon name="angle-right" /> Why do similar URLs show up as separate views in my accessibility report?
+
+Automatic grouping only replaces path segments that are numbers or IDs (UUIDs and UUID-like values) with a wildcard. Segments like usernames or slugs aren't recognized as dynamic, so `/users/alice` and `/users/bob` stay separate views, and a violation on that shared template is reported once per URL. Add a [`views`](/accessibility/configuration/views) pattern to group them into one view and triage the issue once.
+
+### <Icon name="angle-right" /> Do query parameters create separate views in Cypress Accessibility?
+
+No. Query strings are ignored when grouping, so `/dashboard?tab=overview` and `/dashboard?tab=settings` become a single `/dashboard` view. If a query parameter meaningfully changes the page, use a [`views`](/accessibility/configuration/views) pattern with `groupBy` on that parameter to report on each value separately.
+
+### <Icon name="angle-right" /> How do I create a separate accessibility view for each value of a URL parameter?
+
+Write a [`views`](/accessibility/configuration/views) pattern that names the parameter, then list that name in `groupBy`. For a pattern like `/analytics/:type/:id`, `groupBy: ["type"]` creates a distinct view for each `type` value (such as `/analytics/performance/:id` and `/analytics/usage/:id`) while still collapsing the dynamic `:id`. `groupBy` accepts a single string or an array of strings, and each name can come from the path, query string, or hash. See [Using groupBy](/accessibility/configuration/views#Using-groupBy).
+
+### <Icon name="angle-right" /> Does grouping URLs into a view change my accessibility score?
+
+Not your run-level score. The [run score](/accessibility/core-concepts/accessibility-score) averages every snapshot in the run regardless of how snapshots are grouped, so grouping URLs into a view reorganizes the report without moving the top-line number. What changes is the per-view score: the snapshots you group roll up into one view's score instead of several, which makes each page's accessibility easier to read and track over time.
+
+### <Icon name="angle-right" /> What's the difference between views and viewFilters in Cypress Accessibility?
+
+They do opposite things. [`views`](/accessibility/configuration/views) _keeps_ URLs but changes how they're grouped and named, so related pages collapse into a single view or a dynamic route splits into several. [`viewFilters`](/accessibility/configuration/viewfilters) _removes_ URLs, so matching snapshots are never scanned and don't appear in your report or score. Use `views` to organize the pages you scan, and `viewFilters` for pages you don't own or intend to remediate.
+
+### <Icon name="angle-right" /> Can I configure views for Cypress Accessibility without affecting UI Coverage?
+
+No. Unlike [`viewFilters`](/accessibility/configuration/viewfilters) and [`elementFilters`](/accessibility/configuration/elementfilters), `views` is defined only at the root of your configuration and can't be nested under an `accessibility` or `uiCoverage` key. A single set of view patterns groups URLs the same way for both products. To exclude a URL from one product only, use a nested `viewFilters` list instead. See [Scope](/accessibility/configuration/views#Scope).
 
 ## Ignoring views and URLs
 
@@ -121,6 +147,7 @@ There's no dedicated "skip this run" switch in a profile. To suppress a report f
 ## See also
 
 - [Configuration overview](/accessibility/configuration/overview) lists every configuration option and what each one is for.
+- [`views`](/accessibility/configuration/views) is the full reference for grouping and naming views.
 - [`profiles`](/accessibility/configuration/profiles) apply different configuration to runs based on run tags.
 - [`elementFilters`](/accessibility/configuration/elementfilters) is the full reference for ignoring elements.
 - [`viewFilters`](/accessibility/configuration/viewfilters) is the full reference for excluding URLs.

--- a/docs/partials/_views.mdx
+++ b/docs/partials/_views.mdx
@@ -266,6 +266,6 @@ A pattern that doesn't match any URLs in the run is dropped from the report. Con
 
 Each name in `groupBy` must appear in `pattern` as a named parameter. For example, `groupBy: ["type"]` requires `:type` somewhere in the pattern's path, query string, or hash.
 
-### Error: `No duplicate values allowed`
+### Error: `No duplicate values allowed - "..." was added multiple times`
 
-Each pattern in `views` must be unique. Named parameters are compared as wildcards, so `/users/:name` and `/users/*` count as the same pattern.
+Each pattern in `views` must be unique. Named parameters are compared as wildcards, so `/users/:name` and `/users/*` count as the same pattern and trigger this error.


### PR DESCRIPTION
## Summary

Reworks the Cypress Accessibility **Group & name views** (`views`) configuration page to open with accessibility-specific value instead of a bare cross-reference, and adds a **Grouping and naming views** section to the Accessibility FAQ. The `views` reference was verified against the actual `cypress-services` implementation.

## Why

The accessibility `views` page previously led with "Views work the same way in Cypress Accessibility and UI Coverage" and pushed readers to the UI Coverage docs to understand it, so an accessibility user never learned *why* grouping views matters for their reports. It also had no FAQ coverage for the most common view-grouping questions.

To make sure the guidance is correct, the documented behavior was checked against the implementation in `cypress-services` (`discovery/packages/common/src/views.ts`, `ViewPattern.ts`, and the Zod schema in `packages/validations`). All documented claims — automatic numeric/UUID grouping, the `pattern`/`groupBy`/`comment` schema (plus the bare-string form), the root-only scope that can't be nested per product, URL Pattern API matching, `groupBy` semantics, first-match ordering, `viewFilters` precedence, query-string handling, component-test views, and view naming — were confirmed. The one correction: the duplicate-pattern error message was quoted in truncated form.

Changes:

- Rewrite the accessibility `views` page intro to explain how views organize the accessibility report and why grouping dynamic URLs lets you triage a violation once per page instead of once per URL. The page is now self-contained within the accessibility docs.
- Update the page title/description for SEO/AEO and expand its **See also** section.
- Add a **Grouping and naming views** FAQ section (why similar URLs split, query params, `groupBy`, score impact, `views` vs `viewFilters`, and the root-only scope shared with UI Coverage), and surface it in the FAQ description and **See also**.
- Correct the duplicate-pattern error string in the shared `_views.mdx` partial to match the actual message.

## Notes for reviewers

- `_views.mdx` is a **shared partial** rendered by both the accessibility and UI Coverage `views` pages, so the error-string correction there appears on both pages. That's intended — it's an accuracy fix that applies to both products.
- Frontmatter linter passes (321 docs), Prettier is clean on all touched files, and every internal link/anchor was verified to resolve (including the `run-level-reports` path after it moved from `core-concepts/` to `guides/` in #6757, which `main` was merged in to pick up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Kxe9w6VA1FZeWHEdLFRmA

---
_Generated by [Claude Code](https://claude.ai/code/session_012Kxe9w6VA1FZeWHEdLFRmA)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or configuration behavior impact.
> 
> **Overview**
> **Reworks the Cypress Accessibility `views` configuration page** so it stands on its own instead of deferring to UI Coverage. The intro now explains how views organize accessibility reports, why ungrouped dynamic URLs duplicate violations, and how `views` patterns fix that. Title, description, and **See also** links were updated for discoverability (run-level reports, FAQ, `viewFilters` contrast).
> 
> **Adds a "Grouping and naming views" FAQ** covering separate views for similar URLs, query-parameter behavior, `groupBy`, run vs per-view scores, `views` vs `viewFilters`, and root-only scope shared with UI Coverage. The FAQ meta description and **See also** now point at the `views` reference.
> 
> **Fixes the shared `_views.mdx` partial** so the documented duplicate-pattern error matches the real message: `No duplicate values allowed - "..." was added multiple times` (affects both Accessibility and UI Coverage `views` pages).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd5d7e1aeec281544e32a943b70e52cc14c2317d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->