### PR TITLE
docs: document that cy.env() does not protect the value it yields

### DIFF
--- a/docs/api/commands/env.mdx
+++ b/docs/api/commands/env.mdx
@@ -19,6 +19,8 @@ Securely read environment variables set in your Cypress configuration, `cypress.
 
 :::
 
+<CypressEnvYieldedValueCaution />
+
 ## Syntax
 
 ```javascript
@@ -234,13 +236,78 @@ cy.apiRequest('/users').its('status').should('eq', 200)
 
 ### Suppress command logging
 
-Hide the command from the command log:
+Hide the `cy.env()` entry from the Command Log. Because `cy.env()` logs key
+names and never values, use this option when you don't want the key names
+visible in the Command Log:
 
 ```javascript
-cy.env(['apiKey'], { log: false }).then(({ apiKey }) => {
-  // The command and variable name won't appear in command log
+cy.env(['acmeMigrationKey'], { log: false }).then(({ acmeMigrationKey }) => {
+  // The command and the key name don't appear in the Command Log
 })
 ```
+
+## Handling the yielded value safely
+
+`cy.env()` logs the key names you ask for and never the values. That guarantee
+stops the moment the command yields. The object you receive is an ordinary
+JavaScript object, and Cypress does not mask, redact, or track the values
+inside it.
+
+Keep the value inside a `.then()` callback and pass it straight to the command
+that needs it. [`.then()`](/api/commands/then) and
+[`.spread()`](/api/commands/spread) add no entry to the Command Log, so the
+value stays out of it.
+
+### Assert on a derived value, not on the secret
+
+<CypressEnvAssertDerivedValue />
+
+Calling `expect()` inside a `.then()` callback still creates an assertion entry,
+so a `.then()` callback alone is not enough. What you assert on is what matters.
+
+### Avoid .its() and .invoke() on the yielded object
+
+[`.its()`](/api/commands/its) and [`.invoke()`](/api/commands/invoke) both add
+the subject they were applied to and the value they yield to the console
+output, so `cy.env(['apiKey']).its('apiKey')` prints the environment variable
+value twice. Read the property inside a `.then()` callback instead.
+
+<Icon name="exclamation-triangle" color="red" /> **Incorrect Usage**
+
+```javascript
+// ❌ Prints the environment variable value to the console output twice
+cy.env(['apiKey']).its('apiKey')
+```
+
+<Icon name="check-circle" color="green" /> **Correct Usage**
+
+```javascript
+cy.env(['apiKey']).then(({ apiKey }) => {
+  // ✅ Use apiKey here
+})
+```
+
+### Keep the value out of downstream command logs
+
+Commands that accept a `log` option, such as
+[`cy.request()`](/api/commands/request) and [`.type()`](/api/commands/type),
+leave their entry out of the Command Log when you pass `{ log: false }`. Use it
+on any command you hand the value to:
+
+```javascript
+cy.env(['apiKey']).then(({ apiKey }) => {
+  cy.request({
+    url: 'https://api.example.com/users',
+    headers: { Authorization: `Bearer ${apiKey}` },
+    log: false,
+  })
+
+  cy.get('[data-testid="token-field"]').type(apiKey, { log: false })
+})
+```
+
+`{ log: false }` hides the entry from the Command Log. It does not redact the
+value, and it has no effect on assertions.
 
 ## Why use cy.env()?
 

--- a/docs/app/guides/environment-variables.mdx
+++ b/docs/app/guides/environment-variables.mdx
@@ -39,6 +39,15 @@ cy.env(['apiKey']).then(({ apiKey }) => {
 
 See the [`cy.env()`](/api/commands/env) command documentation for complete details.
 
+<CypressEnvYieldedValueCaution />
+
+### Handling the yielded value safely
+
+Keep the value inside a `.then()` callback and pass it straight to the command
+that needs it. [`.then()`](/api/commands/then) adds no entry to the Command Log.
+
+<CypressEnvAssertDerivedValue />
+
 ## Public configuration values
 
 **Use [`Cypress.expose()`](/api/cypress-api/expose)** for public, non-sensitive configuration values.

--- a/docs/app/references/migration-guide.mdx
+++ b/docs/app/references/migration-guide.mdx
@@ -53,6 +53,10 @@ When migrating from `Cypress.env()`, you have two options: `cy.env()` and `Cypre
 
 `cy.env()` is read-only and asynchronous.
 
+<CypressEnvYieldedValueCaution />
+
+<CypressEnvAssertDerivedValue />
+
 #### Read one value
 
 <Badge type="danger">Before: Cypress.env()</Badge>

--- a/docs/partials/_cy-env-assert-derived-value.mdx
+++ b/docs/partials/_cy-env-assert-derived-value.mdx
@@ -1,0 +1,20 @@
+Every assertion writes to the Command Log, and the entry contains the values
+being compared. Assertions accept no logging options, so you cannot suppress
+them. Assert on a boolean you derive from the value instead.
+
+<Icon name="exclamation-triangle" color="red" /> **Incorrect Usage**
+
+```javascript
+cy.env(['apiKey']).should('deep.include', { apiKey: 'secret-key-12345' })
+// ❌ Command Log: assert expected { apiKey: 'secret-key-12345' } to deep
+// include { apiKey: 'secret-key-12345' }
+```
+
+<Icon name="check-circle" color="green" /> **Correct Usage**
+
+```javascript
+cy.env(['apiKey']).then(({ apiKey }) => {
+  expect(Boolean(apiKey)).to.be.true
+})
+// ✅ Command Log: assert expected true to be true
+```

--- a/docs/partials/_cy-env-yielded-value-caution.mdx
+++ b/docs/partials/_cy-env-yielded-value-caution.mdx
@@ -1,0 +1,13 @@
+:::caution
+
+`cy.env()` logs the key names you ask for and never the values. That protection
+ends at the command boundary. The object `cy.env()` yields is an ordinary
+JavaScript object, and Cypress does not mask, redact, or track the values inside
+it. Assertions, [`.its()`](/api/commands/its),
+[`.invoke()`](/api/commands/invoke), and any chained command that fails can all
+print a value to the [Command Log](/app/core-concepts/open-mode#Command-Log) and
+the [console output](/app/core-concepts/open-mode#Console-output). What happens
+to a value after `cy.env()` yields it is up to you. See
+[Handling the yielded value safely](/api/commands/env#Handling-the-yielded-value-safely).
+
+:::

--- a/src/theme/MDXComponents.js
+++ b/src/theme/MDXComponents.js
@@ -15,6 +15,8 @@ import CypressInstallCommands from '@site/docs/partials/_cypress-install-command
 import CypressCacheClearCommands from '@site/docs/partials/_cypress-cache-clear-commands.mdx'
 import CypressInstallBinaryCommands from '@site/docs/partials/_cypress-install-binary-commands.mdx'
 import CypressEnvVsCypressExpose from '@site/docs/partials/_cy-env-vs-cypress-expose.mdx'
+import CypressEnvYieldedValueCaution from '@site/docs/partials/_cy-env-yielded-value-caution.mdx'
+import CypressEnvAssertDerivedValue from '@site/docs/partials/_cy-env-assert-derived-value.mdx'
 import CypressOpenCommands from '@site/docs/partials/_cypress-open-commands.mdx'
 import CypressRunCommands from '@site/docs/partials/_cypress-run-commands.mdx'
 import CypressCommandTabs from '@site/src/components/cypress-command-tabs'
@@ -214,6 +216,8 @@ export default {
   CypressCacheClearCommands,
   CypressInstallBinaryCommands,
   CypressEnvVsCypressExpose,
+  CypressEnvYieldedValueCaution,
+  CypressEnvAssertDerivedValue,
   CypressOpenCommands,
   CypressRunCommands,
   CypressCommandTabs,


### PR DESCRIPTION
## Summary

Adds a caution and a "Handling the yielded value safely" section to the `cy.env()` API page explaining that the object `cy.env()` yields is an ordinary JavaScript object that Cypress does not mask, redact, or track, and shares the caution plus a do/don't assertion example with the Environment Variables & Secrets guide and the `Cypress.env()` migration guide.

## Why

`cy.env()` logs the key names it is given and never the values, but that guarantee ends at the command boundary. Nothing in the docs said where the protection stops, so a reader could reasonably assume values stay hidden no matter what they do with them downstream.

The new content covers what actually surfaces a value today:

- Assertions always write to the Command Log and the entry contains the values being compared. There is no logging option to suppress an assertion, so the guidance is to assert on a boolean derived from the value.
- `.its()` and `.invoke()` add both the subject and the yielded value to the console output, so `cy.env(['apiKey']).its('apiKey')` prints the value twice.
- `{ log: false }` on a downstream command such as `cy.request()` or `.type()` hides that command's entry from the Command Log. It does not redact the value and has no effect on assertions.
- `cy.env([...], { log: false })` is framed as a way to keep key names out of the Command Log, since values were never logged in the first place.

## Notes for reviewers

The caution and the derived-value assertion example appear on three pages, so they live in two new partials registered in `src/theme/MDXComponents.js`:

- `<CypressEnvYieldedValueCaution />` — `docs/partials/_cy-env-yielded-value-caution.mdx`
- `<CypressEnvAssertDerivedValue />` — `docs/partials/_cy-env-assert-derived-value.mdx`

Each page keeps its own lead-in sentence around the shared blocks. The caution links to `/api/commands/env#Handling-the-yielded-value-safely` with an absolute path so it resolves from every page, including the API page itself.

`prettier --check '**/*.{md,mdx}'` and `lint-frontmatter` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LX67v2pQaekCVyMcEueyS1

---
_Generated by [Claude Code](https://claude.ai/code/session_01LX67v2pQaekCVyMcEueyS1)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or test behavior impact.
> 
> **Overview**
> Clarifies that **`cy.env()`** only keeps **key names** out of the Command Log—not the secret **values** after the command yields—and adds reusable guidance so readers don’t assume downstream steps stay safe.
> 
> Two MDX partials—**`<CypressEnvYieldedValueCaution />`** and **`<CypressEnvAssertDerivedValue />`**—are registered in **`MDXComponents.js`** and embedded on the **`cy.env()`** API page, the Environment Variables & Secrets guide, and the **`Cypress.env()`** migration guide. The API page gains a **“Handling the yielded value safely”** section (use **`.then()`**, avoid **`.its()`** / **`.invoke()`** on the yielded object, assert on derived booleans, use **`{ log: false }`** on consuming commands) and clearer **`{ log: false }`** wording for hiding **key names** on the **`cy.env()`** log entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 516e6581a5ea136338456bc0d62a49aaa8333d7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->