### PR TITLE
docs: fix empty right-sidebar TOC on the views config pages

### DIFF
--- a/docs/accessibility/configuration/views.mdx
+++ b/docs/accessibility/configuration/views.mdx
@@ -5,6 +5,13 @@ sidebar_label: 'Group & name views'
 sidebar_position: 20
 ---
 
+import { toc as viewsToc } from '@site/docs/partials/_views.mdx'
+
+export const toc = [
+  ...viewsToc,
+  { value: 'See also', id: 'See-also', level: 2 },
+]
+
 <ProductHeading product="accessibility" />
 
 # Group & name views - `views`

--- a/docs/ui-coverage/configuration/views.mdx
+++ b/docs/ui-coverage/configuration/views.mdx
@@ -5,6 +5,13 @@ sidebar_label: 'Group & name views'
 sidebar_position: 20
 ---
 
+import { toc as viewsToc } from '@site/docs/partials/_views.mdx'
+
+export const toc = [
+  ...viewsToc,
+  { value: 'See also', id: 'See-also', level: 2 },
+]
+
 <ProductHeading product="ui-coverage" />
 
 # Group & name views - `views`


### PR DESCRIPTION
## Summary

Restores the right-sidebar table of contents on the Accessibility and UI Coverage "Group & name views" (`views`) configuration pages, which had collapsed to a single "See also" entry. The pages now list every section (Syntax, Examples, Troubleshooting, and the rest).

## Why

Both pages render all of their content headings from the shared `<Views />` partial (`docs/partials/_views.mdx`); the page files themselves contain only the H1 and a `## See also` heading. Docusaurus builds a page's table of contents **only from headings that appear directly in the page file**, so headings inside an imported partial were dropped — leaving the right sidebar with just "See also" and hiding every real section.

The fix imports the partial's auto-generated `toc` export and merges it with the page's own "See also" heading via `export const toc`, so the sidebar lists all sections while `_views.mdx` remains the single source of truth for both pages.

Closes #<!-- no issue -->

## Notes for reviewers

- The same defect affected the UI Coverage `views` page (same shared partial), so both pages are fixed identically.
- This repo uses a case-preserving heading slugger, so the manually added "See also" TOC entry uses the anchor id `See-also` (not lowercase `see-also`). Docusaurus's broken-anchor check confirms every TOC entry resolves.
- Verified with a full `npm run build` (passes clean, including the broken-anchor check) plus the Prettier and frontmatter linters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EDQQVBQaukepQPeVMVf3Eb

---
_Generated by [Claude Code](https://claude.ai/code/session_01EDQQVBQaukepQPeVMVf3Eb)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only MDX TOC wiring with no runtime, API, or security impact.
> 
> **Overview**
> **Fixes the right-sidebar table of contents** on the Accessibility and UI Coverage **Group & name views** (`views`) configuration pages, which had collapsed to only **See also** because Docusaurus only indexes headings in the page file—not headings rendered from the shared `<Views />` partial.
> 
> Each page now **imports `toc` from `docs/partials/_views.mdx`** and **`export const toc`** merges that list with a manual entry for **See also** (anchor id `See-also` for this repo’s case-preserving slugger). Section labels stay in sync with the partial as the single source of truth for both product pages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff0f6ab5c576c1fcd41c5696747b8e8ec0d0b0e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->