### PR TITLE
docs: document video chapter markers

### DIFF
--- a/docs/app/guides/screenshots-and-videos.mdx
+++ b/docs/app/guides/screenshots-and-videos.mdx
@@ -153,6 +153,43 @@ DEBUG=cypress:server:video
 
 :::
 
+### Video chapters
+
+While encoding a video, Cypress embeds chapter markers into the resulting `.mp4`
+file, one for each test attempt in the spec. Video players that support
+chapters, such as VLC, QuickTime, and IINA, use these markers to let you jump to
+a specific test instead of scrubbing through the whole recording. Each chapter is
+titled with the full title of the test, including the titles of the suites it is
+nested in. When a test runs more than once because of
+[test retries](/app/guides/test-retries), each attempt gets its own chapter.
+
+:::caution
+
+Chapters are only written during video compression, and
+[`videoCompression`](/app/references/configuration#Videos) is disabled by
+default. To get chapters, enable both `video` and `videoCompression`.
+
+:::
+
+::::cypress-config-example
+
+```ts
+{
+  video: true,
+  videoCompression: true
+}
+```
+
+::::
+
+Setting `videoCompression` to a CRF value such as `15` also produces chapters.
+Setting it to `false` or `0` skips encoding entirely, so the video contains no
+chapters.
+
+Chapters are independent of [Cypress Cloud](/cloud/get-started/introduction),
+which jumps to a test in a recorded video using timestamps sent with your run
+results, no matter how you configure `videoCompression`.
+
 ### Control which videos to keep and upload to Cypress Cloud
 
 You may want to have more control over which videos you want to keep and upload

--- a/docs/app/guides/screenshots-and-videos.mdx
+++ b/docs/app/guides/screenshots-and-videos.mdx
@@ -189,14 +189,18 @@ chapters.
 Chapters only help when you open the video file yourself. Record your runs to
 [Cypress Cloud](/cloud/get-started/introduction) and you get this for free:
 every test in the run is listed alongside its video, and selecting one takes you
-straight to that moment—no chapters to configure and no scrubbing.
+straight to that moment, with no chapters to configure and no scrubbing.
 
-Better still, skip the video and debug the run with
+:::note
+
+Skip the video and debug the run with
 [Test Replay](/cloud/features/test-replay). Rather than watching a recording,
 you replay the test exactly as it executed in CI, so you can time travel to the
 point of failure and inspect the DOM, network requests, console logs, JavaScript
-errors, and element rendering—the same debugging experience you have locally,
-without reproducing the failure on your machine.
+errors, and element rendering, giving you the same debugging experience you have
+locally without reproducing the failure on your machine.
+
+:::
 
 ### Control which videos to keep and upload to Cypress Cloud
 

--- a/docs/app/guides/screenshots-and-videos.mdx
+++ b/docs/app/guides/screenshots-and-videos.mdx
@@ -186,9 +186,17 @@ Setting `videoCompression` to a CRF value such as `15` also produces chapters.
 Setting it to `false` or `0` skips encoding entirely, so the video contains no
 chapters.
 
-Chapters are independent of [Cypress Cloud](/cloud/get-started/introduction),
-which jumps to a test in a recorded video using timestamps sent with your run
-results, no matter how you configure `videoCompression`.
+Chapters only help when you open the video file yourself. Record your runs to
+[Cypress Cloud](/cloud/get-started/introduction) and you get this for free:
+every test in the run is listed alongside its video, and selecting one takes you
+straight to that moment—no chapters to configure and no scrubbing.
+
+Better still, skip the video and debug the run with
+[Test Replay](/cloud/features/test-replay). Rather than watching a recording,
+you replay the test exactly as it executed in CI, so you can time travel to the
+point of failure and inspect the DOM, network requests, console logs, JavaScript
+errors, and element rendering—the same debugging experience you have locally,
+without reproducing the failure on your machine.
 
 ### Control which videos to keep and upload to Cypress Cloud
 


### PR DESCRIPTION
## Summary

Adds a "Video chapters" subsection to `docs/app/guides/screenshots-and-videos.mdx`, documenting that Cypress embeds chapter markers into each spec's video (one per test attempt, titled with the test's full title path) and that this only happens when video compression is enabled.

## Why

The behavior was completely undocumented — nothing in the screenshots and videos guide, the configuration reference, or the Test Replay page mentioned it. The caveat especially needs saying: chapters are written only during video compression, and `videoCompression` defaults to `false`, so you get no chapters out of the box even with `video: true`. The section sits directly after "Video encoding" so that dependency reads naturally, and includes a config example showing the two settings required.

The section closes by pointing at Cypress Cloud, which lists each test alongside its video so there is nothing to configure and no scrubbing, and a note recommending Test Replay as the better way to debug a run.

## Notes for reviewers

Documented behavior was verified against the implementation in `cypress-io/cypress` (`packages/server/lib/video_capture.ts`, `packages/server/lib/modes/run.ts`, `packages/config/src/options.ts`) and the assertions in `system-tests/test/video_compression_spec.ts`.

Three things were left out on purpose:

- **Where a chapter starts relative to its test.** `generateFfmpegChaptersConfig` computes the window as `START=videoTimestamp - wallClockDuration` / `END=videoTimestamp`, where `videoTimestamp` is the attempt's start offset — which looks like it places the chapter *before* the test rather than over it. That was not verified against real `ffprobe` output, so the docs make no claim about chapter boundaries. Worth a follow-up if someone can check a recorded run.
- **The retry chapter title format.** The `attempt N` suffix is concatenated with no separator, producing titles like `my testattempt 1`. That reads as a cosmetic bug in the product, so the docs say each attempt gets its own chapter without printing the literal string.
- **Pending/skipped tests.** Unclear what those emit; not covered.

Implementation details (the `.meta` sidecar, FFMETADATA1, ffmpeg flags) are intentionally not documented.

`npm run lint` and `npm run build` pass locally. The sidebar is autogenerated from the docs tree and the repo has no versioned docs, so no sidebar or frontmatter changes were needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_0139c3JfP4zkSjgWM1ibdVNj)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or configuration behavior changes.
> 
> **Overview**
> Adds a **Video chapters** subsection under video encoding in the screenshots and videos guide.
> 
> It documents that Cypress embeds one chapter per test attempt in each spec’s `.mp4` while compressing, with titles that include the full nested suite path and separate chapters for retried attempts. It warns that chapters require **`video`** and **`videoCompression`** (compression is off by default), notes that CRF values still produce chapters while `false`/`0` skips encoding, and points readers to Cypress Cloud and Test Replay as alternatives to scrubbing local files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 116cc98d33908a54472f92690c30ce8d1b5a0e0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->