### PR TITLE
fix: remove the Universal Analytics plugin

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -69,9 +69,6 @@ const config = {
         theme: {
           customCss: require.resolve('./src/css/custom.scss'),
         },
-        googleAnalytics: {
-          trackingID: 'UA-59606812-1',
-        },
         googleTagManager: {
           containerId: 'GTM-KNKBWLD',
         },


### PR DESCRIPTION
## Summary

Removes the `googleAnalytics` (Universal Analytics) plugin config from `docusaurus.config.js`. `googleTagManager` is untouched and continues to handle analytics.

## Why

Universal Analytics stopped processing data in July 2023, so `UA-59606812-1` collects nothing.

It also breaks local production builds. The plugin registers a route-change handler that calls `window.ga()`, and its inline bootstrap is commonly blocked by a consent manager or ad blocker — so the call throws on client-side navigation. Under React 19 that reaches the error boundary and renders "This page crashed. Try again." The dev server is unaffected, because the plugin no-ops when `NODE_ENV !== 'production'`.

## Notes for reviewers

Verified on a production build: `window.ga` and `analytics.js` no longer appear anywhere in `dist/`, and `GTM-KNKBWLD` still does.

To reproduce the crash on `main`: `npm run build && npm run serve`, then click any in-page link with an ad blocker enabled.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single config deletion with no auth or data-path changes; GTM stays in place, so risk is limited to analytics behavior verification.
> 
> **Overview**
> **Removes the Docusaurus `googleAnalytics` preset block** (`trackingID: 'UA-59606812-1'`) from `docusaurus.config.js`. **`googleTagManager` (`GTM-KNKBWLD`) is unchanged** and remains the analytics path.
> 
> This drops dead Universal Analytics wiring that no longer collects data and, in production builds, could call `window.ga()` on route changes when the UA script is blocked—surfacing as a React 19 client-side crash during in-app navigation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 379289a431f3a565f0ab12b71ccebfa0b0c33e51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->