### PR TITLE
docs: add 15.20.0 changelog entries from the Cypress CLI changelog

### DIFF
--- a/docs/api/commands/intercept.mdx
+++ b/docs/api/commands/intercept.mdx
@@ -110,7 +110,7 @@ cy.intercept('/users*', { hostname: 'localhost' }, (req) => {
 
 Match the route to a specific
 [HTTP method](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods) (`GET`,
-`POST`, `PUT`, etc).
+`POST`, `PUT`, `PATCH`, `DELETE`, `QUERY`, etc).
 
 :::note
 
@@ -477,7 +477,9 @@ A [`StaticResponse`][staticresponse] object represents a response to an HTTP
 request, and can be used to stub routes:
 
 ```js
-const staticResponse = {/* some StaticResponse properties here... */}
+const staticResponse = {
+  /* some StaticResponse properties here... */
+}
 
 cy.intercept('/projects', staticResponse)
 ```
@@ -1774,17 +1776,18 @@ information about the request and response to the console:
 
 ## History
 
-| Version                                    | Changes                                                                                                                                                                                                                                                                                              |
-| ------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [14.0.0](/app/references/changelog#14-0-0) | Deprecated `resourceType` property                                                                                                                                                                                                                                                                   |
-| [12.2.0](/app/references/changelog#12-2-0) | Added `resourceType` property to `req` and `RouteMatcher`.                                                                                                                                                                                                                                           |
-| [7.6.0](/app/references/changelog#7-0-0)   | Added `query` option to `req` (The incoming request object yielded to request handler functions).                                                                                                                                                                                                    |
-| [7.0.0](/app/references/changelog#7-0-0)   | Removed `matchUrlAgainstPath` option from `RouteMatcher`, reversed handler ordering, added request events, removed substring URL matching, removed `cy.route2` alias, added `middleware` RouteMatcher option, renamed `res.delay()` to `res.setDelay()` and `res.throttle()` to `res.setThrottle()`. |
-| [6.4.0](/app/references/changelog#6-4-0)   | Renamed `delayMs` property to `delay` (backwards-compatible).                                                                                                                                                                                                                                        |
-| [6.2.0](/app/references/changelog#6-2-0)   | Added `matchUrlAgainstPath` option to `RouteMatcher`.                                                                                                                                                                                                                                                |
-| [6.0.0](/app/references/changelog#6-0-0)   | Renamed `cy.route2()` to `cy.intercept()`.                                                                                                                                                                                                                                                           |
-| [6.0.0](/app/references/changelog#6-0-0)   | Removed `experimentalNetworkStubbing` option and made it the default behavior.                                                                                                                                                                                                                       |
-| [5.1.0](/app/references/changelog#5-1-0)   | Added experimental `cy.route2()` command under `experimentalNetworkStubbing` option.                                                                                                                                                                                                                 |
+| Version                                      | Changes                                                                                                                                                                                                                                                                                              |
+| -------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [15.20.0](/app/references/changelog#15-20-0) | Added support for `QUERY` method.                                                                                                                                                                                                                                                                    |
+| [14.0.0](/app/references/changelog#14-0-0)   | Deprecated `resourceType` property                                                                                                                                                                                                                                                                   |
+| [12.2.0](/app/references/changelog#12-2-0)   | Added `resourceType` property to `req` and `RouteMatcher`.                                                                                                                                                                                                                                           |
+| [7.6.0](/app/references/changelog#7-0-0)     | Added `query` option to `req` (The incoming request object yielded to request handler functions).                                                                                                                                                                                                    |
+| [7.0.0](/app/references/changelog#7-0-0)     | Removed `matchUrlAgainstPath` option from `RouteMatcher`, reversed handler ordering, added request events, removed substring URL matching, removed `cy.route2` alias, added `middleware` RouteMatcher option, renamed `res.delay()` to `res.setDelay()` and `res.throttle()` to `res.setThrottle()`. |
+| [6.4.0](/app/references/changelog#6-4-0)     | Renamed `delayMs` property to `delay` (backwards-compatible).                                                                                                                                                                                                                                        |
+| [6.2.0](/app/references/changelog#6-2-0)     | Added `matchUrlAgainstPath` option to `RouteMatcher`.                                                                                                                                                                                                                                                |
+| [6.0.0](/app/references/changelog#6-0-0)     | Renamed `cy.route2()` to `cy.intercept()`.                                                                                                                                                                                                                                                           |
+| [6.0.0](/app/references/changelog#6-0-0)     | Removed `experimentalNetworkStubbing` option and made it the default behavior.                                                                                                                                                                                                                       |
+| [5.1.0](/app/references/changelog#5-1-0)     | Added experimental `cy.route2()` command under `experimentalNetworkStubbing` option.                                                                                                                                                                                                                 |
 
 ## See also
 

--- a/docs/api/commands/intercept.mdx
+++ b/docs/api/commands/intercept.mdx
@@ -478,7 +478,7 @@ request, and can be used to stub routes:
 
 ```js
 const staticResponse = {
-  /* some StaticResponse properties here... */
+  // some StaticResponse properties here...
 }
 
 cy.intercept('/projects', staticResponse)

--- a/docs/api/commands/request.mdx
+++ b/docs/api/commands/request.mdx
@@ -91,6 +91,7 @@ Supported methods include:
 - `OPTIONS`
 - `TRACE`
 - `COPY`
+- `QUERY`
 - `LOCK`
 - `MKCOL`
 - `MOVE`
@@ -490,11 +491,12 @@ following:
 
 ## History
 
-| Version                                  | Changes                                                                                                                                                                                                                                                                    |
-| ---------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [4.7.0](/app/references/changelog#3-3-0) | Added support for `encoding` option.                                                                                                                                                                                                                                       |
-| [3.3.0](/app/references/changelog#3-3-0) | Added support for options `retryOnStatusCodeFailure` and `retryOnNetworkFailure`.                                                                                                                                                                                          |
-| [3.2.0](/app/references/changelog#3-2-0) | Added support for any valid HTTP `method` argument including `TRACE`, `COPY`, `LOCK`, `MKCOL`, `MOVE`, `PURGE`, `PROPFIND`, `PROPPATCH`, `UNLOCK`, `REPORT`, `MKACTIVITY`, `CHECKOUT`, `MERGE`, `M-SEARCH`, `NOTIFY`, `SUBSCRIBE`, `UNSUBSCRIBE`, `SEARCH`, and `CONNECT`. |
+| Version                                      | Changes                                                                                                                                                                                                                                                                    |
+| -------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [15.20.0](/app/references/changelog#15-20-0) | Added support for `QUERY` method.                                                                                                                                                                                                                                          |
+| [4.7.0](/app/references/changelog#3-3-0)     | Added support for `encoding` option.                                                                                                                                                                                                                                       |
+| [3.3.0](/app/references/changelog#3-3-0)     | Added support for options `retryOnStatusCodeFailure` and `retryOnNetworkFailure`.                                                                                                                                                                                          |
+| [3.2.0](/app/references/changelog#3-2-0)     | Added support for any valid HTTP `method` argument including `TRACE`, `COPY`, `LOCK`, `MKCOL`, `MOVE`, `PURGE`, `PROPFIND`, `PROPPATCH`, `UNLOCK`, `REPORT`, `MKACTIVITY`, `CHECKOUT`, `MERGE`, `M-SEARCH`, `NOTIFY`, `SUBSCRIBE`, `UNSUBSCRIBE`, `SEARCH`, and `CONNECT`. |
 
 ## See also
 

--- a/docs/app/references/changelog.mdx
+++ b/docs/app/references/changelog.mdx
@@ -10,7 +10,7 @@ sidebar_label: Changelog
 
 ## 15.20.0
 
-_Released TBD_
+_Released Aug 4, 2026_
 
 **Performance:**
 

--- a/docs/app/references/changelog.mdx
+++ b/docs/app/references/changelog.mdx
@@ -12,13 +12,42 @@ sidebar_label: Changelog
 
 _Released TBD_
 
+**Performance:**
+
+- Fixed an issue where visibility checks (such as [`.should('be.visible')`](/api/commands/should) and actionability) serialized an element's entire text subtree once per overflow-hidden ancestor, which on text-heavy pages could exhaust the renderer's memory and crash it (`We detected that the Chrome Renderer process just crashed`). Fixes [#34329](https://github.com/cypress-io/cypress/issues/34329).
+- Reduced the sampling overhead of [`experimentalMemoryManagement`](/app/references/experiments) when Cypress runs inside a memory-limited container using cgroup v1. Memory readings no longer spawn helper subprocesses on every sampling interval, which lowers CPU usage that previously competed with the tests, most noticeably on constrained CI machines. Addresses [#34105](https://github.com/cypress-io/cypress/issues/34105). Fixed in [#34331](https://github.com/cypress-io/cypress/pull/34331).
+
 **Features:**
 
 - [`scrollBehavior`](/app/references/configuration#Actionability) now accepts a per-axis value, such as `{ block: 'start', inline: 'nearest' }`, so the vertical and horizontal alignment used to scroll an element into view before an action command can be set independently. The per-axis form takes the same values as the native `scrollIntoView`: `'start'`, `'end'`, `'center'`, and `'nearest'`. A single value also accepts the new `'start'` and `'end'` alignments, which align both axes at once. See [Scrolling](/app/core-concepts/interacting-with-elements#Scrolling). Addresses [#34460](https://github.com/cypress-io/cypress/issues/34460). Addressed in [#34474](https://github.com/cypress-io/cypress/pull/34474).
+- [`cy.request()`](/api/commands/request) and [`cy.intercept()`](/api/commands/intercept) now accept the HTTP `QUERY` method. Previously it was rejected as an invalid method in the browser. Fixes [#28282](https://github.com/cypress-io/cypress/issues/28282).
 
 **Bugfixes:**
 
 - Fixed a regression in [15.18.1](#15-18-1) where action commands scrolled an already-visible element's container horizontally. The [`scrollBehavior`](/app/references/configuration#Actionability) values `'top'` and `'bottom'` revert to aligning only the vertical axis; use `'start'` or `'end'` to align both. Fixes [#34460](https://github.com/cypress-io/cypress/issues/34460).
+- Fixed a regression in [15.19.0](#15-19-0) where commands that read from the application under test, such as [`cy.url()`](/api/commands/url), [`cy.title()`](/api/commands/title) and [`cy.reload()`](/api/commands/reload), targeted the command log instead of your application when the application set `window.name`. Fixes [#34435](https://github.com/cypress-io/cypress/issues/34435).
+- Fixed an issue where a `cy.*` command error message that interpolated a value containing a `$` character could render incorrectly, with a leaked `{{...}}` placeholder or duplicated or dropped surrounding text. Such values are now inserted verbatim. Fixed in [#34221](https://github.com/cypress-io/cypress/pull/34221).
+- Fixed an issue where a Cypress error message that interpolated a value containing a `$` sequence (such as `$&`, `` $` ``, `$'`, or `$$`) could render with corrupted or duplicated text. Such values are now shown verbatim. Fixed in [#34220](https://github.com/cypress-io/cypress/pull/34220).
+- Fixed an issue where [`cy.intercept()`](/api/commands/intercept) matching on the `auth` option compared only the portion of a Basic authentication password before the first colon, so a request whose password contained a colon (permitted by RFC 7617) failed to match. The full password is now compared. Fixed in [#34206](https://github.com/cypress-io/cypress/pull/34206).
+- Fixed an issue where [`cy.intercept()`](/api/commands/intercept) routes specifying a numeric `port` (for example `port: 8080` or `port: [8080]`) did not match requests on non-default ports. Such routes now match as documented. Fixes [#17653](https://github.com/cypress-io/cypress/issues/17653). Fixed in [#34205](https://github.com/cypress-io/cypress/pull/34205).
+- Fixed an issue where inline source maps embedded without a `charset` (for example those emitted by esbuild) were not decoded and were silently dropped. These inline source maps are now decoded. Fixed in [#34204](https://github.com/cypress-io/cypress/pull/34204).
+- Fixed an issue where the TypeScript 7 support added in [15.18.0](#15-18-0) did not work: TypeScript spec and support files failed to compile with `Error: Cannot find module '@babel/preset-typescript'`. Fixes [#34359](https://github.com/cypress-io/cypress/issues/34359).
+- Fixed an issue where a [`cy.origin()`](/api/commands/origin) block could intermittently fail with `TypeError: Cannot read properties of undefined (reading 'applied')`, incorrectly reported as originating from your test code. Addressed in [#34376](https://github.com/cypress-io/cypress/pull/34376).
+- Fixed an issue where, during a [`cy.origin()`](/api/commands/origin) block, session cookies set on the primary origin by the first page visited in a test were not included in the identity provider's callback request back to the primary origin (for example, `POST /auth/callback` in an OAuth Authorization Code flow). Fixes [#29719](https://github.com/cypress-io/cypress/issues/29719). Fixed in [#34287](https://github.com/cypress-io/cypress/pull/34287).
+- Fixed an issue where the configuration validation error shown when `passesRequired` is omitted from the experimental `detect-flake-and-pass-on-threshold` retry strategy reported the value of an unrelated option instead of the `passesRequired` value. Fixed in [#34202](https://github.com/cypress-io/cypress/pull/34202).
+- Fixed an issue where the configuration validation error for an absolute `ca` filepath in `clientCertificates` referenced the wrong certificate. Fixed in [#34201](https://github.com/cypress-io/cypress/pull/34201).
+- Fixed an issue where HTTP `3xx` responses (such as `304 Not Modified`) were shown with a failed (red) indicator in the Command Log. These responses now display as successful. Fixes [#34066](https://github.com/cypress-io/cypress/issues/34066). Fixed in [#34282](https://github.com/cypress-io/cypress/pull/34282).
+
+**Misc:**
+
+- Fixed an issue where passing the `options` argument to [`cy.env()`](/api/commands/env), such as `cy.env(['FOO'], { log: false })`, raised a TypeScript error (`Expected 1 arguments, but got 2`). Fixes [#34284](https://github.com/cypress-io/cypress/issues/34284).
+
+**Dependency Updates:**
+
+- Upgraded `tar` from `6.2.1` to `7.5.21` to address [CVE-2026-59873](https://github.com/advisories/GHSA-23hp-3jrh-7fpw) reported in security scans. Addresses [#34333](https://github.com/cypress-io/cypress/issues/34333). Addressed in [#34335](https://github.com/cypress-io/cypress/pull/34335).
+- Upgraded `arch` from `2.2.0` to `3.0.0`. Addressed in [#34426](https://github.com/cypress-io/cypress/pull/34426).
+- Removed `tslib` (previously `1.14.1`) from the `cypress` package's runtime dependencies. Addressed in [#34372](https://github.com/cypress-io/cypress/pull/34372).
+- Upgraded `ws` from `8.18.3` to `8.21.1`. Addressed in [#34392](https://github.com/cypress-io/cypress/pull/34392).
 
 ## 15.19.0
 


### PR DESCRIPTION
## Summary

Copies the `15.20.0` section of the Cypress CLI changelog (`cli/CHANGELOG.md` on `cypress-io/cypress@develop`) into [docs/app/references/changelog.mdx](https://github.com/cypress-io/cypress-documentation/blob/main/docs/app/references/changelog.mdx), adding the Performance, Misc, and Dependency Updates sections and the remaining Features/Bugfixes entries that were not yet on `release/15.20.0`, and sets the release date to Aug 4, 2026.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or configuration impact.
> 
> **Overview**
> **Documents Cypress App 15.20.0** by expanding `changelog.mdx` with the full CLI release notes: release date **Aug 4, 2026**, plus **Performance**, **Misc**, and **Dependency Updates** sections and the remaining **Features** / **Bugfixes** bullets that were missing on the release branch.
> 
> **Aligns network API docs with the `QUERY` HTTP method** in `intercept.mdx` and `request.mdx` (method lists and **History** rows for 15.20.0). Minor doc polish: expanded HTTP method examples on intercept, reformatted a `StaticResponse` code sample, and normalized changelog table column alignment on those pages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bf05c17346c82a4c2306ff3e2eb70fe1d24c341. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



