### PR TITLE
docs: remove references to the Cypress app proxying requests

### DIFF
--- a/docs/api/commands/visit.mdx
+++ b/docs/api/commands/visit.mdx
@@ -155,9 +155,8 @@ cy.visit('https://wile:coyote@example.cypress.io')
 
 :::info
 
-Cypress will automatically attach this header at the network proxy level,
-outside of the browser. Therefore you **will not** see this header in the Dev
-Tools.
+Cypress attaches the `Authorization` header outside of the browser. Therefore
+you **will not** see this header in the Dev Tools.
 
 :::
 

--- a/docs/app/faq.mdx
+++ b/docs/app/faq.mdx
@@ -1139,7 +1139,7 @@ browser.
 
 [Check out the "Node Modules" example recipe.](/app/references/recipes#Fundamentals)
 
-### <Icon name="angle-right" /> Is there a way to give a proper SSL certificate so the page doesn't show up as "not secure"?
+### <Icon name="angle-right" /> Is there a way to give a proper SSL certificate to Cypress so the page doesn't show up as "not secure"?
 
 No, Cypress modifies network traffic in real time.
 

--- a/docs/app/faq.mdx
+++ b/docs/app/faq.mdx
@@ -1139,7 +1139,7 @@ browser.
 
 [Check out the "Node Modules" example recipe.](/app/references/recipes#Fundamentals)
 
-### <Icon name="angle-right" /> Is there a way to give a proper SSL certificate to your proxy so the page doesn't show up as "not secure"?
+### <Icon name="angle-right" /> Is there a way to give a proper SSL certificate so the page doesn't show up as "not secure"?
 
 No, Cypress modifies network traffic in real time and therefore must sit between
 your server and the browser. There is no other way for us to achieve that.

--- a/docs/app/faq.mdx
+++ b/docs/app/faq.mdx
@@ -100,8 +100,7 @@ testing).
 
 ### <Icon name="angle-right" /> We use WebSockets; will Cypress work with that?
 
-Yes. Cypress transparently proxies WebSocket connections, so your application's
-WebSocket traffic will work as expected during tests.
+Yes. Your application's WebSocket traffic will work as expected during tests.
 
 However, **stubbing or mocking individual WebSocket frames/messages** is not
 natively supported. If your tests need to control the messages sent over a
@@ -1140,10 +1139,9 @@ browser.
 
 [Check out the "Node Modules" example recipe.](/app/references/recipes#Fundamentals)
 
-### <Icon name="angle-right" /> Is there a way to give a proper SSL certificate to your proxy so the page doesn't show up as "not secure"?
+### <Icon name="angle-right" /> Is there a way to give a proper SSL certificate so the page doesn't show up as "not secure"?
 
-No, Cypress modifies network traffic in real time and therefore must sit between
-your server and the browser. There is no other way for us to achieve that.
+No, Cypress modifies network traffic in real time.
 
 ### <Icon name="angle-right" /> Is there any way to detect if my app is running under Cypress?
 
@@ -1621,8 +1619,8 @@ XState model state library.
 ### <Icon name="angle-right" /> Can Cypress be used for performance testing?
 
 Cypress is not built for performance testing. Because Cypress instruments the
-page under test, proxies the network requests, and tightly controls the test
-steps, Cypress adds its own overhead. Thus, the performance numbers you get from
+page under test and tightly controls the test steps, Cypress adds its own
+overhead. Thus, the performance numbers you get from
 Cypress tests are slower than "normal" use. Still, you can access the native
 `window.performance` object and grab the page time measurements, see the
 [Evaluate performance metrics](https://github.com/cypress-io/cypress-example-recipes#testing-the-dom)

--- a/docs/app/faq.mdx
+++ b/docs/app/faq.mdx
@@ -1139,9 +1139,10 @@ browser.
 
 [Check out the "Node Modules" example recipe.](/app/references/recipes#Fundamentals)
 
-### <Icon name="angle-right" /> Is there a way to give a proper SSL certificate to Cypress so the page doesn't show up as "not secure"?
+### <Icon name="angle-right" /> Is there a way to give a proper SSL certificate to your proxy so the page doesn't show up as "not secure"?
 
-No, Cypress modifies network traffic in real time.
+No, Cypress modifies network traffic in real time and therefore must sit between
+your server and the browser. There is no other way for us to achieve that.
 
 ### <Icon name="angle-right" /> Is there any way to detect if my app is running under Cypress?
 

--- a/docs/app/guides/cross-origin-testing.mdx
+++ b/docs/app/guides/cross-origin-testing.mdx
@@ -30,14 +30,13 @@ communicate with your remote application at all times. Unfortunately, browsers
 naturally try to prevent Cypress from doing this.
 
 To get around these restrictions, Cypress implements some strategies involving
-JavaScript code, the browser's internal APIs, and network proxying to _play by
-the rules_ of same-origin policy. It's our goal to fully automate the
+JavaScript code and the browser's internal APIs to _play by the rules_ of
+same-origin policy. It's our goal to fully automate the
 application under test without you needing to modify your application's code -
 and we are _mostly_ able to do this.
 
 ### What Cypress does under the hood
 
-- Proxies all HTTP / HTTPS traffic.
 - Changes the hosted URL to match that of the application under test.
 - Uses the browser's internal APIs for network level traffic.
 

--- a/docs/app/guides/network-requests.mdx
+++ b/docs/app/guides/network-requests.mdx
@@ -535,8 +535,7 @@ cy.wait('@new-user').then(console.log)
 
 ## Working with WebSockets
 
-Cypress transparently proxies WebSocket connections, so your application's
-WebSocket traffic will work as expected during tests.
+Your application's WebSocket traffic will work as expected during tests.
 
 ### Limitations
 

--- a/docs/app/guides/test-performance.mdx
+++ b/docs/app/guides/test-performance.mdx
@@ -176,7 +176,7 @@ Apply these optimizations in order. The highest-impact changes are at the top.
 1. [Eliminate arbitrary cy.wait()](#Avoid-arbitrary-waits-and-adjust-timeouts)
 1. [Slim support file and imports](#Keep-support-and-spec-imports-lean) — avoids bundling unused code on every spec startup
 1. [Block third-party requests with blockHosts](#Block-third-party-requests-with-blockHosts) — analytics and monitoring services consume time in test environments; blocked requests resolve immediately
-1. [Avoid wildcard cy.intercept('\*')](#Intercept-only-the-requests-you-need) — limits proxy overhead to requests the test actually needs
+1. [Avoid wildcard cy.intercept('\*')](#Intercept-only-the-requests-you-need) — limits interception overhead to requests the test actually needs
 1. [Use specific DOM selectors](#Use-specific-selectors) — broad selectors like `*` or `div` force the browser to collect every matching node before filtering
 1. [Modern visibility algorithm](#Use-the-modern-visibility-algorithm) — high impact on complex DOMs; Cypress 16 defaults to the faster `checkVisibility()`-based algorithm
 1. [Test retries (runMode: 1)](#Use-test-retries-deliberately) — prevents flaky tests from blocking CI; keep the count low and use flake data to fix root causes
@@ -545,10 +545,10 @@ See the [Network Requests guide](/app/guides/network-requests) for a full discus
 
 #### Intercept only the requests you need
 
-Using a wildcard pattern to observe or intercept every HTTP request creates real overhead. Cypress routes every intercepted request through its proxy, so every network call the page makes is inspected, matched, and processed. Broad wildcard patterns that match dozens or hundreds of requests per page load multiply that cost across the entire suite.
+Using a wildcard pattern to observe or intercept every HTTP request creates real overhead: every network call the page makes is inspected, matched, and processed. Broad wildcard patterns that match dozens or hundreds of requests per page load multiply that cost across the entire suite.
 
 ```js
-// ❌ Anti-pattern: intercepts every request; Cypress proxies each one
+// ❌ Anti-pattern: intercepts every request; Cypress processes each one
 cy.intercept('*').as('anyRequest')
 
 // ✅ Faster approach: only intercept the specific requests your test needs

--- a/docs/app/references/configuration.mdx
+++ b/docs/app/references/configuration.mdx
@@ -229,7 +229,7 @@ For more options regarding screenshots, view the
 | `blockHosts`            | `null`  | A String or Array of hosts that you wish to block traffic for. [Please read the notes for examples on using this.](#blockHosts)                                                                                                                                                                                                                                      |
 | `hosts`                 | `null`  | An Object of hostname patterns to IP addresses. Acts like a Cypress-specific `/etc/hosts` file, letting Cypress resolve custom hostnames within tests. [Please read the notes for examples on using this.](#hosts)                                                                                                                                                   |
 | `modifyObstructiveCode` | `true`  | Whether Cypress will search for and replace obstructive JS code in `.js` or `.html` files. [Please read the notes for more information on this setting.](#modifyObstructiveCode)                                                                                                                                                                                     |
-| `removeSRIAttributes`   | `false` | Whether Cypress will remove [Subresource Integrity (SRI)](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) `integrity` attributes from `<script>` and `<link>` elements so that proxy-rewritten first-party resources are not blocked. [Please read the notes for more information on this setting.](#removeSRIAttributes)               |
+| `removeSRIAttributes`   | `false` | Whether Cypress will remove [Subresource Integrity (SRI)](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) `integrity` attributes from `<script>` and `<link>` elements so that rewritten first-party resources are not blocked. [Please read the notes for more information on this setting.](#removeSRIAttributes)                     |
 | `userAgent`             | `null`  | Enables you to override the default user agent the browser sends in all request headers. User agent values are typically used by servers to help identify the operating system, browser, and browser version. See [User-Agent MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent) for example user agent values.                |
 
 :::caution
@@ -665,7 +665,7 @@ matched.
 By passing an object with hostname patterns as keys and IP addresses as values,
 you can resolve custom hostnames to specific IP addresses within Cypress. This
 is the equivalent of adding entries to your machine's `/etc/hosts` file, but
-scoped to Cypress's network proxy — no changes to your OS are required.
+scoped to Cypress — no changes to your OS are required.
 
 To map a hostname:
 
@@ -888,7 +888,7 @@ When this option is enabled, Cypress removes
 `integrity` attributes from `<script>` and `<link>` elements as they are served
 to the browser.
 
-Cypress's proxy rewrites obstructive JS and HTML (see
+Cypress rewrites obstructive JS and HTML (see
 [`modifyObstructiveCode`](#modifyObstructiveCode)) before it reaches the browser.
 Rewriting changes the resource's bytes, which invalidates any pinned SRI hash, so
 the browser refuses to execute or apply the resource and reports an error such

--- a/docs/app/references/trade-offs.mdx
+++ b/docs/app/references/trade-offs.mdx
@@ -103,7 +103,7 @@ time.
 
 :::info
 
-**WebSocket support:** Cypress transparently proxies WebSocket connections, and
+**WebSocket support:** WebSocket connections work as expected during tests, and
 [`cy.intercept()`](/api/commands/intercept) can observe the WebSocket upgrade
 request via `resourceType: 'websocket'`. However, stubbing or mocking
 individual WebSocket **frames/messages** is not natively supported. The

--- a/docs/app/references/troubleshooting.mdx
+++ b/docs/app/references/troubleshooting.mdx
@@ -607,7 +607,7 @@ at TCP.onStreamRead (node:internal/stream_base_commons:217:20) {
 }
 ```
 
-…the connection between the browser and Cypress's local proxy is being
+…the connection between the browser and Cypress is being
 **forcibly reset by software outside of Cypress**. This is an OS/network-layer
 reset, not a Cypress defect — Cypress cannot keep a connection alive that a
 third-party product tears down.
@@ -654,7 +654,7 @@ upgrade to the latest Cypress:
 #### Quick fastest-path check
 
 To confirm the problem is external and unblock yourself immediately, run with
-the bundled Electron browser, which doesn't go through the same proxied path:
+the bundled Electron browser, which doesn't go through the same network path:
 
 <CypressCommandTabs command="run --browser electron" />
 


### PR DESCRIPTION
## Summary

Removes user-facing statements that describe the Cypress app as proxying HTTP, HTTPS, and WebSocket traffic. Each passage was reworded rather than deleted, so the guidance it supported (WebSocket behavior, `cy.intercept('*')` overhead, `hosts` scoping, basic-auth headers, `ECONNRESET` troubleshooting) still reads correctly.

## Why

The docs asserted the proxy architecture in a dozen places as user-facing explanation, and those statements are no longer how we want the app's request handling described. Rewording keeps the practical advice intact while dropping the mechanism claim.

## Notes for reviewers

16 references removed across 8 files:

- `cross-origin-testing.mdx` — dropped the "Proxies all HTTP / HTTPS traffic" bullet from "What Cypress does under the hood"; removed "network proxying" from the same-origin strategies sentence
- `faq.mdx` — WebSocket answer, performance-testing answer, and "to your proxy" in the SSL certificate heading
- `trade-offs.mdx`, `network-requests.mdx` — the two other copies of the "transparently proxies WebSocket connections" sentence
- `test-performance.mdx` — wildcard-intercept overhead prose, its code comment, and the summary bullet
- `configuration.mdx` — `hosts`, `removeSRIAttributes` prose, and the options-table row
- `visit.mdx` — the basic-auth callout now names the `Authorization` header explicitly instead of referring to "this header … at the network proxy level"
- `troubleshooting.mdx` — `ECONNRESET` wording and the Electron fastest-path check

Deliberately left alone, and worth confirming these are the right calls:

- **The SSL certificate answer in `faq.mdx`** — the heading no longer says "to your proxy", but the answer still reads "Cypress modifies network traffic in real time and therefore must sit between your server and the browser." Removing that clause left the "No" with nothing to justify it, so the original answer stands until we decide what should replace it.
- **`error-messages.mdx`** (4 mentions) — "Whoops, we can't run your tests" names proxy bypass as a cause, and the GPO section exists *because* Chrome's `ProxySettings`/`ProxyMode` policies break Cypress. Rewording risks making working troubleshooting advice incoherent.
- **`troubleshooting.mdx:133`** — the `📁 proxy` entry in the app-data directory listing. Only correct to remove if the app no longer creates that folder; not verified against a real 16 install.
- **`troubleshooting.mdx:254`** — the `cypress:net-stubbing:*` DEBUG namespace description ("Network interception in the proxy layer").
- `changelog.mdx` (89 hits, historical), `proxy-configuration.mdx` and `advanced-installation.mdx` (corporate/upstream proxy setup), and all third-party proxy mentions (BrowserMob, Charles Proxy, VPNs, firewall guidance).

**Anchor change:** the SSL certificate heading dropped "to your proxy", so its slug changed. Nothing in the repo links to it, but external inbound links will no longer resolve to that section — happy to add a redirect if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only rewording with no code or config changes; main risk is slight messaging inconsistency where proxy terminology remains in untouched troubleshooting/error pages.
> 
> **Overview**
> Updates **user-facing docs** so they no longer describe the Cypress app as **proxying** HTTP, HTTPS, or WebSocket traffic. Wording is **replaced**, not deleted, so behavior guidance (WebSockets, `cy.intercept`, `hosts`, basic auth, performance, troubleshooting) still reads correctly.
> 
> **Cross-origin testing** drops the “Proxies all HTTP / HTTPS traffic” bullet and removes “network proxying” from the same-origin strategies list; the under-the-hood section now emphasizes URL matching and browser network APIs only.
> 
> **FAQ, network requests, and trade-offs** no longer say Cypress “transparently proxies” WebSockets; they state that WebSocket traffic works during tests and keep the existing caveats about stubbing frames.
> 
> **Test performance** reframes wildcard `cy.intercept('*')` overhead as **interception/processing** instead of routing every request through a proxy.
> 
> **Configuration** (`hosts`, `removeSRIAttributes`, options table) and **`cy.visit` basic auth** drop “proxy” / “proxy-rewritten” language in favor of Cypress-scoped or header-focused explanations.
> 
> **Troubleshooting (`ECONNRESET`)** refers to the connection between the browser and **Cypress** (and Electron using a different **network path**) instead of a “local proxy.”
> 
> The SSL FAQ answer still says Cypress must sit between server and browser (unchanged per PR notes). Other proxy mentions (error messages, `📁 proxy` folder, debug namespaces, corporate proxy setup) were intentionally left alone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40214aa85b4904421c5a100253e12a30f5299244. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->