### PR TITLE
docs(accessibility): rework profiles config for accuracy and value

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,10 @@ Each rule is a hard convention. See the linked section for the how and why.
   Always give images meaningful `alt` (describe purpose, not "screenshot of…").
 - Start every product page with `<ProductHeading product="…" />`. Use canonical
   names: Cypress App, Cypress Cloud, Cypress Accessibility, UI Coverage.
-- Reuse `docs/partials/_*.mdx` instead of repeating content.
+- Reuse `docs/partials/_*.mdx` instead of repeating content, but only create a
+  partial for content rendered in **more than one location**. If it's used in a
+  single page, inline it there — don't add a partial (or keep an existing one)
+  that has just one render site.
 - End related pages with a `## See also` section (sentence-case H2, as the page's
   last section): a short bulleted list of doc-to-doc links to closely related
   pages, command names in backticks, with an optional `- short description` after

--- a/AGENTS_REFERENCE.md
+++ b/AGENTS_REFERENCE.md
@@ -107,6 +107,13 @@ Images go in `static/img/...` and are referenced via `/img/...`.
   so they are not built as standalone pages.
 - Most are registered in `src/theme/MDXComponents.js` and used as components
   (e.g. `<CloudFreePlan />`) with no per-file import.
+- **A partial must be rendered in more than one location.** A partial earns its
+  indirection only by sharing content across pages; if it's referenced by a
+  single page, inline the content into that page instead. When splitting a
+  shared partial into product-specific pieces, keep genuinely shared sections in
+  the partial and inline the parts that live on only one page. Before removing
+  the last-but-one reference to a partial, inline it and delete the file (and its
+  `MDXComponents.js` registration).
 
 ## Product heading & naming
 

--- a/docs/accessibility/configuration/profiles.mdx
+++ b/docs/accessibility/configuration/profiles.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'profiles: apply config overrides by run tag'
-description: 'Use the profiles property to apply Cypress Accessibility configuration overrides based on run tags.'
+description: 'Use the profiles property to apply different Cypress Accessibility configuration to different runs, whether a narrow pull request gate, a full regression run, or per-team reports, selected automatically by run tag, without changing your test code.'
 sidebar_label: 'Override config by run tag'
 sidebar_position: 100
 ---
@@ -11,9 +11,181 @@ sidebar_position: 100
 
 <Profiles />
 
+## Examples
+
+Each example shows the App Quality configuration and the `cypress run` command that selects the profile. Anything a profile doesn't mention is inherited from your base configuration.
+
+### Scope a pull request gate to critical flows
+
+The highest-value use of profiles in Cypress Accessibility is a fast, focused gate for pull requests. Your base configuration scans every view so regression runs track accessibility everywhere. A pull request run doesn't need that breadth; it needs a small, unambiguous report a developer can act on before merging. The `aq-config-pr` profile keeps only your most critical flows with [`viewFilters`](/accessibility/configuration/viewfilters), so the pull request report covers login and checkout and nothing else.
+
+#### Config
+
+```json title="App Quality Config"
+{
+  "profiles": [
+    {
+      "name": "aq-config-pr",
+      "comment": "Pull request gate: report only on the flows that block a merge",
+      "config": {
+        "viewFilters": [
+          { "pattern": "/login", "include": true },
+          { "pattern": "/checkout/*", "include": true },
+          {
+            "pattern": "*",
+            "include": false,
+            "comment": "Ignore every other view on pull request runs"
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+#### Usage
+
+Tag pull request runs so they pick up the profile:
+
+```shell
+cypress run --record --tag "aq-config-pr"
+```
+
+`viewFilters` applies the first matching rule, so the two `include: true` rules keep login and checkout while the catch-all excludes everything else. Regression runs record without this tag and use the base configuration, scanning every view. Pair the narrow report with the [Results API](/accessibility/results-api) to fail the build when a critical flow regresses.
+
+### Re-include a widget for a dedicated audit
+
+Your base configuration excludes two third-party widgets with [`elementFilters`](/accessibility/configuration/elementfilters), a cookie banner and an embedded support chat, because another vendor owns them and their violations only add noise. One suite exists specifically to audit the support-chat integration's accessibility, recorded under the `aq-config-support-audit` tag. For that run, the chat widget should be scanned while the cookie banner stays excluded.
+
+#### Config
+
+```json title="App Quality Config"
+{
+  "elementFilters": [
+    {
+      "selector": "#onetrust-banner-sdk, #onetrust-banner-sdk *",
+      "include": false,
+      "comment": "Third-party cookie banner, reported upstream to the vendor"
+    },
+    {
+      "selector": "#support-chat, #support-chat *",
+      "include": false,
+      "comment": "Vendor support-chat widget, excluded from everyday reports"
+    }
+  ],
+  "profiles": [
+    {
+      "name": "aq-config-support-audit",
+      "config": {
+        "elementFilters": [
+          {
+            "selector": "#onetrust-banner-sdk, #onetrust-banner-sdk *",
+            "include": false,
+            "comment": "Still exclude the cookie banner during the support-chat audit"
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+#### Usage
+
+```shell
+cypress run --record --tag "aq-config-support-audit"
+```
+
+A profile's `elementFilters` replaces the base list rather than adding to it, so the profile repeats the cookie-banner rule it still needs and simply omits the support-chat rule. In Cypress Accessibility an element is scanned unless an `include: false` rule matches it, so dropping the support-chat exclusion is all it takes to bring the widget back into this run's report; you don't add an `include: true` rule. On every other run, both widgets stay excluded.
+
+### Apply an accessibility-only override for a labels audit
+
+Profiles can override configuration nested under an `accessibility` key, and those objects merge one level deep, so a profile can replace a single accessibility setting while inheriting the rest. Here the base configuration identifies violation targets by their [`components`](/accessibility/configuration/components) context for everyday reports. A quarterly audit of accessible names, tagged `aq-config-label-audit`, wants each violation target shown by its `aria-label` instead, using [`significantAttributes`](/accessibility/configuration/significantattributes), so a reviewer can spot a vague label like `aria-label="button"` at a glance. The audit keeps the same component context.
+
+#### Config
+
+```json title="App Quality Config"
+{
+  "accessibility": {
+    "components": {
+      "componentAttributes": [
+        { "attributeName": "data-component-name", "includeInSelector": true }
+      ]
+    },
+    "significantAttributes": ["data-cy"]
+  },
+  "profiles": [
+    {
+      "name": "aq-config-label-audit",
+      "config": {
+        "accessibility": {
+          "significantAttributes": ["aria-label"]
+        }
+      }
+    }
+  ]
+}
+```
+
+#### Usage
+
+```shell
+cypress run --record --tag "aq-config-label-audit"
+```
+
+Inside `accessibility`, the profile replaces only `significantAttributes`; the sibling `components` object is inherited, so violation targets still carry their component context and are now identified by their label text. On every other run, elements are identified by `data-cy` as usual.
+
+### Choose between profiles when several tags match
+
+Two teams share one Cypress Cloud project, and each has a profile that scopes the accessibility report to the views it owns with [`viewFilters`](/accessibility/configuration/viewfilters). A shared nightly job is tagged for both teams. When more than one tag matches a profile name, Cypress Cloud uses the **first matching profile in the `profiles` array**, regardless of the order the tags appear on the run.
+
+#### Config
+
+```json title="App Quality Config"
+{
+  "profiles": [
+    {
+      "name": "aq-config-team-checkout",
+      "config": {
+        "viewFilters": [
+          { "pattern": "/checkout/*", "include": true },
+          {
+            "pattern": "*",
+            "include": false,
+            "comment": "Checkout team: report only on checkout views"
+          }
+        ]
+      }
+    },
+    {
+      "name": "aq-config-team-account",
+      "config": {
+        "viewFilters": [
+          { "pattern": "/account/*", "include": true },
+          {
+            "pattern": "*",
+            "include": false,
+            "comment": "Account team: report only on account views"
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+#### Usage
+
+```shell
+cypress run --record --tag "aq-config-team-account,aq-config-team-checkout"
+```
+
+Both tags match a profile, but Cypress Cloud applies `aq-config-team-checkout` because it appears first in the `profiles` array, even though `aq-config-team-account` is listed first among the tags. To change which profile wins, reorder the `profiles` array; tag order on the command line never changes the outcome.
+
 ## See also
 
 - [Cypress run `--tag`](/app/references/command-line#cypress-run-tag-lt-tag-gt) is the flag that selects which profile a run uses.
 - [Configuration overview](/accessibility/configuration/overview) lists every option a profile's `config` can override and how to regenerate reports after changing configuration.
-- [`viewFilters`](/accessibility/configuration/viewfilters) and [`elementFilters`](/accessibility/configuration/elementfilters) are common properties to scope a profile's report.
-- [Cypress Accessibility FAQ](/accessibility/faq) answers common questions about configuration.
+- [`viewFilters`](/accessibility/configuration/viewfilters) and [`elementFilters`](/accessibility/configuration/elementfilters) are common properties for scoping a profile's report.
+- [Block pull requests](/accessibility/guides/block-pull-requests) pairs a narrow pull request profile with the Results API to gate merges.
+- [Cypress Accessibility FAQ](/accessibility/faq#Profiles) answers common questions about profiles, including merge behavior and tag matching.

--- a/docs/accessibility/configuration/profiles.mdx
+++ b/docs/accessibility/configuration/profiles.mdx
@@ -137,7 +137,7 @@ Inside `accessibility`, the profile replaces only `significantAttributes`; the s
 
 ### Choose between profiles when several tags match
 
-Two teams share one Cypress Cloud project, and each has a profile that scopes the accessibility report to the views it owns with [`viewFilters`](/accessibility/configuration/viewfilters). A shared nightly job is tagged for both teams. When more than one tag matches a profile name, Cypress Cloud uses the **first matching profile in the `profiles` array**, regardless of the order the tags appear on the run.
+Two teams share one Cypress Cloud project, and each has a profile that scopes the accessibility report to the views it owns with [`viewFilters`](/accessibility/configuration/viewfilters). A shared nightly job is tagged for both teams, so both profiles match and the array order decides which one applies.
 
 #### Config
 
@@ -180,7 +180,7 @@ Two teams share one Cypress Cloud project, and each has a profile that scopes th
 cypress run --record --tag "aq-config-team-account,aq-config-team-checkout"
 ```
 
-Both tags match a profile, but Cypress Cloud applies `aq-config-team-checkout` because it appears first in the `profiles` array, even though `aq-config-team-account` is listed first among the tags. To change which profile wins, reorder the `profiles` array; tag order on the command line never changes the outcome.
+The nightly run gets `aq-config-team-checkout`, the first of the two in the array, rather than `aq-config-team-account`, even though its tag is listed first on the command line. Reorder the `profiles` array to hand the shared run to the other team.
 
 ## Confirm which profile a run used
 
@@ -189,15 +189,15 @@ After you tag and record a run, check which configuration was actually applied s
 - **In Cypress Cloud**, open the run's **Properties** tab to see the exact configuration that was applied.
 - **In CI**, read it from the [Accessibility Results API](/accessibility/results-api), where `config.value` is the applied App Quality configuration and `config.updatedAt` is when it was last saved.
 
-If the applied configuration matches your base rather than the profile you expected, the tag didn't select the profile — see [Troubleshooting](#Troubleshooting). For more on reading a run's configuration, see [Viewing configuration for a run](/accessibility/configuration/overview#Viewing-Configuration-for-a-Run).
+If the applied configuration matches your base rather than the profile you expected, the tag didn't select the profile; see [Troubleshooting](#Troubleshooting). For more on reading a run's configuration, see [Viewing configuration for a run](/accessibility/configuration/overview#Viewing-Configuration-for-a-Run).
 
 ## Troubleshooting
 
 ### A profile you tagged wasn't applied
 
-- The run tag doesn't exactly match the profile `name`. Matching is case-sensitive and exact, so `aq-config-regression` matches only the tag `aq-config-regression`, not `AQ-Config-Regression` or `aq-config-regression-nightly`.
-- The tag never reached Cypress Cloud. Profiles are selected from the tags passed to `cypress run --record --tag`, so a run recorded without `--record`, or without that `--tag`, uses the base configuration.
-- An earlier profile in the array also matches one of the run's tags and is used instead, because the first match wins. Reorder the `profiles` array to change precedence.
+- The run's tag doesn't exactly match the profile `name`. Matching is case-sensitive and exact.
+- The tag never reached Cypress Cloud. A run recorded without `--record`, or without that `--tag`, uses the base configuration.
+- Another profile earlier in the array also matches one of the run's tags and wins. Reorder the array to change precedence.
 - The report was processed before you saved the configuration. Regenerate the run to apply your current profiles. See [Setting configuration](/accessibility/configuration/overview#Setting-Configuration).
 
 ## See also

--- a/docs/accessibility/configuration/profiles.mdx
+++ b/docs/accessibility/configuration/profiles.mdx
@@ -182,6 +182,24 @@ cypress run --record --tag "aq-config-team-account,aq-config-team-checkout"
 
 Both tags match a profile, but Cypress Cloud applies `aq-config-team-checkout` because it appears first in the `profiles` array, even though `aq-config-team-account` is listed first among the tags. To change which profile wins, reorder the `profiles` array; tag order on the command line never changes the outcome.
 
+## Confirm which profile a run used
+
+After you tag and record a run, check which configuration was actually applied so you know the profile took effect. Every run permanently records its resolved configuration: your base configuration with any matching profile already merged in.
+
+- **In Cypress Cloud**, open the run's **Properties** tab to see the exact configuration that was applied.
+- **In CI**, read it from the [Accessibility Results API](/accessibility/results-api), where `config.value` is the applied App Quality configuration and `config.updatedAt` is when it was last saved.
+
+If the applied configuration matches your base rather than the profile you expected, the tag didn't select the profile — see [Troubleshooting](#Troubleshooting). For more on reading a run's configuration, see [Viewing configuration for a run](/accessibility/configuration/overview#Viewing-Configuration-for-a-Run).
+
+## Troubleshooting
+
+### A profile you tagged wasn't applied
+
+- The run tag doesn't exactly match the profile `name`. Matching is case-sensitive and exact, so `aq-config-regression` matches only the tag `aq-config-regression`, not `AQ-Config-Regression` or `aq-config-regression-nightly`.
+- The tag never reached Cypress Cloud. Profiles are selected from the tags passed to `cypress run --record --tag`, so a run recorded without `--record`, or without that `--tag`, uses the base configuration.
+- An earlier profile in the array also matches one of the run's tags and is used instead, because the first match wins. Reorder the `profiles` array to change precedence.
+- The report was processed before you saved the configuration. Regenerate the run to apply your current profiles. See [Setting configuration](/accessibility/configuration/overview#Setting-Configuration).
+
 ## See also
 
 - [Cypress run `--tag`](/app/references/command-line#cypress-run-tag-lt-tag-gt) is the flag that selects which profile a run uses.

--- a/docs/accessibility/faq.mdx
+++ b/docs/accessibility/faq.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Cypress Accessibility FAQ'
-description: 'Get answers to common questions about Cypress Accessibility, including grouping and naming views, ignoring elements with elementFilters, excluding URLs with viewFilters, the Ignored status, score impact, element identification, component context, configuration scope, reading applied config, which Axe Core® rules run and color contrast, component testing, the Axe Core® version, and per-run profiles.'
+description: 'Get answers to common questions about Cypress Accessibility, including grouping and naming views, ignoring elements with elementFilters, excluding URLs with viewFilters, the Ignored status, score impact, element identification, component context, configuration scope, reading applied config, which Axe Core® rules run and color contrast, component testing, the Axe Core® version, and per-run profiles for pull request gating and per-team reports.'
 sidebar_label: FAQ
 sidebar_position: 160
 ---
@@ -190,12 +190,14 @@ The most common causes are:
 
 There's no dedicated "skip this run" switch in a profile. To suppress a report for certain runs, point a profile at a deliberately narrow configuration (for example, [`viewFilters`](/accessibility/configuration/viewfilters) that exclude every view) so Cypress Cloud produces an empty or tightly scoped accessibility report for the run instead. See [Why use profiles?](/accessibility/configuration/profiles#Why-use-profiles).
 
-## See also
+### <Icon name="angle-right" /> How do I make accessibility checks on pull requests faster and more focused than regression runs?
 
-- [Configuration overview](/accessibility/configuration/overview) lists every configuration option and what each one is for.
-- [`views`](/accessibility/configuration/views) is the full reference for grouping and naming views.
-- [`profiles`](/accessibility/configuration/profiles) apply different configuration to runs based on run tags.
-- [`elementFilters`](/accessibility/configuration/elementfilters) is the full reference for ignoring elements.
-- [`viewFilters`](/accessibility/configuration/viewfilters) is the full reference for excluding URLs.
-- [Axe Core® configuration](/accessibility/configuration/axe-core-configuration) is the full reference for enabling, disabling, and scoping accessibility rules.
-- [Run-level reports](/accessibility/guides/run-level-reports) explains element statuses, including **Ignored**.
+Add a profile (for example, `aq-config-pr`) whose `config` narrows the report to your most critical flows with [`viewFilters`](/accessibility/configuration/viewfilters), then tag pull request runs with `cypress run --record --tag "aq-config-pr"`. The pull request report covers only those flows, so it's small and unambiguous for a developer to act on before merging, while regression runs record without the tag and keep the full base configuration. Combine the profile with the [Results API](/accessibility/results-api) to fail the build when a critical flow regresses. See [Block pull requests](/accessibility/guides/block-pull-requests#Using-Profiles-for-PR-specific-configuration).
+
+### <Icon name="angle-right" /> Can a Cypress Accessibility profile change which Axe Core® rules run for a specific run?
+
+No. A profile's `config` can override the App Quality settings in the editor ([`views`](/accessibility/configuration/views), [`viewFilters`](/accessibility/configuration/viewfilters), [`elementFilters`](/accessibility/configuration/elementfilters), [`significantAttributes`](/accessibility/configuration/significantattributes), [`attributeFilters`](/accessibility/configuration/attributefilters), and [`components`](/accessibility/configuration/components)), but the [Axe Core® ruleset](/accessibility/configuration/axe-core-configuration) isn't one of those settings. Enabling a rule that's off by default (such as `color-contrast`), turning off a false positive, or scoping to a WCAG target is a guided change Cypress applies at the project level, so it can't vary run to run through a profile. To ignore a rule only for certain elements yourself, use the [`data-a11y-ignore` attribute](/accessibility/configuration/ignoring-rules-per-element) in your application code.
+
+### <Icon name="angle-right" /> Can a Cypress Accessibility profile change how violation targets are identified, such as components or significantAttributes, for certain runs?
+
+Yes. Anything you can set under an `accessibility` key can go in a profile's `config`, including [`components`](/accessibility/configuration/components) and [`significantAttributes`](/accessibility/configuration/significantattributes). Because the `accessibility` object merges one level deep, a profile can override just one of them, for example identifying elements by `aria-label` during a labels audit, while inheriting the rest. See [How a profile changes your configuration](/accessibility/configuration/profiles#How-a-profile-changes-your-configuration).

--- a/docs/partials/_profiles.mdx
+++ b/docs/partials/_profiles.mdx
@@ -12,7 +12,7 @@ Before reaching for profiles, consider whether separate Cypress Cloud projects w
 
 ### Selecting a profile
 
-Profiles are selected by matching run tags to profile names. When you record a run with the [`--tag`](/app/references/command-line#cypress-run-tag-lt-tag-gt) flag, Cypress Cloud walks the `profiles` array in order and applies the **first profile whose `name` exactly matches one of the run's tags**. Matching is an exact, case-sensitive string comparison: the profile name `aq-config-regression` matches only the tag `aq-config-regression`, not `AQ-Config-Regression`, and not `aq-config-regression-nightly`. If no tag matches a profile name, your base configuration is used unchanged.
+Profiles are selected by matching run tags to profile names. When you record a run with the [`--tag`](/app/references/command-line#cypress-run-tag-lt-tag-gt) flag, Cypress Cloud walks the `profiles` array in order and applies the **first profile whose `name` exactly matches one of the run's tags**. Matching is an exact, case-sensitive string comparison: `aq-config-regression` matches only the tag `aq-config-regression`, not `AQ-Config-Regression` or `aq-config-regression-nightly`. When several tags match different profiles, the first match in the array wins (so list more specific profiles before broader ones), and the order the tags appear on the run makes no difference. If no tag matches, your base configuration is used unchanged.
 
 Profiles are resolved when a run is processed, not when your tests execute. Reprocessing a past run re-applies the profiles and configuration you have saved now, so you can adjust a profile and see its effect on an existing run without recording again.
 
@@ -36,8 +36,6 @@ A profile's `config` accepts any App Quality configuration setting your base con
 Use a naming convention like `aq-config-*` (for example, `aq-config-regression`, `aq-config-pr`) so it's obvious that a tag exists for configuration lookup rather than for filtering or grouping runs in Cypress Cloud.
 
 Being explicit this way helps avoid accidentally changing or removing a tag that a profile depends on. Because names are matched exactly against run tags, keep them stable: renaming a profile or changing a tag silently falls back to the base configuration for those runs.
-
-When a run could match more than one profile, order matters: the first match in the array wins, so list more specific profiles before broader ones.
 
 ## Syntax
 

--- a/docs/partials/_profiles.mdx
+++ b/docs/partials/_profiles.mdx
@@ -14,6 +14,8 @@ Before reaching for profiles, consider whether separate Cypress Cloud projects w
 
 Profiles are selected by matching run tags to profile names. When you record a run with the [`--tag`](/app/references/command-line#cypress-run-tag-lt-tag-gt) flag, Cypress Cloud walks the `profiles` array in order and applies the **first profile whose `name` exactly matches one of the run's tags**. Matching is an exact, case-sensitive string comparison: the profile name `aq-config-regression` matches only the tag `aq-config-regression`, not `AQ-Config-Regression`, and not `aq-config-regression-nightly`. If no tag matches a profile name, your base configuration is used unchanged.
 
+Profiles are resolved when a run is processed, not when your tests execute. Reprocessing a past run re-applies the profiles and configuration you have saved now, so you can adjust a profile and see its effect on an existing run without recording again.
+
 ### How a profile changes your configuration
 
 When a profile applies, its `config` is laid over your base configuration one setting at a time. Only the settings you include in the profile change; everything else stays exactly as it is in your base configuration. A few things are worth knowing so the result matches what you expect:
@@ -34,6 +36,8 @@ A profile's `config` accepts any App Quality configuration setting your base con
 Use a naming convention like `aq-config-*` (for example, `aq-config-regression`, `aq-config-pr`) so it's obvious that a tag exists for configuration lookup rather than for filtering or grouping runs in Cypress Cloud.
 
 Being explicit this way helps avoid accidentally changing or removing a tag that a profile depends on. Because names are matched exactly against run tags, keep them stable: renaming a profile or changing a tag silently falls back to the base configuration for those runs.
+
+When a run could match more than one profile, order matters: the first match in the array wins, so list more specific profiles before broader ones.
 
 ## Syntax
 

--- a/docs/partials/_profiles.mdx
+++ b/docs/partials/_profiles.mdx
@@ -1,18 +1,18 @@
-The `profiles` property lets a single Cypress Cloud project serve many kinds of runs. Instead of maintaining separate projects (or living with one configuration that has to compromise between smoke tests, full regression suites, and per-team reporting), you keep one base configuration and layer targeted overrides on top of it. The right override is selected automatically from the [run tags](/app/references/command-line#cypress-run-tag-lt-tag-gt) you already pass to `cypress run`, so a regression run and a pull request run can each get exactly the App Quality configuration that makes their report actionable, with no changes to your test code.
+One Cypress Cloud project usually records many kinds of runs (pull request checks, nightly regression suites, per-team smoke tests), and each kind is best served by a different App Quality configuration. The `profiles` property lets you keep a single base configuration and layer targeted overrides on top of it. The right override is selected automatically from the [run tags](/app/references/command-line#cypress-run-tag-lt-tag-gt) you already pass to `cypress run`, so a pull request run and a full regression run can each get exactly the configuration that makes their report actionable, with no changes to your test code and no second project to maintain.
 
-In many cases, the need for different profiles can be avoided completely by having distinct Cypress Cloud projects for different kinds of runs or different team ownership. This is the recommended first choice, because it usually simplifies reporting and tracking. But where distinct projects are not the right answer, profiles will help.
+Before reaching for profiles, consider whether separate Cypress Cloud projects would be simpler. Distinct projects for different applications or teams usually keep reporting and tracking clearer, and are the recommended first choice. Reach for profiles when the runs belong in one project but need different configuration.
 
 ## Why use profiles?
 
-- **Team-specific reporting**: If multiple teams use the same Cypress Cloud project, they may care about completely different pages or DOM elements in their accessibility or UI Coverage reports. Profiles let each team tag their runs to see and track only the results that matter to them, filtering out everything else.
-- **Run-type customization**: Use different filters or settings for regression runs versus pull requests. It can be useful to have a narrow config for blocking a merge, optimized for the most critical areas of your app and high "solvability", while still running a wide config on a full regression suite to manage findings on a different cadence.
-- **Scope a report down for specific runs**: When a full report isn't useful for a certain kind of run, point a profile at a deliberately narrow configuration (for example, `viewFilters` that keep only a handful of views, or exclude everything else) so the report stays focused on what matters for that run type. There is no dedicated "skip this run" switch; you scope reporting by supplying a narrower configuration through the profile.
+- **Tune pull request checks against regression runs**: Gate merges with a narrow configuration focused on your most critical flows, so the report a developer sees on a PR is small, fast to act on, and high in "solvability". Keep a wide configuration on the full regression suite to track everything else on a slower cadence.
+- **Team-specific reporting**: When multiple teams share one project, each team can tag its runs and see a report scoped to the pages or elements it owns, filtering out everyone else's. Nobody has to read around results they don't care about.
+- **Purpose-built audit runs**: A one-off audit, such as a localization pass, a design-system sweep, or a deep dive on an area you normally exclude, can use configuration you'd never want applied to every run.
 
 ## How profiles work
 
 ### Selecting a profile
 
-Profiles are selected by matching run tags to profile names. When you record a run with the [`--tag`](/app/references/command-line#cypress-run-tag-lt-tag-gt) flag, Cypress Cloud walks the `profiles` array in order and applies the **first profile whose `name` exactly matches one of the run's tags**. Matching is an exact, case-sensitive string comparison: the profile name `aq-config-regression` matches only the tag `aq-config-regression`, not `AQ-Config-Regression`, and not `aq-config-regression-nightly`.
+Profiles are selected by matching run tags to profile names. When you record a run with the [`--tag`](/app/references/command-line#cypress-run-tag-lt-tag-gt) flag, Cypress Cloud walks the `profiles` array in order and applies the **first profile whose `name` exactly matches one of the run's tags**. Matching is an exact, case-sensitive string comparison: the profile name `aq-config-regression` matches only the tag `aq-config-regression`, not `AQ-Config-Regression`, and not `aq-config-regression-nightly`. If no tag matches a profile name, your base configuration is used unchanged.
 
 ### How a profile changes your configuration
 
@@ -20,15 +20,20 @@ When a profile applies, its `config` is laid over your base configuration one se
 
 - **A setting in a profile fully replaces the base version of that setting.** Lists are not combined. If your base configuration has three `elementFilters` rules and a profile defines its own `elementFilters`, the profile's rules are used on their own, so copy over any base rules you still want to apply.
 - **Anything you leave out of a profile stays the same.** You only need to list what's different for that kind of run; the rest is inherited from your base configuration.
-- **`uiCoverage` and `accessibility` settings are handled one by one.** Overriding a single setting inside `uiCoverage` (say, `elementGroups`) leaves the other `uiCoverage` settings (like `attributeFilters`) untouched, so you can adjust one product-specific setting without restating the rest.
+- **The `accessibility` and `uiCoverage` objects are merged one level deep.** Overriding a single setting inside one of them, such as `accessibility.significantAttributes`, leaves the sibling settings in that object (like `accessibility.elementFilters`) untouched, so you can adjust one product-specific setting without restating the rest.
 
-You can't put a `profiles` list inside a profile. Profiles live only at the top level of your configuration; a profile's `config` can use any other App Quality setting.
+### What a profile can and can't change
+
+A profile's `config` accepts any App Quality configuration setting your base configuration supports: the same `viewFilters`, `elementFilters`, `views`, and product-specific settings you'd set at the root. Two limits are worth knowing:
+
+- **You can't nest a `profiles` array inside a profile.** Profiles live only at the top level of your configuration; one level of overrides is the maximum.
+- **There's no switch to skip a run or turn a product off.** A profile can only change configuration values. To suppress a report for a certain kind of run, point its profile at a deliberately narrow configuration (for example, `viewFilters` that exclude every view) so the run produces an empty or tightly scoped report instead.
 
 ## Best practices
 
-Use a naming convention like `aq-config-x` (e.g., `aq-config-regression`, `aq-config-staging`) to make it clear that a tag is used for configuration lookup purposes.
+Use a naming convention like `aq-config-*` (for example, `aq-config-regression`, `aq-config-pr`) so it's obvious that a tag exists for configuration lookup rather than for filtering or grouping runs in Cypress Cloud.
 
-While relying on existing tags works just fine, being explicit will help avoid unintentionally changing or removing a tag which is depended on for a profile. Because names are matched exactly against run tags, keep them stable; renaming a profile or changing a tag silently falls back to the base configuration for those runs.
+Being explicit this way helps avoid accidentally changing or removing a tag that a profile depends on. Because names are matched exactly against run tags, keep them stable: renaming a profile or changing a tag silently falls back to the base configuration for those runs.
 
 ## Syntax
 
@@ -53,212 +58,3 @@ While relying on existing tags works just fine, being explicit will help avoid u
 | `name`    | Required | Identifies the profile so a run can select it. Its only purpose is matching: the profile applies when one of the run's tags is an exact, case-sensitive match for this value. It isn't shown in reports or used anywhere else. |
 | `config`  | Required | An object containing any App Quality configuration options, except a nested `profiles` array. These values override the root configuration.                                                                                    |
 | `comment` | Optional | A note about why this profile exists, for your team's benefit. Comments appear only in the configuration itself. They have no effect on behavior and are not displayed in reports.                                             |
-
-## Examples
-
-### Basic profile structure
-
-Your base configuration excludes the support-chat widget, since another team owns it and it just adds noise to most reports. But one suite exists specifically to test the support-chat flow, and it records under the `aq-config-support-chat` tag. For that run, and only that run, the widget should count toward coverage.
-
-#### Config
-
-```json title="App Quality Config"
-{
-  "elementFilters": [
-    {
-      "selector": "#support-chat-widget",
-      "include": false,
-      "comment": "Exclude the support-chat widget from most reports"
-    }
-  ],
-  "profiles": [
-    {
-      "name": "aq-config-support-chat",
-      "config": {
-        "elementFilters": [
-          {
-            "selector": "#support-chat-widget",
-            "include": true,
-            "comment": "The support-chat suite tests this widget, so count it here"
-          }
-        ]
-      }
-    }
-  ]
-}
-```
-
-#### Usage
-
-Record the support-chat suite with a matching tag:
-
-```shell
-cypress run --record --tag "aq-config-support-chat"
-```
-
-On every other run the widget stays excluded. On the tagged run, the profile's `elementFilters` replaces the base list, so the `include: true` rule wins and the widget counts toward coverage. Because a profile's list replaces the base list rather than adding to it, list every rule the run needs, not only the one that changed.
-
----
-
-### Multiple profiles
-
-You can define several profiles, each for a different kind of run. Here, two focused audit suites want the same routes broken down into separate [views](/ui-coverage/core-concepts/views) so they can see coverage per value: a reporting audit splits `/reports/:type` by report type, and a localization audit splits `/:locale/account` by locale. You wouldn't want either split applied to every run, since it would fragment your normal reports into many low-traffic views, so each `views` rule is scoped to its own tag.
-
-#### Config
-
-```json title="App Quality Config"
-{
-  "profiles": [
-    {
-      "name": "aq-config-reporting-audit",
-      "config": {
-        "views": [
-          {
-            "pattern": "/reports/:type",
-            "groupBy": ["type"],
-            "comment": "One view per report type for the reporting audit"
-          }
-        ]
-      }
-    },
-    {
-      "name": "aq-config-localization-audit",
-      "config": {
-        "views": [
-          {
-            "pattern": "/:locale/account",
-            "groupBy": ["locale"],
-            "comment": "One view per locale for the localization audit"
-          }
-        ]
-      }
-    }
-  ]
-}
-```
-
-#### Usage
-
-Use different tags to activate different profiles:
-
-```shell
-# Reporting audit runs
-cypress run --record --tag "aq-config-reporting-audit"
-
-# Localization audit runs
-cypress run --record --tag "aq-config-localization-audit"
-```
-
----
-
-### Profile with nested configuration
-
-Profiles can override configuration at any level, including configuration specific to Cypress Accessibility or UI Coverage when your project has both products enabled. Because `uiCoverage` and `accessibility` merge one level deep, a profile can add or replace a single nested property while inheriting the rest.
-
-Here the base configuration groups every product card into one [element group](/ui-coverage/configuration/elementgroups) so the repeated cards count once and don't dominate the score. A suite that specifically exercises each card variant, tagged `aq-config-card-variants`, needs the opposite: the same cards split into separate groups so featured and standard cards are tracked independently. The two groupings can't both be the base configuration, so the difference lives in a profile.
-
-#### Config
-
-```json title="App Quality Config"
-{
-  "uiCoverage": {
-    "attributeFilters": [
-      {
-        "attribute": "id",
-        "value": ":r.*:",
-        "include": false,
-        "comment": "Ignore React auto-generated IDs so elements stay stable across renders"
-      }
-    ],
-    "elementGroups": [
-      {
-        "selector": "[data-cy='product-card']",
-        "name": "Product card",
-        "comment": "Count the repeated product cards as one group"
-      }
-    ]
-  },
-  "profiles": [
-    {
-      "name": "aq-config-card-variants",
-      "config": {
-        "uiCoverage": {
-          "elementGroups": [
-            {
-              "selector": "[data-cy='product-card'][data-variant='featured']",
-              "name": "Featured product card"
-            },
-            {
-              "selector": "[data-cy='product-card'][data-variant='standard']",
-              "name": "Standard product card"
-            }
-          ]
-        }
-      }
-    }
-  ]
-}
-```
-
-#### Usage
-
-```shell
-cypress run --record --tag "aq-config-card-variants"
-```
-
-Inside `uiCoverage`, the profile replaces `elementGroups` with its own two groups while the sibling `attributeFilters` is inherited; only the keys the profile names are replaced. On every other run, the single "Product card" group still applies.
-
----
-
-### Profile selection with multiple matching tags
-
-Two teams share one Cypress Cloud project, and each has a profile that scopes the report to the views they own. A shared nightly job is tagged for both teams. When more than one tag matches a profile name, Cypress Cloud uses the first matching profile in the `profiles` array, regardless of the order the tags appear on the run.
-
-#### Config
-
-```json title="App Quality Config"
-{
-  "profiles": [
-    {
-      "name": "aq-config-team-checkout",
-      "config": {
-        "viewFilters": [
-          {
-            "pattern": "/checkout/*",
-            "include": true
-          },
-          {
-            "pattern": "*",
-            "include": false,
-            "comment": "Checkout team: report only on checkout views"
-          }
-        ]
-      }
-    },
-    {
-      "name": "aq-config-team-account",
-      "config": {
-        "viewFilters": [
-          {
-            "pattern": "/account/*",
-            "include": true
-          },
-          {
-            "pattern": "*",
-            "include": false,
-            "comment": "Account team: report only on account views"
-          }
-        ]
-      }
-    }
-  ]
-}
-```
-
-#### Usage
-
-```shell
-cypress run --record --tag "aq-config-team-account,aq-config-team-checkout"
-```
-
-Both tags match a profile, but Cypress Cloud applies `aq-config-team-checkout` because it appears first in the `profiles` array, even though `aq-config-team-account` is listed first among the tags. The checkout team's report is produced; tag order on the command line doesn't change the outcome.

--- a/docs/ui-coverage/configuration/profiles.mdx
+++ b/docs/ui-coverage/configuration/profiles.mdx
@@ -11,6 +11,209 @@ sidebar_position: 110
 
 <Profiles />
 
+## Examples
+
+### Basic profile structure
+
+Your base configuration excludes the support-chat widget, since another team owns it and it just adds noise to most reports. But one suite exists specifically to test the support-chat flow, and it records under the `aq-config-support-chat` tag. For that run, and only that run, the widget should count toward coverage.
+
+#### Config
+
+```json title="App Quality Config"
+{
+  "elementFilters": [
+    {
+      "selector": "#support-chat-widget",
+      "include": false,
+      "comment": "Exclude the support-chat widget from most reports"
+    }
+  ],
+  "profiles": [
+    {
+      "name": "aq-config-support-chat",
+      "config": {
+        "elementFilters": [
+          {
+            "selector": "#support-chat-widget",
+            "include": true,
+            "comment": "The support-chat suite tests this widget, so count it here"
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+#### Usage
+
+Record the support-chat suite with a matching tag:
+
+```shell
+cypress run --record --tag "aq-config-support-chat"
+```
+
+On every other run the widget stays excluded. On the tagged run, the profile's `elementFilters` replaces the base list, so the `include: true` rule wins and the widget counts toward coverage. Because a profile's list replaces the base list rather than adding to it, list every rule the run needs, not only the one that changed.
+
+### Multiple profiles
+
+You can define several profiles, each for a different kind of run. Here, two focused audit suites want the same routes broken down into separate [views](/ui-coverage/core-concepts/views) so they can see coverage per value: a reporting audit splits `/reports/:type` by report type, and a localization audit splits `/:locale/account` by locale. You wouldn't want either split applied to every run, since it would fragment your normal reports into many low-traffic views, so each `views` rule is scoped to its own tag.
+
+#### Config
+
+```json title="App Quality Config"
+{
+  "profiles": [
+    {
+      "name": "aq-config-reporting-audit",
+      "config": {
+        "views": [
+          {
+            "pattern": "/reports/:type",
+            "groupBy": ["type"],
+            "comment": "One view per report type for the reporting audit"
+          }
+        ]
+      }
+    },
+    {
+      "name": "aq-config-localization-audit",
+      "config": {
+        "views": [
+          {
+            "pattern": "/:locale/account",
+            "groupBy": ["locale"],
+            "comment": "One view per locale for the localization audit"
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+#### Usage
+
+Use different tags to activate different profiles:
+
+```shell
+# Reporting audit runs
+cypress run --record --tag "aq-config-reporting-audit"
+
+# Localization audit runs
+cypress run --record --tag "aq-config-localization-audit"
+```
+
+### Profile with nested configuration
+
+Profiles can override configuration at any level, including configuration specific to Cypress Accessibility or UI Coverage when your project has both products enabled. Because `uiCoverage` and `accessibility` merge one level deep, a profile can add or replace a single nested property while inheriting the rest.
+
+Here the base configuration groups every product card into one [element group](/ui-coverage/configuration/elementgroups) so the repeated cards count once and don't dominate the score. A suite that specifically exercises each card variant, tagged `aq-config-card-variants`, needs the opposite: the same cards split into separate groups so featured and standard cards are tracked independently. The two groupings can't both be the base configuration, so the difference lives in a profile.
+
+#### Config
+
+```json title="App Quality Config"
+{
+  "uiCoverage": {
+    "attributeFilters": [
+      {
+        "attribute": "id",
+        "value": ":r.*:",
+        "include": false,
+        "comment": "Ignore React auto-generated IDs so elements stay stable across renders"
+      }
+    ],
+    "elementGroups": [
+      {
+        "selector": "[data-cy='product-card']",
+        "name": "Product card",
+        "comment": "Count the repeated product cards as one group"
+      }
+    ]
+  },
+  "profiles": [
+    {
+      "name": "aq-config-card-variants",
+      "config": {
+        "uiCoverage": {
+          "elementGroups": [
+            {
+              "selector": "[data-cy='product-card'][data-variant='featured']",
+              "name": "Featured product card"
+            },
+            {
+              "selector": "[data-cy='product-card'][data-variant='standard']",
+              "name": "Standard product card"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+
+#### Usage
+
+```shell
+cypress run --record --tag "aq-config-card-variants"
+```
+
+Inside `uiCoverage`, the profile replaces `elementGroups` with its own two groups while the sibling `attributeFilters` is inherited; only the keys the profile names are replaced. On every other run, the single "Product card" group still applies.
+
+### Profile selection with multiple matching tags
+
+Two teams share one Cypress Cloud project, and each has a profile that scopes the report to the views they own. A shared nightly job is tagged for both teams. When more than one tag matches a profile name, Cypress Cloud uses the first matching profile in the `profiles` array, regardless of the order the tags appear on the run.
+
+#### Config
+
+```json title="App Quality Config"
+{
+  "profiles": [
+    {
+      "name": "aq-config-team-checkout",
+      "config": {
+        "viewFilters": [
+          {
+            "pattern": "/checkout/*",
+            "include": true
+          },
+          {
+            "pattern": "*",
+            "include": false,
+            "comment": "Checkout team: report only on checkout views"
+          }
+        ]
+      }
+    },
+    {
+      "name": "aq-config-team-account",
+      "config": {
+        "viewFilters": [
+          {
+            "pattern": "/account/*",
+            "include": true
+          },
+          {
+            "pattern": "*",
+            "include": false,
+            "comment": "Account team: report only on account views"
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+#### Usage
+
+```shell
+cypress run --record --tag "aq-config-team-account,aq-config-team-checkout"
+```
+
+Both tags match a profile, but Cypress Cloud applies `aq-config-team-checkout` because it appears first in the `profiles` array, even though `aq-config-team-account` is listed first among the tags. The checkout team's report is produced; tag order on the command line doesn't change the outcome.
+
 ## See also
 
 - [Cypress run `--tag`](/app/references/command-line#cypress-run-tag-lt-tag-gt) is the flag that selects which profile a run uses.


### PR DESCRIPTION
## Summary

Reworks the Cypress Accessibility [`profiles`](https://docs.cypress.io/accessibility/configuration/profiles) configuration page so it's accurate, leads with value, and uses accessibility-realistic examples. The concept content stays shared with the UI Coverage profiles page through the `_profiles` partial; the product-specific examples are inlined on each page.

## Why

The profiles page was built on a partial whose examples were UI-Coverage-flavored (product cards, `elementGroups`, "coverage per value") and, in places, inaccurate for Cypress Accessibility semantics — for example, an `elementFilters` example that relied on `include: true` to "re-include" an element, which isn't how accessibility's "an element is scanned unless an exclude matches it" behavior works.

To ground the rewrite, the selection and merge behavior was verified against the App Quality config implementation in `cypress-services` (`resolveConfigToProfile` in `AppQualityConfigDataSource.ts` and the v0.1 Zod schema): exact/case-sensitive tag matching, first-profile-in-array wins, a shallow override with a one-level-deep merge of the `accessibility`/`uiCoverage` objects, and `config` accepting any App Quality setting except a nested `profiles` array.

## What changed

- **Value-first lead** — one Cypress Cloud project serving many run types, with the right override selected automatically by run tag.
- **Accessibility-accurate examples** — a pull request gate via `viewFilters`; re-including a widget for a dedicated audit via `elementFilters` (framed as "scanned unless excluded", not `include: true`); an accessibility-only nested override of `significantAttributes`/`components` that demonstrates the one-level-deep merge; and first-in-array profile selection when several tags match.
- **Partial hygiene** — the shared `_profiles` partial keeps the product-neutral concepts (selection, merge, best practices, syntax, options); the examples are inlined per page rather than split into single-use partials. This rule ("a partial must render in more than one location") is now recorded in `AGENTS.md` and `AGENTS_REFERENCE.md`.
- **`App Quality Config` title** on every config example.
- **FAQ / SEO-AEO** — extended the accessibility FAQ Profiles section (PR gating, Axe Core rule scope, identifying-attribute overrides) and refreshed the page's See also.

## Notes for reviewers

- **UI Coverage rendered output is essentially unchanged**: its examples were only relocated out of the shared partial and inlined into its own page (byte-identical content), plus the horizontal-rule separators between examples were removed to match the accessibility page.
- **One deliberate omission**: profiles *can* technically override the `policies` config key, but `policies` isn't documented as a public App Quality setting, so it's intentionally not featured here.
- Verified locally with `prettier --check`, the FAQ structured-data test (37 passing), and a full `npm run build` with `onBrokenLinks`/`onBrokenAnchors: 'throw'`, so every cross-link and anchor resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rjFCckG7gJL9ATYzoX8my

---
_Generated by [Claude Code](https://claude.ai/code/session_018rjFCckG7gJL9ATYzoX8my)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to MDX and agent guides; no application code or runtime behavior.
> 
> **Overview**
> Reworks **Cypress Accessibility** `profiles` documentation so shared concept copy stays in `_profiles.mdx` while **accessibility-specific examples** live on the accessibility profiles page, and **UI Coverage examples** move from the partial into the UI Coverage profiles page (behavior unchanged for UI Coverage readers).
> 
> The shared partial is tightened (value-first lead, PR vs regression framing, tag/precedence and reprocessing notes, limits on nested `profiles` and “skip run”). **Accessibility** gains realistic examples (PR `viewFilters` gate, `elementFilters` re-inclusion without misleading `include: true`, nested `accessibility.significantAttributes`, multi-tag precedence), plus **Confirm which profile a run used** and **Troubleshooting**. The **FAQ** Profiles section adds PR gating, Axe rules scope, and identification overrides; the accessibility profiles **See also** and meta **description** are refreshed.
> 
> **Agent docs** now require partials only when content renders in **more than one** location.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acbd7b28466737c536a78ccc726b5987642dad2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->