### PR TITLE
docs(accessibility): rework config overview for accuracy, add FAQs, share partials

### DIFF
--- a/docs/accessibility/configuration/overview.mdx
+++ b/docs/accessibility/configuration/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: Configure Cypress Accessibility
-description: 'Customize Cypress Accessibility element identification, filters, profiles, and Axe Core® rules'
+description: 'Configure Cypress Accessibility to get an accessibility score you can trust: group URLs into views, ignore third-party elements, identify violations by your own attributes, and scope reports to the application you own.'
 sidebar_label: Overview
 sidebar_position: 10
 ---
@@ -9,66 +9,84 @@ sidebar_position: 10
 
 # Configuration overview
 
-Configuration allows you to customize and fine-tune accessibility reports in Cypress. While Cypress Accessibility is designed to work seamlessly out of the box, there are instances where custom configuration may be necessary, or preferred. Using configuration, you can avoid reporting on pages or elements that don't matter to your team, combine related urls together into a single View, and modify the element identification and deduplication behavior to reflect your application's specific structure.
+Cypress Accessibility works out of the box with no setup, but a few lines of configuration make your reports match your application. Configuration lets you get an [accessibility score](/accessibility/core-concepts/accessibility-score) you can trust and act on by:
 
-**Note**: By default, setting configuration is limited to Admin users. At your request, this can be changed to allow setting config by all users. Reach out to your Cypress point-of-contact if you would like to change this.
+- **Reporting on the application you own**: ignore third-party widgets, embedded content, and pages outside your control so violations you can't fix stop counting against your score.
+- **Organizing reports around your product**: group related URLs into [views](/accessibility/configuration/views) that map to real pages and flows, so a violation on a shared template is triaged once instead of once per URL.
+- **Speaking your team's vocabulary**: identify violation targets by your own attributes, such as a component name or automation ID, so an issue reads as "the ProductImage component" instead of a generated selector.
+- **Stabilizing identification across snapshots**: stop dynamic or auto-generated attributes from splitting one element into many, so the same element is recognized as one across the many snapshots in a run.
+
+You don't need any of this to get started, and you can add it incrementally. Reprocess a past run after each change to see the effect immediately, without re-running your tests.
 
 ## Setting Configuration
 
-To add or modify the configuration for your project, navigate to the "App Quality" tab in your project settings.
+<AppQualityConfigEditing />
 
 <DocsImage
   src="/img/accessibility/configuration/cypress-accessibility-configuration-editor.png"
-  alt="The Cypress Cloud UI showing the configuration editor"
+  alt="The App Quality tab of a project's settings in Cypress Cloud, showing the configuration editor with JSON configuration"
 />
 
-You can use the provided editor to write configuration in JSON format.
+After you save configuration changes, you can reprocess any historical run to apply them. You can start a reprocess from two places:
 
-After new configuration changes have been saved, you can reprocess any historical run using the "regenerate" button on the properties tab where the configuration values that were used for that run are displayed.
-
-This allows you to iterate on the config quickly without having to execute test runs and wait for the results. You can try out different configurations and see what effects your changes have to make sure everything works the way you intend.
-
-## Viewing Configuration for a Run
-
-You can view configuration information for each run in the Properties tab, as shown below. This configuration is determined when your run begins.
+- The **Properties** tab, using the "regenerate" button next to the configuration values that were used for that run.
+- The accessibility report, using the "configuration updated" message that appears when you view a historical run that was processed with an older configuration.
 
 <DocsImage
   src="/img/accessibility/configuration/cypress-cloud-properties-tab-application-quality-config.png"
-  alt="The properties tab for a run, with an Application Quality section at the bottom"
+  alt="The Properties tab of a run in Cypress Cloud, showing the Application Quality configuration that was applied and the regenerate button used to reprocess the run"
 />
 
-## Comments
+Regenerating reports in this way lets you iterate on configuration and see the effects immediately, without running your Cypress tests again.
 
-All configuration objects support an optional `comment` property that you can use to provide context and explanations for why certain values are set. This helps make your configuration easier to understand and maintain, especially when working in teams or revisiting configuration after some time.
+<AppQualityConfigWhoCanEdit />
 
-```json
+## Configuration options
+
+### Which option do I need?
+
+Several options change what appears in reports and how it's organized. Pick the one that matches your goal:
+
+| Your goal                                                      | Use                                                                                     |
+| -------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| Group related URLs into a single view                          | [`views`](/accessibility/configuration/views)                                           |
+| Remove entire pages or URLs from reports                       | [`viewFilters`](/accessibility/configuration/viewfilters)                               |
+| Remove elements from reports and the score entirely            | [`elementFilters`](/accessibility/configuration/elementfilters)                         |
+| Enable, disable, or tune individual Axe Core® rules            | [Axe Core® configuration](/accessibility/configuration/axe-core-configuration)          |
+| Keep an element but ignore specific rules for it               | [`data-a11y-ignore` attribute](/accessibility/configuration/ignoring-rules-per-element) |
+| Identify violation targets by your own attributes              | [`significantAttributes`](/accessibility/configuration/significantattributes)           |
+| Stop dynamic or generated attributes from identifying elements | [`attributeFilters`](/accessibility/configuration/attributefilters)                     |
+| Add component context to violation-target selectors            | [`components`](/accessibility/configuration/components)                                 |
+| Apply different configuration to runs based on run tags        | [`profiles`](/accessibility/configuration/profiles)                                     |
+
+### Comments
+
+Most configuration rules support an optional `comment` property that you can use to record why a value is set. This makes your configuration easier to understand and maintain, especially when working in a team or revisiting configuration after some time. Any rule defined as an object accepts a `comment`; the options that are plain lists of strings, such as [`significantAttributes`](/accessibility/configuration/significantattributes), do not take a per-entry comment.
+
+A `comment` lives inside the rule and has no effect on behavior. Comments appear only in the configuration itself and are never displayed in reports. Because Cypress Cloud validates every rule and rejects properties it doesn't recognize, `comment` is the supported place to keep notes.
+
+```json title="App Quality Config"
 {
   "elementFilters": [
     {
-      "selector": "[data-testid*='temp']",
+      "selector": "#onetrust-banner-sdk, #onetrust-banner-sdk *",
       "include": false,
-      "comment": "Exclude temporary test elements from accessibility reports"
+      "comment": "Third-party cookie consent banner, violations reported upstream to the vendor"
     }
   ]
 }
 ```
 
-## Profiles
+### Full configuration reference
 
-The `profiles` property allows you to use different configuration settings for different runs based on [run tags](/app/references/command-line#cypress-run-tag-lt-tag-gt). See the [Profiles](/accessibility/configuration/profiles) guide for more details.
+The shape of every available option, with the type each value expects. Every property is optional, and you only include the ones you need:
 
-## Complete configuration example
-
-A complete configuration with all available options looks as follows:
-
-```json
+```json title="App Quality Config"
 {
   "views": [
     {
       "pattern": string,
-      "groupBy": [
-        string
-      ],
+      "groupBy": string | [string],
       "comment": string
     }
   ],
@@ -87,9 +105,7 @@ A complete configuration with all available options looks as follows:
       "comment": string
     }
   ],
-  "significantAttributes": [
-    string
-  ],
+  "significantAttributes": [string],
   "attributeFilters": [
     {
       "attribute": string,
@@ -98,22 +114,31 @@ A complete configuration with all available options looks as follows:
       "comment": string
     }
   ],
-  "components": {
-    "componentAttributes": [
-      {
-        "attributeName": string,
-        "includeInSelector": boolean,
-        "comment": string
-      }
-    ],
-    "componentAttributeFilters": [
-      {
-        "attribute": string,
-        "value": string,
-        "include": boolean,
-        "comment": string
-      }
-    ],
+  "accessibility": {
+    // Any of the shared properties above can be nested here to apply to
+    // Cypress Accessibility only, replacing the root value for that property.
+    "viewFilters": [ /* same shape as the root viewFilters */ ],
+    "elementFilters": [ /* same shape as the root elementFilters */ ],
+    "significantAttributes": [string],
+    "attributeFilters": [ /* same shape as the root attributeFilters */ ],
+    "components": {
+      "componentAttributes": [
+        {
+          "attributeName": string,
+          "includeInSelector": boolean,
+          "comment": string
+        }
+      ],
+      "componentAttributeFilters": [
+        {
+          "attribute": string,
+          "value": string,
+          "include": boolean,
+          "comment": string
+        }
+      ],
+      "comment": string
+    },
     "comment": string
   },
   "profiles": [
@@ -121,8 +146,69 @@ A complete configuration with all available options looks as follows:
       "name": string,
       "config": {
         // Any App Quality configuration options
-      }
+      },
+      "comment": string
     }
   ]
 }
 ```
+
+Two accessibility-specific controls live outside this JSON: [Axe Core® rule configuration](/accessibility/configuration/axe-core-configuration) is handled with your Account Executive, and the per-element [`data-a11y-ignore`](/accessibility/configuration/ignoring-rules-per-element) attribute is added to your application's markup.
+
+## How rules are applied
+
+A few behaviors govern the rules you write, and some of them differ from [UI Coverage](/ui-coverage/configuration/overview):
+
+- **`viewFilters`: first match wins.** URLs are compared against your rules top to bottom, and the first rule whose `pattern` matches decides whether that URL is included. List specific rules before broad, catch-all rules. URLs that match no rule are included by default.
+- **`elementFilters`: any exclude wins.** In Cypress Accessibility, an element is ignored when any `include: false` rule matches it, regardless of where the rule sits in the list, and an `include: true` rule can't protect an element from an exclusion elsewhere. This is different from UI Coverage, where the first matching rule wins. See [When to use include: true](/accessibility/configuration/elementfilters#When-to-use-include-true).
+- **`significantAttributes`: order sets priority.** The attributes you list are checked before the default attributes, in the order you list them, and the first one that uniquely identifies an element becomes its violation-target selector.
+- **Unknown properties are rejected.** When you save, Cypress Cloud validates your configuration against a strict schema and rejects anything it doesn't recognize, such as a misspelled property, a value of the wrong type, or a note on a property that doesn't accept one. Correct the flagged property to save, and keep freeform notes in a [`comment`](#Comments).
+
+## Configuration scope
+
+Some properties are shared across App Quality products, and some belong to Cypress Accessibility alone.
+
+- **Shared properties**: `viewFilters`, `elementFilters`, `significantAttributes`, and `attributeFilters` apply to both Cypress Accessibility and UI Coverage when set at the root of your configuration. To apply one to Cypress Accessibility only, nest it under an `accessibility` key. A nested value **completely replaces** the root-level value for that product (the two are not merged), so repeat any shared rules you still want in the nested list.
+- **Shared, but not nestable**: `views` applies to both Cypress Accessibility and UI Coverage and can only be set at the root.
+- **Accessibility only**: `components` shapes the violation-target selectors in your accessibility reports and is always set under the `accessibility` key. UI Coverage has its own product-only options (`elements`, `elementGroups`, and interaction commands) set under a `uiCoverage` key. See the [UI Coverage configuration overview](/ui-coverage/configuration/overview) for those.
+
+## Viewing Configuration for a Run
+
+Every run permanently records the exact configuration it was processed with, so the runs themselves are the history of how your configuration has changed over time. You can review a run's configuration in Cypress Cloud, or read it programmatically with the Results API.
+
+### In Cypress Cloud
+
+To review the configuration a specific run used, open its **Properties** tab, shown in the [Setting Configuration](#Setting-Configuration) screenshot above. This displays the configuration as it was applied when the run was processed. When you open a run that was processed with an older configuration than the one currently saved, the report flags it with a "configuration updated" message, and you can [regenerate](#Setting-Configuration) the run to reprocess it with the current configuration.
+
+### From the Results API
+
+The [Accessibility Results API](/accessibility/results-api) exposes the applied configuration on the `config` property of its result, so you can read it in a CI workflow:
+
+```js title="read-accessibility-config.js"
+const { getAccessibilityResults } = require('@cypress/extract-cloud-results')
+
+getAccessibilityResults().then((results) => {
+  if (results.config) {
+    // ISO timestamp of when the applied configuration was last saved
+    console.log(results.config.updatedAt)
+
+    // The App Quality configuration that was applied to the run
+    console.log(results.config.value)
+  }
+})
+```
+
+If no configuration was applied to the run, `config` may be absent, so check for it before reading `value`.
+
+## See also
+
+- [Group & name views](/accessibility/configuration/views)
+- [Exclude views](/accessibility/configuration/viewfilters)
+- [Exclude elements](/accessibility/configuration/elementfilters)
+- [Ignore rules per element](/accessibility/configuration/ignoring-rules-per-element)
+- [Axe Core® configuration](/accessibility/configuration/axe-core-configuration)
+- [Prioritize identifying attributes](/accessibility/configuration/significantattributes)
+- [Ignore attributes for identification](/accessibility/configuration/attributefilters)
+- [Define components](/accessibility/configuration/components)
+- [Override config by run tag](/accessibility/configuration/profiles)
+- [Cypress Accessibility FAQ](/accessibility/faq)

--- a/docs/accessibility/faq.mdx
+++ b/docs/accessibility/faq.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Cypress Accessibility FAQ'
-description: 'Get answers to common questions about Cypress Accessibility, including grouping and naming views, ignoring elements with elementFilters, excluding URLs with viewFilters, the Ignored status, score impact, element identification, configuration, and per-run profiles.'
+description: 'Get answers to common questions about Cypress Accessibility, including grouping and naming views, ignoring elements with elementFilters, excluding URLs with viewFilters, the Ignored status, score impact, element identification, component context, configuration scope, reading applied config, Axe Core® rules and color contrast, component testing, and per-run profiles.'
 sidebar_label: FAQ
 sidebar_position: 160
 ---
@@ -107,6 +107,10 @@ No. Your attributes are checked first, and the defaults still apply after them, 
 
 Yes. Any valid HTML attribute qualifies, not only `data-*` attributes. Listing [`aria-label`](/accessibility/configuration/significantattributes) identifies elements by their label text, so the elements you triage are shown by their labels. This adds a manual check on top of the automated one: Cypress Accessibility confirms that a control has an accessible name, but not that the name is understandable, so `aria-label="button"` passes the same name-presence rules as `aria-label="Close dialog"`. Seeing the label as the identifier makes an unclear one easy to catch.
 
+### <Icon name="angle-right" /> How do I add component or page context to my Cypress Accessibility violation selectors?
+
+Use [`components`](/accessibility/configuration/components), a Cypress Accessibility-only option that requires attributes like `data-page-area` or `data-component-name` in the violation-target selector when they're present. Instead of a bare `#button-123`, the target reads as `[data-page-area="hero"] [data-design-system="IconButton"]#button-123`, so whoever picks up the issue, whether a developer, a Jira ticket, or an AI agent triaging through [Cypress Cloud MCP](/accessibility/work-with-ai-agents), can see where it lives without opening the page HTML. This differs from [`significantAttributes`](/accessibility/configuration/significantattributes), which chooses the single attribute that _identifies_ the element, whereas `components` adds required context _around_ it.
+
 ## Configuration
 
 ### <Icon name="angle-right" /> Where do I set Cypress Accessibility configuration?
@@ -116,6 +120,32 @@ In the **App Quality** tab of your project settings in Cypress Cloud. See [Setti
 ### <Icon name="angle-right" /> Do I need to rerun my tests after changing configuration?
 
 No. You can regenerate any historical run from its **Properties** tab, and the report is reprocessed with the current configuration. This lets you iterate on configuration and see the effects immediately without running your Cypress tests again.
+
+### <Icon name="angle-right" /> How do I apply a setting to Cypress Accessibility without changing UI Coverage?
+
+Nest the property under an `accessibility` key. `viewFilters`, `elementFilters`, `significantAttributes`, and `attributeFilters` apply to both products when set at the root, but a copy nested under `accessibility` applies to Cypress Accessibility alone. A nested value completely replaces the root value for that product rather than merging, so repeat any rules you still want. `views` is the exception: it's shared and can only be set at the root. See [Configuration scope](/accessibility/configuration/overview#Configuration-scope).
+
+### <Icon name="angle-right" /> Can I read the configuration a Cypress Accessibility run was processed with?
+
+Yes, two ways. In Cypress Cloud, open the run's **Properties** tab to see the exact configuration that was applied. In CI, the [Accessibility Results API](/accessibility/results-api) exposes it on the `config` property of `getAccessibilityResults()`, where `config.value` is the applied App Quality configuration and `config.updatedAt` is when it was last saved. See [Viewing configuration for a run](/accessibility/configuration/overview#Viewing-Configuration-for-a-Run).
+
+### <Icon name="angle-right" /> How do I add a note explaining a Cypress Accessibility configuration rule?
+
+Add a `comment` property to the rule. Any rule defined as an object accepts one, and it's the supported place for notes because Cypress Cloud rejects properties it doesn't recognize. Comments live in your Cypress Accessibility configuration only and never appear in reports. See [Comments](/accessibility/configuration/overview#Comments).
+
+## Axe Core® rules
+
+### <Icon name="angle-right" /> Why isn't color contrast reported in my Cypress Accessibility results?
+
+The Axe Core® color-contrast rule is off by default in Cypress Accessibility. It's both the slowest rule in the ruleset and the one most prone to false positives and incomplete checks, so Cypress leaves it off unless you ask for it. It works well in many applications, and your Account Executive can turn it on for your project. See [Axe Core® configuration](/accessibility/configuration/axe-core-configuration).
+
+### <Icon name="angle-right" /> Does Cypress Accessibility work with component tests?
+
+Yes. Cypress Accessibility runs against component tests as well as end-to-end tests. Because a component is usually a page fragment, "page-level" rules that check page structure and document-wide attributes don't run for component tests, while the rest of the ruleset does. See [Component testing](/accessibility/configuration/axe-core-configuration#Component-Testing).
+
+### <Icon name="angle-right" /> How often does Cypress Accessibility update its Axe Core® version?
+
+Cypress Accessibility doesn't commit to a fixed schedule, but always waits at least 30 days before adopting a new Axe Core® release. Because updates can add rules or change how issues are detected, that buffer gives you time to adjust your [Results API](/accessibility/results-api) logic if needed. The exact version used for a run appears on its **Properties** tab and in the Results API. See [Updates to the Axe Core® library](/accessibility/configuration/axe-core-configuration#Updates-to-the-Axe-Core-library).
 
 ## Profiles
 

--- a/docs/partials/_app-quality-config-editing.mdx
+++ b/docs/partials/_app-quality-config-editing.mdx
@@ -1,0 +1,7 @@
+Configuration lives in Cypress Cloud, not in your repository. To view or change it for a project:
+
+1. Open your project in Cypress Cloud and go to **Project Settings**.
+2. Select the **App Quality** tab, which holds the configuration editor.
+3. Edit the configuration as JSON, then **Save**. **Discard** reverts unsaved edits back to the last saved version.
+
+The editor validates your JSON against the schema when you save, so an invalid configuration can't be saved, and it shows how long ago the configuration was last saved.

--- a/docs/partials/_app-quality-config-who-can-edit.mdx
+++ b/docs/partials/_app-quality-config-who-can-edit.mdx
@@ -1,0 +1,3 @@
+### Who can edit configuration
+
+Editing is limited to Admin users by default. Your Cypress point-of-contact can enable editing for all users on request.

--- a/docs/ui-coverage/configuration/overview.mdx
+++ b/docs/ui-coverage/configuration/overview.mdx
@@ -20,13 +20,7 @@ You don't need any of this to get started, and you can add it incrementally. Rep
 
 ## Setting configuration
 
-Configuration lives in Cypress Cloud, not in your repository. To view or change it for a project:
-
-1. Open your project in Cypress Cloud and go to **Project Settings**.
-2. Select the **App Quality** tab, which holds the configuration editor.
-3. Edit the configuration as JSON, then **Save**. **Discard** reverts unsaved edits back to the last saved version.
-
-The editor validates your JSON against the schema when you save, so an invalid configuration can't be saved, and it shows how long ago the configuration was last saved.
+<AppQualityConfigEditing />
 
 <DocsImage
   src="/img/ui-coverage/configuration/cypress-ui-coverage-configuration-editor.png"
@@ -40,9 +34,7 @@ After you save configuration changes, you can reprocess any historical run to ap
 
 Regenerating reports in this way allows you to make config changes and see their effects without running your Cypress tests again.
 
-### Who can edit configuration
-
-Editing is limited to Admin users by default. Your Cypress point-of-contact can enable editing for all users on request.
+<AppQualityConfigWhoCanEdit />
 
 ## Configuration options
 

--- a/src/theme/MDXComponents.js
+++ b/src/theme/MDXComponents.js
@@ -36,6 +36,8 @@ import ImportMountFunctions from '@site/docs/partials/_import-mount-functions.md
 import IntellisenseCodeCompletion from '@site/docs/partials/_intellisense-code-completion.mdx'
 import InvertedContainsSelection from '@site/docs/partials/_inverted-contains-selection.mdx'
 import ProductHeading from '@site/src/components/product-heading'
+import AppQualityConfigEditing from '@site/docs/partials/_app-quality-config-editing.mdx'
+import AppQualityConfigWhoCanEdit from '@site/docs/partials/_app-quality-config-who-can-edit.mdx'
 import Profiles from '@site/docs/partials/_profiles.mdx'
 import RecordKeyEnvVar from '@site/docs/partials/_record-key-env-var.mdx'
 import SignificantAttributesValidation from '@site/docs/partials/_significantattributes-validation.mdx'
@@ -233,6 +235,8 @@ export default {
   IntellisenseCodeCompletion,
   InvertedContainsSelection,
   ProductHeading,
+  AppQualityConfigEditing,
+  AppQualityConfigWhoCanEdit,
   Profiles,
   RecordKeyEnvVar,
   SignificantAttributesValidation,


### PR DESCRIPTION
## Summary

Reworks the Cypress Accessibility **configuration overview** to lead with value and match the actual App Quality config schema, expands the Accessibility **FAQ** for SEO/AEO, and factors the config content that is identical to UI Coverage into shared partials.

## Why

The Accessibility configuration overview lagged behind the UI Coverage equivalent and contained inaccuracies when checked against the App Quality config schema in `cypress-services` (`packages/validations/.../discoverySchema_0_1.ts`). Most notably, the "complete configuration example" showed `components` as a root-level property when it is Accessibility-only (nested under `accessibility`), and typed `views.groupBy` as `[string]` when the schema accepts `string | [string]`. The page also had no explanation of shared vs. product-scoped configuration, which every sub-page already relies on.

## Notes for reviewers

**Accuracy fixes (verified against the schema):**
- `components` moved out of the root of the full configuration reference — it is only valid under `accessibility`.
- `views.groupBy` corrected to `string | [string]`; profile objects now show `comment`.
- New **How rules are applied** section calls out that Accessibility `elementFilters` is "any exclude wins" (order-independent), unlike UI Coverage's first-match-wins — a real behavioral difference.
- Documented reading the applied config via the **Accessibility Results API** (`config.value` / `config.updatedAt`), which was previously undocumented but is exposed by `getAccessibilityResults()`.

**Clarity / structure:**
- Value-led intro, a "Which option do I need?" table, and a "Configuration scope" section (shared vs. Accessibility-only vs. root-only `views`).
- Every JSON example is titled "App Quality Config"; a screenshot now illustrates the reprocess/regenerate state; a See also section links related pages.
- Existing inbound anchors preserved (`#Setting-Configuration`, `#Viewing-Configuration-for-a-Run`, `#Comments`).

**FAQ (SEO/AEO):** Seven new self-contained Q&As (each referencing Cypress Accessibility) covering component/page context in selectors, config scope, reading applied config, comments, color contrast being off by default, component testing, and the Axe Core® update cadence.

**Shared partials:** The byte-identical, product-agnostic "how to edit config" and "who can edit configuration" blocks are extracted into `_app-quality-config-editing.mdx` and `_app-quality-config-who-can-edit.mdx`, registered in `MDXComponents`, and consumed by **both** the Accessibility and UI Coverage configuration overviews. Each page keeps its own `Setting Configuration` heading (so anchors stay valid) and product-specific screenshots.

Prettier (`yarn lint:markdown`) and the frontmatter linter pass locally. This PR intentionally also touches `docs/ui-coverage/configuration/overview.mdx`, since the shared partials only pay off if both consumers use them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GGu3sddtkxVffq1Yj9goJ6

---
_Generated by [Claude Code](https://claude.ai/code/session_01GGu3sddtkxVffq1Yj9goJ6)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or product behavior impact.
> 
> **Overview**
> Reworks the **Cypress Accessibility configuration overview** to be value-led and aligned with the App Quality config schema, and expands the Accessibility **FAQ** with new SEO-oriented Q&As.
> 
> The overview now includes a goal-to-option table, corrected full JSON reference (`components` under `accessibility` only; `views.groupBy` as `string | [string]`; profile `comment`), sections on **how rules are applied** (including Accessibility `elementFilters` “any exclude wins” vs UI Coverage), **configuration scope** (shared vs product-nested), and reading applied config via Cypress Cloud or **`getAccessibilityResults().config`**. Shared “how to edit” and “who can edit” copy is extracted into **`AppQualityConfigEditing`** / **`AppQualityConfigWhoCanEdit`** partials, registered in `MDXComponents`, and used by both Accessibility and UI Coverage configuration overviews.
> 
> The FAQ adds answers on component context in selectors, scoping config to Accessibility, reading applied config, rule comments, default-off color contrast, component testing, and Axe Core® update cadence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43046408cb25af7adce6544ac006f0b493d52670. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->