### PR TITLE
docs: document the Firefox CDP removal in the Cypress 15 migration guide

### DIFF
--- a/docs/app/references/launching-browsers.mdx
+++ b/docs/app/references/launching-browsers.mdx
@@ -81,10 +81,11 @@ lets Cypress rely on stable, modern automation APIs.
 
 :::info
 
-Regardless of the above, Cypress cannot launch **Firefox versions older than 135**.
+Regardless of the above, Cypress cannot launch **Firefox versions older than 140**.
 Cypress automates Firefox through
-[WebDriver BiDi](https://w3c.github.io/webdriver-bidi/), which is only available
-in Firefox 135 and above, so older versions will fail with an error.
+[WebDriver BiDi](https://w3c.github.io/webdriver-bidi/), and Firefox versions
+below 140 implement it incompletely, so older versions will fail with an error.
+Cypress `15.0.0` through `15.18.1` set this floor at Firefox 135.
 
 :::
 

--- a/docs/app/references/migration-guide.mdx
+++ b/docs/app/references/migration-guide.mdx
@@ -373,7 +373,7 @@ When `allowCypressEnv` is set to `false`:
   defaultCollapsed
   excludeFromLlmExport
   title="Upgrade to Cypress 15 with your AI assistant"
-  prompt={`Read https://docs.cypress.io/app/references/migration-guide/migrating-to-cypress-15-0.md, then upgrade this project from Cypress 14 to 15 by working through these steps:\n\n1. Confirm the starting point. If the project isn't on Cypress 14.x yet, stop and tell me; majors should be upgraded one at a time.\n\n2. Check requirements. Verify my environment meets the requirements in that section (Node.js 20, 22, or 24+, a supported Linux distribution, and webpack 5 / Vite 5 / Angular 18+ if I use component testing) and flag anything unsupported.\n\n3. Update Cypress. Detect my package manager and update the cypress dependency.\n\n4. Fix breaking changes. Fix every breaking change in that section that affects my code and config.\n\n5. Verify. Run npx cypress verify and my Cypress tests.\n\nFinish with a summary of what changed and anything you couldn't safely automate.`}
+  prompt={`Read https://docs.cypress.io/app/references/migration-guide/migrating-to-cypress-15-0.md, then upgrade this project from Cypress 14 to 15 by working through these steps:\n\n1. Confirm the starting point. If the project isn't on Cypress 14.x yet, stop and tell me; majors should be upgraded one at a time.\n\n2. Check requirements. Verify my environment meets the requirements in that section (Node.js 20, 22, or 24+, a supported Linux distribution, Firefox 140+ if I run tests in Firefox, and webpack 5 / Vite 5 / Angular 18+ if I use component testing) and flag anything unsupported.\n\n3. Update Cypress. Detect my package manager and update the cypress dependency.\n\n4. Fix breaking changes. Fix every breaking change in that section that affects my code and config.\n\n5. Verify. Run npx cypress verify and my Cypress tests.\n\nFinish with a summary of what changed and anything you couldn't safely automate.`}
 />
 
 This guide details the code changes needed to migrate to Cypress
@@ -426,6 +426,21 @@ This support is in line with Node.js's support for Linux in 20+.
 If you're using a Linux distribution based on glibc `<2.31`, you'll need to
 update your system to a newer version to install Cypress 15+.
 To display which version of glibc your Linux system is running, execute `ldd --version`.
+
+### Firefox is automated with WebDriver BiDi only
+
+Support for the [Chrome DevTools Protocol](https://chromedevtools.github.io/devtools-protocol/) (CDP) with Firefox has been removed.
+[Cypress 14.1.0](/app/references/changelog#14-1-0) began automating Firefox 135 and above with [WebDriver BiDi](https://w3c.github.io/webdriver-bidi/) — Firefox's supported automation interface — and fell back to CDP for older versions.
+Cypress 15 drops that fallback, so WebDriver BiDi is the only way Cypress automates Firefox.
+
+Because WebDriver BiDi is only available in newer Firefox releases, this sets a minimum Firefox version.
+Cypress cannot launch a version below the minimum and will fail with an error naming the version to install.
+
+- Cypress `15.0.0` through `15.18.1` require Firefox `135` or newer.
+- [Cypress 15.19.0](/app/references/changelog#15-19-0) and newer require Firefox `140` or newer, the oldest release line Mozilla still ships.
+
+If you pin a Firefox version — an ESR build, a Docker image tag, or a browser installed by your CI provider — update it before upgrading.
+Chrome, Edge, Electron, and experimental WebKit are unaffected, and no test code changes are needed: Cypress commands behave the same in Firefox under WebDriver BiDi.
 
 ### Webpack `4` is no longer supported
 

--- a/docs/app/references/migration-guide.mdx
+++ b/docs/app/references/migration-guide.mdx
@@ -430,7 +430,8 @@ To display which version of glibc your Linux system is running, execute `ldd --v
 ### Firefox is automated with WebDriver BiDi only
 
 Support for the [Chrome DevTools Protocol](https://chromedevtools.github.io/devtools-protocol/) (CDP) with Firefox has been removed.
-[Cypress 14.1.0](/app/references/changelog#14-1-0) began automating Firefox 135 and above with [WebDriver BiDi](https://w3c.github.io/webdriver-bidi/) — Firefox's supported automation interface — and fell back to CDP for older versions.
+[WebDriver BiDi](https://w3c.github.io/webdriver-bidi/) is Firefox's supported automation interface.
+[Cypress 14.1.0](/app/references/changelog#14-1-0) began automating Firefox 135 and above with it and fell back to CDP for older versions.
 Cypress 15 drops that fallback, so WebDriver BiDi is the only way Cypress automates Firefox.
 
 Because WebDriver BiDi is only available in newer Firefox releases, this sets a minimum Firefox version.
@@ -439,7 +440,7 @@ Cypress cannot launch a version below the minimum and will fail with an error na
 - Cypress `15.0.0` through `15.18.1` require Firefox `135` or newer.
 - [Cypress 15.19.0](/app/references/changelog#15-19-0) and newer require Firefox `140` or newer, the oldest release line Mozilla still ships.
 
-If you pin a Firefox version — an ESR build, a Docker image tag, or a browser installed by your CI provider — update it before upgrading.
+If you pin a Firefox version, such as an ESR build, a Docker image tag, or a browser installed by your CI provider, update it before upgrading.
 Chrome, Edge, Electron, and experimental WebKit are unaffected, and no test code changes are needed: Cypress commands behave the same in Firefox under WebDriver BiDi.
 
 ### Webpack `4` is no longer supported


### PR DESCRIPTION
## Summary

Adds a "Firefox is automated with WebDriver BiDi only" breaking change to the **Migrating to Cypress 15.0** section of the migration guide, and corrects the minimum Firefox version on the browser support page from 135 to 140.

## Why

This started as a [Context7](https://context7.com/cypress-io/cypress-documentation) suggestion asking for a dedicated Cypress 15 migration page consolidating breaking changes, including Node.js version requirements and the CDP-for-Firefox removal.

Most of that ask is already satisfied. The `Migrating to Cypress 15.0` section exists with 10 breaking changes, Node.js 20/22/24+ is the first entry in it, the `15.0.0` changelog entry already links to it, and the `plugins/llm` section exporter already emits it as a standalone `app/references/migration-guide/migrating-to-cypress-15-0.md`. Context7 indexes the raw `docs/` folder rather than the built site, so it only ever sees the single 104 KB `.mdx` and read the section as missing.

One part of the suggestion was correct, though. **Removing CDP support for Firefox was a real Cypress 15.0 breaking change that only ever appeared as a one-line changelog entry.** It never made it into the migration guide, even though it is the change behind Cypress's minimum Firefox version, which is exactly the kind of thing someone pinning a Firefox build in CI needs while planning the upgrade.

Tracing that through the code turned up a second, unrelated problem. `launching-browsers.mdx` documented a Firefox floor of 135, but the shipped code requires 140:

| Version | Firefox floor | Source |
| --- | --- | --- |
| 14.1.0 | 135 (BiDi added, CDP fallback kept) | changelog `14.1.0` |
| 15.0.0 through 15.18.1 | 135 (CDP removed) | `known-browsers.ts` at `v15.0.0` |
| 15.19.0+ | **140** | `known-browsers.ts` at `v15.21.0` |

The bump landed in [cypress-io/cypress#34248](https://github.com/cypress-io/cypress/pull/34248) under a `misc:`/`chore:` commit, so it never got a changelog entry and the docs had no way to know it had changed.

## Notes for reviewers

- The new section is placed after "Unsupported Linux Distributions," matching where the v14 section puts "Updated Browser Support."
- It documents both floors and when each applied, since a reader on 15.0 through 15.18 needs 135 and a reader upgrading today needs 140.
- The v15 `CopyPrompt` requirements checklist gained "Firefox 140+" so the AI-assisted upgrade path checks it too.
- Verified with `npx prettier --check` and a full `npm run build`. Since `onBrokenLinks` is `throw`, the green build confirms the new `#14-1-0` and `#15-19-0` anchors resolve.

**Follow-up intentionally left out:** Cypress `15.19.0` shipped a browser support change with no changelog entry at all. Backfilling `changelog.mdx` for an already-released version felt like a maintainer call, so this PR does not touch it. A `**Misc:**` line under `15.19.0` noting the Firefox 140 minimum would close that gap, and `cli/CHANGELOG.md` in the main repo likely needs the same since that is the upstream source.

**Not done, and I would recommend against it:** splitting the migration guide into per-version pages, which the original suggestion floated. The single-page structure is load-bearing for the section exporter and for all the inbound `#Migrating-to-Cypress-XX0` anchors. The "search keywords" part of the suggestion is also not actionable as written, since `AGENTS.md` forbids `keywords` frontmatter.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PVwdSTmzJxbwJuefY7RLV9)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to the Cypress 15 migration guide and browser support page; no product or security behavior changes.
> 
> **Overview**
> ## Summary
> 
> Documents Cypress 15’s removal of CDP for Firefox (WebDriver BiDi only) in the **Migrating to Cypress 15.0** guide, and raises the documented Firefox launch floor from **135** to **140**.
> 
> ## Why
> 
> Firefox CDP removal was a real 15.0 breaking change that only appeared as a one-line changelog note, so people pinning Firefox in CI had no migration guidance. The browser support page also still said 135 after 15.19.0 raised the floor to 140 (Mozilla’s oldest shipped line) without a changelog.
> 
> ## Notes for reviewers
> 
> The new section sits after **Unsupported Linux Distributions** and lists both floors (`15.0.0`–`15.18.1` → Firefox 135; `15.19.0+` → 140). The v15 `CopyPrompt` now checks Firefox 140+. Changelog backfill for 15.19.0 is intentionally omitted.
> 
> ## Release
> 
> Not applicable — docs correction, not a product release PR.
> 
> ## Included changes
> 
> - [ ] **Changelog entry** — not included (follow-up: a Misc line under 15.19.0 for the Firefox 140 floor).
> - **Migrating to Cypress 15.0** — new “Firefox is automated with WebDriver BiDi only” breaking change.
> - **Launching Browsers** — minimum Firefox version 140, with a note that 15.0.0–15.18.1 used 135.
> - v15 upgrade `CopyPrompt` — requirements include Firefox 140+ when running Firefox.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1d61b4c72d639d46b771857818583b1f78b30bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->