### PR TITLE
docs: document Okta for Government SSO support

### DIFF
--- a/docs/cloud/account-management/enterprise-sso.mdx
+++ b/docs/cloud/account-management/enterprise-sso.mdx
@@ -113,6 +113,37 @@ below, refer to
    Cloud.
 1. [Save Configuration](#Save-Configuration).
 
+#### Okta for Government
+
+We support Okta for Government. Our Okta integration is a standard SAML 2.0
+integration rather than an Okta API integration, so the setup steps above apply
+without change.
+
+Two values differ from a commercial Okta setup:
+
+- **Identity Provider Single sign-on URL:** copy the URL from your Okta for
+  Government app, not from a commercial Okta app.
+- **X.509 certificate:** download the signing certificate from your Okta for
+  Government app and upload it to Cypress Cloud. Certificates do not transfer
+  between tenants, so an existing commercial Okta certificate will not work.
+
+Everything else stays the same, including the Single sign on URL and Audience
+URI you copy from Cypress Cloud and the `User.Email`, `User.FirstName`, and
+`User.LastName` attribute statements.
+
+:::caution
+
+<strong>Migrating from commercial Okta</strong>
+
+We store one SSO configuration per organization, so saving your Okta for
+Government details replaces your existing Okta configuration. Create and test
+the Okta for Government app before you save, and make the switch outside of
+peak hours to limit the window in which your team could be locked out.
+
+:::
+
+For advanced SAML requirements, contact support at support@cypress.io.
+
 ### **SAML**
 
 Cypress Cloud can integrate with your identity provider via SAML. In addition to

--- a/docs/cloud/faq.mdx
+++ b/docs/cloud/faq.mdx
@@ -642,6 +642,17 @@ and removes the previous one. To update your billing email, use the
 [billing@cypress.io](mailto:billing@cypress.io). See
 [User updates](/cloud/account-management/users#User-updates).
 
+### <Icon name="angle-right" /> Does Cypress Cloud support Okta for Government?
+
+Yes. Our Okta integration is a standard SAML 2.0 integration, so Okta for
+Government uses the same setup steps as commercial Okta. Two values differ: the
+Identity Provider Single sign-on URL and the X.509 signing certificate, which
+you need to download from your Okta for Government app because certificates do
+not transfer between tenants. If you are migrating from commercial Okta, note
+that we store one SSO configuration per organization, so saving your Okta for
+Government details replaces the existing configuration. See
+[Okta for Government](/cloud/account-management/enterprise-sso#Okta-for-Government).
+
 ## Teams
 
 ### <Icon name="angle-right" /> What is a team in Cypress Cloud?


### PR DESCRIPTION
## Summary

Adds an `Okta for Government` subsection to the Enterprise SSO page, and a matching entry to the Cypress Cloud FAQ. Both say the same thing: Okta for Government works with the existing Okta setup flow, only the Identity Provider Single sign-on URL and the X.509 certificate differ, and saving replaces an organization's existing SSO configuration.

## Why

A customer migrating from commercial Okta to Okta for Government asked whether we support it. We do, but nothing in the docs said so, so the question had to be answered by reading source code.

Our Okta connection type is a generic SAML 2.0 integration with Okta-specific UI labels, not an Okta API integration. The strategy is built from two customer-supplied values (the SAML endpoint and the x509 certificate), there is no hostname validation on save, and config changes take effect immediately. Okta for Government therefore works today with no code changes.

The FAQ entry exists because that page generates schema.org FAQPage JSON-LD, so the answer becomes eligible for search rich results and answer-engine citations. That is the surface where this question actually gets asked.

## Notes for reviewers

**Scope decisions:**

- Added to the existing Okta section rather than creating a standalone page, and used a plain `####` heading so it reads as a subsection of Okta rather than appearing as a fifth provider in the provider list at the top of the page.
- Cross-referenced the ACS URL and Audience URI rather than restating them. The page consistently says "provided in Cypress Cloud" and never hardcodes a hostname or the Audience URI value; I kept that. Attribute statements are named explicitly, matching how the SAML and OneLogin sections already list them.
- "X.509" spelling matches the OneLogin section on the same page.
- No screenshots. The Okta section is heavily illustrated, but capturing an Okta for Government console requires a real tenant, and stale screenshots are worse than none. Reasonable follow-up for someone with access.

**Deliberately not included:** anything about compliance posture or authorization level, SCIM or automated provisioning, and advanced SAML options that have no self-serve UI. The advanced-SAML pointer is the generic "contact support" line.

**One thing worth a second opinion:** a reader arriving at "Okta for Government is supported" may read that as a compliance signal regardless of what the page says. I did not write a bounding statement, since that wording should come from whoever owns it rather than from a docs PR. Flagging in case someone wants to make that call.

**Verification:** full `npm run build` passes. Worth knowing that this caught a real bug mid-review: this repo uses a custom heading-id scheme that preserves case (`## Save Configuration` becomes `#Save-Configuration`, not the Docusaurus default lowercase), and with `onBrokenAnchors: 'throw'` my initial `#okta-for-government` link failed the build. Corrected to `#Okta-for-Government` and verified against the generated HTML. The FAQ structured-data plugin picks up the new entry with its full answer text intact. Prettier clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_012i2JwX13WYjAdphvP7DqjT)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no product, auth, or runtime code changes.
> 
> **Overview**
> Documents **Okta for Government** as supported on Cypress Cloud, clarifying that it follows the same SAML 2.0 Okta flow as commercial Okta with only two customer-supplied values changing: the **Identity Provider Single sign-on URL** and the **X.509** signing certificate from the Government tenant (commercial certs do not carry over).
> 
> Adds an **`#### Okta for Government`** subsection under the existing Okta instructions on the Enterprise SSO page, including a migration **caution** that each org has a single SSO config—saving Government details **replaces** commercial Okta—and guidance to test before save and switch off-peak. Points readers with advanced SAML needs to **support@cypress.io**.
> 
> Adds a matching **Cypress Cloud FAQ** question under account management with a link to `#Okta-for-Government` on the SSO page so the answer can surface in FAQ structured data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efb710dc374270ed565d71109bc19cdeebbd3734. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->