### PR TITLE
docs: cypress release 15.20.1

### DIFF
--- a/docs/app/references/changelog.mdx
+++ b/docs/app/references/changelog.mdx
@@ -8,6 +8,23 @@ sidebar_label: Changelog
 
 # Changelog
 
+## 15.20.1
+
+_Released Aug 10, 2026_
+
+**Bugfixes:**
+
+- Fixed a regression in [15.20.0](#15-20-0) where the Cypress app sent all Cypress Cloud requests to `http://localhost:3000` instead of Cypress Cloud. Logging in could not complete, and the Runs and Debug pages reported no data. Addressed in [#34536](https://github.com/cypress-io/cypress/pull/34536).
+- Fixed a regression in [15.18.0](#15-18-0) where pinning a command in the Command Log could leave the AUT snapshot permanently blank, with the pin stuck on. Stopping a run in open mode also no longer clears the AUT. Addressed in [#34502](https://github.com/cypress-io/cypress/pull/34502).
+
+**Misc:**
+
+- Fixed an issue where the error reported in CI when the Cypress binary is missing suggested caching and persisting the default binary cache location, ignoring any [`CYPRESS_CACHE_FOLDER`](/app/references/advanced-installation#Binary-cache) override. The suggestions now name the directory Cypress actually looked in. Addresses [#23009](https://github.com/cypress-io/cypress/discussions/23009). Addressed in [#34543](https://github.com/cypress-io/cypress/pull/34543).
+
+**Dependency Updates:**
+
+- Upgraded `tsx` from `4.22.4` to `4.23.12`. Fixes [#34461](https://github.com/cypress-io/cypress/issues/34461).
+
 ## 15.20.0
 
 _Released Aug 4, 2026_


### PR DESCRIPTION
## Release

Target release: Cypress App 15.20.1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog sync with no runtime or API changes.
> 
> **Overview**
> Documents **Cypress App 15.20.1** (Aug 10, 2026) by adding a new section at the top of `changelog.mdx`, aligned with `cli/CHANGELOG.md`.
> 
> The entry covers **bugfixes** for Cloud requests incorrectly targeting `localhost:3000` and Command Log pinning leaving a blank AUT snapshot, a **misc** fix so missing-binary CI errors reference the actual cache path (including `CYPRESS_CACHE_FOLDER`), and a **`tsx`** upgrade to `4.23.12`. The `CYPRESS_CACHE_FOLDER` link uses the repo-relative advanced-installation anchor instead of the absolute docs URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f97624af027b45090a79c956c6651c051d4febf2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->