### PR TITLE
docs: rewrite the Cypress Accessibility local development guide

### DIFF
--- a/docs/accessibility/faq.mdx
+++ b/docs/accessibility/faq.mdx
@@ -39,6 +39,44 @@ Configure [Cypress Cloud MCP](/cloud/integrations/cloud-mcp) so your agent can r
 
 Keep a list of remediated rules in your CI verification script and fail the build when any of them appear in a run's results, using the [Results API](/accessibility/results-api). This inverts the more common pattern of allowlisting known failures: instead of tracking what's still broken, you lock in each rule the day it reaches zero violations. Add a rule to the list as soon as it passes, and the list becomes a record of the barriers your application no longer has.
 
+## Local development
+
+### <Icon name="angle-right" /> Can I get Cypress Accessibility results without waiting for CI?
+
+Yes. Record the specs you're working on from your own machine with `cypress run --record --spec "cypress/e2e/checkout.cy.js"`. Cypress Accessibility is generated in Cypress Cloud from the run's [Test Replay](/cloud/features/test-replay) data, so a run recorded from your laptop is processed exactly like a CI run: same App Quality Config, same Axe Core® version, same element identification. Limiting the run with `--spec` keeps the report to the code you changed and shortens the feedback loop to a couple of minutes. See [Local development](/accessibility/guides/local-development).
+
+### <Icon name="angle-right" /> Does cypress open produce a Cypress Accessibility report?
+
+No. Interactive mode never records a run to Cypress Cloud, and reports are only generated for recorded runs. Use `cypress run --record` to get accessibility results from your machine.
+
+### <Icon name="angle-right" /> Which browser should I use to record a local run for Cypress Accessibility?
+
+Chrome, Edge, Chromium, or Electron. Reports are built from [Test Replay](/cloud/features/test-replay) data, which is only captured in Chromium-based browsers, so a run recorded with `--browser firefox` or `--browser webkit` produces no accessibility report. `cypress run` defaults to Electron, which is supported, so you get a report without passing `--browser` at all. See [No accessibility report was generated for a run](/accessibility/troubleshooting#No-accessibility-report-was-generated-for-a-run) for the other requirements.
+
+### <Icon name="angle-right" /> How do I check an accessibility fix before I push my branch?
+
+Record the same specs twice and compare them in [Branch Review](/accessibility/guides/compare-reports): once from your base branch before you start (or with your changes stashed), then again from your branch after the fix. Set your branch's run as the Changed run and the base branch's run as the Base run. **Resolved elements** confirms the rule you fixed cleared everywhere it was failing, and **New failed elements** catches the violation the fix introduced. Recording the same specs in both runs is what makes the comparison meaningful. See [Local development](/accessibility/guides/local-development).
+
+### <Icon name="angle-right" /> Can I use the Cypress Accessibility Results API on my local machine?
+
+No. `getAccessibilityResults()` identifies which run to report on from the CI environment variables present when the run was recorded, so running it outside CI fails with "It appears you are not running in CI." The Results API is for enforcing a policy in your pipeline. For local feedback, read the report in Cypress Cloud, compare runs in Branch Review, or query results through [Cypress Cloud MCP](/cloud/integrations/cloud-mcp).
+
+### <Icon name="angle-right" /> Is my Cypress Accessibility score from a local run comparable to my CI score?
+
+No, and it isn't meant to be. A run's [accessibility score](/accessibility/core-concepts/accessibility-score) averages every snapshot in that run, so a two-spec local run and a full CI suite have different denominators. Compare rules and failed element counts between two local runs of the same specs, and track the score on your full suite.
+
+### <Icon name="angle-right" /> Why does my local Cypress Accessibility report include pages my CI report excludes?
+
+Your [`viewFilters`](/accessibility/configuration/viewfilters) patterns most likely name a deployed hostname, and hostnames must match exactly, so a rule for `https://app.example.com/*` never matches `http://localhost:3000`. Write path-only patterns like `/auth/*`, which match any protocol, hostname, and port, or add a [`profiles`](/accessibility/configuration/profiles) entry for local runs and tag them with `--tag`. See [Make your configuration match localhost](/accessibility/guides/local-development#Make-your-configuration-match-localhost).
+
+### <Icon name="angle-right" /> Why is my Cypress Accessibility report not ready as soon as the run finishes?
+
+Each spec's data starts processing as it uploads, but the run-level report is assembled only after Cypress Cloud marks the run complete. For grouped and parallelized runs, completion waits out the project's [Run Completion Delay](/cloud/features/smart-orchestration/parallelization#Run-Completion-Delay), a grace period of 60 seconds by default that lets late machines join, and report finalization waits with it. A single run recorded without `--group` or `--parallel` skips that delay and completes as soon as its specs are done, which is why local runs turn around quickly. To speed up a grouped run, shorten the delay in [project settings](/cloud/account-management/projects#Run-Completion-Delay) or close the run with the [Run Completion API](/cloud/features/smart-orchestration/parallelization#Run-Completion-API).
+
+### <Icon name="angle-right" /> How do I keep local runs from cluttering my Cypress Cloud project?
+
+Tag them with `cypress run --record --tag "local"`. Tags appear on the run and are filterable in Cypress Cloud, so everyone can skip past them in the run list. A separate Cypress Cloud project for local runs is possible but costs you the comparison workflow, since Branch Review compares runs within one project and App Quality Config is per project. Note that every recorded run consumes [test results](/cloud/account-management/billing-and-usage#Cloud-test-results) from your plan regardless of where it ran, which is another reason to keep local runs scoped with `--spec`.
+
 ## Ignoring elements
 
 ### <Icon name="angle-right" /> How do I exclude elements from Cypress Accessibility?

--- a/docs/accessibility/guides/detect-changes.mdx
+++ b/docs/accessibility/guides/detect-changes.mdx
@@ -37,13 +37,7 @@ See the main [Accessibility Branch Review docs](/accessibility/guides/compare-re
 
 #### Compare reports during local development (without waiting for CI)
 
-You might expect that every Cypress Accessibility report requires a full standard Cypress test run in your Continuous Integration (CI) pipeline.
-
-A common accessibility workflow is to [create small Cypress Cloud recordings from your local development environment](/accessibility/guides/local-development) to preview the effects of any code changes. This allows for fast analysis of just a single test or two, or as much as you need to have confidence your changes are working -- especially if you are actively remediating accessibility issues.
-
-To get a high-quality comparison for a small set of tests, record the tests locally from your main branch, and then on the branch with changes. In Cypress Cloud, you will be able to compare these two runs knowing they cover exactly the same scope.
-
-This completely sidesteps the usual "push, build, run tests, report" cycle you might be used to, and is great when you need fast feedback.
+Branch Review doesn't require CI runs. Recording a spec or two from your own machine on your base branch and again on your branch gives you the same comparison over a scope you control, which is the fastest way to confirm a fix while you're actively remediating. See [Accessibility feedback during local development](/accessibility/guides/local-development).
 
 #### See what's changing between scheduled runs
 

--- a/docs/accessibility/guides/introduction.mdx
+++ b/docs/accessibility/guides/introduction.mdx
@@ -46,7 +46,7 @@ Passing automated checks is not the end goal—creating a truly usable, accessib
 1. [Fix accessibility violations](/accessibility/guides/improve-accessibility)
 1. [Maintain accessibility](/accessibility/guides/maintain-accessibility)
 1. [Block pull requests and set policies](/accessibility/guides/block-pull-requests)
-1. [Feedback during local development](/accessibility/guides/local-development)
+1. [Accessibility feedback during local development](/accessibility/guides/local-development)
 1. [Work with AI agents](/accessibility/work-with-ai-agents)
 1. [Production monitoring](/accessibility/guides/production-monitoring)
 1. [Detect and manage changes](/accessibility/guides/detect-changes)

--- a/docs/accessibility/guides/local-development.mdx
+++ b/docs/accessibility/guides/local-development.mdx
@@ -1,65 +1,153 @@
 ---
-title: 'Feedback during local development'
-description: 'Get precise, fast, and scoped accessibility feedback during local development by recording Cypress tests directly to Cypress Cloud—bypassing CI pipelines and ensuring accurate insights with minimal effort.'
-sidebar_label: Feedback during local development
+title: 'Accessibility feedback during local development'
+description: 'Record one spec from your machine to get a full Cypress Accessibility report without waiting for CI: confirm a fix, catch the violation it introduced, and compare against your base branch before you push.'
+sidebar_label: Local development
 sidebar_position: 40
 ---
 
 <ProductHeading product="accessibility" />
 
-# Feedback during local development
+# Accessibility feedback during local development
 
-For reliable accessibility feedback during local development, the best approach is recording your tests directly to Cypress Cloud. By running tests related to your changes locally, you can bypass build pipelines and CI processes entirely. This can be achieved with a single command:
+Accessibility fixes are easy to get subtly wrong. An `aria-label` added to a button can override the visible text a speech-recognition user says out loud. Correcting one heading level can break the outline further down the page. Reordering a form to fix focus order can strip a label off the field below it. In each case the rule you were working on starts passing and a different one starts failing, and you don't find out until the next CI run.
 
-<Tabs>
-  <TabItem value="npm">
+Recording a spec from your own machine closes that gap. One command produces the same Cypress Accessibility report your CI runs produce, processed in Cypress Cloud with the same App Quality Config and the same Axe Core® version. You can confirm a fix, spot the violation the fix introduced, and iterate before you write the commit message.
 
-```shell
-npx cypress run --key <record_key> --record --spec "cypress/e2e/my-spec.cy.js"
-```
+## Record the specs you're working on
 
-  </TabItem>
-  <TabItem value="yarn">
+Record only the specs that exercise the code you changed:
 
-```shell
-yarn cypress run --key <record_key> --record --spec "cypress/e2e/my-spec.cy.js"
-```
+<CypressCommandTabs command='run --record --key <record_key> --spec "cypress/e2e/checkout.cy.js"' />
 
-  </TabItem>
-  <TabItem value="pnpm">
+Recording is what produces the report, so this has to be `cypress run --record`. Interactive mode (`cypress open`) never records a run to Cypress Cloud, so it never generates accessibility results.
+
+When the run finishes, Cypress prints its URL at the end of the run summary:
 
 ```shell
-pnpm cypress run --key <record_key> --record --spec "cypress/e2e/my-spec.cy.js"
+  ────────────────────────────────────────────────────────────────────────────────
+
+  Recorded Run: https://cloud.cypress.io/projects/7s5okt/runs/1042
 ```
 
-  </TabItem>
-  <TabItem value="bun">
+Open that URL and go to the **Accessibility** tab.
 
-```shell
-bunx cypress run --key <record_key> --record --spec "cypress/e2e/my-spec.cy.js"
+<RecordKeyEnvVar />
+
+Nothing else is required.
+
+The requirements are the same as for any recorded run, with one that catches people locally: reports need a Chromium-based or Electron browser, so a habit of running `--browser firefox` locally produces no report at all. See [No accessibility report was generated for a run](/accessibility/troubleshooting#No-accessibility-report-was-generated-for-a-run) for the full list.
+
+To stay in your editor for the whole loop rather than switching to the browser after each recording, configure [Cypress Cloud MCP](/cloud/integrations/cloud-mcp) and ask your agent for the run's results. See [Work with AI agents](/accessibility/work-with-ai-agents) for prompt patterns.
+
+## When the report is ready
+
+Each spec's data starts processing as soon as that spec finishes uploading, but the run-level report is assembled only once Cypress Cloud marks the run **complete**.
+
+For grouped and parallelized runs, completion waits out the project's [Run Completion Delay](/cloud/features/smart-orchestration/parallelization#Run-Completion-Delay), a grace period (60 seconds by default) that lets late machines join the run before it closes. Report finalization waits with it, so on a CI run the accessibility report can trail the last machine by that much.
+
+A single local run without `--group` or `--parallel` skips the delay entirely. Cypress Cloud completes it as soon as its specs are done, which is why the loop on this page stays fast. You inherit the delay only when you reproduce a CI invocation locally with grouping or parallelization. If you do, shorten the delay in [project settings](/cloud/account-management/projects#Run-Completion-Delay) or close the run yourself with the [Run Completion API](/cloud/features/smart-orchestration/parallelization#Run-Completion-API).
+
+## Compare two local runs to prove a fix landed
+
+Seeing zero violations for the rule you fixed is weaker evidence than seeing that rule move from failing to resolved. [Branch Review](/accessibility/guides/compare-reports) gives you that, and it works just as well with two runs recorded from your own machine. Cypress reads your branch and commit from your local `.git` directory on every recorded run, whether or not it detects a CI provider, so local runs land on the correct branch and can be compared like any other run.
+
+1. Record the specs from your base branch first, before you start work, or by stashing your changes:
+
+   <CypressCommandTabs command='run --record --spec "cypress/e2e/checkout.cy.js"' />
+
+1. Make your fix, then record the same specs again from your branch.
+
+1. In Cypress Cloud, open Branch Review with your branch's run as the Changed run and the base branch's run as the Base run.
+
+   <DocsImage
+     src="/img/cloud/features/branch-review/branch-review-header.png"
+     alt="The Branch Review header in Cypress Cloud, showing the base and feature branch labels with the Cypress Cloud run number selected for each side of the comparison"
+   />
+
+The **Resolved elements** section should list the rule you worked on in every view where it was failing, which is how you confirm the fix reached more than the one element you tested by hand. The **New failed elements** section is the more valuable half: it's where the `aria-label` that duplicates visible text shows up.
+
+Recording the **same specs** in both runs is what makes the comparison trustworthy. Branch Review compares what each run actually saw, so a base run covering the whole suite and a changed run covering one spec produces a long list of "resolved" elements that only means those pages weren't visited.
+
+:::caution
+
+The score for a two-spec local run isn't comparable to the score for a full CI run. A run's [accessibility score](/accessibility/core-concepts/accessibility-score) averages every snapshot in that run, so changing which specs ran changes the denominator. Compare rules and element counts between local runs, and leave score tracking to your full suite.
+
+:::
+
+## Make your configuration match localhost
+
+The one thing that may differ between a local run and a CI run is the URL your tests visit. [`viewFilters`](/accessibility/configuration/viewfilters) patterns that name a hostname match that hostname exactly, so a configuration written for a deployed environment silently stops applying when you run against `http://localhost:3000`. Pages you meant to exclude reappear, and the local report stops matching the one your team sees in CI.
+
+Path-only patterns match any hostname, so they work in both places:
+
+```json title="App Quality Config"
+{
+  "viewFilters": [
+    {
+      "pattern": "/auth/*",
+      "include": false,
+      "comment": "Hosted sign-in provider, out of scope. Path-only so it matches localhost and deployed environments alike"
+    }
+  ]
+}
 ```
 
-  </TabItem>
-</Tabs>
+When a rule has to name a hostname, add a [profile](/accessibility/configuration/profiles) for local runs and override just that setting:
 
-(You can skip the `--key` option by setting `CYPRESS_RECORD_KEY` as an environment variable. Learn more about recording in our [Recorded Runs documentation](/cloud/features/recorded-runs)).
+```json title="App Quality Config"
+{
+  "viewFilters": [
+    { "pattern": "https://app.example.com/*", "include": true },
+    {
+      "pattern": "*",
+      "include": false,
+      "comment": "Report only on our own application"
+    }
+  ],
+  "profiles": [
+    {
+      "name": "aq-config-local",
+      "comment": "Local runs serve the app from localhost, so the hostname rules above never match",
+      "config": {
+        "viewFilters": [
+          { "pattern": "http://localhost:*/*", "include": true },
+          { "pattern": "*", "include": false }
+        ]
+      }
+    }
+  ]
+}
+```
 
-## Key benefits
+Select the profile by tagging the run:
 
-- **Accuracy:** See how Cypress processes your new code changes, taking into account your project's configuration, and using the Cloud's version of Axe Core®. There will be no violation reports for rules, pages, or elements your team has chosen to ignore, for example.
-- **Speed:** With the application already built locally, tests can run immediately without requiring your build pipeline.
-- **Scope:** Execute only the tests you need to focus on your changes, ensuring faster results and excluding unrelated issues.
+<CypressCommandTabs command='run --record --tag "aq-config-local" --spec "cypress/e2e/checkout.cy.js"' />
 
-Recording tests locally offers early feedback, helping you quickly detect if resolving one accessibility issue introduces another. This targeted testing workflow can significantly enhance development efficiency and quality.
+A profile replaces each setting it defines rather than merging with it, so repeat any base rules the local run still needs. See [`profiles`](/accessibility/configuration/profiles) for how selection and overriding work.
 
-## Organizing Local Runs
+## Keep local runs from cluttering the project
 
-If your team frequently records local runs and you're concerned about cluttering your Cypress Cloud project, consider setting up a dedicated Cloud project for "local runs". This keeps your main project organized while supporting local testing workflows.
+Local runs land in the same project as your CI runs, and their reports are just as real. To keep them recognizable, tag them:
 
-## Querying local run results with Cloud MCP
+<CypressCommandTabs command='run --record --tag "local" --spec "cypress/e2e/checkout.cy.js"' />
 
-If you have [Cloud MCP](/cloud/integrations/cloud-mcp) configured, you can ask your AI agent to summarize the accessibility results from your local run without switching to the browser:
+Tags are shown on the run and are filterable in Cypress Cloud, so a shared `local` tag lets anyone skip past them when scanning the run list.
 
-> "Pull the accessibility report from Cypress Cloud for my latest local run and summarize any critical or serious violations."
+Every recorded run also consumes [test results](/cloud/account-management/billing-and-usage#Cloud-test-results) from your plan, whether it came from CI or your laptop. That's an argument for narrow `--spec` runs, which you want anyway.
 
-This keeps the feedback loop inside your editor while you're actively making changes.
+## What a local run can't do
+
+The [Results API](/accessibility/results-api) is a CI tool and doesn't have a local equivalent. `getAccessibilityResults()` identifies the run to report on from the CI environment variables present when the run was recorded, so calling it from your machine fails with "It appears you are not running in CI." Keep policy enforcement in your pipeline and use Cypress Cloud, Branch Review, or Cloud MCP for local feedback.
+
+## See also
+
+- [Compare reports](/accessibility/guides/compare-reports) is the full guide to Branch Review for Cypress Accessibility.
+- [Detect and manage changes](/accessibility/guides/detect-changes) covers the other ways to catch a regression, including scheduled runs and analytics.
+- [Fix accessibility violations](/accessibility/guides/improve-accessibility) is the workflow this page speeds up: pick a rule, fix it, prove it landed.
+- [How Cypress Accessibility works](/accessibility/core-concepts/how-it-works) explains the recording, processing, and reporting stages.
+- [`profiles`](/accessibility/configuration/profiles) documents run-tag-based configuration overrides in full.
+- [`viewFilters`](/accessibility/configuration/viewfilters) covers URL pattern matching, including path-only patterns.
+- [Work with AI agents](/accessibility/work-with-ai-agents) has more Cypress Cloud MCP prompt patterns.
+- [Block pull requests and set policies](/accessibility/guides/block-pull-requests) is where the Results API belongs, once local feedback is in place.
+- [Troubleshooting](/accessibility/troubleshooting) covers reports that are missing or don't match what you expect.
+- [Cypress Accessibility FAQ](/accessibility/faq) answers focused questions about local runs, scoring, and configuration.

--- a/docs/accessibility/troubleshooting.mdx
+++ b/docs/accessibility/troubleshooting.mdx
@@ -17,9 +17,25 @@ This page maps each symptom to its cause and the configuration that resolves it.
 
 Every run is processed with the configuration that was saved **at that moment**, so edits you make afterward don't change an existing report until you reprocess it. This timing is the single most common reason a rule "doesn't work."
 
-After saving configuration in the **App Quality** tab of your project settings, open a run's **Properties** tab and use its "regenerate" button. The configuration that was used for that run is displayed there, so you can confirm what was applied. Every fix on this page assumes you regenerate the run after changing configuration. See [Setting configuration](/accessibility/configuration/overview#Setting-Configuration).
+After saving configuration in the **App Quality** tab of your project settings, open a run's **Properties** tab and use its "regenerate" button. The configuration that was used for that run is displayed there, so you can confirm what was applied. Every configuration fix on this page assumes you regenerate the run afterward. See [Setting configuration](/accessibility/configuration/overview#Setting-Configuration).
 
 :::
+
+## No accessibility report was generated for a run
+
+The run recorded to Cypress Cloud, but its **Accessibility** tab is empty or absent.
+
+**Cause.** Reports are built in Cypress Cloud from the run's [Test Replay](/cloud/features/test-replay) data. When that data wasn't captured or wasn't uploaded, there is nothing to scan, so no report is produced. This is a different problem from a report that looks wrong, and none of the configuration fixes on this page apply to it.
+
+**Fixes.** A recorded run produces an accessibility report when all of the following are true:
+
+- **Cypress Accessibility is enabled for the project.** It's a paid premium solution, so a project on a plan without it records normally and produces no accessibility report.
+- **The run was recorded** with `cypress run --record` and a valid record key, against a project with a `projectId`. Interactive mode (`cypress open`) never records a run, so it never generates results.
+- **Cypress v13 or later** was used. Test Replay was introduced in Cypress 13.
+- **Test Replay is enabled** in the project's settings in Cypress Cloud. A run recorded while it's turned off uploads no data to process.
+- **The browser was Chromium-based or Electron.** Chrome, Edge, Chromium, and Electron capture Test Replay data. Firefox and WebKit do not, so `--browser firefox` and `--browser webkit` runs produce no accessibility report. `cypress run` defaults to Electron, which is supported.
+
+When a report exists but is missing specific specs, check the terminal output from the run. Cypress prints the Test Replay upload status for every spec, and a spec that reports "Nothing to upload" or a capture failure contributes nothing to the accessibility report.
 
 ## An element you excluded still appears in the report
 


### PR DESCRIPTION
## Summary

Rewrites the Cypress Accessibility "Feedback during local development" guide so it accurately describes what a locally recorded run does and doesn't produce, moves the universal "why is there no report at all" requirements to the troubleshooting page where they serve every reader, and adds a "Local development" section to the Accessibility FAQ.

## Why

The page was built around one command and three benefit bullets. Several things it implied were wrong, and several things a developer needs were missing entirely. I checked each claim against the recording service, the capture-protocol gating, and the accessibility processing pipeline rather than against the existing docs.

**Corrections**

- **Requirements were undocumented.** A report needs Cypress Accessibility enabled on the project, Cypress v13+, Test Replay enabled in project settings, `--record`, and a Chromium-based or Electron browser. Firefox and WebKit capture no Test Replay data, so `--browser firefox` produces no report at all: a silent failure that is far more likely locally than in CI, where the browser is pinned.
- **`cypress open` never records**, so it never produces a report. This is the first thing a reader is likely to try.
- **Report timing.** Each spec's data is processed as it uploads, but the run-level report is assembled only after Cypress Cloud marks the run complete. Grouped and parallelized runs wait out the project's [Run Completion Delay](https://docs.cypress.io/cloud/features/smart-orchestration/parallelization#Run-Completion-Delay) and their reports trail with it; a single local run without `--group` or `--parallel` skips the delay and completes as soon as its specs are done.
- **The Results API does not work locally.** `getAccessibilityResults()` resolves the run from CI environment variables and fails outside CI with "It appears you are not running in CI." The page previously implied local runs were a full substitute for the CI loop.
- **`viewFilters` hostname patterns don't match `localhost`.** Hostnames match exactly, so a filter written for a deployed environment silently stops applying when you run against `http://localhost:3000` and the local report diverges from the CI one. This was documented nowhere. Added path-only and profile-based fixes.
- **A local run's score isn't comparable to a full suite's score**, since the run score averages every snapshot in that run.
- **The separate-Cloud-project recommendation was misleading.** Branch Review compares runs within one project and App Quality Config is per project, so a separate project costs you the comparison that makes local runs worth recording. Replaced with run tags.
- Branch and commit metadata is read from local git on every recorded run, with or without a CI provider, so local runs land on the right branch and can be compared in Branch Review.

**Structure**

- Leads with the problem (an accessibility fix commonly introduces a new violation) instead of a command.
- Retitled for search; sidebar label shortened to "Local development". URL unchanged, in-repo links updated.
- Replaced the hand-written npm/Yarn/pnpm/Bun tab block with `<CypressCommandTabs>` and reused the `<RecordKeyEnvVar />` partial, per the repo conventions in `AGENTS.md`.
- Both config examples are titled `App Quality Config`.
- Added a terminal preview of the recorded run URL and the Branch Review header screenshot.
- Added a `## See also` section.

**Moved rather than duplicated**

- The requirements list went to `troubleshooting.mdx` as a new first section, "No accessibility report was generated for a run". That question had no home: the page covered reports that look wrong, never reports that are missing. Also softened that page's regenerate tip, which claimed every fix on the page is a configuration fix.
- `detect-changes.mdx` had a six-paragraph "Compare reports during local development" subsection making the same pitch as this page. Cut to a cross-reference.

**FAQ**

Nine question-form entries under a new "Local development" heading: getting results without CI, `cypress open`, browser support, verifying a fix before pushing, the Results API locally, score comparability, report timing, localhost view filters, and keeping local runs organized.

## Notes for reviewers

- **The Run Completion Delay does not apply to a plain local run**, which is the opposite of what you might expect. `shouldCompleteImmediately` is set when a run is not parallelized, not grouped, and carries the synthetic `_ha_without-ci-build-id-…` build id, and the completion delay is then `0`. Since Cypress rejects `--ci-build-id` without `--parallel`/`--group`, a plain `cypress run --record --spec …` always lands in that case. The guide says grouped and parallelized runs inherit the delay and a single local run doesn't. This is consistent with the parallelization guide, which already notes a long delay "can slow down notifications and delay the finalization of UI Coverage and Cypress Accessibility reports."
- **Screenshot choice.** I used `/img/cloud/features/branch-review/branch-review-header.png` because the step is about selecting the Base and Changed runs and that image shows both branch labels with run numbers. The four accessibility-specific Branch Review images are all already used on `compare-reports.mdx`, and `branch-review-a11y-resolved-elements.png` also appears on `improve-accessibility.mdx`.
- **Scope judgment.** An earlier draft of this page was about a third longer. I cut a "Why the local report matches your CI report" section and trimmed the Cloud MCP section to a sentence and a link, since it restated `work-with-ai-agents`. Everything remaining is something a reader can only learn on this page. If you'd rather this page not exist at all, the alternative is folding the four genuinely local-only items into `detect-changes.mdx` with a 301; I kept it because "test accessibility locally" and "Cypress Accessibility without CI" are real search intents that want a page with that title.
- **Verification.** `npm run build` passes, which is the meaningful check here since `onBrokenLinks` and `onBrokenMarkdownLinks` are `throw`, so every new cross-page anchor resolves. Prettier is clean.
- No changelog entry: this documents existing behavior and ships with no Cypress release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012QUeKEpHXsi6Q5nG7Ra8xW


---
_Generated by [Claude Code](https://claude.ai/code/session_012QUeKEpHXsi6Q5nG7Ra8xW)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no application or API behavior; link and anchor updates are covered by the docs build.
> 
> **Overview**
> **Rewrites** the Cypress Accessibility local development guide from a short command-centric page into a full workflow: `cypress run --record` with scoped `--spec`, report timing (including when Run Completion Delay applies), Branch Review on two local runs, localhost `viewFilters` / profiles, run tagging, and explicit limits (no `cypress open`, Chromium/Electron only, Results API not available locally).
> 
> **Adds** troubleshooting section **No accessibility report was generated for a run** (product enabled, record mode, Cypress 13+, Test Replay, browser requirements) and a **Local development** FAQ with nine Q&As that mirror those topics.
> 
> **Trims** duplicate local-dev copy in `detect-changes.mdx` to a cross-link; **renames** the guide title/sidebar to “Accessibility feedback during local development” / “Local development” and updates the introduction next-steps link.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25063c1ccebeabfca0565e359f6a05a74814d8b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->