### PR TITLE
docs(accessibility): rework Axe Core® configuration for accuracy and value

### DIFF
--- a/docs/accessibility/configuration/axe-core-configuration.mdx
+++ b/docs/accessibility/configuration/axe-core-configuration.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Configure Axe Core® rules in Cypress Accessibility'
-description: 'Enable, disable, and tune individual Axe Core® rules to control which accessibility checks run in Cypress.'
+title: 'Axe Core® configuration in Cypress Accessibility'
+description: 'How Cypress Accessibility runs the Axe Core® ruleset, which rules are off by default, and how Cypress can tune rules for your project.'
 sidebar_label: 'Axe Core® configuration'
 sidebar_position: 50
 ---
@@ -9,27 +9,64 @@ sidebar_position: 50
 
 # Axe Core® configuration
 
-Configuration for Axe-Core® rules is available through your Account Executive. We are happy to have a call with you to dial in your report config to make sure you are getting the most useful reports possible, and we find this onboarding very effective.
+Cypress Accessibility runs the full [Axe-Core®](https://github.com/dequelabs/axe-core) ruleset against every snapshot captured during your test run, with no setup, assertions, or `cy.` commands to add to your specs. The ruleset is tuned to favor high-confidence results, so the report you get out of the box is already the recommended configuration for most teams.
 
-In most cases, configuration of these rules as they run in Cypress Cloud isn't needed, because your implementation of any policies about what should "fail a build" is handled using the [Accessibility Results API](/accessibility/results-api), where you have full control over how to parse the results and what rules need to be reacted to. Keeping the results in Cypress Cloud broad helps you to still be able to see and understand all of the accessibility information, even if only a subset of the results would be considered blocking.
+Because you decide what actually blocks a build with the [Accessibility Results API](/accessibility/results-api), where you have full control over how to parse results and which rules to react to, there is rarely a need to change which rules run in Cypress Cloud. Keeping the ruleset broad means you can still see and understand every accessibility finding, even when only a subset of results is treated as blocking in your pipeline.
 
-**Note.** Certain Axe Core® rules are off by default. Here are the rules that are currently either ignored by configuration, or for which results cannot be detected.
+When you do need to change how the ruleset behaves for your project, Cypress can tune it for you. This is a guided process handled through your Cypress point of contact rather than a setting in the App Quality editor, so you get results that fit your application without the risk of silently turning off important checks.
 
-- `Elements must meet minimum color contrast ratio thresholds`
-  - This is off by default. This is both the slowest rule in the Axe Core® ruleset, and the one that can have the highest percentage of false positives or incomplete checks.
-  - It does work perfectly in many projects, so we are happy to turn this on for you if requested, so that you can see the results.
-- `<video> or <audio> elements must not play automatically`
-  - Ignored because Test Replay does not yet capture the metadata to check this
-- `Delayed refresh under 20 hours must not be used`
-  - Ignored because Test Replay does not collect the metadata for this
+## How Cypress can tune the ruleset for your project {#how-cypress-can-tune-the-ruleset-for-your-project}
 
-## Component Testing
+Teams reach out for a few common adjustments. In each case, Cypress applies the change on your behalf and can regenerate historical runs so you can preview the effect before adopting it:
 
-Cypress Accessibility works great with component testing. In addition to the rules mentioned above that are off by default, "page-level" rules do not run for component tests. Since a component is usually a page fragment, rules related to page structure and expected attributes do no need to run.
+- **Enable a rule that is off by default.** The most common request is turning on [color contrast checking](#rules-that-are-off-by-default) for a project where you've confirmed it produces reliable results.
+- **Turn off a rule that is a known false positive.** If a specific rule consistently misfires because of a third-party framework you can't change, it can be disabled project-wide so it stops adding noise to your reports.
+- **Scope the report to a conformance target.** Cypress can narrow the ruleset to the standard your team is committed to, such as WCAG 2.1 Level A and AA, so the report reflects exactly the criteria you're measuring against.
 
-## Updates to the Axe Core® library
+We're happy to have a call to dial in your report configuration and make sure you're getting the most useful reports possible.
 
-Updates to the Axe Core® library are released several times each year. While Cypress does not commit to updating our internal Axe Core® version within a specific timeframe, we will always wait at least 30 days before making an update.
-Since some updates introduce new rules or address bugs that change how issues are detected, this buffer is intended to give you time to make changes in your use of our [Results API](/accessibility/results-api) if needed. Axe Core® releases can be tracked [in GitHub](https://github.com/dequelabs/axe-core/releases).
+### Adjustments you can make yourself
 
-The specific Axe Core® version used by Cypress for a run can be seen in the Properties tab for that run in Cypress Cloud, and is also included in the Results API.
+Some ways of shaping your results don't require any rule configuration and are fully in your control:
+
+- To ignore a specific rule for individual elements, add the [`data-a11y-ignore` attribute](/accessibility/configuration/ignoring-rules-per-element) in your application code.
+- To keep a rule enabled but stop a particular element or page from being reported, use [`elementFilters`](/accessibility/configuration/elementfilters) or [`viewFilters`](/accessibility/configuration/viewfilters).
+- To decide which findings block a build in CI, parse your run's results with the [Results API](/accessibility/results-api). Leaving a rule reported but non-blocking is often the best choice, since you keep full visibility into the issue.
+
+## Rules that are off by default {#rules-that-are-off-by-default}
+
+A small number of Axe-Core® rules are turned off in Cypress Accessibility by default. Color contrast can be enabled per project on request. The other two depend on live runtime behavior that isn't reproduced when Cypress re-renders a captured snapshot for analysis, so they can't be evaluated reliably.
+
+| Rule                                                        | Why it's off by default                                                                                                                                                                                      |
+| ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Elements must meet minimum color contrast ratio thresholds  | This is the slowest rule in the Axe-Core® ruleset and the one most likely to produce false positives or incomplete results. It works well in many projects, so we're happy to turn it on for you on request. |
+| `<video>` or `<audio>` elements must not play automatically | Detecting a violation requires loading and playing the media to measure how long it plays. Cypress analyzes a reconstructed snapshot of the page without playable media, so this rule can't be evaluated.    |
+| Delayed refresh under 20 hours must not be used             | This rule reads a page's meta refresh directive, which Cypress disables while it analyzes a run so the reconstructed page doesn't navigate away. With the directive disabled, the rule can't be evaluated.   |
+
+In addition, the custom [Cypress rule](/accessibility/core-concepts/cypress-rules) _Interactive elements should be semantically correct_ is available in all projects but is not enabled by default. Reach out to Cypress if you'd like it turned on.
+
+You can confirm which rules were turned off for any run in its Accessibility report. In the **Rules** view, disabled rules are listed with an **Ignored by configuration** status, so it's always clear which checks a run did and did not include.
+
+## Component testing {#component-testing}
+
+Cypress Accessibility works with [component testing](/app/component-testing/get-started) as well as end-to-end testing. Alongside the rules that are off by default above, **page-level rules do not run for component tests**. Because a component is usually a fragment of a page rather than a complete document, rules that assert on overall page structure would report failures that don't apply to a component in isolation.
+
+Rules skipped for component tests include page-structure and document-level checks, such as whether the page has a main landmark, a single top-level heading, a language attribute, and a document title. Rules that evaluate the components themselves, such as color contrast (when enabled), button naming, and image alternative text, run as normal.
+
+The exact set of skipped rules isn't a fixed list Cypress maintains. It's derived from which rules Axe-Core® classifies as page-level, so it can shift when Cypress updates its Axe-Core® version. In a component's report, these page-structure rules are reported as not applicable rather than as failures.
+
+## Axe-Core® library version and updates {#axe-core-library-version-and-updates}
+
+Cypress pins a specific, tested version of the Axe-Core® library. New Axe-Core® versions are released several times a year. While Cypress doesn't commit to updating our internal version within a specific timeframe, we always wait at least 30 days before adopting a new release.
+
+Because some updates introduce new rules or change how existing issues are detected, this buffer gives you time to adjust how you use the [Results API](/accessibility/results-api) if needed. You can track Axe-Core® releases [on GitHub](https://github.com/dequelabs/axe-core/releases).
+
+The exact Axe-Core® version used for a given run is shown in the **Properties** tab for that run in Cypress Cloud, and is also included as `axeVersion` in the [Results API](/accessibility/results-api) response. To get a heads-up in CI when the version changes, see [how to detect a change in the axe-core version](/accessibility/results-api#how-to-detect-a-change-in-the-axe-core-version).
+
+## See also
+
+- [Configuration overview](/accessibility/configuration/overview) lists every App Quality Config option you can set yourself and how to apply and regenerate configuration.
+- [Results API](/accessibility/results-api) is where you decide which rules block a build in CI.
+- [Ignore rules per element - `data-a11y-ignore`](/accessibility/configuration/ignoring-rules-per-element) turns off specific rules for individual elements from your application code.
+- [Cypress rules](/accessibility/core-concepts/cypress-rules) documents the custom rules Cypress layers on top of Axe-Core®.
+- [Cypress Accessibility FAQ](/accessibility/faq) answers common questions about rules and configuration.

--- a/docs/accessibility/faq.mdx
+++ b/docs/accessibility/faq.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Cypress Accessibility FAQ'
-description: 'Get answers to common questions about Cypress Accessibility, including grouping and naming views, ignoring elements with elementFilters, excluding URLs with viewFilters, the Ignored status, score impact, element identification, configuration, and per-run profiles.'
+description: 'Get answers to common questions about Cypress Accessibility, including which Axe Core® rules run, enabling color contrast, grouping and naming views, ignoring elements with elementFilters, excluding URLs with viewFilters, the Ignored status, score impact, element identification, configuration, and per-run profiles.'
 sidebar_label: FAQ
 sidebar_position: 160
 ---
@@ -117,6 +117,32 @@ In the **App Quality** tab of your project settings in Cypress Cloud. See [Setti
 
 No. You can regenerate any historical run from its **Properties** tab, and the report is reprocessed with the current configuration. This lets you iterate on configuration and see the effects immediately without running your Cypress tests again.
 
+## Axe-Core® rules
+
+### <Icon name="angle-right" /> Which accessibility rules does Cypress Accessibility run?
+
+Cypress Accessibility runs the full [Axe-Core®](https://github.com/dequelabs/axe-core) ruleset against every captured snapshot, plus a few [custom Cypress rules](/accessibility/core-concepts/cypress-rules). A small number of Axe-Core® rules are [off by default](/accessibility/configuration/axe-core-configuration#rules-that-are-off-by-default): `color-contrast`, `no-autoplay-audio`, and `meta-refresh`. You don't add any assertions or `cy.` commands to your tests to run these checks; they run automatically when Cypress Accessibility is enabled.
+
+### <Icon name="angle-right" /> Can I change which Axe-Core® rules Cypress Accessibility runs?
+
+Yes. Cypress can [tune the Cypress Accessibility ruleset for your project](/accessibility/configuration/axe-core-configuration#how-cypress-can-tune-the-ruleset-for-your-project), including enabling a rule that's off by default, turning off a rule that's a known false positive, or scoping the report to a WCAG conformance target. This is a guided change applied by Cypress rather than a setting in the App Quality editor, so reach out to your Cypress point of contact. To ignore a rule for individual elements yourself, use the [`data-a11y-ignore` attribute](/accessibility/configuration/ignoring-rules-per-element) in your application code.
+
+### <Icon name="angle-right" /> Why isn't color contrast reported in my Cypress Accessibility results?
+
+Color contrast checking is off by default in Cypress Accessibility because it's the slowest Axe-Core® rule and the most likely to produce false positives or incomplete results. It works well in many projects, so Cypress can turn it on for your project on request. Reach out to your Cypress point of contact. See [Rules that are off by default](/accessibility/configuration/axe-core-configuration#rules-that-are-off-by-default).
+
+### <Icon name="angle-right" /> How do I stop Cypress Accessibility from reporting a rule I can't fix?
+
+You have three options in Cypress Accessibility, from broadest to narrowest. Ask Cypress to disable the rule project-wide, which is a [guided change applied for you](/accessibility/configuration/axe-core-configuration#how-cypress-can-tune-the-ruleset-for-your-project); ignore the rule for specific elements yourself with the [`data-a11y-ignore` attribute](/accessibility/configuration/ignoring-rules-per-element); or leave the rule on and control whether it blocks your build in CI with the [Results API](/accessibility/results-api). Keeping a rule reported but non-blocking is often the best choice, since you retain visibility into the issue.
+
+### <Icon name="angle-right" /> Why does Cypress Accessibility skip some rules for my component tests?
+
+Cypress Accessibility skips page-level rules such as `region`, `landmark-one-main`, and `document-title` for [component tests](/accessibility/configuration/axe-core-configuration#component-testing). A component is usually a fragment of a page, so rules that assert on overall page structure would report failures that don't apply to a component in isolation. Rules that evaluate the component itself, such as `button-name` and `image-alt`, still run.
+
+### <Icon name="angle-right" /> Which version of Axe-Core® does Cypress Accessibility use?
+
+Cypress Accessibility pins a specific, tested version of Axe-Core® and waits at least 30 days before adopting a new release, so new or changed rules don't alter your results without warning. The exact version used for a run is shown in that run's **Properties** tab in Cypress Cloud and in the [Results API](/accessibility/results-api) response. See [Axe-Core® library version and updates](/accessibility/configuration/axe-core-configuration#axe-core-library-version-and-updates).
+
 ## Profiles
 
 ### <Icon name="angle-right" /> How do I apply different Cypress Accessibility settings to different runs?
@@ -151,4 +177,5 @@ There's no dedicated "skip this run" switch in a profile. To suppress a report f
 - [`profiles`](/accessibility/configuration/profiles) apply different configuration to runs based on run tags.
 - [`elementFilters`](/accessibility/configuration/elementfilters) is the full reference for ignoring elements.
 - [`viewFilters`](/accessibility/configuration/viewfilters) is the full reference for excluding URLs.
+- [Axe Core® configuration](/accessibility/configuration/axe-core-configuration) is the full reference for enabling, disabling, and scoping accessibility rules.
 - [Run-level reports](/accessibility/guides/run-level-reports) explains element statuses, including **Ignored**.

--- a/docs/accessibility/results-api.mdx
+++ b/docs/accessibility/results-api.mdx
@@ -157,6 +157,50 @@ getAccessibilityResults({
 })
 ```
 
+#### How to detect a change in the axe-core version {#how-to-detect-a-change-in-the-axe-core-version}
+
+Each result includes the `axeVersion` used to generate the report. Cypress updates its internal Axe-Core® version periodically, and a new version can add rules or change how issues are detected. You can pin the version your team has reviewed and get a heads-up when it changes, so you can reconcile any new results before they surprise you. See [Axe Core® library version and updates](/accessibility/configuration/axe-core-configuration#axe-core-library-version-and-updates) for the update policy.
+
+```javascript title="scripts/checkAxeVersion.js"
+const { getAccessibilityResults } = require('@cypress/extract-cloud-results')
+
+// The Axe-Core® version your team has last reviewed and calibrated against.
+// Bump this deliberately, after reconciling a new Axe-Core® release.
+const EXPECTED_AXE_VERSION = '4.12.1'
+
+getAccessibilityResults().then((results) => {
+  if (!results) {
+    console.warn('No Accessibility report was found for this run.')
+    return
+  }
+
+  const { axeVersion, runNumber, accessibilityReportUrl } = results
+
+  if (axeVersion === EXPECTED_AXE_VERSION) {
+    console.log(
+      `Accessibility report used the expected Axe-Core® ${axeVersion}.`
+    )
+    return
+  }
+
+  console.warn(
+    `Cypress Accessibility used Axe-Core® ${axeVersion} for run #${runNumber}, but this project is calibrated against ${EXPECTED_AXE_VERSION}.`
+  )
+  console.warn(
+    `Review the release notes at https://github.com/dequelabs/axe-core/releases, reconcile any new results, then update EXPECTED_AXE_VERSION. Report: ${accessibilityReportUrl}`
+  )
+
+  // Opt in to a hard failure so the pipeline blocks until the bump is reviewed:
+  if (process.env.FAIL_ON_AXE_VERSION_CHANGE === 'true') {
+    throw new Error(
+      `Axe-Core® version changed from ${EXPECTED_AXE_VERSION} to ${axeVersion}. Review the changes and update the expected version.`
+    )
+  }
+})
+```
+
+Warning by default is usually the right posture, since a version change isn't a failure on its own. Set `FAIL_ON_AXE_VERSION_CHANGE=true` when you want CI to stop until someone reviews the bump.
+
 ### `getAccessibilityResults` Arguments
 
 `getAccessibilityResults` uses the following attributes to identify the Cypress run and return the Accessibility results:


### PR DESCRIPTION
## Summary

Reworks the UI Coverage / Cypress Accessibility **Axe Core® configuration** page to match the actual `discovery` implementation and lead with value, and aligns the **FAQ** and **Results API** pages with it.

## Why

The Axe Core® configuration page had drifted from the implementation and buried its value:

- It implied rule configuration was something users apply themselves, but `axeConfig` is an experimental/admin-only field that the App Quality settings editor rejects (it lives only in the experimental schema, not the public one). Rule tuning is applied by Cypress on a project's behalf.
- The reasons the `no-autoplay-audio` and `meta-refresh` rules are off were inaccurate. Verified against the capture-protocol and discovery replay pipeline: the DOM snapshot **does** capture `<video>`/`<audio>` attributes and the `<meta http-equiv="refresh">` tag. The rules fail because of how the snapshot is re-rendered for analysis — media isn't loadable/playable (and axe runs with `preload: false`), and the meta refresh directive is deliberately neutralized during replay so the reconstructed page doesn't navigate away.
- The component-test "page-level rules" set was described as if fixed, but it's derived from Axe-Core®'s own page-level classification and shifts when Cypress bumps its Axe-Core® version.
- The page led with an Account Executive note instead of the value the ruleset provides out of the box.

What changed:

- **Axe Core® configuration**: value-first intro; rule tuning framed as a guided change through your Cypress point of contact; removed the `axeConfig` shape and JSON examples that implied self-serve use, keeping the genuinely self-serve levers (`data-a11y-ignore`, `elementFilters`, `viewFilters`, Results API); corrected the off-by-default reasons; clarified component-test behavior and where disabled rules surface (**Ignored by configuration**); added a See also section.
- **FAQ**: new "Axe-Core® rules" section (which rules run, changing rules, color contrast, ignoring a rule, component tests, library version), each entry referencing Cypress Accessibility by name for SEO/AEO.
- **Results API**: added a "How to detect a change in the axe-core version" example that reads `results.axeVersion`, warns on a change, and can hard-fail via `FAIL_ON_AXE_VERSION_CHANGE`.

## Notes for reviewers

- Implementation cross-checks (cypress-services): `axeConfig` is in `discoverySchema_0_1_experimental` and excluded from the public editor schema (`discoveryConfigManifest.ts`); off-by-default rules set in `discovery/packages/processing/src/processing/a11y/a11yProcessing.ts`; meta refresh neutralized in `frontend/packages/test-replay/src/utils/safelyApplyAttribute.ts`; axe run with `preload: false` in `discovery/packages/accessibility/src/render/accessibility.ts`; Results API `axeVersion` field in `packages/extract-cloud-results/src/getAccessibilityResults.ts`.
- Verified with `npm run build` (which throws on broken links/anchors); Prettier clean.
- Deliberately did **not** claim profiles can override `axeConfig` (profile config uses the public schema, which excludes it).
- **Screenshot request follow-up:** there's no existing asset showing skipped/disabled rules, so I documented where they surface in text (Rules view, "Ignored by configuration"). If you want a `<DocsImage>`, drop a capture at `static/img/accessibility/configuration/cypress-accessibility-ignored-by-configuration-rules.png` and I'll wire it in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only changes to accessibility docs and example scripts; no application or API behavior changes.
> 
> **Overview**
> **Reworks the Axe Core® configuration doc** so it leads with out-of-the-box value (full ruleset, no extra test code) and states that **rule tuning is a guided Cypress change**, not self-serve App Quality editor config. It adds structured guidance on Cypress-applied adjustments (enable color contrast, disable noisy rules, WCAG scoping), **self-serve levers** (`data-a11y-ignore`, `elementFilters`, `viewFilters`, Results API), a **table of default-off rules** with corrected reasons for `no-autoplay-audio` and `meta-refresh` (snapshot replay limits), clearer **component-test page-level rule** behavior, **Ignored by configuration** in the Rules view, and cross-links including axe version detection.
> 
> **FAQ** gains an expanded **Axe Core® rules** section (which rules run, changing rules, color contrast, ignoring unfixable rules, component skips, pinned axe version) and updated anchor links.
> 
> **Results API** adds **“How to detect a change in the axe-core version”** with a sample script that compares `results.axeVersion` to `EXPECTED_AXE_VERSION`, warns on drift, and optional `FAIL_ON_AXE_VERSION_CHANGE` hard-fail.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7db8de79d322c3ac34199c76ad4c008cbb765327. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->