### PR TITLE
docs: fix cypress tap troubleshooting to drop previousStartedAt

### DIFF
--- a/docs/app/tooling/cypress-tap.mdx
+++ b/docs/app/tooling/cypress-tap.mdx
@@ -1048,10 +1048,10 @@ Together these tools provide the availability for you or an AI agent to fully en
   it stays `loading` indefinitely and the build error appears only in the
   Cypress app. Give any poll loop a timeout and check the app when it expires.
 
-- **A verdict looks wrong, or arrives too fast.** Compare `startedAt` against
-  the `previousStartedAt` that `run` returned. A rerun leaves the previous run's
-  verdict readable until the new one starts, and both payloads are otherwise
-  identical.
+- **A verdict looks wrong, or arrives too fast.** Read `status` before you rerun
+  and keep its `startedAt`, then wait for a verdict whose `startedAt` differs. A
+  rerun leaves the previous run's verdict readable until the new one starts, and
+  both payloads are otherwise identical.
 
 - **`passed` with nothing having run.** `passed` means the run finished with no
   failures, so an empty spec, or one whose tests were all skipped, reports


### PR DESCRIPTION
## Summary

The Troubleshooting section of the `cypress tap` page told readers to compare `status.startedAt` against a `previousStartedAt` returned by `cypress tap run`. That field does not exist. This reworks the bullet to describe the mechanism the CLI actually implements: keep the `startedAt` from `status` before rerunning, then wait for a verdict whose `startedAt` differs.

## Why

Closes #6830

The reporter found this while following the page as an agent would: with nothing to compare against, a poll loop stalls at the polling step. Confirmed against the `cypress` source rather than only the shipped binary:

- `cli/lib/tap/commands/run.ts` — `TapRunResult` is exactly `{ spec, testingType, browser }`.
- `previousStartedAt` has zero occurrences anywhere in the monorepo, so the field was never implemented rather than removed.
- `packages/cypress-sessions/lib/tap-contract.ts` — the `run` command's help text already spells out the real mechanism: "Read status first and keep its startedAt: a verdict still carrying that same startedAt describes the spec before this one, so wait for a verdict whose startedAt differs."

The page also contradicted itself — three other passages (the `status --json` description, the polling checklist, and the agent-instructions snippet) already describe the correct approach and name no second field. This aligns the outlier with them.

## Notes for reviewers

The new wording is deliberately close to the CLI's own help text so the docs and `--help` stay in agreement.

One nearby nit left untouched to keep the diff to the reported bug: the checklist bullet further up the page writes `startedAt` bare rather than in backticks in one spot. Happy to fold that in if you'd rather it ride along.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GeaDs1rWvuZVymGqevG5hF)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or API impact.
> 
> **Overview**
> Fixes the **Troubleshooting** bullet for misleading verdicts on the `cypress tap` page. It no longer tells readers to compare `status.startedAt` to a nonexistent `previousStartedAt` from `cypress tap run`.
> 
> The updated text matches the real workflow already documented elsewhere on the page: read **`status`** before rerunning, save **`startedAt`**, then treat a **`passed`/`failed`** only as yours when **`startedAt`** has changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d39727e8f9af8d952ac3a034ecd6e6f802ec64e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->