### PR TITLE
docs: list required packages for React + Webpack component testing

### DIFF
--- a/docs/app/component-testing/react/overview.mdx
+++ b/docs/app/component-testing/react/overview.mdx
@@ -113,8 +113,29 @@ import customViteConfig from './customConfig'
 
 ### React with Webpack
 
-Cypress Component Testing works with React apps that use Webpack 4+ as the
+Cypress Component Testing works with React apps that use Webpack 5+ as the
 bundler.
+
+#### Required Packages
+
+Install these packages in your project to run React component tests with
+Webpack:
+
+| Package     | Version  | Purpose                                                                                           |
+| ----------- | -------- | ------------------------------------------------------------------------------------------------- |
+| `cypress`   | Latest   | The Cypress App. Ships with the React mount adapter and the Webpack dev server                    |
+| `react`     | 18 or 19 | The React library your components are built with                                                  |
+| `react-dom` | 18 or 19 | Renders your components into the DOM during a test                                                |
+| `webpack`   | 5        | Your app's bundler. Cypress compiles your specs with the Webpack config it detects in the project |
+
+:::info
+
+You do not need to install `@cypress/react`, `@cypress/webpack-dev-server`, or
+`webpack-dev-server` separately. All three ship inside the `cypress` package, so
+`import { mount } from 'cypress/react'` and `bundler: 'webpack'` work as soon as
+Cypress is installed.
+
+:::
 
 #### Webpack Configuration
 


### PR DESCRIPTION
## Summary

Adds a "Required Packages" section to the "React with Webpack" section of the React component testing overview: a table of the packages a project actually needs (`cypress`, `react`, `react-dom`, `webpack`) plus a callout stating that `@cypress/react`, `@cypress/webpack-dev-server`, and `webpack-dev-server` ship inside the `cypress` package and are not installed separately. Also corrects the stated Webpack support from "4+" to "5+".

## Why

The fact that the Cypress dev-server packages are bundled with the Cypress App is currently only stated in [Component Testing Configuration](https://docs.cypress.io/app/component-testing/component-framework-configuration#Dev-Server-and-Bundler), several clicks away from the page a reader lands on when setting up React component testing. Readers following the React quickstart had to dig through the framework configuration page to learn which packages they need, and were left guessing whether to `npm install @cypress/webpack-dev-server`. Surfacing the list where the setup actually happens removes that guesswork.

The package list and versions were verified against the `cypress` repo rather than written from memory:

- The Launchpad's dependency list for React + Webpack is `webpack`, `react`, `react-dom` (`packages/scaffold-config/src/frameworks.ts`), with React `^18 || ^19` and Webpack `^5.0.0` (`packages/scaffold-config/src/dependencies.ts`).
- `@cypress/react` is synced into `cli/` at build time and exported as `cypress/react`; scaffolding uses `mountModule: 'cypress/react'`.
- `@cypress/webpack-dev-server` is bundled with the binary, and `sourceWebpackDevServer` falls back to the `webpack-dev-server` copy shipped with it when the project has none (`npm/webpack-dev-server/src/helpers/sourceRelativeWebpackModules.ts`), so users do not need their own install of either.

The Webpack version fix comes from the same check: `getMajorVersion(webpack.packageJson, [5])` throws on anything other than Webpack 5, and the Vue and Svelte overviews already say "Webpack 5+", so the React page was the outlier.

## Notes for reviewers

- Scoped deliberately to the Webpack section, matching where the confusion originates. The Vite and Next.js sections are unchanged; happy to mirror the pattern there if reviewers want it applied consistently across the page.
- The `cypress` row says "Latest" rather than a pinned major so the table does not go stale each release.
- `npm run build` passes locally (broken links and anchors are build errors), and Prettier ran via lint-staged on commit.
- Out of scope but worth a follow-up: `react/api.mdx` still shows `import { mount } from '@cypress/react'` in one example while the rest of the page uses `cypress/react`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DEqRVvp8iZePcQM3zV7enU)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change to the React component testing overview; no product, security, or runtime impact.
> 
> **Overview**
> Clarifies setup for **React with Webpack** component testing so readers know which packages to install and which ones already ship inside `cypress`.
> 
> Adds a **Required Packages** table (`cypress`, `react`, `react-dom`, `webpack`) and an info callout that `@cypress/react`, `@cypress/webpack-dev-server`, and `webpack-dev-server` should not be installed separately. Also updates stated Webpack support from 4+ to **5+**, matching Vue/Svelte docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee11f120b20d9c0b4c69ef5acd32a65baf91c294. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->