### PR TITLE
docs: clarify that retry-ability after cy.wait() follows the chain

### DIFF
--- a/docs/api/commands/wait.mdx
+++ b/docs/api/commands/wait.mdx
@@ -273,6 +273,47 @@ cy.get(...)
 Read
 [Guide: Introduction to Cypress](/app/core-concepts/introduction-to-cypress#Commands-Run-Serially)
 
+### Retry-ability
+
+[Retry-ability](/app/core-concepts/retry-ability) is a property of the chain,
+not of a single command. `cy.wait()` itself is not a query, so an assertion
+chained directly to it is evaluated only once against the interception object
+that `cy.wait()` yielded:
+
+```js
+// runs the assertion a single time - no retries
+cy.wait('@getAccount').should(
+  'have.nested.property',
+  'response.statusCode',
+  200
+)
+```
+
+Chaining a query such as [`.its()`](/api/commands/its) or
+[`.invoke()`](/api/commands/invoke) after `cy.wait()` starts a new retryable
+chain. The query re-reads the property from the interception object and any
+assertions after it retry for the duration of
+[`defaultCommandTimeout`](/app/references/configuration#Timeouts) (`4000` ms by
+default):
+
+```js
+// the .its() query and the assertion retry for up to 4 seconds
+cy.wait('@getAccount').its('response.statusCode').should('eq', 200)
+```
+
+Because the assertion retries, it does not fail on the first attempt. If the
+value never satisfies the assertion, the test fails only after
+`defaultCommandTimeout` has elapsed.
+
+To opt out of retrying, override the timeout on the query to `0`:
+
+```js
+// asserts synchronously against the value at that moment - no retries
+cy.wait('@getAccount')
+  .its('response.statusCode', { timeout: 0 })
+  .should('eq', 200)
+```
+
 ### Timeouts {#Notes-Timeouts}
 
 #### `requestTimeout` and `responseTimeout`
@@ -328,8 +369,11 @@ requests to complete within the given `requestTimeout` and `responseTimeout`.
 
 <HeaderAssertions />
 
-- `cy.wait()` will only run assertions you have chained once, and will not
+- Assertions chained _directly_ to `cy.wait()` run once and will not
   [retry](/app/core-concepts/retry-ability).
+- Assertions chained after a query such as [`.its()`](/api/commands/its) or
+  [`.invoke()`](/api/commands/invoke) _do_ retry, because
+  [retry-ability follows the chain](#Retry-ability), not the command.
 
 <HeaderTimeouts />
 

--- a/docs/api/commands/wait.mdx
+++ b/docs/api/commands/wait.mdx
@@ -275,13 +275,17 @@ Read
 
 ### Retry-ability
 
-[Retry-ability](/app/core-concepts/retry-ability) is a property of the chain,
-not of a single command. `cy.wait()` itself is not a query, so an assertion
-chained directly to it is evaluated only once against the interception object
-that `cy.wait()` yielded:
+How you write the chain after `cy.wait()` decides whether your assertions
+[retry](/app/core-concepts/retry-ability), and how long a failing assertion
+takes to fail. Both styles below work, so pick the one that matches what you
+want.
+
+Retry-ability belongs to the chain, not to a single command. `cy.wait()` is not
+a query, so an assertion chained straight onto it gets a single attempt against
+the interception object it yielded:
 
 ```js
-// runs the assertion a single time - no retries
+// one attempt: fails as soon as the status code is wrong
 cy.wait('@getAccount').should(
   'have.nested.property',
   'response.statusCode',
@@ -289,26 +293,29 @@ cy.wait('@getAccount').should(
 )
 ```
 
-Chaining a query such as [`.its()`](/api/commands/its) or
-[`.invoke()`](/api/commands/invoke) after `cy.wait()` starts a new retryable
-chain. The query re-reads the property from the interception object and any
-assertions after it retry for the duration of
+Add a query such as [`.its()`](/api/commands/its) or
+[`.invoke()`](/api/commands/invoke) and you start a new retryable chain. The
+query re-reads the property, and everything after it retries for up to
 [`defaultCommandTimeout`](/app/references/configuration#Timeouts) (`4000` ms by
 default):
 
 ```js
-// the .its() query and the assertion retry for up to 4 seconds
+// retries for up to 4 seconds before passing or failing
 cy.wait('@getAccount').its('response.statusCode').should('eq', 200)
 ```
 
-Because the assertion retries, it does not fail on the first attempt. If the
-value never satisfies the assertion, the test fails only after
-`defaultCommandTimeout` has elapsed.
+What to expect from each:
 
-To opt out of retrying, override the timeout on the query to `0`:
+- **Assertion chained directly to `cy.wait()`:** one attempt, and a wrong value
+  fails the test right away.
+- **Assertion chained after a query:** retries, so a wrong value keeps the test
+  running until `defaultCommandTimeout` runs out.
+
+If you want the retrying version to fail fast instead, set the query's timeout
+to `0`:
 
 ```js
-// asserts synchronously against the value at that moment - no retries
+// checks the value once, at that moment
 cy.wait('@getAccount')
   .its('response.statusCode', { timeout: 0 })
   .should('eq', 200)

--- a/docs/api/commands/wait.mdx
+++ b/docs/api/commands/wait.mdx
@@ -304,13 +304,6 @@ default):
 cy.wait('@getAccount').its('response.statusCode').should('eq', 200)
 ```
 
-What to expect from each:
-
-- **Assertion chained directly to `cy.wait()`:** one attempt, and a wrong value
-  fails the test right away.
-- **Assertion chained after a query:** retries, so a wrong value keeps the test
-  running until `defaultCommandTimeout` runs out.
-
 If you want the retrying version to fail fast instead, set the query's timeout
 to `0`:
 


### PR DESCRIPTION
## Summary

Corrects the assertion rule on the `cy.wait()` page and adds a **Retry-ability** note explaining that retry-ability is a property of the chain rather than of the command. Assertions chained directly to `cy.wait()` run once, but adding a query such as `.its()` or `.invoke()` starts a new retryable chain, so everything after it retries for `defaultCommandTimeout`.

## Why

The Rules → Assertions section stated:

> `cy.wait()` will only run assertions you have chained once, and will not retry.

That is accurate only for an assertion chained directly to `cy.wait()`. It is misleading for the form the page's own examples use, where the assertion does retry for the full `defaultCommandTimeout`:

```js
cy.wait('@alias').should('eq', …)                      // runs once
cy.wait('@alias').its('response.statusCode').should(…) // retries 4s
```

Readers comparing the rule against those examples get contradictory guidance, and the difference is observable: the retrying form keeps a failing test running until the timeout elapses, while the direct form fails immediately.

## Notes for reviewers

- All pre-existing examples on the page are unchanged. The new note adds its own examples.
- The new **Retry-ability** subsection sits under Notes, after *Nesting*, and covers the `{ timeout: 0 }` override on the query for readers who want the retrying form to fail fast.
- The section is written impact-first per the Cypress Style Guide: it leads with what the reader needs to decide, then explains the mechanism.
- The Rules → Assertions bullet now links to the new section with `#Retry-ability`, matching the case-preserving anchor convention used elsewhere in the docs (for example `#Only-queries-are-retried`).
- Prettier formatting checked on the changed file.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EGb6wkrP32cTuG6E4jVdS1)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to `wait.mdx` with no runtime or test behavior impact.
> 
> **Overview**
> Updates **`cy.wait()`** documentation so assertion retry behavior matches the page’s own chained examples.
> 
> Adds a **Retry-ability** note under Notes (after *Nesting*) explaining that retry-ability is a property of the **chain**, not `cy.wait()` itself: assertions chained **directly** to `cy.wait()` run once, while inserting a query such as **`.its()`** or **`.invoke()`** starts a retryable chain (up to **`defaultCommandTimeout`**), with **`{ timeout: 0 }`** on the query to fail fast.
> 
> Refines **Rules → Assertions** into two bullets—direct assertions do not retry; assertions after a query do—and links to **`#Retry-ability`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b59fb3260a1473c34746e50457b000154c847769. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->