### PR TITLE
docs: note that res.statusMessage can be empty

### DIFF
--- a/docs/api/commands/intercept.mdx
+++ b/docs/api/commands/intercept.mdx
@@ -1339,12 +1339,11 @@ modified:
 
 :::note
 
-`res.statusMessage` is an empty string in Chrome, Chromium, and Edge when your server
-delivered the response over HTTP/2 or HTTP/3, which do not carry a reason phrase on the
-wire. An HTTP/1.1 response still reports the phrase your server sent. Firefox, WebKit, and
-Electron route traffic through the Cypress HTTP/1.1 proxy and always report a phrase. See
-[Native network interception](/app/guides/native-network-interception) for the other
-properties this affects and how to write assertions that pass in every browser.
+`res.statusMessage` is an empty string when the response reached the browser over a
+protocol that carries no reason phrase. HTTP/2 and HTTP/3 do not carry one, so a response
+your server delivered over either reports `''`. An HTTP/1.1 response reports the phrase
+your server sent, which may itself be empty. Prefer `res.statusCode`, which is always
+reported, and treat the phrase for a standard code as redundant with it.
 
 :::
 

--- a/docs/api/commands/intercept.mdx
+++ b/docs/api/commands/intercept.mdx
@@ -1337,6 +1337,17 @@ modified:
 | statusCode    | response status code (`number`)                   |
 | statusMessage | response status message (`string`)                |
 
+:::note
+
+`res.statusMessage` is an empty string in Chrome, Chromium, and Edge when your server
+delivered the response over HTTP/2 or HTTP/3, which do not carry a reason phrase on the
+wire. An HTTP/1.1 response still reports the phrase your server sent. Firefox, WebKit, and
+Electron route traffic through the Cypress HTTP/1.1 proxy and always report a phrase. See
+[Native network interception](/app/guides/native-network-interception) for the other
+properties this affects and how to write assertions that pass in every browser.
+
+:::
+
 **Note about `body`:** If the response header contains
 `Content-Type: application/json` and the body contains valid JSON, this will be
 an `object`. And if the body contains binary content, this will be a buffer.

--- a/docs/app/guides/native-network-interception.mdx
+++ b/docs/app/guides/native-network-interception.mdx
@@ -45,6 +45,7 @@ example:
 | -------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
 | [`content-encoding` is not reported on responses](#Response-headers-do-not-report-content-encoding)                                    | Assert on the decoded body instead of the compression headers.             |
 | [`httpVersion` is not reported](#httpVersion-is-not-reported)                                                                          | Assert on request properties that describe your application.               |
+| [`statusMessage` is empty when the protocol has no reason phrase](#statusMessage-is-empty-when-the-protocol-has-no-reason-phrase)      | Assert on `statusCode` instead of the reason phrase.                       |
 | [Responses the browser rejects are not observable](#Responses-the-browser-rejects-are-not-observable)                                  | Assert on the error state your application renders.                        |
 | [Responses served without a network request are not cached](#Responses-served-without-a-network-request-are-not-cached-by-the-browser) | Expect the intercept to see the request again on a second navigation.      |
 | [Stubbed bodies are decoded from their declared `content-encoding`](#Stubbed-bodies-are-decoded-from-their-declared-content-encoding)  | Make sure a declared encoding matches the bytes you supply.                |
@@ -161,6 +162,41 @@ cy.intercept('/api/users', (req) => {
 ```
 
 If a cross-browser suite needs the assertion for browsers on the legacy network path, see
+[Writing tests that pass in every browser](#Writing-tests-that-pass-in-every-browser).
+
+### `statusMessage` is empty when the protocol has no reason phrase
+
+`res.statusMessage` is an empty string for a response your server delivered over HTTP/2 or
+HTTP/3 in Chrome, Chromium, and Edge on the native browser network. A response delivered
+over HTTP/1.1 still reports the phrase your server sent, including a custom one. Firefox,
+WebKit, and Electron use the legacy network path and always report a phrase.
+
+HTTP/2 and HTTP/3 do not carry a reason phrase on the wire, so there is no value for
+Cypress to report. The browser's own `fetch()` reports the same empty string for those
+responses. On the legacy network path, Cypress terminated the connection itself and spoke
+HTTP/1.1 to the browser, so a phrase was always present.
+
+```js
+// Cypress 15 and earlier
+cy.intercept('/api/users', (req) => {
+  req.on('response', (res) => {
+    expect(res.statusMessage).to.equal('OK')
+  })
+})
+```
+
+```js
+// Cypress 16: assert on the status code
+cy.intercept('/api/users', (req) => {
+  req.on('response', (res) => {
+    expect(res.statusCode).to.equal(200)
+  })
+})
+```
+
+The reason phrase for a standard status code carries no information the code does not
+already give you. If a cross-browser suite needs the assertion for browsers on the legacy
+network path, see
 [Writing tests that pass in every browser](#Writing-tests-that-pass-in-every-browser).
 
 ### Responses the browser rejects are not observable

--- a/docs/app/guides/native-network-interception.mdx
+++ b/docs/app/guides/native-network-interception.mdx
@@ -45,7 +45,6 @@ example:
 | -------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
 | [`content-encoding` is not reported on responses](#Response-headers-do-not-report-content-encoding)                                    | Assert on the decoded body instead of the compression headers.             |
 | [`httpVersion` is not reported](#httpVersion-is-not-reported)                                                                          | Assert on request properties that describe your application.               |
-| [`statusMessage` is empty when the protocol has no reason phrase](#statusMessage-is-empty-when-the-protocol-has-no-reason-phrase)      | Assert on `statusCode` instead of the reason phrase.                       |
 | [Responses the browser rejects are not observable](#Responses-the-browser-rejects-are-not-observable)                                  | Assert on the error state your application renders.                        |
 | [Responses served without a network request are not cached](#Responses-served-without-a-network-request-are-not-cached-by-the-browser) | Expect the intercept to see the request again on a second navigation.      |
 | [Stubbed bodies are decoded from their declared `content-encoding`](#Stubbed-bodies-are-decoded-from-their-declared-content-encoding)  | Make sure a declared encoding matches the bytes you supply.                |
@@ -162,41 +161,6 @@ cy.intercept('/api/users', (req) => {
 ```
 
 If a cross-browser suite needs the assertion for browsers on the legacy network path, see
-[Writing tests that pass in every browser](#Writing-tests-that-pass-in-every-browser).
-
-### `statusMessage` is empty when the protocol has no reason phrase
-
-`res.statusMessage` is an empty string for a response your server delivered over HTTP/2 or
-HTTP/3 in Chrome, Chromium, and Edge on the native browser network. A response delivered
-over HTTP/1.1 still reports the phrase your server sent, including a custom one. Firefox,
-WebKit, and Electron use the legacy network path and always report a phrase.
-
-HTTP/2 and HTTP/3 do not carry a reason phrase on the wire, so there is no value for
-Cypress to report. The browser's own `fetch()` reports the same empty string for those
-responses. On the legacy network path, Cypress terminated the connection itself and spoke
-HTTP/1.1 to the browser, so a phrase was always present.
-
-```js
-// Cypress 15 and earlier
-cy.intercept('/api/users', (req) => {
-  req.on('response', (res) => {
-    expect(res.statusMessage).to.equal('OK')
-  })
-})
-```
-
-```js
-// Cypress 16: assert on the status code
-cy.intercept('/api/users', (req) => {
-  req.on('response', (res) => {
-    expect(res.statusCode).to.equal(200)
-  })
-})
-```
-
-The reason phrase for a standard status code carries no information the code does not
-already give you. If a cross-browser suite needs the assertion for browsers on the legacy
-network path, see
 [Writing tests that pass in every browser](#Writing-tests-that-pass-in-every-browser).
 
 ### Responses the browser rejects are not observable


### PR DESCRIPTION
## Summary

Adds one note to the [`cy.intercept()`](https://docs.cypress.io/api/commands/intercept) reference: `res.statusMessage` can be an empty string, because HTTP/2 and HTTP/3 carry no reason phrase on the wire. One file, 10 lines.

## Why

Came out of cypress-io/cypress#34656, where `res.statusMessage` was `null` on the native browser network, breaking the non-optional `string` the field is published as. cypress-io/cypress#34665 fixes that, reporting the phrase the server actually sent over HTTP/1.1 and an empty string when the protocol carries none.

The `res` properties table documents `statusMessage` as `response status message (string)` with no indication it can be empty, so the caveat belongs there — that is where someone writing an assertion on it will be looking.

Closes cypress-io/cypress#34656

## Notes for reviewers

**This PR started larger and was deliberately cut down.** The first version also added a section to the [Native network interception](https://docs.cypress.io/app/guides/native-network-interception) behavior-differences list, next to the `httpVersion` entry. That was the wrong call and it has been reverted:

- HTTP/2 having no reason phrase is the protocol, not a Cypress behavior difference. The browser's own `fetch().statusText` is `""` for the same response, with no Cypress involved.
- Every other entry on that page is a genuine Cypress-specific observability loss — `content-encoding` not reported, rejected responses not observable, revalidated responses reporting `200`. Listing this beside them implied Cypress had lost information it ought to report.
- `httpVersion` is genuinely different: the legacy path reported `'1.1'` describing the browser-to-Cypress hop, so there is no protocol-level truth for a user to reason from and it needs explaining. This has one.
- An HTTP/1.1 server may legally send an empty reason phrase, so `statusMessage` could always have been `""` — on any network path, in any Cypress version. That makes it a property caveat rather than a 16.0 migration note.

What remains is version-independent reference information: the note describes when the property is empty and points at `statusCode` instead, without reference to Cypress 16, the native browser network, or specific browsers.

`prettier --check` and `scripts/lint-frontmatter.js` both pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only caveat on intercept response fields; no runtime or API changes.
> 
> **Overview**
> Documents that `res.statusMessage` on `cy.intercept()` can be `''`. HTTP/2 and HTTP/3 carry no reason phrase, and HTTP/1.1 may send an empty one. The note sits under the response properties table and recommends asserting on `res.statusCode` instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f60d7a34d9fab6630d13909d6af2c5d4f82f1628. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->