### PR TITLE
docs(ci): note source control credential handling for recorded runs

### DIFF
--- a/docs/app/continuous-integration/overview.mdx
+++ b/docs/app/continuous-integration/overview.mdx
@@ -557,6 +557,28 @@ to see why the commit information is unavailable.
 DEBUG=cypress:server:record
 ```
 
+**_Source control credentials_**
+
+The remote origin Cypress records comes from `git config --get remote.origin.url`,
+and some CI providers authenticate the checkout by embedding a token in that URL.
+Any credential sitting there is readable by every later step in the job and
+becomes part of the recorded run.
+
+Use your CI provider's standard checkout authentication rather than supplying
+your own long-lived token. Providers issue credentials that expire when the job
+ends, such as the GitHub Actions `GITHUB_TOKEN`, the GitLab CI/CD job token, a
+CircleCI checkout key, or the Azure Pipelines `System.AccessToken`. Substituting
+a personal access token puts a credential that lasts months in the same exposed
+position.
+
+If your checkout leaves a credential in the remote URL, set `COMMIT_INFO_REMOTE`
+to a clean URL so the recorded remote does not include it. On GitLab CI, for
+example, `CI_PROJECT_URL` has no token in it:
+
+```shell
+export COMMIT_INFO_REMOTE="$CI_PROJECT_URL.git"
+```
+
 #### CI Build Information
 
 In some newer CI providers, Cypress can't map the system environment variables required


### PR DESCRIPTION
## Summary

Adds a short `**_Source control credentials_**` subsection to the existing `#### Git information` section of the Continuous Integration overview. It tells readers to use their CI provider's standard checkout authentication rather than supplying their own long-lived token, and documents setting `COMMIT_INFO_REMOTE` to a clean URL when the checkout leaves a credential in the Git remote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvEbsZiCyuRK5Npe8VX52j

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvEbsZiCyuRK5Npe8VX52j)_


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or application code impact.
> 
> **Overview**
> Adds a **Source control credentials** subsection under **Git information** in the CI overview, explaining that recorded `remote.origin.url` values can leak CI-embedded tokens into Cypress Cloud and later job steps.
> 
> The new text recommends using provider-scoped checkout auth (e.g. `GITHUB_TOKEN`, GitLab job token) instead of long-lived PATs, and shows overriding `COMMIT_INFO_REMOTE` with a token-free URL (GitLab `CI_PROJECT_URL` example) when the checkout leaves credentials in the remote.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87a0beb14dfc9c0e7b4b68d67adb0d372eae09b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->