### PR TITLE
docs: stop describing the app as proxying requests

### DIFF
--- a/docs/api/commands/intercept.mdx
+++ b/docs/api/commands/intercept.mdx
@@ -845,11 +845,15 @@ cy.wait('@createUser')
   .should('have.property', 'x-custom-header', 'added by cy.intercept')
 ```
 
-:::caution
+:::info
 
-The request modification cannot be verified by inspecting the browser's network
-traffic (for example, in Chrome DevTools), since the browser logs network
-traffic _before_ Cypress can intercept it.
+In Chrome, Chromium, and Edge the browser sends the modified request, so the
+modification is reflected in the browser's network traffic (for example, in Chrome
+DevTools). On the
+[legacy network path](/app/guides/native-network-interception#Using-the-legacy-network-path)
+the browser logs the request before Cypress modifies it, so the modification does
+not appear there — verify it from the Cypress command log, or with an assertion on
+`request.headers` after `cy.wait()`.
 
 :::
 

--- a/docs/api/commands/visit.mdx
+++ b/docs/api/commands/visit.mdx
@@ -155,9 +155,11 @@ cy.visit('https://wile:coyote@example.cypress.io')
 
 :::info
 
-Cypress will automatically attach this header at the network proxy level,
-outside of the browser. Therefore you **will not** see this header in the Dev
-Tools.
+Cypress attaches the `Authorization` header for you on requests to the origin
+you visited. Other origins do not receive it. On the
+[legacy network path](/app/guides/native-network-interception#Using-the-legacy-network-path)
+the header is attached outside of the browser, so it does **not** appear in the
+Dev Tools.
 
 :::
 

--- a/docs/app/faq.mdx
+++ b/docs/app/faq.mdx
@@ -100,8 +100,7 @@ testing).
 
 ### <Icon name="angle-right" /> We use WebSockets; will Cypress work with that?
 
-Yes. Cypress transparently proxies WebSocket connections, so your application's
-WebSocket traffic will work as expected during tests.
+Yes. Your application's WebSocket traffic will work as expected during tests.
 
 However, **stubbing or mocking individual WebSocket frames/messages** is not
 natively supported. If your tests need to control the messages sent over a
@@ -1140,10 +1139,12 @@ browser.
 
 [Check out the "Node Modules" example recipe.](/app/references/recipes#Fundamentals)
 
-### <Icon name="angle-right" /> Is there a way to give a proper SSL certificate to your proxy so the page doesn't show up as "not secure"?
+### <Icon name="angle-right" /> Is there a way to give a proper SSL certificate so the page doesn't show up as "not secure"?
 
-No, Cypress modifies network traffic in real time and therefore must sit between
-your server and the browser. There is no other way for us to achieve that.
+No, and it isn't about your site's certificate. The browser's security indicator
+describes the Cypress app's page, which is served over `http` on `localhost`.
+Your application under test loads inside that page, and its own HTTPS connection
+is unaffected.
 
 ### <Icon name="angle-right" /> Is there any way to detect if my app is running under Cypress?
 
@@ -1221,12 +1222,15 @@ There are a few ways.
 ### <Icon name="angle-right" /> When I visit my site directly, the certificate is verified, however the browser launched through Cypress is showing it as "Not Secure". Why?
 
 When using Cypress to test an HTTPS site, you might see a browser warning next
-to the browser URL. This is normal. Cypress modifies the traffic between your
-server and the browser. The browser notices this and displays a certificate
-warning. However, this is purely cosmetic and does not alter the way your
-application under test runs in any way, so you can safely ignore this warning.
-The network traffic between Cypress and the backend server still happens via
-HTTPS.
+to the browser URL. This is normal. The indicator describes the Cypress app's
+page, which is served over `http` on `localhost` — not your application, which
+loads inside it with its certificate validated as usual. On the
+[legacy network path](/app/guides/native-network-interception#Using-the-legacy-network-path),
+Cypress modifies the traffic between your server and the browser and presents a
+certificate it generates, which the browser reports as untrusted. Either way this
+is purely cosmetic and does not alter the way your application under test runs in
+any way, so you can safely ignore the warning. The network traffic between
+Cypress and the backend server still happens via HTTPS.
 
 See also the [Cross Origin Testing](/app/guides/cross-origin-testing) guide.
 
@@ -1621,7 +1625,7 @@ XState model state library.
 ### <Icon name="angle-right" /> Can Cypress be used for performance testing?
 
 Cypress is not built for performance testing. Because Cypress instruments the
-page under test, proxies the network requests, and tightly controls the test
+page under test, intercepts the network requests, and tightly controls the test
 steps, Cypress adds its own overhead. Thus, the performance numbers you get from
 Cypress tests are slower than "normal" use. Still, you can access the native
 `window.performance` object and grab the page time measurements, see the

--- a/docs/app/guides/cross-origin-testing.mdx
+++ b/docs/app/guides/cross-origin-testing.mdx
@@ -30,14 +30,14 @@ communicate with your remote application at all times. Unfortunately, browsers
 naturally try to prevent Cypress from doing this.
 
 To get around these restrictions, Cypress implements some strategies involving
-JavaScript code, the browser's internal APIs, and network proxying to _play by
-the rules_ of same-origin policy. It's our goal to fully automate the
-application under test without you needing to modify your application's code -
-and we are _mostly_ able to do this.
+JavaScript code and the browser's internal APIs to _play by the rules_ of
+same-origin policy. It's our goal to fully automate the application under test
+without you needing to modify your application's code - and we are _mostly_
+able to do this.
 
 ### What Cypress does under the hood
 
-- Proxies all HTTP / HTTPS traffic.
+- Intercepts and can modify HTTP / HTTPS traffic.
 - Changes the hosted URL to match that of the application under test.
 - Uses the browser's internal APIs for network level traffic.
 
@@ -54,12 +54,19 @@ expected.
 
 <strong>How is HTTPS supported?</strong>
 
-Cypress must assign and manage browser certificates to be able to
-modify the traffic in real time. You'll notice Chrome display a warning that the 'SSL certificate does not
-match'. This is expected behavior. Under the hood we act as our own CA
-authority and issue certificates dynamically in order to intercept requests
-otherwise impossible to access. We only do this for the origin currently
-under test, and bypass other traffic.
+Your application's certificate is used and validated as usual. Because the
+Cypress app itself is served over `http` on `localhost`, the browser reports
+that page as not secure — that indicator describes the Cypress app, not the
+application under test loading inside it.
+
+On the
+[legacy network path](/app/guides/native-network-interception#Using-the-legacy-network-path),
+Cypress must assign and manage browser certificates in order to modify the
+traffic in real time. Chrome then warns that the certificate was issued by an
+unknown authority, which is expected behavior. Under the hood we act as our own
+CA authority and issue certificates dynamically in order to intercept requests
+otherwise impossible to access. We only do this for the origin currently under
+test, and bypass other traffic.
 
 Note, that Cypress allows you to optionally specify CA / client certificate
 information for use with HTTPS sites. See

--- a/docs/app/guides/native-network-interception.mdx
+++ b/docs/app/guides/native-network-interception.mdx
@@ -346,6 +346,34 @@ cy.intercept('/api/users', (req) => {
 })
 ```
 
+### Your application's certificate is used
+
+Cypress no longer terminates TLS for the application under test, so the browser makes its
+own connection and validates your origin's real certificate. Chrome no longer reports a
+certificate issued by an unknown authority, and Cypress does not generate one.
+
+The browser still reports the page as not secure, because the Cypress app itself is served
+over `http` on `localhost`. That indicator describes the Cypress app, not your application
+loading inside it.
+
+On the legacy network path Cypress acts as its own certificate authority and issues a
+certificate for the origin under test, which the browser reports as untrusted.
+
+### `cy.intercept()` changes are visible in the browser
+
+The browser sends the request and receives the response, so everything an intercept
+changes is what the browser itself records: modified request headers and bodies, stubbed
+or rewritten responses, and overridden status codes all appear in the browser's network
+panel. The `Authorization` header attached by
+[`cy.visit()`](/api/commands/visit#Add-basic-auth-headers) appears there too.
+
+On the legacy network path, request modifications are applied after the browser has
+already logged the request, so they do not appear in the network panel. Response
+modifications do, because the browser only ever sees the response Cypress returns.
+
+Assertions on `request.headers` after `cy.wait()` and the Cypress command log report the
+modified request on both paths.
+
 ## Writing tests that pass in every browser
 
 Assertions that describe your application rather than the transport pass in every browser

--- a/docs/app/guides/network-requests.mdx
+++ b/docs/app/guides/network-requests.mdx
@@ -535,8 +535,7 @@ cy.wait('@new-user').then(console.log)
 
 ## Working with WebSockets
 
-Cypress transparently proxies WebSocket connections, so your application's
-WebSocket traffic will work as expected during tests.
+Your application's WebSocket traffic will work as expected during tests.
 
 ### Limitations
 

--- a/docs/app/guides/test-performance.mdx
+++ b/docs/app/guides/test-performance.mdx
@@ -176,7 +176,7 @@ Apply these optimizations in order. The highest-impact changes are at the top.
 1. [Eliminate arbitrary cy.wait()](#Avoid-arbitrary-waits-and-adjust-timeouts)
 1. [Slim support file and imports](#Keep-support-and-spec-imports-lean) — avoids bundling unused code on every spec startup
 1. [Block third-party requests with blockHosts](#Block-third-party-requests-with-blockHosts) — analytics and monitoring services consume time in test environments; blocked requests resolve immediately
-1. [Avoid wildcard cy.intercept('\*')](#Intercept-only-the-requests-you-need) — limits proxy overhead to requests the test actually needs
+1. [Avoid wildcard cy.intercept('\*')](#Intercept-only-the-requests-you-need) — limits interception overhead to requests the test actually needs
 1. [Use specific DOM selectors](#Use-specific-selectors) — broad selectors like `*` or `div` force the browser to collect every matching node before filtering
 1. [Modern visibility algorithm](#Use-the-modern-visibility-algorithm) — high impact on complex DOMs; Cypress 16 defaults to the faster `checkVisibility()`-based algorithm
 1. [Test retries (runMode: 1)](#Use-test-retries-deliberately) — prevents flaky tests from blocking CI; keep the count low and use flake data to fix root causes
@@ -545,10 +545,10 @@ See the [Network Requests guide](/app/guides/network-requests) for a full discus
 
 #### Intercept only the requests you need
 
-Using a wildcard pattern to observe or intercept every HTTP request creates real overhead. Cypress routes every intercepted request through its proxy, so every network call the page makes is inspected, matched, and processed. Broad wildcard patterns that match dozens or hundreds of requests per page load multiply that cost across the entire suite.
+Using a wildcard pattern to observe or intercept every HTTP request creates real overhead: every request that matches an intercept is paused and handed to your test code before it continues. Broad wildcard patterns that match dozens or hundreds of requests per page load multiply that cost across the entire suite.
 
 ```js
-// ❌ Anti-pattern: intercepts every request; Cypress proxies each one
+// ❌ Anti-pattern: intercepts every request; Cypress processes each one
 cy.intercept('*').as('anyRequest')
 
 // ✅ Faster approach: only intercept the specific requests your test needs

--- a/docs/app/references/configuration.mdx
+++ b/docs/app/references/configuration.mdx
@@ -230,7 +230,7 @@ For more options regarding screenshots, view the
 | `blockHosts`            | `null`  | A String or Array of hosts that you wish to block traffic for. [Please read the notes for examples on using this.](#blockHosts)                                                                                                                                                                                                                                      |
 | `hosts`                 | `null`  | An Object of hostname patterns to IP addresses. Acts like a Cypress-specific `/etc/hosts` file, letting Cypress resolve custom hostnames within tests. [Please read the notes for examples on using this.](#hosts)                                                                                                                                                   |
 | `modifyObstructiveCode` | `true`  | Whether Cypress will search for and replace obstructive JS code in `.js` or `.html` files. [Please read the notes for more information on this setting.](#modifyObstructiveCode)                                                                                                                                                                                     |
-| `removeSRIAttributes`   | `false` | Whether Cypress will remove [Subresource Integrity (SRI)](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) `integrity` attributes from `<script>` and `<link>` elements so that proxy-rewritten first-party resources are not blocked. [Please read the notes for more information on this setting.](#removeSRIAttributes)               |
+| `removeSRIAttributes`   | `false` | Whether Cypress will remove [Subresource Integrity (SRI)](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) `integrity` attributes from `<script>` and `<link>` elements so that first-party resources rewritten by Cypress are not blocked. [Please read the notes for more information on this setting.](#removeSRIAttributes)          |
 | `userAgent`             | `null`  | Enables you to override the default user agent the browser sends in all request headers. User agent values are typically used by servers to help identify the operating system, browser, and browser version. See [User-Agent MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent) for example user agent values.                |
 
 :::caution
@@ -666,7 +666,7 @@ matched.
 By passing an object with hostname patterns as keys and IP addresses as values,
 you can resolve custom hostnames to specific IP addresses within Cypress. This
 is the equivalent of adding entries to your machine's `/etc/hosts` file, but
-scoped to Cypress's network proxy — no changes to your OS are required.
+scoped to Cypress — no changes to your OS are required.
 
 To map a hostname:
 
@@ -920,7 +920,7 @@ When this option is enabled, Cypress removes
 `integrity` attributes from `<script>` and `<link>` elements as they are served
 to the browser.
 
-Cypress's proxy rewrites obstructive JS and HTML (see
+Cypress rewrites obstructive JS and HTML (see
 [`modifyObstructiveCode`](#modifyObstructiveCode)) before it reaches the browser.
 Rewriting changes the resource's bytes, which invalidates any pinned SRI hash, so
 the browser refuses to execute or apply the resource and reports an error such

--- a/docs/app/references/trade-offs.mdx
+++ b/docs/app/references/trade-offs.mdx
@@ -103,10 +103,9 @@ time.
 
 :::info
 
-**WebSocket support:** Cypress transparently proxies WebSocket connections, and
-[`cy.intercept()`](/api/commands/intercept) can observe the WebSocket upgrade
-request via `resourceType: 'websocket'`. However, stubbing or mocking
-individual WebSocket **frames/messages** is not natively supported. The
+**WebSocket support:** WebSocket connections work as expected during tests, but
+Cypress does not intercept them, so stubbing or mocking individual WebSocket
+**frames/messages** is not natively supported. The
 strategies described below are the recommended way to test real-time,
 message-driven features.
 

--- a/docs/app/references/troubleshooting.mdx
+++ b/docs/app/references/troubleshooting.mdx
@@ -251,7 +251,7 @@ want to enable them
 | `cypress:launcher:*`             | Launching the found browser                                   |
 | `cypress:server:video`           | Video recording                                               |
 | `cypress:network:*`              | Adding network interceptors                                   |
-| `cypress:net-stubbing:*`         | Network interception in the proxy layer                       |
+| `cypress:net-stubbing:*`         | Network interception layer                                    |
 | `cypress:server:reporter`        | Problems with test reporters                                  |
 | `cypress:server:preprocessor`    | Processing specs                                              |
 | `cypress:server:socket-e2e`      | Watching spec files                                           |
@@ -607,7 +607,7 @@ at TCP.onStreamRead (node:internal/stream_base_commons:217:20) {
 }
 ```
 
-…the connection between the browser and Cypress's local proxy is being
+…the connection between the browser and Cypress is being
 **forcibly reset by software outside of Cypress**. This is an OS/network-layer
 reset, not a Cypress defect — Cypress cannot keep a connection alive that a
 third-party product tears down.
@@ -654,7 +654,7 @@ upgrade to the latest Cypress:
 #### Quick fastest-path check
 
 To confirm the problem is external and unblock yourself immediately, run with
-the bundled Electron browser, which doesn't go through the same proxied path:
+the bundled Electron browser, which doesn't go through the same network path:
 
 <CypressCommandTabs command="run --browser electron" />
 


### PR DESCRIPTION
## Summary

Stops describing the Cypress app as proxying HTTP, HTTPS, and WebSocket traffic, and corrects three claims that only hold on the legacy network path. Targets the [`forceHttp1` branch](https://github.com/cypress-io/cypress-documentation/pull/6806) because it depends on the Native Network Interception guide added there.

## Why

Rewording alone wasn't enough — some passages promised user-visible symptoms that no longer occur. Verified in a Cypress 16 Chrome session on the default path and with `forceHttp1: true`:

- **Certificates.** The site's own certificate is used and validated as usual; Cypress mints one only on the legacy path. The "not secure" indicator that remains is the Cypress app's page, served over `http` on `localhost`. Two FAQ answers and the HTTPS callout in the cross-origin guide named the wrong cause.
- **Request modifications are visible.** The `Authorization` header from `cy.visit()` — and anything a `cy.intercept()` handler changes — appears in Dev Tools on the default path, and does not with `forceHttp1: true`.
- **WebSockets are not intercepted on either path**, so `trade-offs.mdx` was wrong to promise the upgrade is observable via `resourceType: 'websocket'`, which has also been deprecated as a matcher since 14.0.0.

The first two are documented as behavior differences in the guide; the affected pages link there instead of describing a mechanism.

## Notes for reviewers

Supersedes #6808. Its rewordings are carried over here and Chris is co-authored on the commit, so that PR can be closed without losing anything.

- `intercept.mdx` is outside #6808's file set, but its note claimed request modifications can't be verified in Dev Tools "since the browser logs network traffic _before_ Cypress can intercept it" — false on the native browser network, so it's fixed here.
- Left alone deliberately: the Electron sentence in `troubleshooting.mdx` (Electron really is on the legacy path, so #6808's wording is accurate) and `error-messages.mdx` (Chrome's proxy policies still break Cypress).
- The SSL certificate FAQ anchor changes. Nothing in the repo links to it, and a redirect can't help since fragments never reach the server.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or API impact; risk is limited to possible reader confusion if links or legacy-path descriptions are wrong.
> 
> **Overview**
> This PR **reframes how Cypress handles network traffic** in the docs: it stops saying Cypress “proxies” HTTP/HTTPS/WebSockets and instead describes **interception** and, where relevant, contrasts the **default (native browser network)** path with the **[legacy network path](/app/guides/native-network-interception#Using-the-legacy-network-path)** (`forceHttp1`).
> 
> **`cy.intercept()` and `cy.visit()`** callouts now state that on Chrome/Chromium/Edge, **request/header changes and basic-auth `Authorization` show up in DevTools**; on the legacy path they often do not, and readers are pointed to the command log or `cy.wait()` assertions.
> 
> **HTTPS / “not secure” FAQ and cross-origin guide** explain that the warning usually reflects the **Cypress shell on `http://localhost`**, while the app under test keeps its real certificate—except on the legacy path, where Cypress still mints a CA cert.
> 
> **WebSockets** copy no longer claims transparent proxying or `cy.intercept()` observability of upgrades; **trade-offs** notes WebSockets are not intercepted.
> 
> **Native Network Interception guide** gains sections on **real TLS**, **visible intercept changes in the browser**, and related behavior differences.
> 
> Smaller edits swap “proxy” for neutral terms in **test-performance**, **configuration** (`hosts`, `removeSRIAttributes`), and **troubleshooting** debug labels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fcb7da8c92a13babb4d52a1946ed9f8c405b195. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->