### PR TITLE
docs: `req.httpVersion` is not reported in Chromium-based browsers (Cypress 16)

### DIFF
--- a/docs/api/commands/intercept.mdx
+++ b/docs/api/commands/intercept.mdx
@@ -1080,8 +1080,11 @@ The request object (`req`) has several properties from the HTTP request itself:
   query: Record<string, string|number>
   /**
    * The HTTP version used in the request. Read only.
+   * Not reported in Chromium-based browsers, where the browser negotiates the
+   * protocol with the origin directly and it is not known when the request is
+   * intercepted. Firefox and WebKit still report it.
    */
-  httpVersion: string
+  httpVersion?: string
   /**
    * The resource type of the request. Read only.
    */


### PR DESCRIPTION
- Closes #6800

## Summary

Documents that `req.httpVersion` is not reported to `cy.intercept()` handlers in Chromium-based browsers in Cypress 16. Marks the property optional in the **Request object properties** block on the `cy.intercept` page, with a short doc comment explaining why.

## Why

In Cypress 16, Chromium-based browsers intercept network traffic through the browser rather than through a proxy. Previously the proxy sat in the middle, and the browser-to-proxy hop was always HTTP/1.1, so Cypress could report `'1.1'` and be telling the truth. Without that hop the browser negotiates directly with the origin and may use HTTP/2 or HTTP/3, and the protocol is not knowable at the point the request is intercepted — the request has not been sent yet and the connection may not exist. Rather than report a hardcoded `'1.1'` that would be wrong for every HTTP/2 or HTTP/3 request, Cypress leaves the field unset.

Firefox and WebKit continue to use the proxy and still report `'1.1'`, so the note is scoped to Chromium-based browsers rather than written as a blanket change.

Closes #6800

## Notes for reviewers

Implementation side: cypress-io/cypress#34576, which makes the type `httpVersion?: string`.

Two deliberate omissions worth a look:

- **No mention of `forceHttp1`.** The issue suggested pointing readers at `forceHttp1: true` as a way to restore the old value. That config option is not implemented or documented yet (cypress-io/cypress#33847), so referencing it here would document something that does not exist. Worth adding once it lands.
- **No migration guide entry.** Every other Cypress 16 breaking change has a section in the migration guide, and this arguably deserves one. I left it out because nothing in the v16 docs describes the CDP/proxy switch yet, so an entry would be the first and only mention of a much larger behavioral change with no overview page to link to. That reads like it wants to be part of a broader HTTP/2 documentation effort rather than a one-off note attached to a single property. Happy to add one here if you would rather not wait.

**Merge timing:** this describes behavior that is gated on the proxy-off default landing (cypress-io/cypress#33847). On `release/16.0.0` as it stands today the proxy is still in use and `httpVersion` is still always populated, so this should not merge ahead of that change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the cy.intercept API reference; no runtime or security impact.
> 
> **Overview**
> Documents that `req.httpVersion` is **optional** and unset in Chromium-based browsers under Cypress 16’s direct browser interception, while Firefox and WebKit still report it.
> 
> Updates the Request object properties type from `httpVersion: string` to `httpVersion?: string` with an explanatory comment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fc0addffa529d0046f1d0503d246ab063e53445. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->