### PR TITLE
docs: add 15.21.0 changelog entry

### DIFF
--- a/docs/app/references/changelog.mdx
+++ b/docs/app/references/changelog.mdx
@@ -10,6 +10,30 @@ sidebar_label: Changelog
 
 ## 15.21.0
 
+_Released Aug 18, 2026_
+
+**Deprecations:**
+
+- [`cy.exec()`](/api/commands/exec) has been deprecated and will be removed in a future major release of Cypress. Use [`cy.task()`](/api/commands/task) instead, which runs in Node without depending on the operating system, shell, or terminal of the machine running Cypress. The [`execTimeout`](/app/references/configuration#Timeouts) configuration option is deprecated alongside it, in favor of [`taskTimeout`](/app/references/configuration#Timeouts). Addresses [#34639](https://github.com/cypress-io/cypress/issues/34639).
+
+**Features:**
+
+- Added the `cypress tap` command, which gives your AI agent direct access to your open-mode Cypress session. It lists the open-mode Cypress sessions running on the machine, starts and reruns a spec, reports a run's status and results, prints a failing test's error and Command Log, and inspects the DOM and accessibility tree of the application under test. Every subcommand prints readable output by default and machine-readable JSON with `--json`. Run `cypress tap --help` for the full list of subcommands. Addresses [#34036](https://github.com/cypress-io/cypress/issues/34036).
+- Added a `CYPRESS_DISABLE_GUEST_TELEMETRY` environment variable, which disables any reporting Cypress sends for non-logged sessions. This includes anonymous usage events within Cypress open-mode and the Cypress CLI. Addressed in [#34540](https://github.com/cypress-io/cypress/pull/34540).
+
+**Bugfixes:**
+
+- Fixed an issue where WebKit runs could hang indefinitely when more parallel requests than the browser's per-host connection pool were intercepted by a [`cy.intercept()`](/api/commands/intercept) route with a request handler. Fixes [#33926](https://github.com/cypress-io/cypress/issues/33926) and addresses [#23807](https://github.com/cypress-io/cypress/issues/23807).
+- Fixed an issue where overriding [`blockHosts`](/app/references/configuration#blockHosts) with test configuration (for example `describe('...', { blockHosts: [...] }, ...)`) had no effect, so requests were still blocked or allowed according to the project-level value. Test-level `blockHosts` overrides now take effect at runtime and are restored between specs. Fixes [#21151](https://github.com/cypress-io/cypress/issues/21151).
+- Fixed an issue where `cypress run` printed the `(Attempt N of M)` line twice for the same attempt when a `beforeEach` and an `afterEach` hook both failed during that attempt. Fixes [#26143](https://github.com/cypress-io/cypress/issues/26143).
+- Fixed an issue where passing an object to the [`have.attr`, `have.css`, or `have.prop` assertions](/app/references/assertions), such as `.should('have.css', { backgroundColor: 'rgb(128, 0, 0)' })`, applied those styles, attributes, or properties to the element and passed instead of asserting on them. These assertions now fail with an error stating that the name must be a string. Fixes [#26451](https://github.com/cypress-io/cypress/issues/26451).
+- Fixed an issue where the console props output for a [`cy.env()`](/api/commands/env) command listed the requested environment variable names under numbered keys instead of a single `Env vars` label. Addressed in [#34615](https://github.com/cypress-io/cypress/pull/34615).
+- Fixed an issue on Windows where adding, renaming, moving or deleting a spec file while `cypress open` was running was not reflected in the specs list, leaving stale specs until Cypress was restarted. Clicking a spec that had been renamed or moved could then fail to run. Projects whose [`specPattern`](/app/references/configuration#e2e) contains a directory, such as the End-to-End Testing default `cypress/e2e/**/*.cy.{js,jsx,ts,tsx}`, were affected. Fixes [#22303](https://github.com/cypress-io/cypress/issues/22303).
+
+**Dependency Updates:**
+
+- Upgraded `@sinonjs/fake-timers` from `11.3.1` to `14.0.0`. While [`cy.clock()`](/api/commands/clock) is active, the faked `performance` object now implements `performance.mark()` and `performance.measure()` (previously no-ops that returned `undefined`) and reports a faked `performance.timeOrigin`. Addressed in [#34377](https://github.com/cypress-io/cypress/pull/34377).
+
 ## 15.20.1
 
 _Released Aug 10, 2026_


### PR DESCRIPTION
## Release

Target release: Cypress App 15.21.0

## Included changes

- [x] **Changelog entry** — new `## 15.21.0` section in
      [`docs/app/references/changelog.mdx`](docs/app/references/changelog.mdx),
      dated `_Released Aug 18, 2026_`, with the `Deprecations` / `Features` /
      `Bugfixes` / `Dependency Updates` groupings.
- Entry content is ported verbatim from the `## 15.21.0` section of
  [`cli/CHANGELOG.md`](https://github.com/cypress-io/cypress/blob/develop/cli/CHANGELOG.md)
  on `cypress-io/cypress@develop` — same section order and same bullet order,
  all 10 bullets, no rewording.
- Absolute Cypress URLs were converted to site-relative paths per the
  convention used by the surrounding entries:
  - `https://on.cypress.io/exec` → `/api/commands/exec`
  - `https://on.cypress.io/task` → `/api/commands/task`
  - `https://on.cypress.io/intercept` → `/api/commands/intercept`
  - `https://on.cypress.io/env` → `/api/commands/env`
  - `https://on.cypress.io/clock` → `/api/commands/clock`
  - `https://on.cypress.io/assertions` → `/app/references/assertions`
  - `https://on.cypress.io/configuration#blockHosts` → `/app/references/configuration#blockHosts`
  - `https://docs.cypress.io/app/references/configuration#Timeouts` → `/app/references/configuration#Timeouts`
  - `https://docs.cypress.io/app/references/configuration#e2e` → `/app/references/configuration#e2e`

  GitHub issue/PR links and the intra-changelog version anchors were left
  absolute/unchanged.

No other pages are touched — this is changelog only.

## Notes for reviewers

- **The release date is the item to double-check.** `_Released Aug 18, 2026_`
  reflects the intended ship date at the time this PR was opened; if 15.21.0
  slips, the date line needs updating before merge.
- `npm run build` passes locally (exit 0, no broken-link or broken-anchor
  errors), so every rewritten relative link and anchor resolves. Each target
  page and heading was also confirmed by hand:
  `docs/api/commands/{exec,task,intercept,env,clock}.mdx`,
  `docs/app/references/assertions.mdx`, and the `Timeouts`, `e2e`, and
  `blockHosts` headings in `docs/app/references/configuration.mdx`.
- The 15.21.0 features documented on this release branch (the `cypress tap`
  CLI pages, banner update) are unreleased until 15.21.0 ships, same as this
  entry.
- Intentionally left out: no changes to `docs/accessibility/changelog.mdx` or
  `docs/ui-coverage/changelog.mdx` (N/A — this is an App release), and no
  prose/page updates beyond the changelog, since the ask was changelog only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog addition with no runtime or build logic changes.
> 
> **Overview**
> Adds a new **15.21.0** section at the top of the Cypress App changelog (`changelog.mdx`), dated Aug 18, 2026, with content ported from `cli/CHANGELOG.md`.
> 
> The entry documents **`cy.exec()` / `execTimeout` deprecation** in favor of `cy.task()` / `taskTimeout`, the **`cypress tap` CLI** and **`CYPRESS_DISABLE_GUEST_TELEMETRY`**, six bugfixes (WebKit intercept hangs, `blockHosts` test overrides, duplicate attempt lines, assertion object misuse, `cy.env()` console props, Windows spec list staleness), and the **`@sinonjs/fake-timers` 14** upgrade with `cy.clock()` performance API behavior.
> 
> on.cypress.io / docs.cypress.io links in the source bullets were rewritten to **site-relative paths**; GitHub and intra-changelog anchors were left unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2a8ac45aaf82e359936a6ef63e1026d14c2d6d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->