### PR TITLE
docs: show config option names in UI Coverage and Accessibility config sidebars

### DIFF
--- a/docs/accessibility/configuration/attributefilters.mdx
+++ b/docs/accessibility/configuration/attributefilters.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'attributeFilters: control element identification in Cypress Accessibility'
 description: 'Use attributeFilters to stop dynamic, auto-generated, or state-based attributes from splitting one element into many or mis-grouping violations in Cypress Accessibility reports.'
-sidebar_label: 'Ignore attributes for identification'
+sidebar_label: 'attributeFilters'
 sidebar_position: 80
 ---
 

--- a/docs/accessibility/configuration/components.mdx
+++ b/docs/accessibility/configuration/components.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'components: add component and team context to Cypress Accessibility selectors'
 description: 'Make Cypress Accessibility append component-identifying attributes, such as data-component-name, data-team, or data-page-area, to violation target selectors so every finding shows which component, team, or region it belongs to.'
-sidebar_label: 'Add component context'
+sidebar_label: 'components'
 sidebar_position: 90
 ---
 

--- a/docs/accessibility/configuration/elementfilters.mdx
+++ b/docs/accessibility/configuration/elementfilters.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'elementFilters: ignore elements in Cypress Accessibility'
 description: 'Ignore elements in Cypress Accessibility reports with elementFilters, so third-party widgets and out-of-scope elements stop counting against your accessibility score.'
-sidebar_label: 'Exclude elements'
+sidebar_label: 'elementFilters'
 sidebar_position: 40
 ---
 

--- a/docs/accessibility/configuration/ignoring-rules-per-element.mdx
+++ b/docs/accessibility/configuration/ignoring-rules-per-element.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'data-a11y-ignore: ignore accessibility rules per element'
 description: 'Use the data-a11y-ignore attribute to exclude specific accessibility rules from elements in Cypress Accessibility.'
-sidebar_label: 'Ignore rules per element'
+sidebar_label: 'data-a11y-ignore'
 sidebar_position: 60
 ---
 

--- a/docs/accessibility/configuration/profiles.mdx
+++ b/docs/accessibility/configuration/profiles.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'profiles: apply config overrides by run tag'
 description: 'Use the profiles property to apply different Cypress Accessibility configuration to different runs, whether a narrow pull request gate, a full regression run, or per-team reports, selected automatically by run tag, without changing your test code.'
-sidebar_label: 'Override config by run tag'
+sidebar_label: 'profiles'
 sidebar_position: 100
 ---
 

--- a/docs/accessibility/configuration/significantattributes.mdx
+++ b/docs/accessibility/configuration/significantattributes.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'significantAttributes: identify elements by your attributes in Cypress Accessibility'
 description: 'Make Cypress Accessibility identify elements and build violation target selectors from your own HTML attributes, such as data-component, aria-label, or data-automation-id, by adding them to the priority list of significant attributes.'
-sidebar_label: 'Prioritize identifying attributes'
+sidebar_label: 'significantAttributes'
 sidebar_position: 70
 ---
 

--- a/docs/accessibility/configuration/viewfilters.mdx
+++ b/docs/accessibility/configuration/viewfilters.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'viewFilters: exclude URLs from scans'
 description: 'The viewFilters configuration excludes URLs from Cypress Accessibility, so third-party pages and other URLs outside your control are left out of your accessibility reports.'
-sidebar_label: 'Exclude views'
+sidebar_label: 'viewFilters'
 sidebar_position: 30
 ---
 

--- a/docs/accessibility/configuration/views.mdx
+++ b/docs/accessibility/configuration/views.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'views: group URLs with URL patterns in Cypress Accessibility'
 description: 'The views configuration groups related URLs into a single view in Cypress Accessibility using URL patterns, so accessibility reports and scores are organized around the real pages of your application instead of the shape of your test data.'
-sidebar_label: 'Group & name views'
+sidebar_label: 'views'
 sidebar_position: 20
 ---
 

--- a/docs/ui-coverage/configuration/additionalinteractioncommands.mdx
+++ b/docs/ui-coverage/configuration/additionalinteractioncommands.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'additionalInteractionCommands: count custom commands as coverage in UI Coverage'
 description: 'Make Cypress UI Coverage count your custom Cypress commands and third-party commands, such as cypress-real-events realClick and realType, as interactions so the elements they touch are marked as tested.'
-sidebar_label: 'Track custom commands'
+sidebar_label: 'additionalInteractionCommands'
 sidebar_position: 90
 ---
 

--- a/docs/ui-coverage/configuration/allowedinteractioncommands.mdx
+++ b/docs/ui-coverage/configuration/allowedinteractioncommands.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'allowedInteractionCommands: choose which commands count as coverage'
 description: 'Use allowedInteractionCommands to control which Cypress interaction commands count as coverage for specific elements, so you can require a meaningful interaction or accept commands UI Coverage ignores by default.'
-sidebar_label: 'Limit tracked commands'
+sidebar_label: 'allowedInteractionCommands'
 sidebar_position: 100
 ---
 

--- a/docs/ui-coverage/configuration/attributefilters.mdx
+++ b/docs/ui-coverage/configuration/attributefilters.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'attributeFilters: control element identification'
 description: 'Use attributeFilters to stop dynamic, auto-generated, or state-based attributes from splitting one element into many or mis-grouping elements in Cypress UI Coverage reports.'
-sidebar_label: 'Ignore attributes for identification'
+sidebar_label: 'attributeFilters'
 sidebar_position: 80
 ---
 

--- a/docs/ui-coverage/configuration/elementfilters.mdx
+++ b/docs/ui-coverage/configuration/elementfilters.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'elementFilters: exclude elements from UI Coverage'
 description: 'Exclude elements from Cypress UI Coverage reports and scores with elementFilters, so third-party widgets and other untestable elements stop counting as untested.'
-sidebar_label: 'Exclude elements'
+sidebar_label: 'elementFilters'
 sidebar_position: 40
 ---
 

--- a/docs/ui-coverage/configuration/elementgroups.mdx
+++ b/docs/ui-coverage/configuration/elementgroups.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'elementGroups: group related elements in UI Coverage'
 description: 'The elementGroups configuration in Cypress UI Coverage groups related elements into a single unit, so testing one element counts as testing them all.'
-sidebar_label: 'Group related elements'
+sidebar_label: 'elementGroups'
 sidebar_position: 60
 ---
 

--- a/docs/ui-coverage/configuration/elements.mdx
+++ b/docs/ui-coverage/configuration/elements.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'elements: rename and stabilize element identity in UI Coverage'
 description: 'Rename elements and give them a stable identity in Cypress UI Coverage reports, so dynamic attributes do not create duplicate untested elements.'
-sidebar_label: 'Stabilize element identity'
+sidebar_label: 'elements'
 sidebar_position: 50
 ---
 

--- a/docs/ui-coverage/configuration/profiles.mdx
+++ b/docs/ui-coverage/configuration/profiles.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'profiles: apply config overrides by run tag'
 description: 'Use the profiles property to apply UI Coverage configuration overrides based on run tags.'
-sidebar_label: 'Override config by run tag'
+sidebar_label: 'profiles'
 sidebar_position: 110
 ---
 

--- a/docs/ui-coverage/configuration/significantattributes.mdx
+++ b/docs/ui-coverage/configuration/significantattributes.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'significantAttributes: identify elements by your attributes in UI Coverage'
 description: 'Make Cypress UI Coverage identify, name, and group elements using your own HTML attributes, such as data-component, data-analytics-id, or aria-label, by adding them to the priority list of significant attributes.'
-sidebar_label: 'Prioritize identifying attributes'
+sidebar_label: 'significantAttributes'
 sidebar_position: 70
 ---
 

--- a/docs/ui-coverage/configuration/viewfilters.mdx
+++ b/docs/ui-coverage/configuration/viewfilters.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'viewFilters: exclude URLs from UI Coverage'
 description: 'The viewFilters configuration excludes URLs from UI Coverage reports and scores, so third-party pages, error pages, and the links that point to them stop counting against your coverage.'
-sidebar_label: 'Exclude views'
+sidebar_label: 'viewFilters'
 sidebar_position: 30
 ---
 

--- a/docs/ui-coverage/configuration/views.mdx
+++ b/docs/ui-coverage/configuration/views.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'views: group URLs with URL patterns in UI Coverage'
 description: 'The `views` configuration groups related URLs into a single view in UI Coverage using URL patterns, so reports and scores reflect the actual pages of your application.'
-sidebar_label: 'Group & name views'
+sidebar_label: 'views'
 sidebar_position: 20
 ---
 


### PR DESCRIPTION
## Summary

Changes the `sidebar_label` of every configuration page under UI Coverage and Accessibility to the actual configuration option name instead of a human-readable phrase — for example, "Group & name views" now reads `views` in the sidebar. Only frontmatter `sidebar_label` values changed; page titles, descriptions, headings, and body content are untouched.

## Why

The sidebar is how readers navigate to the option they're about to write into their config file. Labeling entries with prose meant scanning descriptions to find the page for a key you already know the name of. Naming each entry after the option itself makes the sidebar match the vocabulary of the config, so `viewFilters` in your config maps directly to `viewFilters` in the nav.

**UI Coverage** (`docs/ui-coverage/configuration/`):

| Before | After |
|---|---|
| Group & name views | `views` |
| Exclude views | `viewFilters` |
| Exclude elements | `elementFilters` |
| Stabilize element identity | `elements` |
| Group related elements | `elementGroups` |
| Prioritize identifying attributes | `significantAttributes` |
| Ignore attributes for identification | `attributeFilters` |
| Track custom commands | `additionalInteractionCommands` |
| Limit tracked commands | `allowedInteractionCommands` |
| Override config by run tag | `profiles` |

**Accessibility** (`docs/accessibility/configuration/`):

| Before | After |
|---|---|
| Group & name views | `views` |
| Exclude views | `viewFilters` |
| Exclude elements | `elementFilters` |
| Prioritize identifying attributes | `significantAttributes` |
| Ignore attributes for identification | `attributeFilters` |
| Add component context | `components` |
| Ignore rules per element | `data-a11y-ignore` |
| Override config by run tag | `profiles` |

## Notes for reviewers

Two judgment calls worth a look:

- **Left unchanged:** `Overview` and `Axe Core® configuration`. Neither maps to a single configuration key, so there is no option name to use.
- **`data-a11y-ignore`:** the per-element rule page is about an HTML attribute rather than a config property, but it is the code identifier already used in that page's heading, so it follows the same pattern. Happy to revert this one to prose if it reads as out of place.

Sidebar labels render as plain text in Docusaurus, so the option names appear unformatted (no code styling) in the nav.

---
_Generated by [Claude Code](https://claude.ai/code/session_01No1yPiGhv1MZoXnqhhYAi1)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only frontmatter changes with no runtime, API, or build logic impact.
> 
> **Overview**
> Updates **sidebar navigation labels** on Cypress Accessibility and UI Coverage configuration docs so each entry uses the **actual config key** (e.g. `viewFilters`, `elementFilters`, `profiles`) instead of descriptive phrases like “Exclude views” or “Group & name views”.
> 
> Only **`sidebar_label` frontmatter** changes across **18** option pages under `docs/accessibility/configuration/` and `docs/ui-coverage/configuration/`; page titles, descriptions, headings, and body copy are unchanged. **Overview** and **Axe Core® configuration** keep their prose labels because they are not single JSON keys. The per-element ignore page is labeled **`data-a11y-ignore`** to match the attribute identifier used in config/markup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4578c69e6f4a51eaf4ca9d3f6ff57c7d393b68ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->