### PR TITLE
docs: fix cypress tap CLI doc inaccuracies from 15.21.0 release

### DIFF
--- a/docs/api/commands/exec.mdx
+++ b/docs/api/commands/exec.mdx
@@ -256,10 +256,10 @@ the following:
 
 ## History
 
-| Version                                    | Changes                                          |
-| ------------------------------------------ | ------------------------------------------------ |
-| 15.21.0                                    | `cy.exec()` command and `execTimeout` deprecated |
-| [15.0.0](/app/references/changelog#15-0-0) | Renamed property `code` to `exitCode`            |
+| Version                                      | Changes                                          |
+| -------------------------------------------- | ------------------------------------------------ |
+| [15.21.0](/app/references/changelog#15-21-0) | `cy.exec()` command and `execTimeout` deprecated |
+| [15.0.0](/app/references/changelog#15-0-0)   | Renamed property `code` to `exitCode`            |
 
 ## See also
 

--- a/docs/app/core-concepts/best-practices.mdx
+++ b/docs/app/core-concepts/best-practices.mdx
@@ -1148,7 +1148,7 @@ waste.
 
 <Icon name="exclamation-triangle" color="red" /> **Anti-Pattern:** Trying to
 start a web server from within Cypress scripts with
-[`cy.exec()`](/api/commands/exec) or [`cy.task()`](/api/commands/task).
+[`cy.task()`](/api/commands/task).
 
 :::
 
@@ -1162,12 +1162,11 @@ prior to running Cypress.
 We do NOT recommend trying to start your back end web server from within
 Cypress.
 
-Any command run by [cy.exec()](/api/commands/exec) or
-[cy.task()](/api/commands/task) has to exit eventually. Otherwise, Cypress will
-not continue running any other commands.
+Any command run by [cy.task()](/api/commands/task) has to exit eventually.
+Otherwise, Cypress will not continue running any other commands.
 
-Trying to start a web server from [cy.exec()](/api/commands/exec) or
-[cy.task()](/api/commands/task) causes all kinds of problems because:
+Trying to start a web server from [cy.task()](/api/commands/task) causes all
+kinds of problems because:
 
 - You have to background the process
 - You lose access to it via terminal

--- a/docs/app/faq.mdx
+++ b/docs/app/faq.mdx
@@ -2000,7 +2000,7 @@ Cypress session from the terminal. See the
 
 ### <Icon name="angle-right" /> What is `cypress tap` in Cypress?
 
-`cypress tap` is a set of Cypress CLI commands that allows you or an agent to interact with a open mode Cypress
+`cypress tap` is a set of Cypress CLI commands that allows you or an agent to interact with an open-mode Cypress
 session and read its context from the terminal. You can list the
 specs Cypress can run, start a run, poll its status, read test results the way
 the Cypress Command Log shows them, and inspect the DOM and accessibility tree
@@ -2071,13 +2071,13 @@ ships with the `cypress` npm package like every other Cypress CLI command.
 
 ### <Icon name="angle-right" /> Which browsers does `cypress tap` support?
 
-The commands that read the browser (`reporter`, `command`, `pin`, `dom`,
-`aria`, and `inspect`) require a Chromium-family browser open in the Cypress
-session: Chrome, Chromium, Edge, or Electron. Firefox and WebKit are not
-supported for reading the browser.
+`sessions` works with any browser the Cypress session has open, since it only
+lists sessions rather than driving one.
 
-The session-level commands (`sessions`, `status`, `specs`, and `run`) work
-whatever browser the Cypress session has open.
+Every other command — `status`, `specs`, `run`, `reporter`, `command`, `pin`,
+`dom`, `aria`, and `inspect` — requires a Chromium-family browser open in the
+Cypress session: Chrome, Chromium, Edge, or Electron. Firefox and WebKit are
+not supported.
 
 ### <Icon name="angle-right" /> How do I check whether a Cypress session is running from the terminal?
 

--- a/docs/app/guides/debugging.mdx
+++ b/docs/app/guides/debugging.mdx
@@ -154,7 +154,7 @@ terminal.
 ```shell
 npx cypress tap run cypress/e2e/checkout.cy.ts
 npx cypress tap status --json
-npx cypress tap reporter --test <id>
+npx cypress tap reporter --test-id <id>
 ```
 
 See [driving Cypress from the terminal with an AI agent](/app/tooling/cypress-tap)

--- a/docs/app/references/command-line.mdx
+++ b/docs/app/references/command-line.mdx
@@ -857,7 +857,7 @@ output can still change in any release.
 
 :::
 
-`cypress tap` is a set of Cypress CLI commands that enables you or an agent to interact with a open mode Cypress
+`cypress tap` is a set of Cypress CLI commands that enables you or an agent to interact with an open-mode Cypress
 session and read its context from the terminal. You can list the
 specs Cypress can run, start a run, poll its status, read test results the way
 the Cypress Command Log shows them, and inspect the DOM and accessibility tree
@@ -881,7 +881,7 @@ cypress tap [command] [args...] [options]
 | [`specs`](/app/tooling/cypress-tap#cypress-tap-specs)       | Lists the specs the session can run.                                                                                                                                                           |
 | [`run`](/app/tooling/cypress-tap#cypress-tap-run)           | Runs (or reruns) a spec by its project-relative path.                                                                                                                                          |
 | [`reporter`](/app/tooling/cypress-tap#cypress-tap-reporter) | Renders the spec report or a specific tests report. The spec report includes what tests ran and their status. A test's reporter view includes routes, hooks, Command Log, and failure details. |
-| [`command`](/app/tooling/cypress-tap#cypress-tap-command)   | Prints the details of a specific Command Log entry, including it's time travel snapshots and the captured console properties.                                                                  |
+| [`command`](/app/tooling/cypress-tap#cypress-tap-command)   | Prints the details of a specific Command Log entry, including its time travel snapshots and the captured console properties.                                                                   |
 | [`pin`](/app/tooling/cypress-tap#cypress-tap-pin)           | Renders a past command's DOM snapshot as the live app under test so the `dom`, `aria`, and `inspect` tap commands can inspect it.                                                              |
 | [`dom`](/app/tooling/cypress-tap#cypress-tap-dom)           | Retrieves the app under test's HTML markup.                                                                                                                                                    |
 | [`aria`](/app/tooling/cypress-tap#cypress-tap-aria)         | Retrieves the accessibility (ARIA) tree of the app under test.                                                                                                                                 |
@@ -1145,7 +1145,7 @@ and with Windows CMD and PowerShell terminal windows.
 
 | Version                                      | Changes                                                               |
 | -------------------------------------------- | --------------------------------------------------------------------- |
-| [15.21.0](/app/references/changelog)         | Added the `cypress tap` command                                       |
+| [15.21.0](/app/references/changelog#15-21-0) | Added the `cypress tap` command                                       |
 | [15.11.0](/app/references/changelog#15-11-0) | Added `--pass-with-no-tests` flag to `cypress run`                    |
 | [15.5.0](/app/references/changelog#15-5-0)   | Added the 112 exit code scenario when using `--posix-exit-codes` flag |
 | [15.4.0](/app/references/changelog#15-4-0)   | Added `--auto-cancel-after-failures` flag to `cypress run`            |

--- a/docs/app/tooling/cypress-tap.mdx
+++ b/docs/app/tooling/cypress-tap.mdx
@@ -90,7 +90,7 @@ SESSIONS (2)
   222  /projects/other  component  —
 ```
 
-`--json` returns the same rows as an array, with `browserAttached` as a boolean, `browserName` as `null` where the text shows `—`, `browserSupported` as a boolean saying whether `cypress tap` can drive that browser, and `rendererResponsive` present only when there's a runner page to probe:
+`--json` returns the same rows as an array, with `browserAttached` as a boolean and `browserName` as `null` where the text shows `—`:
 
 ```json title="Output"
 [
@@ -99,17 +99,14 @@ SESSIONS (2)
     "projectRoot": "/projects/app",
     "testingType": "e2e",
     "browserAttached": true,
-    "browserName": "Chrome",
-    "browserSupported": true,
-    "rendererResponsive": true
+    "browserName": "Chrome"
   },
   {
     "pid": 222,
     "projectRoot": "/projects/other",
     "testingType": "component",
     "browserAttached": false,
-    "browserName": null,
-    "browserSupported": true
+    "browserName": null
   }
 ]
 ```
@@ -353,7 +350,7 @@ Output is capped so a heavy page never ships megabytes at once. The spec must be
 | ----------------- | --------------------------------------------------------------------------------------------------------------------- | ------- |
 | `--selector, -e`  | CSS selector matching exactly one element                                                                             | `body`  |
 | `--max-chars, -m` | Cap on returned HTML characters                                                                                       | `30000` |
-| `--at`            | When a selector matches multiple elements, the 0-based index of the match to read; required if the match is ambiguous | None    |
+| `--at`            | When a selector matches multiple elements, the 0-based index of the match to read; required if the match is ambiguous |         |
 
 ```shell title="Command"
 cypress tap dom --selector .todo-list
@@ -405,7 +402,7 @@ leaving the compact role/name/state tree browser developer tools show.
 | ----------------- | --------------------------------------------------------------------------------------------------------------------- | ------- |
 | `--selector, -e`  | CSS selector matching exactly one element                                                                             | `body`  |
 | `--max-nodes, -m` | Cap on the number of accessibility nodes returned                                                                     | `200`   |
-| `--at`            | When a selector matches multiple elements, the 0-based index of the match to read; required if the match is ambiguous | None    |
+| `--at`            | When a selector matches multiple elements, the 0-based index of the match to read; required if the match is ambiguous |         |
 
 ```shell title="Command"
 cypress tap aria
@@ -430,7 +427,7 @@ visibility, text, and the box.
 | Option           | Description                                                                                                           | Default  |
 | ---------------- | --------------------------------------------------------------------------------------------------------------------- | -------- |
 | `--selector, -e` | CSS selector matching exactly one element, identifying the element to inspect                                         | Required |
-| `--at`           | When a selector matches multiple elements, the 0-based index of the match to read; required if the match is ambiguous | None     |
+| `--at`           | When a selector matches multiple elements, the 0-based index of the match to read; required if the match is ambiguous |          |
 
 ```shell title="Command"
 cypress tap inspect --selector "[data-testid=username]"
@@ -712,10 +709,8 @@ conditional rather than assuming a fixed shape. In `status`:
 | `totalTests`, `results`                                               | The run has started, so `running` onwards                          |
 | `pinned`                                                              | A pin created by `cypress tap` is active                           |
 
-Elsewhere, `sessions` always reports `pid`, `projectRoot`, `testingType`,
-`browserAttached`, `browserName`, and `browserSupported`, using `null` for an
-absent testing type or browser, and adds `rendererResponsive` only when
-there's a runner page to probe. `specs` always reports `relativePath` and
+Elsewhere, `sessions` always reports all five of its fields, using `null` for
+an absent testing type or browser. `specs` always reports `relativePath` and
 adds `lastModified` only where git history is available. `command` always
 reports `snapshots`, as an empty array when the row has none to pin, and omits
 `consoleProps` entirely when the driver has none to give.
@@ -1078,7 +1073,7 @@ The `cypress tap` CLI is available for use for all Cypress test authors using Cy
 
 The data exposed from the `cypress tap` CLI into your terminal is strictly local session. If using the CLI within a AI agent, be mindful to ensure you are using safe test practices, like using [`cy.env()`](/api/commands/env), to prevent leaking sensitive information to your agent.
 
-Cypress does capture telemetry specifically around the usage of the CLI to inform usage patterns. The data collected includes the command name, the flags used (names only, never their values), whether it errored and with which error code, how long the command took, the detected AI agent (if any), and identifiers for the session, user, and machine it ran against. Flag values, selectors, spec paths, and other content you passed in are never collected. To opt-out of this behavior, set `CYPRESS_DISABLE_GUEST_TELEMETRY=0` in your terminal.
+Cypress does capture telemetry specifically around the usage of the CLI to inform usage patterns. The data collected includes the command name, the flags used and whether it errored. To opt-out of this behavior, set `CYPRESS_DISABLE_GUEST_TELEMETRY=0` in your terminal.
 
 ### CLI Limitations
 

--- a/docs/app/tooling/cypress-tap.mdx
+++ b/docs/app/tooling/cypress-tap.mdx
@@ -31,19 +31,19 @@ output can still change in any release while we gather feedback.
 
 ## How it works
 
-Start Cypress in open mode (`cypress open`) in your project, select your test time and a chromium browser, then run
+Start Cypress in open mode (`cypress open`) in your project, select your testing type and a chromium browser, then run
 `cypress tap` commands from the same project directory in another terminal.
 
 The CLI finds the running Cypress session on its own. If more than one is
 running, it prefers the one whose project matches your current directory. Use
-`--instance <pid>` to target a specific session.
+`--session <pid>` (or `-s`) to target a specific session.
 
 Every command prints a human-readable output by default and a JSON
 result when passed `--json`. Agents and scripts should prefer `--json`.
 
 ## Requirements
 
-- Only works with `cypress open` sessions, not headless `cypres run` sessions.
+- Only works with `cypress open` sessions, not headless `cypress run` sessions.
 - Only supports Chromium-based browsers (Chrome, Chromium, Edge, Electron).
 - Requires Cypress v15.21.0+
 - If the `cypress tap` CLI and the session it attaches to are on incompatible versions, the CLI stops and reports the version mismatch.
@@ -59,19 +59,20 @@ Below is the list of the commands `cypress tap` exposes:
 | [`specs`](#cypress-tap-specs)       | Lists the specs the session can run.                                                                                                                                                           |
 | [`run`](#cypress-tap-run)           | Runs (or reruns) a spec by its project-relative path.                                                                                                                                          |
 | [`reporter`](#cypress-tap-reporter) | Renders the spec report or a specific tests report. The spec report includes what tests ran and their status. A test's reporter view includes routes, hooks, Command Log, and failure details. |
-| [`command`](#cypress-tap-command)   | Prints the details of a specific Command Log entry, including it's time travel snapshots and the captured console properties.                                                                  |
+| [`command`](#cypress-tap-command)   | Prints the details of a specific Command Log entry, including its time travel snapshots and the captured console properties.                                                                   |
 | [`pin`](#cypress-tap-pin)           | Renders a past command's DOM snapshot as the live app under test so the `dom`, `aria`, and `inspect` tap commands can inspect it.                                                              |
 | [`dom`](#cypress-tap-dom)           | Retrieves the app under test's HTML markup.                                                                                                                                                    |
 | [`aria`](#cypress-tap-aria)         | Retrieves the accessibility (ARIA) tree of the app under test.                                                                                                                                 |
 | [`inspect`](#cypress-tap-inspect)   | Retrieves the specified element's tag, attributes, computed styles, and box model.                                                                                                             |
 
-Each subcommands exit with `0` on success and `1` on any failure and accepts these options:
+Each subcommand exits with `0` on success and `1` on any failure and accepts these options:
 
-| Option       | Description                                                               |
-| ------------ | ------------------------------------------------------------------------- |
-| `--session`  | Use to target a specific running Cypress instance by its process id (pid) |
-| `--json`     | Prints the raw JSON result instead of the human-readable rendering        |
-| `--help, -h` | Outputs usage information                                                 |
+| Option          | Description                                                                                                      | Default |
+| --------------- | ---------------------------------------------------------------------------------------------------------------- | ------- |
+| `--session, -s` | Use to target a specific running Cypress instance by its process id (pid)                                        |         |
+| `--json`        | Prints the raw JSON result instead of the human-readable rendering                                               |         |
+| `--timeout`     | How long to wait on any single call into the Cypress session before treating it as unresponsive, in milliseconds | `30000` |
+| `--help, -h`    | Outputs usage information                                                                                        |         |
 
 ### cypress tap sessions {#cypress-tap-sessions}
 
@@ -79,7 +80,7 @@ Lists the running Cypress sessions the CLI can reach. Pass a listed pid to
 `--session` to target that session with another `tap` command.
 
 ```shell title="Command"
-cypress tap session
+cypress tap sessions
 ```
 
 ```css title="Output"
@@ -89,7 +90,7 @@ SESSIONS (2)
   222  /projects/other  component  —
 ```
 
-`--json` returns the same rows as an array, with `browserAttached` as a boolean and `browserName` as `null` where the text shows `—`:
+`--json` returns the same rows as an array, with `browserAttached` as a boolean, `browserName` as `null` where the text shows `—`, `browserSupported` as a boolean saying whether `cypress tap` can drive that browser, and `rendererResponsive` present only when there's a runner page to probe:
 
 ```json title="Output"
 [
@@ -98,14 +99,17 @@ SESSIONS (2)
     "projectRoot": "/projects/app",
     "testingType": "e2e",
     "browserAttached": true,
-    "browserName": "Chrome"
+    "browserName": "Chrome",
+    "browserSupported": true,
+    "rendererResponsive": true
   },
   {
     "pid": 222,
     "projectRoot": "/projects/other",
     "testingType": "component",
     "browserAttached": false,
-    "browserName": null
+    "browserName": null,
+    "browserSupported": true
   }
 ]
 ```
@@ -143,7 +147,7 @@ start time, or `null` while the spec is still building. Always check
 `passed` or `failed` result readable until the new run starts, so a verdict
 carrying the earlier `startedAt` describes the previous run, not yours.
 
-With --json, the output carries startedAt from loading onwards (the run's start time, or null while the spec is still building), and adds totalTests and per-outcome results counts from running onwards. A pinned object rides along whenever a pin is active.
+`--json` also adds `totalTests` and per-outcome `results` counts from `running` onwards. A `pinned` object rides along whenever a pin is active.
 
 ```json title="Output"
 {
@@ -158,6 +162,7 @@ With --json, the output carries startedAt from loading onwards (the run's start 
   "startedAt": "2026-07-29T10:15:00.000Z",
   "totalTests": 5,
   "results": { "passed": 1, "failed": 1, "pending": 2, "skipped": 1 }
+}
 ```
 
 ### cypress tap specs {#cypress-tap-specs}
@@ -204,7 +209,7 @@ its reporter panel.
 | `--test-id, -t` | Test id, as listed by the spec overview this command prints | The spec-level overview |
 | `--attempt, -a` | 1-based attempt, where attempt 1 is the first run           | The latest attempt      |
 
-Without `--testId`, it prints the spec-level report which includes the run's test stats
+Without `--test-id`, it prints the spec-level report which includes the run's test stats
 and every suite's tests, with the test ids the other commands accept.
 
 ```shell title="Command"
@@ -260,7 +265,7 @@ tools console shows after clicking the command in the Cypress app.
 | `--depth, -d`      | How many levels of nested console properties to expand before summarizing the rest: a number or `all`. A section over 8 rows folds at any depth unless this is passed | `3`                |
 
 ```shell title="Command"
-cypress tap command --test r2 --command 3
+cypress tap command --test-id r2 --command-id 3
 ```
 
 ```css title="Output"
@@ -280,7 +285,7 @@ CONSOLE PROPS
 When console properties are deeply nested, cypress tap expands them to --depth levels (default 3) and summarizes the rest. A footer lists what it summarized and how to open it:
 
 ```shell title="Command"
-cypress tap command --test r4 --command e1 --depth 0
+cypress tap command --test-id r4 --command-id e1 --depth 0
 ```
 
 ```css title="Output"
@@ -291,7 +296,7 @@ CONSOLE PROPS
   Matched `cy.intercept()`  {4 keys}
   Alias                     postComment
 
-1 section collapsed — open one with --path 'Matched `cy.intercept()`', or all of it with --depth all
+1 section collapsed — open all of it with --depth all
 ```
 
 A value long enough to bury the rest of the payload, such as a response body,
@@ -344,11 +349,11 @@ Reads the app under test's DOM as HTML: the whole page, or the `outerHTML` of
 each element matching a CSS selector (each match includes its full subtree).
 Output is capped so a heavy page never ships megabytes at once. The spec must be complete to use this command.
 
-| Option            | Description                                                                       | Default |
-| ----------------- | --------------------------------------------------------------------------------- | ------- |
-| `--selector, -e`  | CSS selector matching exactly one element                                         | `body`  |
-| `--max-chars, -m` | Cap on returned HTML characters                                                   | `30000` |
-| `--at`            | When a selector matches multiple elements, the 0-based index of the match to read | `0`     |
+| Option            | Description                                                                                                           | Default |
+| ----------------- | --------------------------------------------------------------------------------------------------------------------- | ------- |
+| `--selector, -e`  | CSS selector matching exactly one element                                                                             | `body`  |
+| `--max-chars, -m` | Cap on returned HTML characters                                                                                       | `30000` |
+| `--at`            | When a selector matches multiple elements, the 0-based index of the match to read; required if the match is ambiguous | None    |
 
 ```shell title="Command"
 cypress tap dom --selector .todo-list
@@ -358,19 +363,16 @@ cypress tap dom --selector .todo-list
 <ul class="todo-list"><li data-id="1786936171215" class=""><div class="view"><input class="toggle" type="checkbox"><label>Walk the dog</label><button class="destroy todo-button"></button></div></li></ul>
 ```
 
-When the selector provided is not unique, use `--at` to help identify the right element.
+When the selector provided is not unique, the command reports the ambiguous match instead of reading it, and exits `1`. Use `--at` with an index from the list to select the right element.
 
 ```shell title="Command"
 cypress tap dom --selector li
 ```
 
-```shell title="Output"
-cypress tap dom --selector li
-```
-
+```css title="Output"
 ⚠ selector 'li' matched 25 elements but must be unique
 provide --at with an index to select an element from the list or update the selector.
-index selector  
+index selector
 0 '.dropdown'
 1 '.dropdown-menu > :nth-child(1)'
 2 '.dropdown-menu > :nth-child(2)'
@@ -383,12 +385,15 @@ index selector
 9 '.dropdown-menu > :nth-child(9)'
 
 showing the first 10 of 25 matches — --at takes any index up to 24.
-
-````
+```
 
 ```shell title="Command"
 cypress tap dom --selector li --at 2
-````
+```
+
+```css title="Output"
+<li data-id="1786936171217" class=""><div class="view"><input class="toggle" type="checkbox"><label>Buy groceries</label><button class="destroy todo-button"></button></div></li>
+```
 
 ### cypress tap aria {#cypress-tap-aria}
 
@@ -396,11 +401,11 @@ Reads the accessibility (ARIA) tree of the app-under-test frame, or the
 subtree rooted at a CSS selector. Structural and text-only roles are dropped,
 leaving the compact role/name/state tree browser developer tools show.
 
-| Option            | Description                                                                       | Default |
-| ----------------- | --------------------------------------------------------------------------------- | ------- |
-| `--selector, -e`  | CSS selector matching exactly one element                                         | `body`  |
-| `--max-nodes, -m` | Cap on the number of accessibility nodes returned                                 | `200`   |
-| `--at`            | When a selector matches multiple elements, the 0-based index of the match to read | `0`     |
+| Option            | Description                                                                                                           | Default |
+| ----------------- | --------------------------------------------------------------------------------------------------------------------- | ------- |
+| `--selector, -e`  | CSS selector matching exactly one element                                                                             | `body`  |
+| `--max-nodes, -m` | Cap on the number of accessibility nodes returned                                                                     | `200`   |
+| `--at`            | When a selector matches multiple elements, the 0-based index of the match to read; required if the match is ambiguous | None    |
 
 ```shell title="Command"
 cypress tap aria
@@ -422,10 +427,10 @@ roughly 350 properties, so `inspect` reports a fixed subset of two dozen that
 answer why an element looks or behaves the way it does, covering layout,
 visibility, text, and the box.
 
-| Option           | Description                                                                       | Default |
-| ---------------- | --------------------------------------------------------------------------------- | ------- |
-| `--selector, -e` | CSS selector matching exactly one element                                         | `body`  |
-| `--at`           | When a selector matches multiple elements, the 0-based index of the match to read | `0`     |
+| Option           | Description                                                                                                           | Default  |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------- | -------- |
+| `--selector, -e` | CSS selector matching exactly one element, identifying the element to inspect                                         | Required |
+| `--at`           | When a selector matches multiple elements, the 0-based index of the match to read; required if the match is ambiguous | None     |
 
 ```shell title="Command"
 cypress tap inspect --selector "[data-testid=username]"
@@ -537,7 +542,7 @@ Ask for the failing test's full reporter view: the same routes, hooks,
 Command Log, and error you'd read in the Cypress app.
 
 ```shell title="Command"
-npx cypress tap reporter --test r5
+npx cypress tap reporter --test-id r5
 ```
 
 ```css title="Output"
@@ -707,8 +712,10 @@ conditional rather than assuming a fixed shape. In `status`:
 | `totalTests`, `results`                                               | The run has started, so `running` onwards                          |
 | `pinned`                                                              | A pin created by `cypress tap` is active                           |
 
-Elsewhere, `sessions` always reports all five of its fields, using `null` for
-an absent testing type or browser. `specs` always reports `relativePath` and
+Elsewhere, `sessions` always reports `pid`, `projectRoot`, `testingType`,
+`browserAttached`, `browserName`, and `browserSupported`, using `null` for an
+absent testing type or browser, and adds `rendererResponsive` only when
+there's a runner page to probe. `specs` always reports `relativePath` and
 adds `lastModified` only where git history is available. `command` always
 reports `snapshots`, as an empty array when the row has none to pin, and omits
 `consoleProps` entirely when the driver has none to give.
@@ -741,10 +748,10 @@ Prefer `--json` output.
 4. Treat `passed` with a `results.passed` of `0` as nothing having run, not as
    a success, and tell me which tests were skipped.
 5. On failure, run `npx cypress tap reporter` for the spec overview, then
-   `npx cypress tap reporter --test <id>` for the failing test's Command Log
+   `npx cypress tap reporter --test-id <id>` for the failing test's Command Log
    and error.
 6. Drill into one command with
-   `npx cypress tap command --test <id> --command <id>`.
+   `npx cypress tap command --test-id <id> --command-id <id>`.
 7. To see the DOM at a past command, pin it with
    `npx cypress tap pin <test> <command>`, read it with `dom`, `aria`, or
    `inspect <selector>`, then release it with `npx cypress tap pin --clear`.
@@ -773,7 +780,7 @@ without relaying results back and forth:
 <CopyPrompt
   title="Reproduce a flaky test"
   subtext="Runs one spec repeatedly through cypress tap, since a single green run never proves a flake is gone."
-  prompt={`The [test name] test in [spec path] is flaky. Use cypress tap to run that spec against my open Cypress session at least 10 times, polling cypress tap status --json for a verdict each time and comparing startedAt so you attribute each verdict to your own run. Record how many runs passed and failed. For every failure, capture the command log with cypress tap reporter --test <id> and compare the failing runs against the passing ones to identify what differs, such as timing, network responses, or leftover state.`}
+  prompt={`The [test name] test in [spec path] is flaky. Use cypress tap to run that spec against my open Cypress session at least 10 times, polling cypress tap status --json for a verdict each time and comparing startedAt so you attribute each verdict to your own run. Record how many runs passed and failed. For every failure, capture the command log with cypress tap reporter --test-id <id> and compare the failing runs against the passing ones to identify what differs, such as timing, network responses, or leftover state.`}
 >
 
 #### Reproduce a flaky test
@@ -834,7 +841,7 @@ runs shell commands.
    browser, so there is something for `cypress tap` to attach to.
 4. **Your agent** runs the same spec with `cypress tap run <spec-path>`, polls
    `cypress tap status --json` for a verdict, and reads the failure with
-   `cypress tap reporter --test <id>` if it is still red.
+   `cypress tap reporter --test-id <id>` if it is still red.
 5. **Your agent** repeats steps 2 and 4 until the spec passes locally, then
    you push a change you already know works.
 
@@ -923,13 +930,13 @@ PID   PROJECT        TYPE  BROWSER
 ✓ 4  ✖ 1  ○ --
 ```
 
-**6. Read the local failure and compare it to CI.** `reporter --test <id>`
+**6. Read the local failure and compare it to CI.** `reporter --test-id <id>`
 gives you the same command log the replay timeline gave you for the CI run, so
 your agent can see whether the failure it reproduced is the one it set out to
 fix.
 
 ```shell title="Command"
-npx cypress tap reporter --test r5
+npx cypress tap reporter --test-id r5
 ```
 
 Repeat steps 4 to 6 until `status` reports `passed`, then push a change you
@@ -1071,7 +1078,7 @@ The `cypress tap` CLI is available for use for all Cypress test authors using Cy
 
 The data exposed from the `cypress tap` CLI into your terminal is strictly local session. If using the CLI within a AI agent, be mindful to ensure you are using safe test practices, like using [`cy.env()`](/api/commands/env), to prevent leaking sensitive information to your agent.
 
-Cypress does capture telemetry specifically around the usage of the CLI to inform usage patterns. The data collected includes the command name, the flags used and whether it errored. To opt-out of this behavior, set `CYPRESS_DISABLE_GUEST_TELEMETRY=0` in your terminal.
+Cypress does capture telemetry specifically around the usage of the CLI to inform usage patterns. The data collected includes the command name, the flags used (names only, never their values), whether it errored and with which error code, how long the command took, the detected AI agent (if any), and identifiers for the session, user, and machine it ran against. Flag values, selectors, spec paths, and other content you passed in are never collected. To opt-out of this behavior, set `CYPRESS_DISABLE_GUEST_TELEMETRY=0` in your terminal.
 
 ### CLI Limitations
 
@@ -1081,9 +1088,9 @@ Cypress does capture telemetry specifically around the usage of the CLI to infor
   [`numTestsKeptInMemory`](/app/references/configuration#Global)), so older
   tests may report that their details are no longer available.
 - `dom`, `aria`, `inspect`, and `pin` work only on a completed run. While a
-  spec is running they fail with `RUN_IN_PROGRESS` until the run reports a
+  spec is running they fail with `SPEC_IN_PROGRESS` until the run reports a
   verdict.
-- Firefox and WebKit are not supported. `cypress tap` only support interacts with Chromium browsers.
+- Firefox and WebKit are not supported. `cypress tap` only supports Chromium-family browsers.
 - `cypress tap` drives the same session you are looking at, and there is no
   lock between the two. Starting a run from the app, switching spec, or
   pinning and unpinning commands all change what your agent's next command

--- a/docs/cloud/features/cypress-ai-features.mdx
+++ b/docs/cloud/features/cypress-ai-features.mdx
@@ -234,7 +234,7 @@ Read the [Cloud CLI documentation →](/cloud/integrations/cloud-cli)
 **Best for:** AI coding agents that need live app context, DOM, command logs, to check their work against a running Cypress session.
 :::
 
-`cypress tap` is an extension of the `cypress` CLI that enables you or an agent to interact with a open mode Cypress
+`cypress tap` is an extension of the `cypress` CLI that enables you or an agent to interact with an open-mode Cypress
 session and read its context from the terminal. An agent can run a spec and poll its status, then
 read the failing test's Command Log and error as the reporter shows them.
 It can also inspect the DOM of the application-under-test at the moment a command ran.


### PR DESCRIPTION
## Summary

Follow-up to #6816 (15.21.0 Release). Reviewing that PR after merge turned up several inaccuracies in the new `cypress tap` guide (`docs/app/tooling/cypress-tap.mdx`) and its cross-links, verified against the actual CLI implementation in `cypress-io/cypress` (`cli/lib/tap/`, `packages/cypress-sessions/lib/tap-contract.ts`, `tap-errors.ts`, `events.ts`).

- Fixed copy-pasteable examples using invented/wrong flag names: `--instance` → `--session`, `--test`/`--command` → `--test-id`/`--command-id`, and a fabricated `--path` option removed
- `inspect --selector`: documented as defaulting to `body`; it's actually required
- `--at`: documented as defaulting to `0`; it has no default and is only required when a match is ambiguous (the doc's own next example already showed this)
- Documented the real `--timeout <ms>` shared option (default `30000`), previously missing entirely
- Fixed wrong error code `RUN_IN_PROGRESS` → `SPEC_IN_PROGRESS`
- Fixed `cypress tap session` → `cypress tap sessions` typo
- Fixed the FAQ's browser-support claim: only `sessions` works with any browser, not `status`/`specs`/`run` too
- Fixed a malformed/nested code fence that broke rendering of one `dom` example, and a `status --json` example missing its closing brace
- Removed stale `cy.exec()` references in `best-practices.mdx` left over after the `cy.exec()` deprecation landed elsewhere in the same release PR
- Linked the History table rows for 15.21.0 to the `#15-21-0` changelog anchor, matching sibling rows
- Misc typos ("a open mode", "cypres run", etc.)

## Review feedback addressed (Emily)

- Reverted the `browserSupported`/`rendererResponsive` additions to the `sessions --json` docs (field list, worked example, and field-summary section) — removing for now per her request
- Reverted the telemetry disclosure paragraph, which didn't need to change
- Reverted the `sessions` field-summary paragraph back to the simpler "all five fields" wording
- Changed the `--at` table rows' Default column from `None` to blank, since it isn't a real default — it's only required when the match is ambiguous, which the description already covers
- `SPEC_IN_PROGRESS` and the `--test-id`/`--command-id` fixes were confirmed correct as-is

## Test plan

- [x] Verified every flag name, default, output shape, and error code referenced above against the actual implementation in the `cypress-io/cypress` monorepo
- [x] Confirmed all code fences balance and all JSON examples in `cypress-tap.mdx` parse as valid JSON
- [x] `npx prettier --check` passes on all changed files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only documentation updates with no runtime or API behavior changes.
> 
> **Overview**
> **Documentation corrections** for the 15.21.0 `cypress tap` release so copy-paste examples and option tables match the implemented CLI.
> 
> The **`cypress tap` guide** and every cross-link (FAQ, command-line, debugging, Cloud AI) now use the real flags: `--session` (not `--instance`), `--test-id` / `--command-id` (not `--test` / `--command`), and documents shared **`--timeout`** (default `30000`). **`inspect --selector`** is required (not default `body`); **`--at`** is documented as required only for ambiguous multi-match selectors, with **`dom`** behavior updated to fail with a disambiguation list instead of silently picking index `0`. Error code **`SPEC_IN_PROGRESS`** replaces `RUN_IN_PROGRESS`; command name typo **`sessions`** is fixed; JSON/example fences and a broken **`status --json`** block are repaired.
> 
> **FAQ browser support** is narrowed: only **`sessions`** works with any browser; Chromium is required for `status`, `specs`, `run`, and DOM/reporter commands. **Best practices** drops deprecated **`cy.exec()`** from the “don’t start a web server from Cypress” anti-pattern ( **`cy.task()`** only). **History** rows for 15.21.0 link to **`#15-21-0`** on exec and command-line pages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8194fd16a91a7fa01e4ef1fc40d704e90679ac8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
