### PR TITLE
docs: walk new Cloud accounts through recording in the Debug Tests guide

### DIFF
--- a/docs/cloud/guides/debug-failing-tests.mdx
+++ b/docs/cloud/guides/debug-failing-tests.mdx
@@ -22,19 +22,6 @@ same tools you use locally, get an AI explanation of what went wrong, and confir
 whether your change introduced the failure or simply surfaced existing
 instability. This guide walks through that workflow end to end.
 
-:::info
-
-<WhatYoullLearn />
-
-- Why a test that passes locally still fails in CI, and why that is so hard to debug
-- A step-by-step workflow to find the root cause of a failing CI test in Cypress Cloud
-- How to debug the exact CI run with [Test Replay](/cloud/features/test-replay) instead of reproducing it locally
-- How AI [Error Summaries](/cloud/features/cypress-ai-features#Error-Summaries) and [Cloud MCP](/cloud/integrations/cloud-mcp) speed up triage and root-cause analysis
-- How to tell a real regression apart from pre-existing [flake](/cloud/features/flaky-test-management) before you merge
-- Which Cypress Cloud tool to reach for, based on the symptom you are seeing
-
-:::
-
 ## Why tests fail in CI but pass locally
 
 Most "works on my machine" failures come down to a difference between your laptop
@@ -59,23 +46,101 @@ and often impossible.
 
 ## The debugging workflow at a glance
 
-When a recorded run fails, the fastest path from red build to root cause is:
+The fastest path from red CI build to root cause is:
 
-1. **[Find the failing test](#Step-1-Go-straight-to-the-failing-test)** in
+1. **[Record your CI runs](#Step-1-Record-your-CI-runs-to-Cypress-Cloud)** so
+   every failure is captured as it happens.
+2. **[Find the failing test](#Step-2-Go-straight-to-the-failing-test)** in
    Cypress Cloud, without scrolling through CI logs.
-2. **[Read the AI Error Summary](#Step-2-Read-the-AI-Error-Summary)** to
+3. **[Read the AI Error Summary](#Step-3-Read-the-AI-Error-Summary)** to
    understand what went wrong in plain language.
-3. **[Replay the exact CI run](#Step-3-Replay-the-exact-failure-with-Test-Replay)**
+4. **[Replay the exact CI run](#Step-4-Replay-the-exact-failure-with-Test-Replay)**
    with Test Replay to inspect the DOM, network, and console at the moment of
    failure.
-4. **[Check whether it's a regression or flake](#Step-4-Is-it-a-regression-or-flake)**
+5. **[Check whether it's a regression or flake](#Step-5-Is-it-a-regression-or-flake)**
    with Branch Review and Flaky Test Management.
-5. **[Fix and verify](#Step-5-Fix-and-verify)**, optionally without leaving your
+6. **[Fix and verify](#Step-6-Fix-and-verify)**, optionally without leaving your
    editor using Cloud MCP.
 
 The rest of this guide covers each step in detail.
 
-## Step 1: Go straight to the failing test
+## Step 1: Record your CI runs to Cypress Cloud
+
+Cypress Cloud can only show you a failure it captured, so debugging CI starts
+with recording. Recording changes nothing about how your tests are written or
+how CI runs them. You add a flag to the `cypress run` command your pipeline
+already executes, and Cypress uploads the results, artifacts, and
+[Test Replay](/cloud/features/test-replay) data as the run happens.
+
+### Connect your project to Cypress Cloud
+
+Recording links your local project to a project in Cypress Cloud. The Cypress
+app walks you through it:
+
+1. Open your project in the Cypress app with
+   [`cypress open`](/app/references/command-line#cypress-open) and click the
+   **Runs** tab.
+2. Click **Connect to Cypress Cloud** and log in, signing up for a free account
+   if you don't have one yet.
+3. Choose who owns the project (yourself, or an
+   [organization](/cloud/account-management/organizations) your team shares),
+   name it, and choose whether it is
+   [public or private](/cloud/account-management/projects#Public-vs-Private).
+4. Click **Setup Project**. Cypress adds a
+   [`projectId`](/cloud/account-management/projects#Project-ID) to your Cypress
+   configuration file and shows you the project's
+   [record key](/cloud/account-management/projects#Record-key).
+
+**Commit the configuration file with its `projectId`.** CI reads it from your
+repository to know which Cloud project the run belongs to.
+
+### Store your record key as a CI secret
+
+The record key authorizes a machine to record runs to your project. Add it to
+your CI provider's secrets or masked environment variables as
+`CYPRESS_RECORD_KEY`, the same way you store any other credential, so it never
+appears in your pipeline configuration or build logs.
+
+<RecordKeyEnvVar />
+
+### Add `--record` to your CI run command
+
+Wherever your pipeline calls `cypress run`, add the
+[`--record`](/app/references/command-line#cypress-run) flag:
+
+<CypressCommandTabs command="run --record" />
+
+With `CYPRESS_RECORD_KEY` set in the CI environment, no other change is needed.
+If you use the
+[Cypress GitHub Action](https://github.com/cypress-io/github-action), set
+`record: true` instead:
+
+```yaml title=".github/workflows/e2e.yml"
+- name: Cypress run
+  uses: cypress-io/github-action@v7
+  with:
+    record: true
+  env:
+    CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+```
+
+Each [CI provider guide](/app/continuous-integration/overview#CI-Examples) shows
+where the flag and the secret go for that provider.
+
+### Confirm the run recorded
+
+Push a commit and let CI run. As the run executes, it appears in
+[Cypress Cloud](https://on.cypress.io/cloud) under your project's
+[Latest Runs](/cloud/features/recorded-runs#Latest-Runs), and in the **Runs** tab
+of the Cypress app. Passing runs are recorded too, which is what gives Cypress
+Cloud the history it needs to tell a new failure apart from a long-standing one.
+
+<DocsImage
+  src="/img/cloud/projects/cloud-runs-list.png"
+  alt="Latest Runs list in Cypress Cloud showing recorded runs with their status, branch, commit, and duration"
+/>
+
+## Step 2: Go straight to the failing test
 
 Instead of reading raw CI output, open the run in Cypress Cloud. The
 [**Tests for Review**](/cloud/features/recorded-runs#Tests-for-Review) panel on a
@@ -101,11 +166,13 @@ all in one place.
 The [**Previous runs**](/cloud/features/recorded-runs#Previous-runs) timeline in
 the sidebar instantly tells you whether you're looking at a brand-new regression
 or a long-standing flaky test, and exactly when its behavior changed. Check it
-first; it often reframes the whole investigation.
+first; it often reframes the whole investigation. On your first recorded run
+this timeline has nothing to compare against yet, and it fills in on its own as
+CI keeps recording.
 
 :::
 
-## Step 2: Read the AI Error Summary
+## Step 3: Read the AI Error Summary
 
 At the top of the failure, Cypress Cloud's AI
 [**Error Summaries**](/cloud/features/cypress-ai-features#Error-Summaries) give a
@@ -125,7 +192,7 @@ The full stack trace, error message, and point-of-failure code frame for each
 attempt sit directly below the summary in the
 [Attempts and errors](/cloud/features/recorded-runs#attempts-and-errors) section.
 
-## Step 3: Replay the exact failure with Test Replay
+## Step 4: Replay the exact failure with Test Replay
 
 This is the core of debugging in Cypress Cloud.
 [**Test Replay**](/cloud/features/test-replay) lets you replay the test _exactly_
@@ -168,7 +235,7 @@ collaborative debugging session instead of a back-and-forth.
 
 :::
 
-## Step 4: Is it a regression or flake?
+## Step 5: Is it a regression or flake?
 
 Before you spend time on a fix, answer the question that determines what you're
 actually dealing with: **did my change cause this, or was it already broken or
@@ -191,6 +258,12 @@ what your change broke, without re-running anything locally.
 This is also the fastest way to **stop chasing pre-existing flake**: if a test was
 already failing intermittently on the base branch, Branch Review makes that
 obvious so you don't waste time on noise you didn't create.
+
+The comparison needs a recorded run on both sides, so make sure your pipeline
+records on your default branch and not only on pull request branches. If your
+base branch has no recorded run yet, merge your recording setup to it, or
+[trigger a run](/app/continuous-integration/overview) on that branch, and the
+comparison is available from then on.
 
 ### Use Flaky Test Management when a test passes on retry
 
@@ -218,23 +291,21 @@ is so easy to miss without dedicated tracking. See
 
 :::
 
-## Step 5: Fix and verify
+## Step 6: Fix and verify
 
 Once you understand the root cause:
 
 - **Fix the issue**, whether it's a true bug in your application, a timing
   assumption in the test, or a missing wait on a network request you spotted in
   Test Replay.
-- **Re-record the run** and use [Branch Review](/cloud/features/branch-review) to
-  confirm the failure is now _resolved_ and that you didn't introduce new failures
-  or flake elsewhere.
-- **Keep failing code out of `main`.** With the
-  [GitHub](/cloud/integrations/github),
-  [GitLab](/cloud/integrations/gitlab), and
-  [Bitbucket](/cloud/integrations/bitbucket) integrations, status checks can block
-  a merge until your tests are green, and PR comments surface failure and
-  [flake](/cloud/features/flaky-test-management#Flake-Alerting) details with deep
-  links back into Cypress Cloud.
+- **Push the fix and let CI record again.** Because recording is part of the
+  pipeline, the verification run happens on its own.
+- **Confirm the fix in [Branch Review](/cloud/features/branch-review)**, which
+  shows the failure as _resolved_ and whether you introduced new failures or
+  flake elsewhere.
+- **Keep failing code out of your default branch** by connecting your source
+  control provider, covered in
+  [Where to go next](#Where-to-go-next).
 
 ### Debug from your editor with Cloud MCP
 
@@ -288,25 +359,33 @@ reference:
 | I want to debug from a terminal or script       | [Cloud CLI](/cloud/integrations/cloud-cli)                                                                                             |
 | Keep failing or flaky code from merging         | [GitHub](/cloud/integrations/github) / [GitLab](/cloud/integrations/gitlab) / [Bitbucket](/cloud/integrations/bitbucket) status checks |
 
-## Get started
+## Where to go next
 
-Every capability in this guide works on runs
-[recorded to Cypress Cloud](/cloud/get-started/setup) from your CI/CD pipeline.
-You keep writing and running tests exactly as you do today, recording is the only
-setup required.
+Once your CI runs are recording and you've debugged your first failure, these
+are the highest-value things to add:
+
+- **[Connect your source control provider](/cloud/integrations/github).** Status
+  checks block a merge until tests are green, and pull request comments surface
+  failures and [flake](/cloud/features/flaky-test-management#Flake-Alerting) with
+  deep links into Cypress Cloud.
+  [GitLab](/cloud/integrations/gitlab) and
+  [Bitbucket](/cloud/integrations/bitbucket) work the same way.
+- **[Get alerted where you work](/cloud/features/flaky-test-management#Slack).**
+  Send run and flake notifications to Slack or Microsoft Teams so a red build
+  reaches you without anyone watching the pipeline.
+- **[Run your specs in parallel](/cloud/features/smart-orchestration/parallelization).**
+  Now that runs are recorded, Cypress Cloud can load-balance specs across CI
+  machines and cut your total run time.
+- **[Connect Cloud MCP](/cloud/integrations/cloud-mcp) or the
+  [Cloud CLI](/cloud/integrations/cloud-cli).** Both are available on every plan
+  at no extra cost, and both let you triage a failing run without opening a
+  browser.
 
 :::success
 
 <CloudFreePlan />
 
 :::
-
-<Btn
-  label="Record your first run ➜"
-  variant="indigo-dark"
-  className="mr-1"
-  href="/cloud/get-started/setup"
-/>
 
 ## See also
 


### PR DESCRIPTION
## Summary

Adds a new first step to the Debug Failing Tests guide that walks a reader through recording their CI runs to Cypress Cloud, and renumbers the existing debugging steps to 2–6 to follow it.

## Why

The guide previously started at "a recorded run fails," which assumes the reader already has runs in Cypress Cloud. That skips over the audience most likely to land on this page: someone who has written Cypress tests, has them running in CI, and has just created a Cypress Cloud account with nothing recorded in it yet. Everything the guide teaches (Test Replay, AI Error Summaries, Branch Review, Flaky Test Management) is gated behind recording, so the guide now starts there and carries the reader all the way to a root cause.

Changes:

- **New Step 1: Record your CI runs to Cypress Cloud**, covering connecting the project in the Cypress app (`projectId` written to config and committed so CI can read it), storing `CYPRESS_RECORD_KEY` as a CI secret, adding `--record` to the CI run command (with a `cypress-io/github-action` `record: true` variant), and confirming the run appears in Latest Runs.
- **Renumbered** the remaining steps and updated the at-a-glance list with the new anchors.
- **Set expectations for a fresh account**: the Previous runs timeline note now says it is empty on a first run and fills in over time, and the Branch Review section explains that the comparison needs a recorded run on the base branch too, and how to get one.
- **Replaced the closing "Get started" section** (which pushed the reader to record, now Step 1) with "Where to go next": source control integration and status checks, Slack/Teams alerting, parallelization, and Cloud MCP / Cloud CLI. The free-plan callout is retained at the end of that section.
- **Removed the "What you'll learn" callout** from the top of the page.

## Notes for reviewers

- The recording walkthrough intentionally summarizes rather than duplicates [`/cloud/get-started/setup`](https://docs.cypress.io/cloud/get-started/setup), keeping the reader in a single debugging narrative. It links out for the concepts that have their own pages (organizations, public vs. private, `projectId`, record key) and reuses the existing `<RecordKeyEnvVar />` partial rather than restating the secret-handling caveat.
- The title, intro, and page description are unchanged from `main`.
- `npm run build` passes. `onBrokenLinks`, `onBrokenAnchors`, and `onBrokenMarkdownLinks` are all set to `throw`, so a clean build confirms every added link and every renumbered heading anchor resolves. Prettier is clean via the pre-commit hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xj74u4Fw9mGeVLqCuAuBeD

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to a single MDX guide; no application code, auth, or data handling.
> 
> **Overview**
> **Restructures the Debug Failing Tests guide** so readers with tests in CI but nothing recorded yet can follow one narrative from setup through root cause, instead of assuming runs already exist in Cloud.
> 
> **New Step 1** walks through connecting the project in the Cypress app (`projectId` committed for CI), storing `CYPRESS_RECORD_KEY`, adding `--record` (plus a GitHub Action `record: true` example), and confirming runs in Latest Runs. The at-a-glance workflow and all later steps are **renumbered** (former steps 1–5 become 2–6).
> 
> **Fresh-account expectations:** notes that **Previous runs** is empty on the first recording, and that **Branch Review** needs recorded runs on the default branch—not only PR branches.
> 
> **Closing section:** removes the top-of-page `<WhatYoullLearn />` info block and the **Get started** CTA button; **Get started** becomes **Where to go next** (SCM status checks, Slack/Teams alerts, parallelization, Cloud MCP/CLI). **Fix and verify** now emphasizes push → CI re-record → Branch Review, with merge protection deferred to that section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 613e6013a50d0340d860491c427482a534997c28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->