### PR TITLE
Add cypress-device-emulate to plugins list

### DIFF
--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -1288,6 +1288,13 @@
           "badge": "community"
         },
         {
+          "name": "cypress-device-emulate",
+          "description": "Real mobile device emulation for Cypress — viewport, touch, user agent, device pixel ratio, and live orientation rotation via Chrome DevTools Protocol.",
+          "link": "https://github.com/sekharsdet/cypress-device-emulate",
+          "keywords": ["mobile", "device-emulation", "viewport", "touch", "cdp", "orientation"],
+          "badge": "community"
+        },
+        {
           "name": "cypress-plugin-tab",
           "description": "A Cypress plugin to add a tab command.",
           "link": "https://github.com/Bkucera/cypress-plugin-tab",


### PR DESCRIPTION
## Summary

Adds [`cypress-device-emulate`](https://www.npmjs.com/package/cypress-device-emulate) to the **User Interactions** category of the plugins list, alongside `cy-mobile-commands`.

`cypress-device-emulate` is a mobile device emulation plugin that drives the Chrome DevTools Protocol connection Cypress already has open (the same mechanism Chrome DevTools' own Device Mode uses) to correctly set:

- Viewport, device pixel ratio, and the mobile flag
- `navigator.userAgent`
- Touch API (`ontouchstart`, `TouchEvent`) and `hover`/`pointer` media queries
- `screen.orientation`, with live rotation via `cy.rotate()`
- Optional `locale`, `timezoneId`, and `geolocation` overrides

It ships with a catalog of ~80 real Android/iOS phones and tablets, Chromium-only scope (Chrome/Edge/Electron — throws a clear error on Firefox rather than failing silently), and 186 passing integration tests run against Cypress itself in CI (3-OS × Chrome/Electron × Node 18/20 matrix).

## Test plan

- [x] `plugins.json` change validated as well-formed JSON
- [x] Entry follows the existing schema/format used by neighboring entries in the same category
- [x] Linked repository is public, has CI, and its `package.json` has complete `homepage`/`repository`/`bugs` metadata