### PR TITLE
docs: replace Roadmap page with Release Stages

### DIFF
--- a/docs/app/references/changelog.mdx
+++ b/docs/app/references/changelog.mdx
@@ -10243,7 +10243,7 @@ _Released May 17, 2019_
 - Updated [.its()](/api/commands/its) and [.invoke()](/api/commands/invoke) docs
   to better explain how default assertions are handled. Addresses
   [#1643](https://github.com/cypress-io/cypress-documentation/issues/1643).
-- Updated our [Roadmap](/app/references/roadmap) to more closely reflect the
+- Updated our [Roadmap](/app/references/release-stages) to more closely reflect the
   work we are doing. Addressed in
   [#1567](https://github.com/cypress-io/cypress-documentation/pull/1639).
 - Added a section about how to request our new

--- a/docs/app/references/experiments.mdx
+++ b/docs/app/references/experiments.mdx
@@ -18,7 +18,7 @@ options described below.
 making it into the core product. Our primary goal for experiments is to collect
 real-world feedback during their development. For more information, see the
 documentation for all
-[Cypress Release Stages](/app/references/roadmap#Release-Stages).
+[Cypress Release Stages](/app/references/release-stages).
 
 :::
 

--- a/docs/app/references/release-stages.mdx
+++ b/docs/app/references/release-stages.mdx
@@ -1,22 +1,12 @@
 ---
-title: 'Roadmap for Cypress App'
-description: 'Learn about the roadmap for the Cypress App, including release stages and strategies for releasing and communicating changes.'
-sidebar_label: Roadmap
+title: 'Release Stages for Cypress App'
+description: 'Learn about the release stages for the Cypress App, including strategies for releasing and communicating changes in each stage.'
+sidebar_label: Release Stages
 ---
 
 <ProductHeading product="app" />
 
-# Roadmap
-
-## Cypress App
-
-At Cypress we love sharing what we are working on and are always striving to
-improve transparency and communication with our community. If you are interested
-in learning more about what we have planned for the future of the Cypress App
-check out our
-[Cypress App Priorities Board](https://github.com/orgs/cypress-io/projects/13/views/1).
-
-## Release Stages
+# Release Stages
 
 Cypress follows Semantic Versioning
 ([see summary here](https://semver.org/#summary)) so that it is clear how you

--- a/netlify.toml
+++ b/netlify.toml
@@ -1095,7 +1095,13 @@
 
 [[redirects]]
   from = "/guides/references/release-stages"
-  to = "/app/references/roadmap"
+  to = "/app/references/release-stages"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/app/references/roadmap"
+  to = "/app/references/release-stages"
   status = 301
   force = true
 


### PR DESCRIPTION
## Summary

Renames `/app/references/roadmap` to `/app/references/release-stages` and removes the "Cypress App Priorities Board" section, leaving the page focused solely on release stages (title, description, and sidebar label updated to match).

## Why

The page's roadmap content pointed readers at the [Cypress App Priorities Board](https://github.com/orgs/cypress-io/projects/13/views/1) GitHub project, which is no longer maintained, so linking to it was misleading. Release stages were the only durable content on the page, and readers were already arriving there via the `/guides/references/release-stages` redirect — so the URL and title now match what the page actually documents.

## Notes for reviewers

- Redirects: `/guides/references/release-stages` now points at the new path, and a new 301 was added for `/app/references/roadmap` so existing inbound links keep working.
- Inbound links updated in `experiments.mdx` (the `#Release-Stages` anchor is no longer needed now that the whole page is release stages) and in the historical `changelog.mdx` entry.
- `npm run build` passes, which is the authoritative check here since `onBrokenLinks`/`onBrokenMarkdownLinks` are set to `throw`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and redirect-only changes with no application or security impact.
> 
> **Overview**
> Replaces the **Roadmap** reference page with a **Release Stages** page at `/app/references/release-stages`, updating title, description, and sidebar label so the URL matches the content.
> 
> The **Cypress App Priorities Board** section and roadmap framing are removed; the page now opens directly on release stages (GA, Beta, Alpha, Experimental). **Netlify** redirects `/guides/references/release-stages` to the new path and adds a **301** from `/app/references/roadmap` for old links. Inbound links in `experiments.mdx` and a historical `changelog.mdx` entry point at the new URL (no `#Release-Stages` anchor).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 280868daff5207e31a033b67115dc60e6f1cb98d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->