### PR TITLE
Studio: add docs for logged-out Studio AI availability

### DIFF
--- a/docs/app/guides/cypress-studio.mdx
+++ b/docs/app/guides/cypress-studio.mdx
@@ -37,7 +37,11 @@ The result is faster test authoring and fewer gaps in coverage without guessing 
 | **AI assertion recommendations**                | -                 | ✅                         |
 | **Review DOM snapshots for AI recommendations** | -                 | ✅                         |
 
-If you don't have a Cloud account, Studio still works for recording interactions and manually adding assertions. The AI recommendations panel will ask you to login and link your project when you open it.
+If you don't have a Cloud account, Studio still works for recording interactions and manually adding assertions.
+
+:::note Try Studio AI without an account
+Studio AI also works without logging in. If you choose, you can generate and accept up to **6 AI recommendations** before you're asked to log in and link a project to continue. You can decline the trial or turn off AI recommendations at any time from the AI status indicator in the Studio panel - see [Disable AI](#Disable-AI).
+:::
 
 ## Get started
 
@@ -271,6 +275,10 @@ You can disable Studio AI for any individual session by clicking the AI status i
   title="Disabling Studio AI for a session"
 />
 
+### For an anonymous trial session
+
+If you're trying Studio AI without logging in, you can decline the trial prompt when it appears, or turn off AI recommendations afterward from the same AI status indicator.
+
 ### For an entire organization
 
 Organization admins and owners can disable AI capabilities for their entire organization from Cypress Cloud organization settings. This affects all users in the organization.
@@ -285,6 +293,8 @@ Recommendation limits are per user, per hour. All plans share a limit of 10 para
 | ---------------------------------- | ------------------------ |
 | Free Cloud account                 | 60                       |
 | Paid Cloud account (or free trial) | 300                      |
+
+If you're not logged in, Studio AI works as a trial: you can accept up to **6 recommendations** per browser session before you're asked to log in and link a project to continue.
 
 During the beta, Studio AI is included at no additional charge. Limits and pricing are subject to change. We'll communicate any adjustments before they take effect.
 

--- a/docs/app/guides/cypress-studio.mdx
+++ b/docs/app/guides/cypress-studio.mdx
@@ -39,8 +39,8 @@ The result is faster test authoring and fewer gaps in coverage without guessing 
 
 If you don't have a Cloud account, Studio still works for recording interactions and manually adding assertions.
 
-:::note Try Studio AI without an account
-Studio AI also works without logging in. If you choose, you can generate and accept up to **6 AI recommendations** before you're asked to log in and link a project to continue. You can decline the trial or turn off AI recommendations at any time from the AI status indicator in the Studio panel - see [Disable AI](#Disable-AI).
+:::note
+**Try Studio AI without an account**. If you choose, you can generate and accept up to **6 AI recommendations** before you're asked to log in and link a project to continue. You can decline the trial or turn off AI recommendations at any time from the AI status indicator in the Studio panel - see [Disable AI](#Disable-AI).
 :::
 
 ## Get started

--- a/docs/cloud/features/cypress-ai-features.mdx
+++ b/docs/cloud/features/cypress-ai-features.mdx
@@ -265,6 +265,8 @@ Some hourly limits apply to all plans. Those are as follows:
 | Cloud CLI requests          | 100 per hour, per user | 100 per hour, per user    |
 | UI Coverage Test Generation | Not available          | Included with UI Coverage |
 
+Studio AI can also be tried without logging in, capped at 6 accepted recommendations per browser session. See [Studio AI usage limits](/app/guides/cypress-studio#Usage-limits) for details.
+
 If you need to increase your limits, contact support at support@cypress.io.
 
 ### Pricing


### PR DESCRIPTION
Document the existence and limitations related to optional logged-out use of Studio AI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates with no product or security behavior changes.
> 
> **Overview**
> **Documents logged-out Studio AI** so readers know they can try recommendations before signing in, instead of only seeing a login prompt when opening the AI panel.
> 
> The **Cypress Studio** guide adds a callout for up to **6 accepted AI recommendations** per browser session, a **Usage limits** note for anonymous trials, and a **Disable AI → For an anonymous trial session** subsection (decline the prompt or use the AI status indicator). The **Cypress AI features** page links the same **6 accepted recommendations per session** cap to the Studio usage limits section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e725db6c682cacf923c1653d3917e0db25aeba2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->