### PR TITLE
docs: state that IndexedDB is not cleared between tests

### DIFF
--- a/docs/app/core-concepts/test-isolation.mdx
+++ b/docs/app/core-concepts/test-isolation.mdx
@@ -75,7 +75,7 @@ test by:
 
 IndexedDB and other browser storage mechanisms are not cleared, even when test
 isolation is enabled. See
-[Storage That Is Not Cleared](#storage-that-is-not-cleared).
+[Storage That Is Not Cleared](#Storage-That-Is-Not-Cleared).
 
 Because the test starts in a fresh browser context, you must re-visit your
 application and perform the series of interactions needed to build the dom and

--- a/docs/app/core-concepts/test-isolation.mdx
+++ b/docs/app/core-concepts/test-isolation.mdx
@@ -73,6 +73,10 @@ test by:
   [`sessionStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage)
   in all domains
 
+That list is complete: IndexedDB and other browser storage mechanisms are not
+cleared, even when test isolation is enabled. See
+[Storage That Is Not Cleared](#storage-that-is-not-cleared).
+
 Because the test starts in a fresh browser context, you must re-visit your
 application and perform the series of interactions needed to build the dom and
 browser state for each test.
@@ -98,6 +102,9 @@ current page is not cleared.
 | `true`        | - clears page by visiting `about:blank`<br/>- clears cookies in all domains<br/>- local storage in all domains<br/>- session storage in all domains | - clears page by visiting `about:blank`<br/>- clears cookies in all domains<br/>- local storage in all domains<br/>- session storage in all domains |
 | `false`       | does not alter the current browser context                                                                                                          | <br/>- clears cookies in all domains<br/>- local storage in all domains<br/>- session storage in all domains                                        |
 
+Neither setting clears IndexedDB or any other browser storage mechanism. See
+[Storage That Is Not Cleared](#storage-that-is-not-cleared).
+
 ## Test Isolation in Component Testing
 
 Cypress does not support configuring the test isolation behavior in component
@@ -115,12 +122,64 @@ each test by:
   [`sessionStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage)
   in all domains
 
+As in end-to-end testing, Cypress does not clear IndexedDB or any other browser
+storage mechanism between component tests. See
+[Storage That Is Not Cleared](#storage-that-is-not-cleared).
+
+## Storage That Is Not Cleared
+
+Cookies, `localStorage`, and `sessionStorage` are the only browser storage
+mechanisms Cypress clears between tests. Every other storage mechanism persists
+for the life of the browser, whether test isolation is enabled or disabled, and
+whether you are running end-to-end tests or component tests.
+
+The one to be most aware of is
+[IndexedDB](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API).
+Data your application writes to IndexedDB, including data written by libraries
+that use it under the hood such as offline caches and client-side databases, is
+still there in the next test. If a test depends on IndexedDB being empty, clear
+it yourself.
+
+The same applies to [`cy.session()`](/api/commands/session): a session caches
+and restores cookies, `localStorage`, and `sessionStorage` only, so IndexedDB
+data is neither saved with a session nor cleared when one is restored.
+
+### Clearing IndexedDB yourself
+
+Delete the databases your application uses in a `beforeEach` hook, after
+visiting the page so a `window` is available:
+
+```javascript
+beforeEach(() => {
+  cy.visit('/')
+  cy.window().then((win) => {
+    return new Cypress.Promise((resolve) => {
+      const request = win.indexedDB.deleteDatabase('my-database')
+
+      // resolve on every outcome so a missing or blocked
+      // database does not hang the test
+      request.onsuccess = resolve
+      request.onerror = resolve
+      request.onblocked = resolve
+    })
+  })
+})
+```
+
+If you do not know the database names ahead of time, and you only run your tests
+in Chromium-based browsers or WebKit, you can enumerate them with
+[`indexedDB.databases()`](https://developer.mozilla.org/en-US/docs/Web/API/IDBFactory/databases).
+Firefox does not implement that method, so name each database explicitly if you
+run your tests in Firefox.
+
 ## Preserving Cookies and Storage Across Tests
 
-Because Cypress clears all cookies, localStorage, and sessionStorage before each
-test when test isolation is enabled, any state your application writes to the
-browser is gone by the next test. There are three approaches for keeping specific
-state available across tests.
+Because Cypress clears all cookies, `localStorage`, and `sessionStorage` before
+each test when test isolation is enabled, state your application writes to those
+three mechanisms is gone by the next test. There are three approaches for
+keeping specific state available across tests. State in other storage
+mechanisms, such as IndexedDB, already persists on its own and needs none of
+them.
 
 ### Re-set a known cookie in `beforeEach`
 

--- a/docs/app/core-concepts/test-isolation.mdx
+++ b/docs/app/core-concepts/test-isolation.mdx
@@ -73,8 +73,8 @@ test by:
   [`sessionStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage)
   in all domains
 
-That list is complete: IndexedDB and other browser storage mechanisms are not
-cleared, even when test isolation is enabled. See
+IndexedDB and other browser storage mechanisms are not cleared, even when test
+isolation is enabled. See
 [Storage That Is Not Cleared](#storage-that-is-not-cleared).
 
 Because the test starts in a fresh browser context, you must re-visit your
@@ -102,9 +102,6 @@ current page is not cleared.
 | `true`        | - clears page by visiting `about:blank`<br/>- clears cookies in all domains<br/>- local storage in all domains<br/>- session storage in all domains | - clears page by visiting `about:blank`<br/>- clears cookies in all domains<br/>- local storage in all domains<br/>- session storage in all domains |
 | `false`       | does not alter the current browser context                                                                                                          | <br/>- clears cookies in all domains<br/>- local storage in all domains<br/>- session storage in all domains                                        |
 
-Neither setting clears IndexedDB or any other browser storage mechanism. See
-[Storage That Is Not Cleared](#storage-that-is-not-cleared).
-
 ## Test Isolation in Component Testing
 
 Cypress does not support configuring the test isolation behavior in component
@@ -121,10 +118,6 @@ each test by:
 - clearing
   [`sessionStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage)
   in all domains
-
-As in end-to-end testing, Cypress does not clear IndexedDB or any other browser
-storage mechanism between component tests. See
-[Storage That Is Not Cleared](#storage-that-is-not-cleared).
 
 ## Storage That Is Not Cleared
 
@@ -149,7 +142,7 @@ data is neither saved with a session nor cleared when one is restored.
 Delete the databases your application uses in a `beforeEach` hook, after
 visiting the page so a `window` is available:
 
-```javascript
+```javascript title="cypress/support/e2e.js"
 beforeEach(() => {
   cy.visit('/')
   cy.window().then((win) => {

--- a/docs/app/faq.mdx
+++ b/docs/app/faq.mdx
@@ -1163,7 +1163,7 @@ beforeEach(() => {
 ```
 
 See
-[Storage That Is Not Cleared](/app/core-concepts/test-isolation#storage-that-is-not-cleared)
+[Storage That Is Not Cleared](/app/core-concepts/test-isolation#Storage-That-Is-Not-Cleared)
 for more details, including how to handle databases whose names you do not know
 ahead of time.
 

--- a/docs/app/faq.mdx
+++ b/docs/app/faq.mdx
@@ -1127,6 +1127,46 @@ test can still pass independently before relying on this approach.
 
 :::
 
+### <Icon name="angle-right" /> Does Cypress clear IndexedDB between tests?
+
+No. Cookies, `localStorage`, and `sessionStorage` are the only browser storage
+mechanisms Cypress clears between tests. Everything your application writes to
+[IndexedDB](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API) is
+still there in the next test, whether
+[test isolation](/app/core-concepts/test-isolation) is enabled or disabled, and
+whether you are running end-to-end tests or component tests. This also applies
+to libraries that use IndexedDB under the hood, such as offline caches and
+client-side databases.
+
+[`cy.session()`](/api/commands/session) behaves the same way: a session caches
+and restores cookies, `localStorage`, and `sessionStorage` only, so IndexedDB
+data is neither saved with a session nor cleared when one is restored.
+
+If a test depends on IndexedDB being empty, delete the databases yourself in a
+`beforeEach` hook, after visiting the page so a `window` is available:
+
+```javascript title="cypress/support/e2e.js"
+beforeEach(() => {
+  cy.visit('/')
+  cy.window().then((win) => {
+    return new Cypress.Promise((resolve) => {
+      const request = win.indexedDB.deleteDatabase('my-database')
+
+      // resolve on every outcome so a missing or blocked
+      // database does not hang the test
+      request.onsuccess = resolve
+      request.onerror = resolve
+      request.onblocked = resolve
+    })
+  })
+})
+```
+
+See
+[Storage That Is Not Cleared](/app/core-concepts/test-isolation#storage-that-is-not-cleared)
+for more details, including how to handle databases whose names you do not know
+ahead of time.
+
 ### <Icon name="angle-right" /> Some of my elements animate in; how do I work around that?
 
 Oftentimes you can usually account for animation by asserting


### PR DESCRIPTION
## Summary

Adds a **Storage That Is Not Cleared** section to the Test Isolation page stating that cookies, `localStorage`, and `sessionStorage` are the only browser storage mechanisms Cypress clears between tests, and that IndexedDB is not. Adds a matching **"Does Cypress clear IndexedDB between tests?"** entry to the App FAQ.

## Why

The Test Isolation page listed what Cypress clears before each test but never said what it leaves alone, so readers had to infer from omission that IndexedDB persists. Applications that use IndexedDB directly, or through a library such as an offline cache or a client-side database, carry that state into the next test, which is a surprising source of order-dependent failures. Naming the boundary explicitly is quicker to read than deducing it from a list.

The FAQ already answers the neighboring question about preserving cookies and `localStorage`, so the IndexedDB question sits directly after it.

## Notes for reviewers

- **Scope of the claim.** IndexedDB is the only mechanism named explicitly. Cache Storage and service-worker state also survive, but I could not confirm the current behavior well enough to assert it in docs, so they fall under the general "every other storage mechanism" statement rather than being listed. Happy to name them if someone can confirm.
- **`cy.session()`.** Both new sections state that a session caches and restores the same three mechanisms only, so IndexedDB data is neither saved with a session nor cleared when one is restored.
- **The `beforeEach` snippet** deletes a database by name and resolves on `onsuccess`, `onerror`, and `onblocked` so a missing or blocked database cannot hang the test. `indexedDB.databases()` is mentioned as the option for unknown database names, with the caveat that Firefox does not implement it.
- **Existing copy corrected.** The intro to "Preserving Cookies and Storage Across Tests" claimed "any state your application writes to the browser is gone by the next test", which contradicts the new section. It is now scoped to the three mechanisms.
- `prettier --check` and `scripts/lint-frontmatter.js` pass on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012EEFQy6FAawk1bvkf5yjGq

---
_Generated by [Claude Code](https://claude.ai/code/session_012EEFQy6FAawk1bvkf5yjGq)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only clarification of existing test-isolation behavior; no product or runtime changes.
> 
> **Overview**
> ## Summary
> 
> Documents that Cypress only clears cookies, `localStorage`, and `sessionStorage` between tests. IndexedDB and other storage persist for the life of the browser, including with `cy.session()`.
> 
> ## Why
> 
> The Test Isolation page listed what Cypress clears but not what it leaves alone, so readers had to infer that IndexedDB survives. That leftover state is a common source of order-dependent failures for apps (and libraries) that use IndexedDB. The FAQ already covers preserving cookies/`localStorage`; this adds the neighboring IndexedDB question.
> 
> Closes none.
> 
> ## Notes for reviewers
> 
> IndexedDB is named explicitly; Cache Storage and service-worker state are only covered by “every other storage mechanism.” The `beforeEach` snippet resolves on success, error, and blocked so a missing DB cannot hang the test. `indexedDB.databases()` is documented as Chromium/WebKit-only. The “Preserving Cookies and Storage” intro no longer claims *all* browser state is cleared.
> 
> ## Release
> 
> Not applicable — docs clarification of existing behavior, not a product release.
> 
> ## Included changes
> 
> - **Test Isolation** — new **Storage That Is Not Cleared** section, a pointer from the enabled-isolation list, a `beforeEach` IndexedDB delete example, and a scoped intro on preserving cookies/storage.
> - **App FAQ** — new **Does Cypress clear IndexedDB between tests?** entry with the same guidance and a link back to Test Isolation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfdff20f8325850b48ab229c1b1d15f1a4f2eb88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->