### PR TITLE
fix: list cypress-docs in the agent-skills index, repair code blocks in the LLM corpus

### DIFF
--- a/plugins/llm/src/MarkdownExporter.ts
+++ b/plugins/llm/src/MarkdownExporter.ts
@@ -6,6 +6,98 @@ import TurndownService from 'turndown'
 import { gfm } from 'turndown-plugin-gfm'
 import { normalizeHtml } from './html-normalize'
 
+const TEXT_NODE = 3
+const ELEMENT_NODE = 1
+
+// Tags that end the line they are on when they close.
+const LINE_BREAKING_TAGS = new Set(['DIV', 'P'])
+
+/**
+ * Reads the source text out of a `<code>` element, preserving its line breaks.
+ *
+ * `textContent` cannot be used here: Docusaurus renders each line of a code block as its own
+ * `<div class="token-line">` ending in a `<br>`, and `textContent` reports neither, so every line
+ * of a multi-line example runs together into a single unusable line. Walking the node lets us turn
+ * those element boundaries back into the newlines they stand for.
+ */
+export function readCodeText(node: Node | null | undefined): string {
+  if (!node) return ''
+
+  let text = ''
+
+  for (const child of Array.from(node.childNodes ?? [])) {
+    if (child.nodeType === TEXT_NODE) {
+      text += child.nodeValue ?? ''
+      continue
+    }
+
+    if (child.nodeType !== ELEMENT_NODE) continue
+
+    const tagName = child.nodeName.toUpperCase()
+
+    if (tagName === 'BR') {
+      text += '\n'
+      continue
+    }
+
+    text += readCodeText(child)
+
+    // A line already terminated by its own <br> must not gain a second newline
+    // from the element that wraps it.
+    if (LINE_BREAKING_TAGS.has(tagName) && !text.endsWith('\n')) {
+      text += '\n'
+    }
+  }
+
+  return text
+}
+
+/**
+ * Builds the HTML-to-markdown converter used for the LLM corpus.
+ *
+ * Exported so the conversion rules can be exercised directly in tests.
+ */
+export function createMarkdownProcessor(): TurndownService {
+  const markdownProcessor = new TurndownService({
+    headingStyle: 'atx',
+    codeBlockStyle: 'fenced',
+    fence: '```',
+    emDelimiter: '_',
+  })
+
+  markdownProcessor.use(gfm)
+  markdownProcessor.addRule('fencedCodeBlocks', {
+    filter: (node) =>
+      node.nodeName === 'PRE' &&
+      !!node.querySelector('code'),
+
+    replacement: (content, node) => {
+      const codeNode = node.querySelector('code');
+      const className = codeNode?.className || '';
+
+      const languageMatch = className.match(/language-(\w+)/);
+      const language = languageMatch ? languageMatch[1] : '';
+
+      const code = readCodeText(codeNode)
+        .replace(/\n+$/, '') // trim trailing newlines
+        .replace(/^\n+/, '');
+
+      // A fence has to be longer than the longest run of backticks inside it. Several
+      // pages show fenced markdown as a code sample, and a three-backtick fence around
+      // one of those closes the block early — silently dropping the rest of the page.
+      const longestBacktickRun = Math.max(
+        0,
+        ...(code.match(/`+/g) ?? []).map((run) => run.length)
+      );
+      const fence = '`'.repeat(Math.max(3, longestBacktickRun + 1));
+
+      return `\n\n${fence}${language}\n${code}\n${fence}\n\n`;
+    }
+  });
+
+  return markdownProcessor
+}
+
 export class MarkdownExporter {
   private readonly markdownRoot: string
   private readonly markdownProcessor: TurndownService
@@ -15,32 +107,7 @@ export class MarkdownExporter {
     private readonly exportRoot: string,
   ) {
     this.markdownRoot = path.join(exportRoot, 'markdown')
-    this.markdownProcessor = new TurndownService({
-      headingStyle: 'atx',
-      codeBlockStyle: 'fenced',
-      fence: '```',
-      emDelimiter: '_',
-    })
-    this.markdownProcessor.use(gfm)
-    this.markdownProcessor.addRule('fencedCodeBlocks', {
-      filter: (node) =>
-        node.nodeName === 'PRE' &&
-        !!node.querySelector('code'),
-    
-      replacement: (content, node) => {
-        const codeNode = node.querySelector('code');
-        const className = codeNode?.className || '';
-        
-        const languageMatch = className.match(/language-(\w+)/);
-        const language = languageMatch ? languageMatch[1] : '';
-    
-        const code = (codeNode?.textContent || '')
-          .replace(/\n+$/, '') // trim trailing newlines
-          .replace(/^\n+/, '');
-    
-        return `\n\n\`\`\`${language}\n${code}\n\`\`\`\n\n`;
-      }
-    });
+    this.markdownProcessor = createMarkdownProcessor()
   }
 
   exportFile(params: {

--- a/plugins/llm/src/skills.ts
+++ b/plugins/llm/src/skills.ts
@@ -23,6 +23,13 @@ export function writeSkillsIndex(distRoot: string) {
         'Explains Cypress tests and provides feedback on their quality.',
       url: 'https://github.com/cypress-io/ai-toolkit/tree/main/skills/cypress-explain',
     },
+    {
+      name: 'cypress-docs',
+      type: 'skill-md',
+      description:
+        'Grounds answers about Cypress in the official documentation.',
+      url: 'https://github.com/cypress-io/ai-toolkit/tree/main/skills/cypress-docs',
+    },
   ]
 
   const skillsIndex = {

--- a/plugins/llm/test/MarkdownExporter.test.ts
+++ b/plugins/llm/test/MarkdownExporter.test.ts
@@ -1,0 +1,129 @@
+import { test, expect, describe } from 'vitest'
+import { createMarkdownProcessor } from '../src/MarkdownExporter'
+
+const toMarkdown = (html: string) => createMarkdownProcessor().turndown(html)
+
+/** The shape Docusaurus renders a code block in: one <div> per line, each ending in a <br>. */
+function docusaurusCodeBlock(lines: string[][]) {
+  const tokenLines = lines
+    .map(
+      (spans) =>
+        `<div class="token-line">${spans
+          .map((span) => `<span class="token plain">${span}</span>`)
+          .join('')}<br></div>`
+    )
+    .join('')
+
+  return `<pre class="prism-code language-js"><code class="codeBlockLines_e6Vv">${tokenLines}</code></pre>`
+}
+
+// ---------------------------------------------------------------------------
+// Fenced code blocks
+//
+// Docusaurus renders each line of a code block as its own <div class="token-line">
+// ending in a <br>. Reading the block with textContent drops both, which ran every
+// line of a multi-line example together into one line that no longer parses.
+// ---------------------------------------------------------------------------
+
+describe('fenced code blocks', () => {
+  test('keeps each line of a multi-line example on its own line', () => {
+    const markdown = toMarkdown(
+      docusaurusCodeBlock([
+        ['// spying only'],
+        ['cy', '.', 'intercept(url)'],
+        ['cy', '.', 'intercept(method, url)'],
+      ])
+    )
+
+    expect(markdown).toContain(
+      '// spying only\ncy.intercept(url)\ncy.intercept(method, url)'
+    )
+  })
+
+  test('does not run statements together', () => {
+    const markdown = toMarkdown(
+      docusaurusCodeBlock([['const a = 1'], ['const b = 2']])
+    )
+    expect(markdown).not.toContain('const a = 1const b = 2')
+  })
+
+  test('emits one newline per line, not one per <br> and wrapper', () => {
+    const markdown = toMarkdown(
+      docusaurusCodeBlock([['first()'], ['second()'], ['third()']])
+    )
+    expect(markdown).toContain('first()\nsecond()\nthird()')
+    expect(markdown).not.toContain('first()\n\nsecond()')
+  })
+
+  test('preserves indentation inside a block', () => {
+    const markdown = toMarkdown(
+      docusaurusCodeBlock([
+        ['describe(\'suite\', () => {'],
+        ['  it(\'works\', () => {})'],
+        ['})'],
+      ])
+    )
+    expect(markdown).toContain(
+      "describe('suite', () => {\n  it('works', () => {})\n})"
+    )
+  })
+
+  test('handles a plain code block with no per-line markup', () => {
+    const markdown = toMarkdown(
+      '<pre><code class="language-bash">npm install cypress</code></pre>'
+    )
+    expect(markdown).toContain('```bash\nnpm install cypress\n```')
+  })
+
+  test('handles newlines carried as text rather than markup', () => {
+    const markdown = toMarkdown(
+      '<pre><code>line one\nline two\nline three</code></pre>'
+    )
+    expect(markdown).toContain('```\nline one\nline two\nline three\n```')
+  })
+
+  test('trims blank lines at the edges of a block', () => {
+    const markdown = toMarkdown(
+      docusaurusCodeBlock([[''], ['only()'], ['']])
+    )
+    expect(markdown).toContain('only()\n```')
+    expect(markdown).not.toContain('\n\nonly()')
+  })
+
+  test('handles an empty code block without emitting a stray fence', () => {
+    expect(toMarkdown('<pre><code></code></pre>').trim()).toBe('')
+  })
+
+  test('uses a longer fence when the sample itself contains a fence', () => {
+    const markdown = toMarkdown(
+      docusaurusCodeBlock([
+        ['# cy.prompt export'],
+        ['```javascript'],
+        ['cy.visit(\'/\')'],
+        ['```'],
+      ])
+    )
+
+    // A three-backtick fence would end the block at the sample's own fence and
+    // spill the rest of the page out of the code block.
+    expect(markdown).toContain('````\n# cy.prompt export')
+    expect(markdown).toContain("cy.visit('/')\n```\n````")
+  })
+
+  test('grows the fence past the longest backtick run in the sample', () => {
+    const markdown = toMarkdown(docusaurusCodeBlock([['````'], ['nested']]))
+    expect(markdown).toContain('`````\n````\nnested\n`````')
+  })
+
+  test('keeps the usual three-backtick fence for ordinary code', () => {
+    const markdown = toMarkdown(docusaurusCodeBlock([['cy.get(\'.btn\')']]))
+    expect(markdown).toContain("```\ncy.get('.btn')\n```")
+    expect(markdown).not.toContain('````')
+  })
+
+  test('does not disturb inline code', () => {
+    expect(toMarkdown('<p>Use <code>cy.get()</code> here.</p>')).toBe(
+      'Use `cy.get()` here.'
+    )
+  })
+})

--- a/plugins/llm/test/skills.test.ts
+++ b/plugins/llm/test/skills.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, test, expect, describe } from 'vitest'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { writeSkillsIndex } from '../src/skills'
+
+type Skill = {
+  name: string
+  type: string
+  description: string
+  url: string
+}
+
+const tempDirs: string[] = []
+
+function makeTempDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'skills-test-'))
+  tempDirs.push(dir)
+  return dir
+}
+
+function writeAndReadIndex() {
+  const dist = makeTempDir()
+  writeSkillsIndex(dist)
+  return JSON.parse(
+    fs.readFileSync(
+      path.join(dist, '.well-known', 'agent-skills', 'index.json'),
+      'utf8'
+    )
+  )
+}
+
+afterEach(() => {
+  for (const dir of tempDirs) {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+  tempDirs.length = 0
+})
+
+// ---------------------------------------------------------------------------
+// Output file
+// ---------------------------------------------------------------------------
+
+describe('writeSkillsIndex: output file', () => {
+  test('creates .well-known/agent-skills/index.json at the distRoot', () => {
+    const dist = makeTempDir()
+    writeSkillsIndex(dist)
+    expect(
+      fs.existsSync(path.join(dist, '.well-known', 'agent-skills', 'index.json'))
+    ).toBe(true)
+  })
+
+  test('declares the discovery 0.2.0 schema', () => {
+    expect(writeAndReadIndex().$schema).toBe(
+      'https://schemas.agentskills.io/discovery/0.2.0/schema.json'
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Published skills
+//
+// The index exists to tell agents which skills Cypress publishes, so it has to
+// stay in step with https://github.com/cypress-io/ai-toolkit/tree/main/skills
+// and with the AI Skills docs page. It is maintained by hand — this is the
+// check that catches a skill being shipped but never advertised.
+// ---------------------------------------------------------------------------
+
+describe('writeSkillsIndex: published skills', () => {
+  test('lists every skill published in cypress-io/ai-toolkit', () => {
+    const names = writeAndReadIndex().skills.map((s: Skill) => s.name)
+    expect(names.sort()).toEqual([
+      'cypress-author',
+      'cypress-docs',
+      'cypress-explain',
+    ])
+  })
+
+  test('advertises cypress-docs, the documentation skill', () => {
+    const docs = writeAndReadIndex().skills.find(
+      (s: Skill) => s.name === 'cypress-docs'
+    )
+    expect(docs).toBeDefined()
+    expect(docs.url).toBe(
+      'https://github.com/cypress-io/ai-toolkit/tree/main/skills/cypress-docs'
+    )
+  })
+
+  test('gives every skill a name, type, description, and url', () => {
+    for (const skill of writeAndReadIndex().skills) {
+      expect(Object.keys(skill).sort()).toEqual([
+        'description',
+        'name',
+        'type',
+        'url',
+      ])
+      expect(skill.name).toMatch(/^[a-z0-9]+(?:-[a-z0-9]+)*$/)
+      expect(skill.type).toBe('skill-md')
+      expect(skill.description.trim().length).toBeGreaterThan(0)
+      expect(skill.url.startsWith('https://')).toBe(true)
+    }
+  })
+
+  test('names are unique', () => {
+    const names = writeAndReadIndex().skills.map((s: Skill) => s.name)
+    expect(new Set(names).size).toBe(names.length)
+  })
+})


### PR DESCRIPTION
Two related fixes, both found while checking that the `cypress-docs` skill actually does what we advertise.

## Summary

1. `/.well-known/agent-skills/index.json` listed two of the three skills Cypress publishes. Adds the missing `cypress-docs`.
2. Code blocks in the `/llm` corpus had lost their line breaks — 377 of 2745 files. Fixes the export, and a second fence bug it uncovered.

## Why

**The missing skill.** `plugins/llm/src/skills.ts` hard-codes the skill list and had fallen behind. Cypress has since published [`cypress-docs`](https://github.com/cypress-io/ai-toolkit/tree/main/skills/cypress-docs), documented on [AI Skills](https://docs.cypress.io/app/tooling/ai-skills) as one of the three we ship — so the index that exists to advertise our skills to agents was omitting the one skill about reading our documentation. The live file on docs.cypress.io confirms it: two entries today.

**The broken code blocks.** Following the `cypress-docs` skill's own instructions against the live docs turned this up. Docusaurus renders each line of a code block as its own `<div class="token-line">` ending in a `<br>`; the export read the block with `textContent`, which reports neither. So every multi-line example arrived as one line:

```
// spying onlycy.intercept(url)cy.intercept(method, url)cy.intercept(routeMatcher)
```

The HTML pages render fine — this is export-only. It matters here specifically because `cypress-docs` tells agents to *prefer* `/llm/*` over the HTML pages, so the skill routes agents to the copy of our docs where every code example is syntactically broken. An agent that copies one emits code that doesn't parse.

**The bug that hid behind it.** With line breaks restored, `app/guides/ai-test-generation` started losing sections. That page embeds a sample `cy.prompt` Markdown report, which itself contains ` ``` ` fences — and the export always emitted a three-backtick fence, so the block closed early at the sample's own fence. Everything after fell out of the code block and stopped parsing as page content, costing that page 4 of its 12 section fragments. Previously the run-together lines meant no line *started* with a fence, which masked it. Fences are now sized past the longest backtick run they contain, per CommonMark.

## Notes for reviewers

The skills change is deliberately minimal: one entry, same shape and same `tree/main` URL style as the two beside it. The list stays hand-maintained, with a test that it lists every skill published in ai-toolkit so the next one is harder to leave out.

The export change extracts the Turndown setup into `createMarkdownProcessor()` so the conversion rules can be tested directly, and adds `readCodeText()` to walk the code element instead of flattening it. Both fixes live in the one Turndown rule; `MarkdownExporter` otherwise behaves as before, and the section and JSON exports inherit the fix because they derive from this markdown.

### Known limitation: the index does not conform to the schema it declares

This is unchanged by this PR, but worth stating plainly rather than leaving implied. The index declares discovery `0.2.0`, which requires a `sha256:` `digest` on every entry and a `url` pointing at the artifact that digest covers. We satisfy neither, so a strict client may be ignoring the index entirely.

Making it conformant is more than adding three digests, and the shape is not obvious:

- `cypress-author` and `cypress-explain` are **not** single-file skills. Their `SKILL.md` instructs the agent to load `./subskills/*.md` and `./references/**`, so publishing them as `skill-md` pointing at a lone `SKILL.md` would install them incomplete. Those two need `type: archive` with a hosted tarball and a digest over the archive bytes.
- Only `cypress-docs` is a true single-file skill and can stay `skill-md`.
- Digests also need URLs pinned to a commit rather than `main`, or the published digest stops matching the bytes the moment a skill is edited.

That is a separate change with real ongoing upkeep for a hand-maintained list, so it is deliberately out of scope here.

Two smaller things I found but did not change:

- Fenced blocks carry no language tag (` ``` ` rather than ` ```js `). The rule reads `language-*` off the `<code>` element, but Docusaurus puts it on the `<pre>` — and `sanitize-html` strips class attributes anyway, so this needs an `html-normalize` change too.
- The `cypress-docs` skill's own routing table points at `/core-concepts/`, `/configuration/`, and `/references/error-messages/`, all of which 404 since the docs moved under `/app/`. That's an `ai-toolkit` fix, not this repo. Agents that crawl `index.md` instead still find everything.

### Verification

- `npm run test:plugins` — 200 passing, including 5 new tests for the skills index and 12 for the code-block conversion.
- `npm run build`, then diffed the corpus against a pre-fix build: **same 2745 files, identical file set**, run-together code lines down from **377 files to 0**, and `ai-test-generation` back to its full 12 fragments.
- Spot-checked that the fix reaches the chunked JSON export too, and that `dist/.well-known/agent-skills/index.json` lists all three skills.