### PR TITLE
docs: align Node.js version range in install guide (16.0.0)

### DIFF
--- a/docs/app/get-started/install-cypress.mdx
+++ b/docs/app/get-started/install-cypress.mdx
@@ -50,7 +50,7 @@ Cypress supports running under these operating systems:
 
 ### Node.js
 
-- **Node.js** 22.x, >=24.x
+- **Node.js** 22.x, 24.x, >=26.x
 
 Follow the instructions on [Download Node.js](https://nodejs.org/en/download/) to download and install [Node.js](https://nodejs.org/).
 


### PR DESCRIPTION
## Summary

Addresses review feedback from @MikeMcC399 on #6451: the "Node.js" line in the system requirements table said `22.x, >=24.x`, which doesn't match the `engines.node` range Cypress 16 actually requires (`^22.0.0 || ^24.0.0 || >=26.0.0` in [`cli/package.json`](https://github.com/cypress-io/cypress/blob/release/16.0.0/cli/package.json#L119-L121)) — Node 25 is dropped, so `24.x` doesn't roll forward into 25+ support the way `>=24.x` implies.

Updates it to `22.x, 24.x, >=26.x`, matching both `cli/package.json` and the existing wording already used in [migration-guide.mdx](https://github.com/cypress-io/cypress-documentation/blob/release/16.0.0/docs/app/references/migration-guide.mdx#nodejs-20-and-25-no-longer-supported).

Ref: https://github.com/cypress-io/cypress-documentation/pull/6451#discussion_r3737409667

## Test plan

- [x] `npx prettier --check` passes on the changed file
- [ ] CI passes on this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line documentation change with no runtime or configuration impact.
> 
> **Overview**
> Updates the **Node.js** system requirement in the install guide from `22.x, >=24.x` to **`22.x, 24.x, >=26.x`**, so the docs match Cypress 16’s supported engines and the migration guide (Node 25 is not supported; only 22, 24, and 26+ are).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42eb18364edc9c43d43f9981d05f16ea7099225d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->