### PR TITLE
docs: rewrite the Cypress Accessibility remediation guide

### DIFF
--- a/docs/accessibility/configuration/axe-core-configuration.mdx
+++ b/docs/accessibility/configuration/axe-core-configuration.mdx
@@ -9,11 +9,31 @@ sidebar_position: 50
 
 # Axe Core® configuration
 
-Cypress Accessibility runs the full [Axe-Core®](https://github.com/dequelabs/axe-core) ruleset against every snapshot captured during your test run, with no setup, assertions, or `cy.` commands to add to your specs. The ruleset is tuned to favor high-confidence results, so the report you get out of the box is already the recommended configuration for most teams.
+Cypress Accessibility runs [Axe-Core®](https://github.com/dequelabs/axe-core)'s default ruleset against every snapshot captured during your test run, with no setup, assertions, or `cy.` commands to add to your specs. The ruleset is tuned to favor high-confidence results, so the report you get out of the box is already the recommended configuration for most teams.
 
 Because you decide what actually blocks a build with the [Accessibility Results API](/accessibility/results-api), where you have full control over how to parse results and which rules to react to, there is rarely a need to change which rules run in Cypress Cloud. Keeping the ruleset broad means you can still see and understand every accessibility finding, even when only a subset of results is treated as blocking in your pipeline.
 
 When you do need to change how the ruleset behaves for your project, Cypress can tune it for you. This is a guided process handled through your Cypress point of contact rather than a setting in the App Quality editor, so you get results that fit your application without the risk of silently turning off important checks.
+
+## What the default ruleset covers {#what-the-default-ruleset-covers}
+
+Cypress applies no conformance filter of its own, so a run evaluates whatever Axe-Core® enables by default, minus the [three rules Cypress turns off by default](#rules-that-are-off-by-default):
+
+| Axe-Core® rule group        | Runs by default | Notes                                                                                                       |
+| --------------------------- | --------------- | ----------------------------------------------------------------------------------------------------------- |
+| WCAG 2.0 Level A and AA     | Yes             | Minus `color-contrast`, `no-autoplay-audio`, and `meta-refresh`, which are WCAG-tagged but off by default   |
+| WCAG 2.1 Level A and AA     | Yes             |                                                                                                             |
+| Best Practices              | Yes             | Deque's own recommendations, such as `region` and `landmark-one-main`. These are not WCAG success criteria. |
+| WCAG 2.2 Level A and AA     | No              | Off by default in Axe-Core® itself. Cypress can enable these for your project.                              |
+| WCAG Level AAA              | No              | Off by default in Axe-Core® itself. Cypress can enable these for your project.                              |
+| Experimental and deprecated | No              | Off by default in Axe-Core® itself.                                                                         |
+
+Two consequences are worth knowing if you're measuring against a formal standard:
+
+- **The default report is broader than any single WCAG level.** Best Practices findings appear alongside WCAG ones, so a violation in your report is not automatically a WCAG failure. Use the **Rules** filter in a report to separate WCAG 2.1 A, WCAG 2.1 AA, and Best Practices results.
+- **The default report is also not complete WCAG coverage.** The three rules that are off by default map to WCAG success criteria (1.4.3, 1.4.2, and 2.2.1), and no automated ruleset can evaluate every success criterion in the first place. See [accessibility automation principles](/accessibility/guides/accessibility-automation) for what conformance requires beyond automation.
+
+To align a project's report with a specific conformance target, ask Cypress to scope the ruleset for you, as described below.
 
 ## How Cypress can tune the ruleset for your project {#how-cypress-can-tune-the-ruleset-for-your-project}
 
@@ -21,7 +41,7 @@ Teams reach out for a few common adjustments. In each case, Cypress applies the 
 
 - **Enable a rule that is off by default.** The most common request is turning on [color contrast checking](#rules-that-are-off-by-default) for a project where you've confirmed it produces reliable results.
 - **Turn off a rule that is a known false positive.** If a specific rule consistently misfires because of a third-party framework you can't change, it can be disabled project-wide so it stops adding noise to your reports.
-- **Scope the report to a conformance target.** Cypress can narrow the ruleset to the standard your team is committed to, such as WCAG 2.1 Level A and AA, so the report reflects exactly the criteria you're measuring against.
+- **Scope the report to a conformance target.** Cypress can narrow the ruleset to the standard your team is committed to, such as WCAG 2.1 Level A and AA, so the report reflects exactly the criteria you're measuring against. This is also how you enable rule groups that Axe-Core® keeps off by default, such as WCAG 2.2 or Level AAA.
 
 We're happy to have a call to dial in your report configuration and make sure you're getting the most useful reports possible.
 

--- a/docs/accessibility/configuration/elementfilters.mdx
+++ b/docs/accessibility/configuration/elementfilters.mdx
@@ -87,7 +87,7 @@ To apply rules to Cypress Accessibility only, nest the property under the `acces
 - **Ignoring an element ignores all of its results.** An `elementFilters` rule applies to every accessibility rule for the matched element. To ignore only specific rules for an element, use the [`data-a11y-ignore` attribute](/accessibility/configuration/ignoring-rules-per-element) in your application code.
 - **Rules match in any document unless scoped.** A rule without `documentScope` can match elements in the main document, in iframes, and in shadow DOMs. Add `documentScope` to restrict a rule to one of those documents.
 
-If a rule doesn't seem to take effect, see [Why is an element still failing after I added an elementFilters rule?](/accessibility/faq#Why-is-an-element-still-failing-after-I-added-an-elementFilters-rule) in the Cypress Accessibility FAQ.
+If a rule doesn't seem to take effect, see [Why is an element still failing in Cypress Accessibility after I added an elementFilters rule?](/accessibility/faq#Why-is-an-element-still-failing-in-Cypress-Accessibility-after-I-added-an-elementFilters-rule) in the Cypress Accessibility FAQ.
 
 ### Validation rules
 

--- a/docs/accessibility/core-concepts/accessibility-score.mdx
+++ b/docs/accessibility/core-concepts/accessibility-score.mdx
@@ -75,6 +75,8 @@ Most accessibility violations can be resolved through HTML and CSS adjustments. 
 
 Refer to the [Inspecting Violation Details section](/accessibility/guides/inspecting-violation-details) for more information on understanding and addressing violations.
 
+When you have more violations than you can act on at once, [Fix accessibility violations](/accessibility/guides/improve-accessibility) covers how to narrow the report to the code you own, choose a first rule your team can finish, and verify the fix before it merges.
+
 ### Ignore Non-relevant Issues
 
 For issues you decide not to fix, update your [configuration](/accessibility/configuration/overview) to ignore them. This keeps the score focused on actionable issues while maintaining visibility into ignored elements for transparency.

--- a/docs/accessibility/faq.mdx
+++ b/docs/accessibility/faq.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Cypress Accessibility FAQ'
-description: 'Get answers to common questions about Cypress Accessibility, including grouping and naming views, ignoring elements with elementFilters, excluding URLs with viewFilters, the Ignored status, score impact, element identification, component context, configuration scope, reading applied config, which Axe Core® rules run and color contrast, component testing, the Axe Core® version, and per-run profiles for pull request gating and per-team reports.'
+description: 'Common Cypress Accessibility questions: which WCAG rules run, what the score means, fixing and ignoring violations, and configuring views and profiles.'
 sidebar_label: FAQ
 sidebar_position: 160
 ---
@@ -9,21 +9,51 @@ sidebar_position: 160
 
 # Cypress Accessibility FAQ
 
+## Fixing violations
+
+### <Icon name="angle-right" /> Where do I start when Cypress Accessibility reports hundreds of violations?
+
+Start by narrowing the report to the code you own with [`viewFilters`](/accessibility/configuration/viewfilters) and [`elementFilters`](/accessibility/configuration/elementfilters), so third-party pages and vendor widgets stop competing for attention. Then open the **Rules** list for a run and pick a single rule with a small number of failing elements and a fix that fits in one component, such as `button-name`. Finishing one rule across the application is usually faster than finishing one page, because the fix has the same shape every time. See [Fix accessibility violations](/accessibility/guides/improve-accessibility) for the full process.
+
+### <Icon name="angle-right" /> Should I fix a violation in Cypress Accessibility or ignore it?
+
+Ignore findings you don't own or have decided not to fix, such as a third-party consent banner or an OAuth provider's sign-in page, so your report reflects work you actually intend to do. Fix findings in your own application: filtering one removes the evidence from the report, but the barrier is still there for the people using your product. When you're unsure, leave the finding reported and use the [Results API](/accessibility/results-api) to decide whether it blocks a build, which keeps full visibility into the issue.
+
+### <Icon name="angle-right" /> Why didn't my Cypress Accessibility score change after I fixed some violations?
+
+The [accessibility score](/accessibility/core-concepts/accessibility-score) weighs each failed rule per snapshot, not each failing element. If a rule fails on 10 elements in a snapshot and you fix nine of them, that snapshot's score is unchanged until the last one is fixed and the rule flips to passing. The run score also averages every snapshot in the run, so a rule failing on one page in a large suite barely moves the top-line number. Track failed element counts for the rule you're working on, and the **Resolved elements** section of Branch Review, rather than watching the score during remediation.
+
+### <Icon name="angle-right" /> How do I confirm an accessibility fix worked in Cypress Accessibility?
+
+Compare your branch against a base run in Branch Review. The **Resolved elements** section should list the rule you worked on across every view where it was failing, which confirms the fix reached more than the one element you tested by hand. Check the **New failed elements** section in the same review: accessibility fixes commonly introduce new findings, such as an added `aria-label` that duplicates visible text. See [Compare reports](/accessibility/guides/compare-reports) for how the comparison works.
+
+### <Icon name="angle-right" /> Do I need to add assertions or commands to my tests for Cypress Accessibility?
+
+No. Cypress Accessibility reports are generated in Cypress Cloud from the artifacts your recorded run already uploads, so there is nothing to add to your specs and no impact on how long your tests take. Every page and component your tests visit is checked automatically once the product is enabled for your project. Because the report is produced after the run, nothing in your Cypress pipeline fails from an accessibility violation unless you opt in with the [Results API](/accessibility/results-api).
+
+### <Icon name="angle-right" /> How do I fix Cypress Accessibility violations with an AI agent?
+
+Configure [Cypress Cloud MCP](/cloud/integrations/cloud-mcp) so your agent can read results directly from Cypress Cloud with three tools: `cypress_get_accessibility_report` for a run's failing rules and worst views, `cypress_get_accessibility_views` to page through every view, and `cypress_get_accessibility_rule_failures` for the failing elements of a specific rule. Scope each prompt to one rule and ask for a plan before any code changes. Narrowing your report first keeps the agent from triaging findings you were never going to fix, and adding [`components`](/accessibility/configuration/components) attributes to violation selectors helps it locate the source file without crawling your markup.
+
+### <Icon name="angle-right" /> How do I stop a Cypress Accessibility rule I already fixed from regressing?
+
+Keep a list of remediated rules in your CI verification script and fail the build when any of them appear in a run's results, using the [Results API](/accessibility/results-api). This inverts the more common pattern of allowlisting known failures: instead of tracking what's still broken, you lock in each rule the day it reaches zero violations. Add a rule to the list as soon as it passes, and the list becomes a record of the barriers your application no longer has.
+
 ## Ignoring elements
 
 ### <Icon name="angle-right" /> How do I exclude elements from Cypress Accessibility?
 
 Add an [`elementFilters`](/accessibility/configuration/elementfilters) rule with `include: false` for a CSS selector that matches the elements. Their failed and incomplete checks move to the **Ignored** status and stop counting against your views and your [accessibility score](/accessibility/core-concepts/accessibility-score). This is the standard way to handle third-party widgets whose violations you can't fix. To ignore only specific rules for an element, use the [`data-a11y-ignore` attribute](/accessibility/configuration/ignoring-rules-per-element) instead, and to ignore entire pages, use [`viewFilters`](/accessibility/configuration/viewfilters).
 
-### <Icon name="angle-right" /> Do ignored elements affect my accessibility score?
+### <Icon name="angle-right" /> Do ignored elements affect my Cypress Accessibility score?
 
 No. An element ignored by [`elementFilters`](/accessibility/configuration/elementfilters) doesn't count as a failed or incomplete element, and its results don't affect the score. It stays visible in the report under the **Ignored** status so you can always audit what your configuration ignores.
 
-### <Icon name="angle-right" /> Why didn't my score improve after ignoring an element?
+### <Icon name="angle-right" /> Why didn't my Cypress Accessibility score improve after ignoring an element?
 
 The [accessibility score](/accessibility/core-concepts/accessibility-score) weighs each failed rule per snapshot, not each failing element. If a rule has several failing elements in a snapshot and you ignore only some of them, the rule still counts against that snapshot and the score doesn't change. The rule stops affecting the snapshot's score once all of its failing elements there are ignored.
 
-### <Icon name="angle-right" /> Why is an element still failing after I added an elementFilters rule?
+### <Icon name="angle-right" /> Why is an element still failing in Cypress Accessibility after I added an elementFilters rule?
 
 The most common causes are:
 
@@ -31,7 +61,7 @@ The most common causes are:
 - The rule has a `documentScope` that doesn't match the element's iframe or shadow DOM hosts.
 - The report was processed before you saved the configuration. Regenerate the run to apply the current configuration.
 
-### <Icon name="angle-right" /> Why do ignored elements still appear in my report?
+### <Icon name="angle-right" /> Why do ignored elements still appear in my Cypress Accessibility report?
 
 This is by design. Ignored elements appear under the **Ignored** [element status](/accessibility/guides/run-level-reports#Elements) rather than being removed, so the report always shows what your configuration is hiding. They don't count as failed or incomplete elements, and they don't affect your score.
 
@@ -45,7 +75,7 @@ Not on its own. Every element is included unless an exclude rule matches it, and
 
 ## Grouping and naming views
 
-### <Icon name="angle-right" /> Why do similar URLs show up as separate views in my accessibility report?
+### <Icon name="angle-right" /> Why do similar URLs show up as separate views in my Cypress Accessibility report?
 
 Automatic grouping only replaces path segments that are numbers or IDs (UUIDs and UUID-like values) with a wildcard. Segments like usernames or slugs aren't recognized as dynamic, so `/users/alice` and `/users/bob` stay separate views, and a violation on that shared template is reported once per URL. Add a [`views`](/accessibility/configuration/views) pattern to group them into one view and triage the issue once.
 
@@ -53,11 +83,11 @@ Automatic grouping only replaces path segments that are numbers or IDs (UUIDs an
 
 No. Query strings are ignored when grouping, so `/dashboard?tab=overview` and `/dashboard?tab=settings` become a single `/dashboard` view. If a query parameter meaningfully changes the page, use a [`views`](/accessibility/configuration/views) pattern with `groupBy` on that parameter to report on each value separately.
 
-### <Icon name="angle-right" /> How do I create a separate accessibility view for each value of a URL parameter?
+### <Icon name="angle-right" /> How do I create a separate Cypress Accessibility view for each value of a URL parameter?
 
 Write a [`views`](/accessibility/configuration/views) pattern that names the parameter, then list that name in `groupBy`. For a pattern like `/analytics/:type/:id`, `groupBy: ["type"]` creates a distinct view for each `type` value (such as `/analytics/performance/:id` and `/analytics/usage/:id`) while still collapsing the dynamic `:id`. `groupBy` accepts a single string or an array of strings, and each name can come from the path, query string, or hash. See [Using groupBy](/accessibility/configuration/views#Using-groupBy).
 
-### <Icon name="angle-right" /> Does grouping URLs into a view change my accessibility score?
+### <Icon name="angle-right" /> Does grouping URLs into a view change my Cypress Accessibility score?
 
 Not your run-level score. The [run score](/accessibility/core-concepts/accessibility-score) averages every snapshot in the run regardless of how snapshots are grouped, so grouping URLs into a view reorganizes the report without moving the top-line number. What changes is the per-view score: the snapshots you group roll up into one view's score instead of several, which makes each page's accessibility easier to read and track over time.
 
@@ -79,7 +109,7 @@ Add a [`viewFilters`](/accessibility/configuration/viewfilters) rule with `inclu
 
 Yes. A `viewFilters` list at the root of your configuration applies to both products, but nesting it under an `accessibility` or `uiCoverage` key applies it to that product only. A nested list completely replaces a root-level one for that product, and the two are not merged. See [Exclude views](/accessibility/configuration/viewfilters#Scope).
 
-### <Icon name="angle-right" /> Why is a URL still in my report after I excluded it with viewFilters?
+### <Icon name="angle-right" /> Why is a URL still in my Cypress Accessibility report after I excluded it with viewFilters?
 
 The most common causes are:
 
@@ -99,7 +129,7 @@ Cypress Accessibility checks a prioritized list of attributes on each element: `
 
 Add the attribute name to [`significantAttributes`](/accessibility/configuration/significantattributes). Attributes you list are checked before the default list, in the order you list them, so an attribute your application already renders, such as `data-component`, can identify elements and appear as the violation target selector in your reports.
 
-### <Icon name="angle-right" /> Does significantAttributes replace the default attribute list?
+### <Icon name="angle-right" /> Does significantAttributes replace the default attribute list in Cypress Accessibility?
 
 No. Your attributes are checked first, and the defaults still apply after them, so an element without any of your attributes is identified exactly as it would be without configuration. Listing a default attribute like `data-qa` promotes it above the other defaults. To stop an attribute from being used at all, use [`attributeFilters`](/accessibility/configuration/attributefilters) instead.
 
@@ -150,11 +180,37 @@ Yes, two ways. In Cypress Cloud, open the run's **Properties** tab to see the ex
 
 Add a `comment` property to the rule. Any rule defined as an object accepts one, and it's the supported place for notes because Cypress Cloud rejects properties it doesn't recognize. Comments live in your Cypress Accessibility configuration only and never appear in reports. See [Comments](/accessibility/configuration/overview#Comments).
 
+## Accessibility standards
+
+### <Icon name="angle-right" /> Does Cypress Accessibility make my application WCAG conformant or ADA compliant?
+
+No automated tool can determine that, and Cypress Accessibility doesn't claim to. What it reports is factual and narrow: which Axe-Core® rules passed, failed, or couldn't be evaluated on the pages and components your tests visited, on a specific run, with a recorded rule configuration and Axe-Core® version.
+
+Determining conformance with the Web Content Accessibility Guidelines (WCAG), published by the W3C, requires human assessment of criteria no scanner can evaluate. Laws and procurement rules in different regions, including the Americans with Disabilities Act (ADA) in the United States, Section 508 for US federal agencies and their suppliers, and the European Accessibility Act (EAA), commonly point to WCAG as the technical reference. How any of those obligations apply to your organization is a legal question for you and your advisors, not an output of a testing tool. See [accessibility automation principles](/accessibility/guides/accessibility-automation) for where automated checks stop.
+
+### <Icon name="angle-right" /> Which WCAG version and level do the Cypress Accessibility rules cover?
+
+By default, a run evaluates Axe-Core®'s default ruleset: rules tagged for WCAG 2.0 and WCAG 2.1 Level A and AA, plus Deque's Best Practices rules. Three WCAG-tagged rules are turned off by default in Cypress Accessibility, and Axe-Core®'s WCAG 2.2, Level AAA, experimental, and deprecated rule groups are off unless Cypress enables them for your project. This means the default report is broader than any single WCAG level in one sense, because Best Practices findings are Deque recommendations rather than WCAG success criteria, and narrower in another, because it doesn't run every WCAG-tagged rule. See [What the default ruleset covers](/accessibility/configuration/axe-core-configuration#what-the-default-ruleset-covers).
+
+### <Icon name="angle-right" /> Can Cypress Accessibility run WCAG 2.2 or Level AAA rules?
+
+Yes, on request. Axe-Core® ships those rules but keeps them off by default, so they don't run in Cypress Accessibility unless they're enabled for your project. Enabling them is a guided change Cypress applies for you rather than a setting in the App Quality editor, and historical runs can be regenerated so you can see the effect before adopting it. See [How Cypress can tune the ruleset for your project](/accessibility/configuration/axe-core-configuration#how-cypress-can-tune-the-ruleset-for-your-project).
+
+### <Icon name="angle-right" /> Can I use Cypress Accessibility results in a VPAT or accessibility conformance report?
+
+You can reference them as one source of evidence, but they don't produce the document. A VPAT or accessibility conformance report is written by people evaluating a product against each criterion, and automated results speak only to the subset of criteria a scanner can check, on the pages and components your tests happened to visit.
+
+What Cypress Accessibility contributes is a durable, dated record: every run permanently stores the rule configuration and Axe-Core® version it was processed with, viewable in the run's **Properties** tab, and the [Results API](/accessibility/results-api) exposes per-rule and per-view results you can archive alongside your own assessment notes.
+
+### <Icon name="angle-right" /> Does a 100% Cypress Accessibility score mean my application is accessible?
+
+No. A 100% score means Axe-Core® detected no violations in the scope your tests covered, with the rules that were enabled for that run. It says nothing about criteria automated checks can't evaluate, such as whether a label is understandable, whether focus order matches the visual layout, or whether the experience works for someone using a screen reader end to end. Automated checks detect around [57% of the issues a manual audit surfaces](https://www.deque.com/blog/automated-testing-study-identifies-57-percent-of-digital-accessibility-issues/). Treat a clean report as a solid foundation and a signal that your team is actively managing accessibility, not as a finished state. See [What a 100% score means](/accessibility/core-concepts/accessibility-score#What-a-100-score-means).
+
 ## Axe Core® rules
 
 ### <Icon name="angle-right" /> Which accessibility rules does Cypress Accessibility run?
 
-Cypress Accessibility runs the full [Axe-Core®](https://github.com/dequelabs/axe-core) ruleset against every captured snapshot, plus a few [custom Cypress rules](/accessibility/core-concepts/cypress-rules). A small number of Axe-Core® rules are [off by default](/accessibility/configuration/axe-core-configuration#rules-that-are-off-by-default): `color-contrast`, `no-autoplay-audio`, and `meta-refresh`. You don't add any assertions or `cy.` commands to your tests to run these checks; they run automatically when Cypress Accessibility is enabled.
+Cypress Accessibility runs [Axe-Core®](https://github.com/dequelabs/axe-core)'s default ruleset against every captured snapshot, plus a few [custom Cypress rules](/accessibility/core-concepts/cypress-rules). That covers WCAG 2.0 and 2.1 Level A and AA, along with Deque's Best Practices rules, which are recommendations rather than WCAG success criteria. Rule groups that Axe-Core® keeps off by default, including WCAG 2.2, Level AAA, experimental, and deprecated rules, don't run unless Cypress enables them for your project. Three further rules are [off by default](/accessibility/configuration/axe-core-configuration#rules-that-are-off-by-default) in Cypress Accessibility: `color-contrast`, `no-autoplay-audio`, and `meta-refresh`. You don't add any assertions or `cy.` commands to your tests to run these checks; they run automatically when Cypress Accessibility is enabled. See [What the default ruleset covers](/accessibility/configuration/axe-core-configuration#what-the-default-ruleset-covers).
 
 ### <Icon name="angle-right" /> Can I change which Axe-Core® rules Cypress Accessibility runs?
 
@@ -207,7 +263,7 @@ The most common causes are:
 
 There's no dedicated "skip this run" switch in a profile. To suppress a report for certain runs, point a profile at a deliberately narrow configuration (for example, [`viewFilters`](/accessibility/configuration/viewfilters) that exclude every view) so Cypress Cloud produces an empty or tightly scoped accessibility report for the run instead. See [Why use profiles?](/accessibility/configuration/profiles#Why-use-profiles).
 
-### <Icon name="angle-right" /> How do I make accessibility checks on pull requests faster and more focused than regression runs?
+### <Icon name="angle-right" /> How do I make Cypress Accessibility checks on pull requests faster and more focused than regression runs?
 
 Add a profile (for example, `aq-config-pr`) whose `config` narrows the report to your most critical flows with [`viewFilters`](/accessibility/configuration/viewfilters), then tag pull request runs with `cypress run --record --tag "aq-config-pr"`. The pull request report covers only those flows, so it's small and unambiguous for a developer to act on before merging, while regression runs record without the tag and keep the full base configuration. Combine the profile with the [Results API](/accessibility/results-api) to fail the build when a critical flow regresses. See [Block pull requests](/accessibility/guides/block-pull-requests#Using-Profiles-for-PR-specific-configuration).
 

--- a/docs/accessibility/get-started/introduction.mdx
+++ b/docs/accessibility/get-started/introduction.mdx
@@ -63,11 +63,13 @@ From there, you can integrate with CI to set your own standards for handling the
       aria-labelledby="card-title-1"
     >
       <Icon name="chart-line" />
-      <div class="card__title" id="card-title-1">Improve Accessibility</div>
+      <div class="card__title" id="card-title-1">
+        Fix accessibility violations
+      </div>
       <p>
-        Discover how to break down accessibility reports, prioritize fixes, and
-        make impactful progress toward accessible software with Cypress
-        Accessibility.
+        Turn a large accessibility report into work your team can finish: scope
+        the report to the code you own, pick a first rule, fix it, and prove the
+        fix landed before the code merges.
       </p>
     </a>
   </li>

--- a/docs/accessibility/get-started/setup.mdx
+++ b/docs/accessibility/get-started/setup.mdx
@@ -61,4 +61,6 @@ To add or modify the configuration for your project, navigate to the **App Quali
 
 Cypress Accessibility supports many different accessibility automation workflows that might not be obvious at first glance, such as production monitoring of large content-managed websites. There is also an API for programmatic access to the results from each run, and a report comparison feature in Branch Review that allows for reviewing only the new violations discovered in a certain run. The guides walk you through many of the scenarios and use cases supported by Cypress Accessibility in detail so you can see how you might apply the results in your own team.
 
+If you're looking at your first report and deciding what to do with it, start with [Fix accessibility violations](/accessibility/guides/improve-accessibility), which turns a large report into work your team can finish.
+
 Learn more about [how to maximize the impact of Cypress Accessibility](/accessibility/guides/introduction) for your organization.

--- a/docs/accessibility/guides/block-pull-requests.mdx
+++ b/docs/accessibility/guides/block-pull-requests.mdx
@@ -35,7 +35,18 @@ The Results API offers full flexibility to analyze results and take tailored act
 
 ## Defining policies in the verification step
 
-The [Results API Documentation](/accessibility/results-api) provides detailed guidance on the API's capabilities. Here's a simplified example demonstrating how to enforce a "no new failing accessibility rules" policy:
+The [Results API Documentation](/accessibility/results-api) provides detailed guidance on the API's capabilities. Two rule-level policies cover most teams, and they're mirror images of each other. Both read `results.rules`, which lists only the rules that failed in the run.
+
+| Policy                                                                       | Blocks when                                         | Best for                                                                       |
+| ---------------------------------------------------------------------------- | --------------------------------------------------- | ------------------------------------------------------------------------------ |
+| [Allowlist known failures](#Policy-block-any-rule-that-isnt-already-failing) | Any rule fails that isn't on your known-issues list | Reports that are close to clean, where anything unexpected should stop a merge |
+| [Protect what you've fixed](#Policy-block-regressions-in-rules-youve-fixed)  | A rule you already remediated fails again           | A large backlog you're working through, where most rules still fail            |
+
+For a policy that tracks violations per view rather than per rule, see [comparing against a baseline](#comparing-against-a-baseline).
+
+### Policy: block any rule that isn't already failing {#Policy-block-any-rule-that-isnt-already-failing}
+
+This enforces "no new failing accessibility rules". You keep a list of the rules you already know about, and anything outside it fails the build:
 
 ```js
 const { getAccessibilityResults } = require('@cypress/extract-cloud-results')
@@ -62,6 +73,44 @@ getAccessibilityResults().then((results) => {
 })
 ```
 
+The list shrinks as you fix things, and every entry you remove raises the standard the build enforces.
+
+### Policy: block regressions in rules you've fixed {#Policy-block-regressions-in-rules-youve-fixed}
+
+This is the inverse, and it suits a project still working through a large backlog. Rather than listing what's broken, you list what you've finished, and only a reappearance of those rules fails the build:
+
+```javascript title="scripts/verifyAccessibilityResults.js"
+const { getAccessibilityResults } = require('@cypress/extract-cloud-results')
+
+// Rules this team has remediated. Add a rule here the day it reaches zero
+// violations, so any reappearance is treated as a regression.
+const remediatedRules = ['button-name', 'image-alt', 'label']
+
+getAccessibilityResults().then((results) => {
+  const regressions = results.rules.filter((rule) =>
+    remediatedRules.includes(rule.name)
+  )
+
+  if (regressions.length === 0) {
+    console.log(`No regressions in ${remediatedRules.length} remediated rules.`)
+    return
+  }
+
+  console.error('Previously remediated accessibility rules are failing again:')
+  regressions.forEach((rule) => {
+    console.error(
+      `  - ${rule.name} (${rule.severity}): ${rule.accessibilityReportUrl}`
+    )
+  })
+
+  throw new Error(
+    `${regressions.length} remediated rule(s) regressed and must be fixed before merging.`
+  )
+})
+```
+
+Here the list grows as you work. It never blocks a merge for a rule you haven't gotten to yet, which keeps the gate credible while the backlog is still large. See [Fix accessibility violations](/accessibility/guides/improve-accessibility) for how to work through that backlog one rule at a time.
+
 By examining the results and customizing your response, you gain maximum control over how to handle accessibility violations. Leverage CI environment context, such as tags, to fine-tune responses to specific accessibility outcomes.
 
 ## Using Profiles for PR-specific configuration
@@ -72,13 +121,38 @@ You can use [Profiles](/accessibility/configuration/profiles) to apply different
 - Maintain a broader configuration for regression runs that tracks all issues for long-term monitoring
 - Apply team-specific configurations when multiple teams share the same Cypress Cloud project
 
-For example, you might configure a profile named `aq-config-pr` that excludes non-critical pages and focuses only on the most important accessibility rules, while your base configuration includes all pages and rules for comprehensive regression tracking.
+For example, a profile named `aq-config-pr` can narrow pull request reports to a single flow that's under active remediation, while your base configuration keeps every page for regression tracking. The first rule includes the flow and the catch-all `*` rule excludes everything else, because [`viewFilters`](/accessibility/configuration/viewfilters) apply in order and the first match wins:
+
+```json title="App Quality Config"
+{
+  "profiles": [
+    {
+      "name": "aq-config-pr",
+      "comment": "Pull request runs report only on the checkout flow while we remediate it",
+      "config": {
+        "viewFilters": [
+          {
+            "pattern": "/checkout/*",
+            "include": true
+          },
+          {
+            "pattern": "*",
+            "include": false
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+Record pull request runs with the matching tag to select the profile:
 
 ```shell
 cypress run --record --tag "aq-config-pr"
 ```
 
-This approach ensures that PR checks are fast and focused, while still maintaining comprehensive reporting for your full test suite.
+This approach ensures that PR checks are fast and focused, while still maintaining comprehensive reporting for your full test suite. A profile can't change which Axe-Core® rules run, so which rules block a merge stays a decision you make in the verification step above.
 
 ## Comparing against a baseline {#comparing-against-a-baseline}
 

--- a/docs/accessibility/guides/compare-reports.mdx
+++ b/docs/accessibility/guides/compare-reports.mdx
@@ -175,6 +175,6 @@ If your application is unstable between runs in terms of content, pages, or diff
 
 When everything is dialled in correctly, the Branch Review diff will be 100% clean, unless something has actually changed in an area you didn't already know about. This gives you the highest confidence that if an issue is blocking a merge, it is genuinely a new problem introduced by the incoming Pull Request.
 
-If the team is not already familiar with accessibility, it's useful to consider which rules to start with. See the [starting from scratch guide](/accessibility/guides/improve-accessibility) for suggestions about this.
+If the team is not already familiar with accessibility, it's useful to consider which rules to start with. See [Fix accessibility violations](/accessibility/guides/improve-accessibility) for how to choose a first rule and scope the report around it.
 
 If multiple teams are working on the same project and need accessibility results to be isolated from each other, consider splitting runs into dedicated Cypress projects or using [configuration profiles](/accessibility/configuration/profiles) so that each team can have a customized report for the areas they are responsible for.

--- a/docs/accessibility/guides/improve-accessibility.mdx
+++ b/docs/accessibility/guides/improve-accessibility.mdx
@@ -1,90 +1,233 @@
 ---
-title: 'Improve accessibility'
-description: 'Discover how to break down accessibility reports, prioritize fixes, and make impactful progress toward accessible software with Cypress Accessibility.'
-sidebar_label: Improve accessibility
+title: 'Fix accessibility violations: prioritize and work through a backlog'
+description: 'Turn a large Cypress Accessibility report into work your team can finish: scope the report to the code you own, pick a first rule, fix it, and prove the fix landed before the code merges.'
+sidebar_label: Fix violations
 sidebar_position: 20
 ---
 
 <ProductHeading product="accessibility" />
 
-# Improve accessibility
+# Fix accessibility violations
 
-This guide explains how to break down accessibility reports and create a focused plan for remediation using Cypress Accessibility.
+Your first Cypress Accessibility report covers every page and component your existing Cypress tests already visit, with no assertions or `cy.` commands added to your specs. On an application that has never been checked, that usually means hundreds or thousands of findings across dozens of rules, which is more than any team can act on at once.
+
+This guide turns that report into work your team can finish. You'll narrow the report to the code you own, pick one rule you can complete in a single cycle, fix it, and confirm in Branch Review that the fix landed before the code merges. Then you repeat with a wider scope.
+
+## Agree on the scope before you start
+
+Remediation almost always crosses team boundaries: engineering changes markup, design decides the colors, and content authors write the text that ends up in labels and headings. Before you triage the first rule, get agreement on a few things that decide what "finished" means:
+
+- **Your target.** The conformance level you're working toward, such as WCAG 2.1 Level AA, and the parts of the application it applies to first.
+- **Your timeline and capacity.** How much of each cycle the team can spend on remediation.
+- **Your risk.** The cost of leaving specific flows inaccessible, which is usually highest on sign-up, sign-in, checkout, and account management.
+- **Your roadmap.** Areas of the codebase that are about to be rewritten are often worth deferring, because the rewrite is the cheaper place to fix them.
+
+You don't need to settle all of this to start. You do need enough agreement that nobody has to relitigate the plan halfway through the first rule.
+
+## Narrow the report to the code you own
+
+A report full of findings nobody intends to act on makes prioritization harder and hides real regressions. Before you triage, remove what isn't yours to fix, so that everything left in the report is either work you plan to do or a genuine new problem.
+
+Cypress Accessibility gives you three levers, from broadest to narrowest:
+
+| What you want to remove                                   | Use                                                                                     | Where you set it        |
+| --------------------------------------------------------- | --------------------------------------------------------------------------------------- | ----------------------- |
+| A whole page or URL, such as a third-party sign-in screen | [`viewFilters`](/accessibility/configuration/viewfilters)                               | App Quality Config      |
+| Every finding on an element, such as a vendor widget      | [`elementFilters`](/accessibility/configuration/elementfilters)                         | App Quality Config      |
+| One rule on one element, such as a known false positive   | [`data-a11y-ignore`](/accessibility/configuration/ignoring-rules-per-element) attribute | Your application markup |
+
+A configuration that removes an OAuth provider's sign-in page, a cookie consent banner, and a vendor chat widget might look like this:
+
+```json title="App Quality Config"
+{
+  "viewFilters": [
+    {
+      "pattern": "https://accounts.google.com/*",
+      "include": false,
+      "comment": "OAuth provider our sign-in tests pass through, not our markup"
+    }
+  ],
+  "elementFilters": [
+    {
+      "selector": "#onetrust-consent-sdk, #onetrust-consent-sdk *",
+      "include": false,
+      "comment": "OneTrust consent banner, violations reported upstream to the vendor"
+    },
+    {
+      "selector": "#hubspot-messages-iframe-container, #hubspot-messages-iframe-container *",
+      "include": false,
+      "comment": "Support chat widget rendered by HubSpot"
+    }
+  ]
+}
+```
+
+Both selectors repeat themselves with a descendant form, such as `#onetrust-consent-sdk *`, because an `elementFilters` selector matches the element that has the finding, not its container.
+
+When a single rule misfires on an element you otherwise want reported, keep the element and ignore just that rule from your application code:
+
+```html
+<div role="grid" data-a11y-ignore="aria-required-children">…</div>
+```
+
+Two things make this safe to do early:
+
+- **Ignoring is visible, not silent.** Ignored elements stay in the report under the **Ignored** [element status](/accessibility/guides/run-level-reports#Elements) instead of disappearing, so you can always audit what your configuration hides. They stop counting as failures and stop affecting your [accessibility score](/accessibility/core-concepts/accessibility-score).
+- **You don't have to re-run your tests to see the effect.** Save the configuration, then regenerate a past run from its **Properties** tab in Cypress Cloud. The report is reprocessed with your current configuration in place, so you can iterate on scope in minutes.
+
+<DocsImage
+  src="/img/accessibility/configuration/cypress-cloud-properties-tab-application-quality-config.png"
+  alt="The Properties tab of a run in Cypress Cloud, showing the App Quality configuration the run was processed with and the regenerate button that reprocesses the run against the configuration currently saved."
+/>
+
+### Inconclusive elements are not part of the backlog
+
+Some checks come back **Inconclusive** rather than passed or failed. Axe-Core® either couldn't complete them for technical reasons, or the answer depends on judgment an automated scanner can't make. They don't count as failures, they don't affect your [accessibility score](/accessibility/core-concepts/accessibility-score), and they never keep a rule from reaching zero violations.
+
+Treat them as a separate review queue rather than remediation work. They make a poor first goal precisely because "done" isn't something the report can confirm for you, so pick a rule with clear failures first and come back to the inconclusive list once your team has the accessibility experience to judge them.
+
+## Choose a first goal you can finish
+
+A goal with a finish line is worth more than a broad one, because reaching it tells your team the process works. Effective first goals take one of two shapes:
+
+- **Rule focused.** Resolve every violation of one rule across the application, such as every failing `button-name` element.
+- **View focused.** Resolve every violation on one page or component, such as the checkout flow.
+
+Rule-focused goals tend to be the better first choice. The fix is the same shape every time, so the second element takes a fraction of the time the first one did, and whoever picks up the work only has to learn one accessibility concept to finish it.
+
+In a component-driven codebase the leverage is larger than the element count suggests. One shared button, form field, or dialog can be responsible for a rule's failures across dozens of views, so a single file can clear the rule everywhere at once. This cuts both ways when you're sizing the work: check whether the failing elements trace back to one component before you estimate, because 200 failing elements and 200 places to edit are rarely the same number. Adding [`components`](/accessibility/configuration/components) attributes to your violation selectors makes that grouping visible in the report itself.
 
 <DocsImage
   src="/img/accessibility/guides/a11y-standards.png"
-  alt="A list of accessibility rules where some are passing and failing. Two major sections are identified - the passing rules as 'Your current standard', and the failing rules as 'Your issues to address'. Within the failing rules list, 2 rules are called out as 'Your next tasks' because they have the smallest count of elements failing the rule."
+  alt="The rules list from an accessibility report, annotated into three groups: the passing rules marked 'Your current standard', the failing rules marked 'Your issues to address', and the two failing rules with the fewest failing elements marked 'Your next tasks'."
   noBorder={true}
 />
 
-## Starting from Scratch
+Open the **Rules** list in a run's [accessibility report](/accessibility/guides/run-level-reports#Rules) and read it as three groups. The passing rules are the standard you already meet. The failing rules are your backlog. The failing rules with the fewest failing elements are your next tasks, because they're closest to moving into the first group.
 
-If you're beginning with a legacy application that has many accessibility issues, Cypress Accessibility provides actionable insights to help you prioritize fixes. Use the [Accessibility tab for a run](/accessibility/guides/run-level-reports) to identify violations across pages and components. Although the volume of issues might seem overwhelming, focusing on key factors can guide your approach:
+Expect the first report to include concepts your team hasn't worked with before, such as [ARIA attributes](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA) or [nesting interactive controls inside each other](https://dequeuniversity.com/rules/axe/4.12/nested-interactive). That's a reason to start small, not a reason to wait: every Axe-Core® violation in Cypress Cloud links to a Deque University page explaining the barrier and how to fix it, so the context an engineer or agent needs is one click from the failing element.
 
-- **Goals**: Define your accessibility objectives.
-- **Timeline**: Establish a realistic timeline for improvements.
-- **Resources**: Assess the resources available for remediation.
-- **Future Code Changes**: Focus on areas of the codebase likely to evolve.
-- **Risk Assessment**: Consider the risks and costs of remaining inaccessible.
+### What makes a good first rule
 
-Effective remediation often requires collaboration across departments, emphasizing the importance of an organization-wide commitment to accessibility, so understanding your organization's stance on accessibility and who needs to be in the conversation is also helpful.
+Look for a rule where the fix is local, unambiguous, and easy to confirm:
 
-If your organization or team is newer to accessibility, you're likely to find plenty of issues reported by Axe Core® in Cypress Accessibility. Many of the issues in your first report may relate to concepts that are new, such as [ARIA attributes](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA) or [invalid nesting of interactive controls](https://dequeuniversity.com/rules/axe/4.2/nested-interactive). Since it will be impossible to fix all issues overnight, we recommend finding some low-hanging fruit as a starting point. This can help your team build confidence by getting some wins on the board, and teach them the overall idea of how accessibility problems get fixed.
+- It appears often enough that finishing it visibly changes the report.
+- Axe-Core® flags it as critical or serious, so the work is defensible.
+- The fix is contained in one component or file, with no design or content decision blocking it.
+- You can confirm the fix by hand, with a screen reader or the browser's accessibility inspector.
 
-If you are use Claude, Cursor, or other AI agents in your development process, this is a good time to consider using the [Cypress Cloud MCP's accessibility tools](#Fixing-violations-with-your-AI-agent) to help triage your accessibility findings and develop action plans based on the source of each issue.
+Rules that support [WCAG SC 4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html) usually fit all four. They cover whether interactive controls expose a name and a role to assistive technology, they're common in component-driven interfaces, and they directly change whether a screen reader user can tell what a control does.
 
-## Good low-hanging fruit
+### Example: buttons must have discernible text
 
-Some accessibility issues are easier to address but have a significant impact. Consider issues related to [WCAG SC 4.2.1 \- Name, role, value](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html), which ensures interactive controls are appropriately labeled. Violations in this category often:
+Icon-only buttons with no text label are one of the most common findings in a first report, and the [`button-name` rule](https://dequeuniversity.com/rules/axe/4.12/button-name) is a good first target:
 
-- Appear frequently in applications.
-- Are flagged as Critical or Serious by Axe Core®.
-- Directly impact usability for screen reader users.
+- The fix is usually one attribute or one piece of visually hidden text.
+- A screen reader user goes from hearing "button" to hearing something meaningful, for example "Delete invoice".
+- It rarely needs a decision from outside the team, as long as the correct label is obvious from the surrounding UI.
+- New code is easy to hold to the same standard, because "what does this control announce?" is a question a designer or product manager can answer during the ticket, not after the pull request.
 
-### Example: "Buttons Must Have Discernible Text"
+:::note
 
-A common issue in modern interfaces is unlabeled icons used as buttons. The [button-name rule](https://dequeuniversity.com/rules/axe/4.7/button-name), which ensures buttons have descriptive text, is an ideal starting point because:
+**Passing the rule isn't the same as choosing a good label.** Axe-Core® checks that a control exposes an accessible name, not that the name is understandable, so `aria-label="button"` passes `button-name` exactly as `aria-label="Delete invoice"` does. When you settle on a label, write it into a test assertion so the choice is specified rather than incidental, and a later refactor can't quietly replace it with something that still passes. [Maximize coverage](/accessibility/guides/maximize-coverage) shows what that assertion looks like.
 
-- Adding a label is a simple code update.
-- Proper labels improve usability for all users.
-- Fixes typically don't require cross-team involvement.
-- Straightforward to validate with a screen reader.
+:::
 
-Existing code failing the button-name rule can usually be remediated pretty quickly, as long as it is clear what the correct text label is for a given control. And when it comes to new code, this text label content is also easy to add to discussions in the design and requirements stages of the development cycle, shifting the accessibility conversation left.
+If `button-name` isn't in your report, choose another rule with the same properties. The point of the first rule is to build the workflow and the team's confidence, not to pick the perfect rule.
 
-Since every violation in Cypress is linked to a Deque University page with details about the nature of the problem and how to fix it, all the needed context is available, even to engineers who may be new to the topic of accessibility.
+## How fixes move your accessibility score
 
-Even if your first rule is not "Buttons must have discernible text", we suggest finding one with a similarly small amount of coordination or understanding needed to fix, so the team can experience success as quickly as possible.
+The [accessibility score](/accessibility/core-concepts/accessibility-score) is a useful trend line, but it's a poor progress bar for a single rule. Two behaviors surprise teams that watch it during remediation.
 
-## Check your changes in Branch Review
+**A rule counts once per snapshot, however many elements fail it.** Each snapshot's score is a weighted ratio of passing to failing rules, and severity sets the weight. So if `button-name` fails on 10 buttons in one snapshot and you fix nine of them, that snapshot's score doesn't move at all. It moves when the last failing element is fixed and the rule flips to passing.
 
-One of the most frustrating experiences in accessibility is fixing one issue, only to discover you introduced some other issue in the process. Especially if the feedback cycles are long, it can reduce everybody's confidence in the remediation process. When making changes to improve accessibility, you can use [Branch Review](/cloud/features/branch-review#Get-started) to see the effect of your solutions - including seeing any increase in issues that might be related to your code changes.
+**The run score averages every snapshot in the run.** A rule that fails on one page in a suite that captures hundreds of snapshots barely registers, even though the barrier on that page might be severe.
 
-## Setting achievable goals
+Track the counts that respond to your work instead, and treat the score as the long-term trend:
 
-Define a clear objective for each effort, such as fixing all violations of a specific rule within a defined scope. For example:
+- **Failed elements** for the rule you're working on, which drop with every element you fix.
+- **Failing rules per view**, which tells you which pages are close to clean.
+- The **Resolved elements** section of [Branch Review](/accessibility/guides/compare-reports#Resolved-elements), which attributes the improvement to your change.
 
-- **View Focused**: Address all rule violations on a single page or component.
-- **Rule Focused**: Resolve a single rule violation across multiple pages or the entire application.
+## Prove the fix landed in Branch Review
 
-Achieving these milestones provides a clear finish line for you and your team. It also provides time to assess the impact of the changes. Often, fixing one issue can cascade changes across your application, especially in componentized architectures: it's fine for these first goals to be small at first. In fact, it's preferable.
+The most expensive outcome in accessibility work is fixing one issue and introducing another without noticing, because the new issue is found later, by someone else, at a point where the change is no longer fresh. [Branch Review](/cloud/features/branch-review#Get-started) compares the accessibility report for your branch against a base run, so you can see the effect of a change while you still have the context to act on it.
 
-## Iterating towards success {#iterating-towards-success}
+When you review your remediation branch, check both directions:
 
-Incremental progress is key to long-term accessibility improvements. By focusing on manageable goals, your team can:
+- **Resolved elements** should list the rule you worked on, with the elements you fixed counted against the views they appear on. This is your evidence that the fix reached everywhere the rule was failing, not only the example you tested by hand.
+- **New failed elements** should be empty. Accessibility fixes commonly introduce new findings, such as an added `aria-label` that duplicates visible text or a new landmark that leaves other content outside it.
 
-- Gain expertise in specific accessibility rules.
-- Build workflows for preventing future regressions.
-- Gradually raise the accessibility standard across your projects.
+<DocsImage
+  src="/img/accessibility/core-concepts/branch-review-a11y-resolved-elements.png"
+  alt="The Resolved elements section of a Branch Review accessibility report, listing each rule that had failures in the base run which are no longer detected in the changed run, with the number of resolved elements beside each rule."
+/>
 
-With support from Deque University's "Learn More" links in the reports, even teams new to accessibility can learn the related context and confidently address violations.
+Comparisons are cleanest when both runs execute a similar test suite against similar content. If dynamic URLs or generated class names make unchanged elements look new, stabilize the comparison with [`views`](/accessibility/configuration/views), [`attributeFilters`](/accessibility/configuration/attributefilters), and [`significantAttributes`](/accessibility/configuration/significantattributes). See [comparing accessibility reports](/accessibility/guides/compare-reports#Stabilizing-the-comparison) for the full process.
 
-For guidance on preventing regressions and enforcing accessibility policies, explore our [Blocking Pull Requests Section](/accessibility/guides/block-pull-requests).
+## Work through repeated violations with an AI agent
 
-## Fixing violations with your AI agent
+Once you've fixed the first few elements of a rule by hand, the remaining ones follow the same pattern. That's the point where handing the work to an agent pays off.
 
-If you have [Cloud MCP](/cloud/integrations/cloud-mcp) configured, you can ask your agent to pull violation details from Cypress Cloud and work through fixes. Here's an example prompt that focuses on a specific rule and asks the agent to create a plan:
+With [Cypress Cloud MCP](/cloud/integrations/cloud-mcp) configured, an agent reads your accessibility results directly from Cypress Cloud through three tools: `cypress_get_accessibility_report` for a run's failing rules and worst views, `cypress_get_accessibility_views` to page through every view, and `cypress_get_accessibility_rule_failures` for the failing elements of one rule, optionally scoped to a single view.
 
-> "Pull all `button-name` failures from the latest Cypress Cloud run. For each failing element: verify whether it's actually a problem given how the code is constructed. If it's valid, summarize the fix in markdown for my code review and propose a plan — wait for my approval before making any changes. If it's not a real issue, note it and move on. If you need more context to solve it, tell me what's missing — and if it's something only Cypress Cloud would have, submit feedback to the Cypress team."
+This prompt scopes the work to a single rule and asks for a plan before any edits. It works as written on any project with Cypress Cloud MCP configured: name a rule if you have one in mind, or let the agent pick the rule with the most failing elements.
 
-This works especially well for rules that appear across many elements, where the pattern of the fix is consistent once you've seen the first example.
+<CopyPrompt
+  title="Work through one accessibility rule"
+  subtext="Pulls every failing element for one rule from your latest Cypress Cloud run, then proposes a fix plan before touching any code."
+  prompt={`Using Cypress Cloud MCP, get the Cypress Accessibility report for the latest run on this project. List the failing rules with their severity and failing element counts.
+
+Then pick one rule to work on: use the rule I name below if there is one, and otherwise the failing rule with the most failing elements. Tell me which rule you picked and why.
+
+RULE (optional):
+
+For that rule, get every failing element, including the view each one was found on. For each element, find the component in this codebase that renders it and decide whether the finding is a real problem given how the code is constructed.
+
+Then give me:
+
+1. A markdown summary of the proposed fixes that I can paste into a pull request description.
+2. Any findings you believe are not real issues, with a one-line reason each.
+3. Anything you could not determine from the code or the report, and what you would need.
+
+Propose a plan and wait for my approval before changing any code.`}
+/>
+
+Two things make an agent's output more reliable here:
+
+- **Narrow the report first.** An agent triaging a vendor widget you were never going to fix costs tokens and produces work you'll reject. The scoping step above pays for itself immediately.
+- **Give elements names your codebase uses.** [`components`](/accessibility/configuration/components) adds attributes such as `data-component` or `data-team` to violation target selectors, so a failing element reads as `[data-cy="signup"][data-component="IconButton"]` instead of a generated selector, and the agent can find the source file without crawling your markup.
+
+[Work with AI agents](/accessibility/work-with-ai-agents) has more prompts for Cypress Accessibility, such as grouping violations by owner across the roles on your team.
+
+## Prevent finished rules from regressing {#iterating-towards-success}
+
+A finished rule is only finished if it stays finished. As each rule reaches zero violations, add it to a list your CI pipeline enforces with the [Results API](/accessibility/results-api), so a reappearance fails the build instead of surfacing in next quarter's audit.
+
+While your backlog is still large, keep the list of rules you've **finished** rather than the more common list of rules you know are **failing**. Both are one-line policies in a verification script, but only the first one stays credible on a project with hundreds of open violations, because it never blocks a merge for a rule nobody has gotten to yet. Both policies, with complete scripts, are in [blocking pull requests and setting policies](/accessibility/guides/block-pull-requests#Defining-policies-in-the-verification-step).
+
+That list grows as you work, and it's the clearest measure of progress you have: every rule on it is a barrier your application no longer has.
+
+While a single flow is under active remediation, you can also shrink what pull request runs report on, using a [profile](/accessibility/configuration/profiles) selected by a run tag. Pull request reports stay narrow while regression runs keep full coverage. See [using profiles for pull request configuration](/accessibility/guides/block-pull-requests#Using-Profiles-for-PR-specific-configuration).
+
+## Widen the scope and repeat
+
+Each completed rule leaves your team with something durable: expertise in a specific rule, a workflow for catching regressions, and a higher baseline that new code has to meet. Pick the next rule from the same list, or move from a rule-focused goal to a view-focused one and finish a whole page.
+
+Keep the ceiling in view while you do it. Automated checks detect around [57% of the issues a manual audit surfaces](https://www.deque.com/blog/automated-testing-study-identifies-57-percent-of-digital-accessibility-issues/), so a clean Cypress Accessibility report means Axe-Core® found nothing in the tested scope, not that your application works for everyone. Whether a label is meaningful, whether focus order follows the visual layout, and whether an error message is announced are all judgments a scanner can't make. Plan for people to check those, and turn what they find into assertions you can run every build: [accessibility automation principles](/accessibility/guides/accessibility-automation) covers where automation stops, and [maximize coverage](/accessibility/guides/maximize-coverage) covers writing the tests that pick up from there.
+
+When the rules and pages that matter to your business are all passing, your work shifts from remediation to prevention. See [maintaining accessibility](/accessibility/guides/maintain-accessibility) for what that looks like, and [blocking pull requests and setting policies](/accessibility/guides/block-pull-requests) for enforcing the standard you've reached.
+
+## See also
+
+- [Run-level reports](/accessibility/guides/run-level-reports) explains every metric in a run's accessibility report.
+- [Inspect violation details](/accessibility/guides/inspecting-violation-details) covers the element detail view, DOM snapshots, and creating Jira issues from a violation.
+- [How the accessibility score is calculated](/accessibility/core-concepts/accessibility-score) documents the severity weights behind the score.
+- [Compare reports](/accessibility/guides/compare-reports) is the full guide to Branch Review for Cypress Accessibility.
+- [Configuration overview](/accessibility/configuration/overview) lists every App Quality Config option and how to apply it.
+- [Results API](/accessibility/results-api) is how you enforce a standard in CI.
+- [Maximize coverage](/accessibility/guides/maximize-coverage) shows how to turn a fixed violation into an assertion that keeps the specific fix in place.
+- [Accessibility automation principles](/accessibility/guides/accessibility-automation) explains what automated checks can and can't detect.
+- [Maintain accessibility](/accessibility/guides/maintain-accessibility) covers the shift from remediation to prevention.
+- [Work with AI agents](/accessibility/work-with-ai-agents) has more Cypress Cloud MCP prompt patterns.
+- [Cypress Accessibility FAQ](/accessibility/faq) answers common questions about scoping, scoring, and fixing violations.

--- a/docs/accessibility/guides/introduction.mdx
+++ b/docs/accessibility/guides/introduction.mdx
@@ -43,8 +43,8 @@ Passing automated checks is not the end goal—creating a truly usable, accessib
 
 ## Next Steps
 
-1. [Improve Accessibility](/accessibility/guides/improve-accessibility)
-1. [Maintain Accessibility](/accessibility/guides/maintain-accessibility)
+1. [Fix accessibility violations](/accessibility/guides/improve-accessibility)
+1. [Maintain accessibility](/accessibility/guides/maintain-accessibility)
 1. [Block pull requests and set policies](/accessibility/guides/block-pull-requests)
 1. [Feedback during local development](/accessibility/guides/local-development)
 1. [Work with AI agents](/accessibility/work-with-ai-agents)

--- a/docs/accessibility/guides/maintain-accessibility.mdx
+++ b/docs/accessibility/guides/maintain-accessibility.mdx
@@ -11,7 +11,9 @@ sidebar_position: 30
 
 Accessibility is never a one-time project that can be completed in a certain timeframe and considered done. For an actively developed application, accessibility is a continuous process like all other aspects of quality. This guide explains how to transition from addressing known issues to maintaining long-term accessibility in your projects.
 
-## Switching from "improving" to "maintaining"
+If you still have a backlog of known violations to work through, start with [Fix accessibility violations](/accessibility/guides/improve-accessibility) and come back here once your first rules are passing.
+
+## Switching from "fixing" to "maintaining"
 
 When a specific accessibility rule reaches zero violations for a page, component, or application, you enter _maintenance mode_ for that rule. From this point a few areas are important to focus on:
 

--- a/docs/accessibility/troubleshooting.mdx
+++ b/docs/accessibility/troubleshooting.mdx
@@ -56,7 +56,7 @@ You removed a failing element with [`elementFilters`](/accessibility/configurati
 **Fixes.**
 
 - **Confirm the element was actually removed** using the section above, then look at whether the same rule still fails elsewhere.
-- **Address the underlying violations** rather than filtering, when the elements are part of your application. See [Improve accessibility](/accessibility/guides/improve-accessibility) and [How the accessibility score is calculated](/accessibility/core-concepts/accessibility-score).
+- **Address the underlying violations** rather than filtering, when the elements are part of your application. See [Fix accessibility violations](/accessibility/guides/improve-accessibility) and [How the accessibility score is calculated](/accessibility/core-concepts/accessibility-score).
 
 ## A rule keeps failing and you can't resolve it yet
 


### PR DESCRIPTION
## Summary

Rewrites the Cypress Accessibility "Improve accessibility" guide around the workflow teams actually run, renames it to **Fix accessibility violations** (URL unchanged), and corrects several inaccuracies found by checking each claim against the implementation in `cypress-services`. Also expands the Accessibility FAQ with two new sections and links the guide from the pages that already lead readers toward remediation.

## Why

The guide was the only page answering "I have thousands of findings — what do I do Monday morning?", but it didn't do that job well:

- **It was inaccurate in places.** It cited "WCAG SC 4.2.1" for Name, Role, Value (it's 4.1.2), linked Deque University at axe `4.2` and `4.7` paths when the pinned version is `4.12.1`, and carried an "If you are use Claude" typo.
- **It missed the concepts that trip teams up mid-remediation.** Nothing explained why the score doesn't move when you fix nine of ten failing elements, what to do with Inconclusive results, or how to scope a report before triaging it.
- **A bigger accuracy problem surfaced while verifying.** Our docs said Cypress runs "the full Axe-Core® ruleset." It doesn't. `discovery/packages/accessibility/src/render/accessibility.ts` sets `runOnly` only when a project has an admin-set `axeConfig`, and `ResolvedAppQualityConfig.axeConfig` returns `null` otherwise — so a run gets Axe-Core's *default* set: WCAG 2.0 and 2.1 A and AA plus Best Practices. Axe-Core's own WCAG 2.2, AAA, experimental, and deprecated groups never run unless Cypress enables them. That matters most on exactly the question this page's readers are asking.

## Notes for reviewers

**Verified against the implementation, not from memory.** Each claim was traced in `cypress-services`: the scoring nuance to `discovery/packages/accessibility/src/processing/score.ts` (weights are summed per axe *result* — one rule per snapshot — so a rule counts in full until every failing element is fixed), the MCP tool names and shapes to `packages/cloud-mcp/src/tools/accessibility/`, `data-a11y-ignore` to `AccessibilityPostProcessingContext.ts`, and the default ruleset to the axe-core 4.12.1 `rule-descriptions.md`.

**The rename keeps the URL.** `sidebar_label`, H1, and page title changed; `/accessibility/guides/improve-accessibility` did not, so inbound links keep working. The short sidebar label ("Fix violations") matches the section's convention — 10 of 12 guides already omit "accessibility" from their labels. Referring link text was updated in six places, and the `{#iterating-towards-success}` anchor is preserved.

**Content moved rather than duplicated.** A Results API script and a `profiles` example that had grown on the guide moved to `block-pull-requests.mdx`, where a reader hunting for CI code will look. That page now presents the two rule-level policies as a pair with a chooser table: allowlist known failures (for a report close to clean) versus protect rules you've already fixed (for a large backlog).

**The new FAQ standards section is deliberately claim-free.** It names WCAG, ADA, Section 508, the EAA, and VPAT because people search for those terms, but the search term lives in the *question* and each answer declines the claim — "No automated tool can determine that, and Cypress Accessibility doesn't claim to" — then describes what the product measures and records. Laws are framed as context that exists and commonly references WCAG, with how they apply left explicitly to the reader and their advisors. I ran a claim-language audit across the accessibility docs; the only pre-existing matches are disclaimers, so nothing contradicts this.

**Two follow-ups intentionally left out**, both on cypress.io rather than in this repo:

1. `cypress.io/accessibility/compliance` states Cypress "runs WCAG 2.1 AA checks by default (configurable up to WCAG 2.2 AAA)." Per the above that's wrong in both directions — Best Practices rules also run and aren't WCAG success criteria, while three WCAG-tagged rules (`color-contrast`, `no-autoplay-audio`, `meta-refresh`) are off — and "configurable" implies self-serve when `axeConfig` is admin-only and stripped from the Results API response. Suggested replacement: *"Runs Deque's Axe-Core® ruleset — WCAG 2.0 and 2.1 Level A and AA plus best-practice checks — with WCAG 2.2 and AAA available on request."* Worth confirming against live page copy first.
2. An outbound link from the docs to that compliance page. It's a reasonable addition once the copy above is corrected, but linking a carefully-hedged FAQ answer into copy that contradicts it would undercut both.

**Verification:** `npm run build` passes with `onBrokenLinks: 'throw'` and `onBrokenAnchors: 'throw'`, so every internal link and anchor resolves — including one FAQ anchor a rename changed, whose referring link in `elementfilters.mdx` was updated. Prettier clean. The FAQ's `FAQPage` structured data emits 56 questions (up from 44), and the `CopyPrompt` card renders in the built HTML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UfPe5Yyj7SJjvgdq2x3BuU

---
_Generated by [Claude Code](https://claude.ai/code/session_01UfPe5Yyj7SJjvgdq2x3BuU)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or API impact; main risk is editorial accuracy of product behavior claims, which the PR author says were verified against implementation.
> 
> **Overview**
> **Fix accessibility violations** replaces the old “Improve accessibility” guide (same URL) with a practical backlog workflow: agree scope, narrow with `viewFilters`/`elementFilters`, pick a first rule, explain score behavior (per-rule-per-snapshot), verify in Branch Review, use Cloud MCP, and lock remediated rules via the Results API. It also fixes WCAG **4.1.2** (was 4.2.1), Deque links to axe **4.12**, and adds a `CopyPrompt` for agent-driven remediation.
> 
> **Axe configuration and FAQ** no longer say Cypress runs the “full” Axe ruleset. New **What the default ruleset covers** documents WCAG 2.0/2.1 A+AA, Best Practices, three Cypress-disabled rules, and that WCAG 2.2/AAA need Cypress enablement. The FAQ gains **Fixing violations** and **Accessibility standards** (WCAG/ADA/VPAT/100% score hedges) and retitles several headings for clarity.
> 
> **Block pull requests** now pairs allowlist vs “protect remediated rules” policies (with scripts), adds a `viewFilters` PR profile example, and notes profiles cannot change which Axe rules run.
> 
> Smaller edits: cross-links on setup, score, maintain, troubleshooting, and compare-reports; one FAQ anchor fix in `elementfilters.mdx`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fa02dafaf61db9e7c8e0c9c8b6cc91e739ad437. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->