### PR TITLE
Update announcement bar link in docusaurus.config.js

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -177,7 +177,7 @@ const config = {
         //give id a unique value to get a new announcement bar to appear
         id: 'cypress-tap-beta-aug-2026',
         // Visual content (including Cypress Design icon) is rendered in src/theme/AnnouncementBar/Content
-        content: `🌟 Give your agent the context the Cypress app shows you. &mdash; <a href="https://www.cypress.io/blog/cypress-app-cli?utm_source=docs.cypress.io&utm_medium=announcement-bar&utm_campaign=cypress-tap-cli">Meet cypress tap</a>`,
+        content: `🌟 Give your agent the context the Cypress app shows you. &mdash; <a href="https://www.cypress.io/blog/cypress-tap-cli?utm_source=docs.cypress.io&utm_medium=announcement-bar&utm_campaign=cypress-tap-cli">Meet cypress tap</a>`,
         isCloseable: true,
       },
       footer: {


### PR DESCRIPTION
<!--
Fill in every section. This template doubles as the historical record of the
change, so future readers can understand not just what changed but
why. Delete a section only if it is genuinely not applicable, and say so.
-->

## Summary

<!-- What does this PR change, in one or two sentences? Write for a reader who
has never seen the task. -->

## Why

<!-- The motivation and context. If this originated from an issue, a Slack/
Discord thread, a broken link, an outdated example, or a release, capture it
here so the reasoning survives after the source is gone. -->

Closes #<!-- issue number, or remove this line if none -->

## Notes for reviewers

<!-- Anything a reviewer should focus on: decisions made, alternatives
considered, areas of uncertainty, or follow-ups intentionally left out. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single marketing URL change in Docusaurus config with no impact on app logic or data handling.
> 
> **Overview**
> Updates the docs site **announcement bar** “Meet cypress tap” link so it targets the correct blog post slug (`/blog/cypress-tap-cli` instead of `/blog/cypress-app-cli`). Copy and other UTM parameters are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aaea25f68c0f1b1449f903348815beeb6bb6a9ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->