### PR TITLE
docs(ui-coverage): enrich premium note and surface it across the docs

### DIFF
--- a/docs/app/core-concepts/interacting-with-elements.mdx
+++ b/docs/app/core-concepts/interacting-with-elements.mdx
@@ -19,13 +19,7 @@ sidebar_position: 35
 
 :::
 
-:::tip
-
-Learn how [UI Coverage](/ui-coverage/get-started/introduction) highlights areas
-where interactive elements have not been tested. Understand coverage gaps,
-inform your testing strategy, and ship high-quality code with confidence.
-
-:::
+<UICovPremiumNote />
 
 ## Visibility
 

--- a/docs/app/get-started/why-cypress.mdx
+++ b/docs/app/get-started/why-cypress.mdx
@@ -161,6 +161,8 @@ _You can't act on coverage gaps you can't see. UI Coverage makes them visible to
 - **Results where you work:** Use the [Results API](/ui-coverage/results-api) to integrate results into CI, and [Cloud MCP](/cloud/integrations/cloud-mcp) to surface them in your AI agent for faster diagnosis and iteration.
 - **Branch Review:** Compare runs to see newly introduced elements in your application or unexpected reductions in test coverage.
 
+<UICovPremiumNote />
+
 ## Solutions
 
 Cypress can be used to ensure several different types of tests. Used together, they give you broader, more dependable coverage before release.

--- a/docs/app/guides/test-performance.mdx
+++ b/docs/app/guides/test-performance.mdx
@@ -810,6 +810,8 @@ Test suites grow organically. A welcome screen, an onboarding modal, or a cookie
 
 [Cypress UI Coverage](/ui-coverage/get-started/introduction) surfaces this from the other direction. While most test coverage tools tell you what's not tested, UI Coverage also shows you what's tested far more than it needs to be: elements with disproportionately high interaction counts that signal redundancy across your suite.
 
+<UICovPremiumNote />
+
 #### How to find over-tested elements
 
 In [Cypress Cloud](/cloud/get-started/introduction), open any recorded run and navigate to the **UI Coverage** tab. In the **Tested elements** section, elements are listed with their interaction counts and the number of snapshots they appear in. Sort by highest interaction count and look for elements whose numbers are far out of proportion with how important they are.

--- a/docs/app/tooling/code-coverage.mdx
+++ b/docs/app/tooling/code-coverage.mdx
@@ -89,6 +89,8 @@ written — no extra instrumentation is required like with code coverage.
 To learn more about UI coverage,
 please see our [UI Coverage](/ui-coverage/get-started/introduction) guide.
 
+<UICovPremiumNote />
+
 <DocsImage
   src="/img/ui-coverage/get-started/uicov-docs-1.gif"
   alt="UI Coverage demo showing UI of Cloud product"

--- a/docs/partials/_ui-coverage-premium-note.mdx
+++ b/docs/partials/_ui-coverage-premium-note.mdx
@@ -1,5 +1,5 @@
-:::tip
+:::note
 
-**UI Coverage** is a paid premium solution. [Schedule a demo](<https://www.cypress.io/ui-coverage?utm_medium=premium-solution-tip&utm_source=docs.cypress.io&utm_content=Schedule a demo>) today and see how easy it is to enhance your testing while speeding up your development process.
+<Icon useCypressIcon name="technology-ui-coverage" size="16" className="inline mt-[-2px]" /> **UI Coverage** turns your runs into a visual map of the interactive elements your tests exercise and the ones they miss, with no code changes or instrumentation. [Schedule a demo](<https://www.cypress.io/ui-coverage?utm_medium=premium-solution-tip&utm_source=docs.cypress.io&utm_content=Schedule a demo>).
 
 :::

--- a/docs/ui-coverage/configuration/overview.mdx
+++ b/docs/ui-coverage/configuration/overview.mdx
@@ -18,6 +18,8 @@ UI Coverage works out of the box with no setup, but a few lines of configuration
 
 You don't need any of this to get started, and you can add it incrementally. Reprocess a past run after each change to see the effect immediately, without re-running your tests.
 
+<UICovPremiumNote />
+
 ## Setting configuration
 
 <AppQualityConfigEditing />

--- a/docs/ui-coverage/core-concepts/interactivity.mdx
+++ b/docs/ui-coverage/core-concepts/interactivity.mdx
@@ -19,6 +19,8 @@ Put simply, your score is the share of interactive elements your tests exercise:
 
 This page covers all three, along with the configuration and markup overrides you can use to make each one match your application. All three are computed from [Test Replay](/cloud/features/test-replay) data, so they work automatically with no setup or instrumentation. Reach for the overrides only when the defaults don't fit.
 
+<UICovPremiumNote />
+
 <DocsImage
   src="/img/ui-coverage/core-concepts/how-ui-coverage-fits-together.svg"
   alt="Flow diagram: Test Replay captures DOM snapshots, UI Coverage analyzes each one to detect interactive elements (the total) and the interaction commands that mark them tested (the numerator), and flags untested links, all feeding the coverage score and report."

--- a/docs/ui-coverage/faq.mdx
+++ b/docs/ui-coverage/faq.mdx
@@ -9,6 +9,8 @@ sidebar_position: 160
 
 # Cypress UI Coverage FAQ
 
+<UICovPremiumNote />
+
 ## General
 
 ### <Icon name="angle-right" /> What is UI Coverage?

--- a/docs/ui-coverage/get-started/setup.mdx
+++ b/docs/ui-coverage/get-started/setup.mdx
@@ -11,6 +11,8 @@ sidebar_position: 20
 
 UI Coverage turns every run you already record to Cypress Cloud into a visual map of which interactive elements your tests exercise and which they miss, plus a coverage score you can track over time. There's nothing to install and no code to instrument: reports are generated in Cypress Cloud from the [Test Replay](/cloud/features/test-replay) data your runs already capture. If you record to Cypress Cloud with Test Replay, you can be reading your first report in minutes.
 
+<UICovPremiumNote />
+
 <DocsImage
   src="/img/ui-coverage/get-started/Cypress_UI_Coverage_demo.gif"
   alt="Animated walkthrough of a UI Coverage report in Cypress Cloud: an overall coverage score, per-view scores, and a drilldown highlighting tested and untested elements on a DOM snapshot"

--- a/docs/ui-coverage/guides/identify-coverage-gaps.mdx
+++ b/docs/ui-coverage/guides/identify-coverage-gaps.mdx
@@ -17,6 +17,8 @@ exercised, every one they missed, and every page they never opened. It reads
 this from [Test Replay](/cloud/features/test-replay) data in Cypress Cloud, so
 there's no code to instrument and nothing to add to your app.
 
+<UICovPremiumNote />
+
 This workflow takes you from a recorded run to a prioritized list of gaps to
 close:
 

--- a/docs/ui-coverage/guides/monitor-changes.mdx
+++ b/docs/ui-coverage/guides/monitor-changes.mdx
@@ -15,6 +15,8 @@ before it merges, rather than discovered months later. This guide walks through
 a repeatable monitoring workflow, from establishing a cadence of runs to
 reviewing individual changes and tracking long-term trends.
 
+<UICovPremiumNote />
+
 :::note
 This guide assumes UI Coverage is enabled and your tests are recording to
 Cypress Cloud. If you haven't set that up yet, start with the

--- a/docs/ui-coverage/results-api.mdx
+++ b/docs/ui-coverage/results-api.mdx
@@ -15,6 +15,8 @@ nothing in your Cypress pipeline fails on its own when coverage drops. The
 into your CI job and decide, in code, whether the coverage is good enough to
 merge.
 
+<UICovPremiumNote />
+
 With the `getUICoverageResults` helper from the
 `@cypress/extract-cloud-results` module you can:
 


### PR DESCRIPTION
## Summary

Rewrites the `_ui-coverage-premium-note.mdx` partial to actually describe what UI Coverage does (and lead with the UI Coverage product icon), then renders it on the pages where UI Coverage is introduced or highlighted as a benefit.

## Why

The `UICovPremiumNote` partial was registered in `src/theme/MDXComponents.js` but never rendered on any page, and its copy was a generic one-liner ("a paid premium solution... enhance your testing while speeding up your development process") with no real value. Rather than delete the dead partial, this gives it substance and puts it to work:

- **Rewrote the copy** to explain what UI Coverage is: it turns runs you already record to Cypress Cloud into a visual map of which interactive elements your tests exercise and which they miss, with no code changes or instrumentation. The "Schedule a demo" CTA (with its existing UTM params) is preserved, and the note now leads with the `technology-ui-coverage` icon so it reads as a UI Coverage callout at a glance.
- **Placed it at natural breakpoints** on high-intent UI Coverage pages: setup, interactivity, configuration overview, identify coverage gaps, monitor changes, FAQ, and the Results API.
- **Placed it on App docs pages that highlight a UI Coverage benefit**: test performance (eliminating over-tested UI), code coverage (UI-level vs. code-level gaps), and why-cypress (UI Coverage feature section).
- On `interacting-with-elements`, the ad-hoc UI Coverage `:::tip` was **replaced** with the shared partial so it carries the demo CTA and stays consistent with the rest of the docs.

Pages that already carry a UI Coverage trial/demo CTA (e.g. `ui-coverage/get-started/introduction`, `cloud/get-started/introduction`) were intentionally left untouched to avoid redundancy.

## Notes for reviewers

- The note is a single shared partial, so all 11 placements draw from the same source; wording or icon tweaks propagate everywhere.
- Worth a quick visual check on icon alignment: it's set to `size="16"` to sit inline with the callout text, but callout line-height can vary by theme — easy to bump to `size="20"` if it looks off in either theme.
- No changes to `MDXComponents.js` (the partial was already registered) — this PR only touches the partial and the pages that use it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nuppw82WKFR4X3nx1dD1ff)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only MDX changes to a shared partial and callout placement; no runtime, auth, or application logic.
> 
> **Overview**
> Updates the shared **`UICovPremiumNote`** partial and wires it into docs where UI Coverage is introduced or highlighted.
> 
> The partial moves from a generic **`:::tip`** to a **`:::note`** with the UI Coverage icon and copy that explains the product (visual map of exercised vs. missed interactive elements, no instrumentation) while keeping the Schedule a demo CTA.
> 
> **`<UICovPremiumNote />`** is added on UI Coverage guides (setup, interactivity, configuration, gaps, monitoring, FAQ, Results API) and on App pages that mention UI Coverage (why Cypress, code coverage, test performance). On **interacting-with-elements**, the one-off UI Coverage tip is **replaced** with the same partial for consistent messaging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae684d0ade65f784e019a780d3fa70928e4fcdc0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->