### PR TITLE
feat: CLI - add note for agent sandboxing affecting cache

### DIFF
--- a/docs/cloud/integrations/cloud-cli.mdx
+++ b/docs/cloud/integrations/cloud-cli.mdx
@@ -993,7 +993,7 @@ Test Replay data can cover an entire spec, so the CLI downloads the replay once 
 
 Inspect or clear the cache at any time with the [`cache info`](#cy-cloud-cache-info) and [`cache clear`](#cy-cloud-cache-clear) commands. To turn off automatic maintenance, set `CYCLOUD_DISABLE_CACHE_MGMT=true`.
 
-:::note
+:::tip
 Some AI agents automatically run inside sandbox environments, which causes them to build a fresh cache for each session. This can slow things down and affect your rate limits. Review your agent's documentation to configure the `CYCLOUD_CACHE_DIR` environment variable to a persistent filesystem location shared across agent invocations.
 :::
 

--- a/docs/cloud/integrations/cloud-cli.mdx
+++ b/docs/cloud/integrations/cloud-cli.mdx
@@ -994,7 +994,7 @@ Test Replay data can cover an entire spec, so the CLI downloads the replay once 
 Inspect or clear the cache at any time with the [`cache info`](#cy-cloud-cache-info) and [`cache clear`](#cy-cloud-cache-clear) commands. To turn off automatic maintenance, set `CYCLOUD_DISABLE_CACHE_MGMT=true`.
 
 :::note
-Some AI agents automatically run inside "sandbox" environments which cause them to build a fresh cache for each session. This can slow things down and affect your rate limits. Review your agent's documentation to establish a `CYCLOUD_CACHE_DIR` environment variable that points to a persistent filesystem location that can be shared across agent invocations.
+Some AI agents automatically run inside sandbox environments, which causes them to build a fresh cache for each session. This can slow things down and affect your rate limits. Review your agent's documentation to configure the `CYCLOUD_CACHE_DIR` environment variable to a persistent filesystem location shared across agent invocations.
 :::
 
 ## Configuration

--- a/docs/cloud/integrations/cloud-cli.mdx
+++ b/docs/cloud/integrations/cloud-cli.mdx
@@ -993,6 +993,10 @@ Test Replay data can cover an entire spec, so the CLI downloads the replay once 
 
 Inspect or clear the cache at any time with the [`cache info`](#cy-cloud-cache-info) and [`cache clear`](#cy-cloud-cache-clear) commands. To turn off automatic maintenance, set `CYCLOUD_DISABLE_CACHE_MGMT=true`.
 
+:::note
+Some AI agents automatically run inside "sandbox" environments which cause them to build a fresh cache for each session. This can slow things down and affect your rate limits. Review your agent's documentation to establish a `CYCLOUD_CACHE_DIR` environment variable that points to a persistent filesystem location that can be shared across agent invocations.
+:::
+
 ## Configuration
 
 The CLI stores configuration and credentials under `~/.config/cy-cloud`. If the `XDG_CONFIG_HOME` environment variable is set, it uses `$XDG_CONFIG_HOME/cy-cloud` instead. Credentials are written with owner-only permissions.


### PR DESCRIPTION
<!--
Fill in every section. This template doubles as the historical record of the
change, so future readers can understand not just what changed but
why. Delete a section only if it is genuinely not applicable, and say so.
-->

## Summary

Adding a note to address potential issues with the filesystem cache when agent sandboxes/environments are in play.

<img width="690" height="479" alt="Screenshot 2026-08-21 at 8 46 32 AM" src="https://github.com/user-attachments/assets/bafe4c46-f3dc-491e-9e6b-5262022b8560" />

## Why

<!-- The motivation and context. If this originated from an issue, a Slack/
Discord thread, a broken link, an outdated example, or a release, capture it
here so the reasoning survives after the source is gone. -->

Closes #<!-- issue number, or remove this line if none -->

## Notes for reviewers

<!-- Anything a reviewer should focus on: decisions made, alternatives
considered, areas of uncertainty, or follow-ups intentionally left out. -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only tip with no code, auth, or data-handling changes.
> 
> **Overview**
> Adds a tip in the Cloud CLI **Test Replay Caching** docs warning that AI agents in sandboxes rebuild a fresh cache each session, which can slow queries and hit rate limits.
> 
> It tells users to point `CYCLOUD_CACHE_DIR` at a persistent, shared filesystem across agent invocations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b98799e02305dbb76e47aecb06adcccda9fedb96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->