### PR TITLE
docs(ui-coverage): improve FAQ SEO/AEO and close content gaps

### DIFF
--- a/docs/ui-coverage/faq.mdx
+++ b/docs/ui-coverage/faq.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'UI Coverage FAQ'
+title: 'Cypress UI Coverage FAQ'
 description: 'Answers to common questions about Cypress UI Coverage: how it differs from code coverage, coverage scores, closing gaps, configuration, and the Results API.'
 sidebar_label: FAQ
 sidebar_position: 160
@@ -7,7 +7,7 @@ sidebar_position: 160
 
 <ProductHeading product="ui-coverage" />
 
-# UI Coverage FAQ
+# Cypress UI Coverage FAQ
 
 ## General
 
@@ -58,6 +58,10 @@ Yes, and no. UI Coverage analyzes the rendered DOM captured by [Test Replay](/cl
 ### <Icon name="angle-right" /> What's the difference between UI Coverage and Cypress Accessibility?
 
 Both are Cypress Cloud [App Quality](/ui-coverage/configuration/overview) features built on the same [Test Replay](/cloud/features/test-replay) data, and both need no code changes. They measure different things: UI Coverage tells you _how much_ of your interactive UI your tests exercise (a coverage score plus untested elements and links), while [Cypress Accessibility](/accessibility/get-started/introduction) tells you _whether_ the UI your tests render has accessibility violations. They share configuration properties like [`viewFilters`](/ui-coverage/configuration/viewfilters) and [`elementFilters`](/ui-coverage/configuration/elementfilters), which you can scope to one product or the other. See [Configuration scope](/ui-coverage/configuration/overview#Configuration-scope).
+
+### <Icon name="angle-right" /> Can I use UI Coverage with AI agents?
+
+Yes. Because every report is structured data about which interactive elements your tests exercised, a compatible AI agent can read it and act on it through the [Cypress Cloud MCP](/cloud/integrations/cloud-mcp). An agent can pull a run's coverage score and untested elements, summarize the biggest gaps, correlate a coverage drop with specific specs, and draft targeted tests to close the gaps, while your team keeps ownership of what "enough coverage" means for each area. See [Use AI agents with UI Coverage](/ui-coverage/work-with-ai-agents) for example prompts and how to tune reports for clearer agent signal.
 
 ## Finding coverage gaps
 
@@ -140,6 +144,20 @@ No. Branch Review compares two runs that are already recorded to Cypress Cloud, 
 ### <Icon name="angle-right" /> Can I compare UI Coverage reports with an AI agent or the Cypress Cloud MCP?
 
 Yes. The [Cypress Cloud MCP](/cloud/integrations/cloud-mcp) lets a compatible AI agent pull the UI Coverage for two runs and report the diff from your editor, using `cypress_get_runs` to find the runs and `cypress_get_ui_coverage_report`, `cypress_get_ui_coverage_views`, and `cypress_get_ui_coverage_elements` to read each run's coverage. There's no single compare tool; the agent assembles the diff and can then draft a test to close a regression. It's a peer to Branch Review, which remains the place to see full-page DOM snapshots of what changed. See [Compare reports with the Cypress Cloud MCP](/ui-coverage/guides/compare-reports#Compare-reports-with-the-Cypress-Cloud-MCP).
+
+## Monitoring coverage over time
+
+### <Icon name="angle-right" /> How do I track my UI Coverage score over time?
+
+Record runs on a regular cadence so there's always something to compare, then watch the direction the score moves rather than a single number. Record a run for every pull request to catch regressions before they merge, and add a scheduled job (such as a nightly CI cron) that records against a stable environment for a consistent baseline that isn't affected by which files a given pull request touched. From there, [Branch Review](/cloud/features/branch-review) diffs any two runs and the [Results API](/ui-coverage/results-api) enforces the trend in CI. See [Monitor changes](/ui-coverage/guides/monitor-changes) for the full workflow.
+
+### <Icon name="angle-right" /> How do I get notified when my UI Coverage changes?
+
+Connect [Slack](/cloud/integrations/slack) or [Microsoft Teams](/cloud/integrations/microsoft-teams) to your project so your team is alerted whenever a run finishes, with Slack surfacing UI Coverage results directly. To put the change in front of reviewers, connect a version control integration ([GitHub](/cloud/integrations/github#Pull-request-comments), [GitLab](/cloud/integrations/gitlab#Merge-Request-comments), or [Bitbucket](/cloud/integrations/bitbucket#Pull-Request-comments)) so Cypress Cloud comments on each pull request with the run summary and a link straight to Branch Review. See [Monitor changes](/ui-coverage/guides/monitor-changes#Step-1-Record-runs-on-a-regular-cadence).
+
+### <Icon name="angle-right" /> Can I see UI Coverage trends across all my projects?
+
+Yes. [Enterprise Reporting](/cloud/features/analytics/enterprise-reporting#UI-Coverage) in Cypress Cloud, available on the Enterprise plan, rolls UI Coverage trends up across every project in your organization rather than one run at a time. You can view high-level trends, download reports, or pull the numbers through the [data extract API](/cloud/integrations/data-extract-api) to build your own dashboards. See [Track trends across projects](/ui-coverage/guides/monitor-changes#Step-4-Track-trends-across-projects).
 
 ## Reducing test duplication
 
@@ -539,6 +557,8 @@ Start by [regenerating the run](/ui-coverage/configuration/overview#Setting-conf
 ## See also
 
 - [Troubleshooting UI Coverage](/ui-coverage/troubleshooting) maps common report problems to their causes and fixes.
+- [Monitor changes](/ui-coverage/guides/monitor-changes) sets up a repeatable workflow to track coverage trends and catch regressions before they merge.
+- [Work with AI agents](/ui-coverage/work-with-ai-agents) uses the Cypress Cloud MCP to read reports, summarize gaps, and draft tests.
 - [Results API](/ui-coverage/results-api) fetches a run's UI Coverage results in CI so you can enforce coverage standards.
 - [Configuration overview](/ui-coverage/configuration/overview) lists every configuration option and what each one is for.
 - [Profiles](/ui-coverage/configuration/profiles) apply different configuration to runs based on run tags.

--- a/plugins/faq-structured-data.js
+++ b/plugins/faq-structured-data.js
@@ -112,6 +112,8 @@ function toPlainText(markdown) {
   text = text.replace(/^\s{0,3}(?:[-*+]|\d+\.)\s+/gm, ' ')
   // Heading markers
   text = text.replace(/^#{1,6}\s+/gm, ' ')
+  // Explicit heading IDs (Docusaurus/Markdown): "Title {#custom-id}"
+  text = text.replace(/\{#[\w-]+\}/g, ' ')
   // Inline code backticks
   text = text.replace(/`([^`]*)`/g, '$1')
   // Bold / italic / strikethrough markers

--- a/plugins/faq-structured-data.test.js
+++ b/plugins/faq-structured-data.test.js
@@ -80,6 +80,12 @@ describe('toPlainText', () => {
     )
   })
 
+  test('strips explicit heading id attributes', () => {
+    expect(
+      toPlainText('What is Test Generation? {#What-is-Test-Generation}')
+    ).toBe('What is Test Generation?')
+  })
+
   test('unescapes markdown backslash escapes', () => {
     expect(toPlainText('version 1\\.0 costs \\#1 priority')).toBe(
       'version 1.0 costs #1 priority'


### PR DESCRIPTION
## Summary

Polishes the UI Coverage FAQ for search and answer-engine discoverability and closes two content gaps, without rewriting the existing (well-authored) answers. Also hardens the shared FAQ structured-data generator so leftover heading-ID text no longer leaks into the JSON-LD that answer engines cite.

## Why

The UI Coverage FAQ is already the most complete FAQ in the docs, but a read-through surfaced concrete, low-risk improvements:

- **SEO — brand keyword missing from the `<title>`.** The page title/H1 were `UI Coverage FAQ`, while the sibling is `Cypress Accessibility FAQ`. The `<title>` tag is a top ranking signal, so both now read **`Cypress UI Coverage FAQ`** for brand + keyword coverage and cross-page consistency.
- **AEO — structured-data pollution.** `plugins/faq-structured-data.js` (`toPlainText`) didn't strip Docusaurus explicit heading IDs (`{#custom-id}`). As a result the Test Generation question shipped `{#What-is-Test-Generation-in-Cypress-UI-Coverage}` as literal text inside its schema.org `Question.name` — the exact string AI answer engines quote. Added a one-line strip plus a unit test; the generated name is now clean (`"What is Test Generation in Cypress UI Coverage?"`). This fix applies to every FAQ page the plugin processes.
- **Completeness — two orphaned guides.** `monitor-changes` and `work-with-ai-agents` were never linked from the FAQ. Added a **"Monitoring coverage over time"** section (tracking score over time, notifications, cross-project trends) and a general **"Can I use UI Coverage with AI agents?"** question, and linked both guides from **See also**. FAQ grew 114 → 118 questions.

## Notes for reviewers

- Changes are additive; no existing answer prose was rewritten.
- All link targets and heading anchors were verified to resolve.
- `plugins/faq-structured-data.test.js` passes (37 tests), including the integration test that recomputes entry counts and re-validates well-formed `FAQPage` JSON-LD for the modified FAQ. `prettier --check` is clean on all three files.
- If you'd prefer the visible H1 stay `UI Coverage FAQ` and only the `<title>` carry the brand, that's a one-line change — happy to adjust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016JFjBzqb6LBRfp6UeGS321)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation additions and a localized plain-text cleanup in the FAQ structured-data plugin; no runtime product or security-sensitive code paths.
> 
> **Overview**
> **Brands the UI Coverage FAQ** by updating the page `<title>` and H1 to **Cypress UI Coverage FAQ**, aligning with the Accessibility FAQ for SEO.
> 
> **Closes content gaps** with a new **Monitoring coverage over time** section (tracking scores, notifications, cross-project trends), a **Can I use UI Coverage with AI agents?** answer, and **See also** links to `monitor-changes` and `work-with-ai-agents`. Existing answers are unchanged.
> 
> **Fixes FAQ JSON-LD text** in `toPlainText` by stripping Docusaurus explicit heading IDs (`{#custom-id}`) so they no longer appear in schema.org `Question.name` on any FAQ page the plugin processes; adds a unit test for the strip.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 835e9c837eb46bae6b868e207cd4eafbfd348bbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->