### PR TITLE
fix: follow the changelog to docs/app/releases/changelog.mdx

### DIFF
--- a/.github/workflows/tag-docs-release.yml
+++ b/.github/workflows/tag-docs-release.yml
@@ -10,7 +10,10 @@ on:
     branches:
       - main
     paths:
-      - 'docs/app/references/changelog.mdx'
+      # Keep in step with CHANGELOG_PATHS in scripts/tag-docs-release.mjs: this
+      # is the current location, the script also reads the older ones so a range
+      # spanning a move still works. If the changelog moves, update both.
+      - 'docs/app/releases/changelog.mdx'
   workflow_dispatch:
     inputs:
       before:

--- a/.github/workflows/tag-docs-release.yml
+++ b/.github/workflows/tag-docs-release.yml
@@ -10,9 +10,7 @@ on:
     branches:
       - main
     paths:
-      # Keep in step with CHANGELOG_PATHS in scripts/tag-docs-release.mjs: this
-      # is the current location, the script also reads the older ones so a range
-      # spanning a move still works. If the changelog moves, update both.
+      # On a move, update CHANGELOG_PATHS in scripts/tag-docs-release.mjs too.
       - 'docs/app/releases/changelog.mdx'
   workflow_dispatch:
     inputs:

--- a/scripts/tag-docs-release.mjs
+++ b/scripts/tag-docs-release.mjs
@@ -19,10 +19,8 @@
 
 import { execFileSync } from 'node:child_process'
 
-// This repository has relocated its changelog five times, and a commit range
-// can straddle a move. Newest location first: each commit is read at the first
-// of these that exists there, so `before` and `after` are compared like with
-// like even when the file was renamed between them.
+// Newest first. A range can straddle a move, so each commit is read at
+// whichever of these exists there.
 const CHANGELOG_PATHS = [
   'docs/app/releases/changelog.mdx',
   'docs/app/references/changelog.mdx',
@@ -48,9 +46,7 @@ function gitOrNull(...args) {
   }
 }
 
-// The changelog as it stood at `sha`, or null if none of the known locations
-// exist there — a commit from before the changelog was introduced, or from
-// after a move this script has not been told about yet.
+// Changelog content at `sha`, or null if no known location exists there.
 function changelogAt(sha) {
   for (const path of CHANGELOG_PATHS) {
     const content = gitOrNull('show', `${sha}:${path}`)
@@ -253,8 +249,7 @@ async function main() {
   const before = args.before ? git('rev-parse', args.before).trim() : null
   const after = git('rev-parse', args.after).trim()
 
-  // If the changelog moves again, fail loudly — a silent no-op would stop
-  // tagging releases indefinitely.
+  // Fail loudly on another move; a silent no-op would stop tagging releases.
   if (changelogAt(after) === null) {
     throw new Error(
       `No changelog found at ${after.slice(0, 9)}; looked for ` +

--- a/scripts/tag-docs-release.mjs
+++ b/scripts/tag-docs-release.mjs
@@ -19,7 +19,14 @@
 
 import { execFileSync } from 'node:child_process'
 
-const CHANGELOG = 'docs/app/references/changelog.mdx'
+// This repository has relocated its changelog five times, and a commit range
+// can straddle a move. Newest location first: each commit is read at the first
+// of these that exists there, so `before` and `after` are compared like with
+// like even when the file was renamed between them.
+const CHANGELOG_PATHS = [
+  'docs/app/releases/changelog.mdx',
+  'docs/app/references/changelog.mdx',
+]
 const API = process.env.GITHUB_API_URL || 'https://api.github.com'
 
 function git(...args) {
@@ -41,11 +48,22 @@ function gitOrNull(...args) {
   }
 }
 
+// The changelog as it stood at `sha`, or null if none of the known locations
+// exist there — a commit from before the changelog was introduced, or from
+// after a move this script has not been told about yet.
+function changelogAt(sha) {
+  for (const path of CHANGELOG_PATHS) {
+    const content = gitOrNull('show', `${sha}:${path}`)
+    if (content !== null) return content
+  }
+  return null
+}
+
 // Headings are matched at one to three hashes on purpose: the 14.4.0 entry
 // shipped as `# 14.4.0` and the typo was only fixed the following day. Being
 // strict here would silently skip a release.
 function versionsIn(sha) {
-  const content = gitOrNull('show', `${sha}:${CHANGELOG}`)
+  const content = changelogAt(sha)
   if (content === null) return new Set()
   const versions = new Set()
   for (const line of content.split('\n')) {
@@ -56,7 +74,7 @@ function versionsIn(sha) {
 }
 
 function releaseDate(sha, version) {
-  const content = gitOrNull('show', `${sha}:${CHANGELOG}`) || ''
+  const content = changelogAt(sha) || ''
   const escaped = version.replace(/\./g, '\\.')
   const match = new RegExp(
     `^#{1,3}\\s+${escaped}\\s*\\n\\n_Released ([^_\\n]+)_`,
@@ -172,7 +190,14 @@ async function runProbe(token, repository) {
 // same commit; for a push carrying several commits they are not.
 function findIntroducingCommit(version, before, after) {
   const range = before ? `${before}..${after}` : after
-  const commits = git('log', '--reverse', '--format=%H', range, '--', CHANGELOG)
+  const commits = git(
+    'log',
+    '--reverse',
+    '--format=%H',
+    range,
+    '--',
+    ...CHANGELOG_PATHS
+  )
     .split('\n')
     .filter(Boolean)
 
@@ -228,13 +253,14 @@ async function main() {
   const before = args.before ? git('rev-parse', args.before).trim() : null
   const after = git('rev-parse', args.after).trim()
 
-  // This repository has relocated its changelog four times. If it moves again,
-  // fail loudly — a silent no-op would stop tagging releases indefinitely.
-  if (gitOrNull('cat-file', '-e', `${after}:${CHANGELOG}`) === null) {
+  // If the changelog moves again, fail loudly — a silent no-op would stop
+  // tagging releases indefinitely.
+  if (changelogAt(after) === null) {
     throw new Error(
-      `${CHANGELOG} does not exist at ${after.slice(0, 9)}. If the changelog moved, ` +
-        'update CHANGELOG in this script and the paths filter in ' +
-        '.github/workflows/tag-docs-release.yml.'
+      `No changelog found at ${after.slice(0, 9)}; looked for ` +
+        `${CHANGELOG_PATHS.join(', ')}. If the changelog moved, add its new ` +
+        'location to the front of CHANGELOG_PATHS in this script and update ' +
+        'the paths filter in .github/workflows/tag-docs-release.yml.'
     )
   }
 


### PR DESCRIPTION
## Summary

Points the release-tagging workflow and script at the changelog's new home, `docs/app/releases/changelog.mdx`, and teaches the script to read older locations as well so a commit range that straddles a move still works.

## Why

The App section restructure (#6852) moved `docs/app/references/changelog.mdx` to `docs/app/releases/changelog.mdx`. The workflow's `paths` filter and the script's hardcoded `CHANGELOG` constant both still pointed at the old path, so the run on that very commit failed with:

```
docs/app/references/changelog.mdx does not exist at c83f231dc. If the changelog
moved, update CHANGELOG in this script and the paths filter in
.github/workflows/tag-docs-release.yml.
```

Left as a single hardcoded path, the next range spanning a move would read an empty changelog at `before` and treat every version in the file as newly added — the existing-tag check absorbs most of that, but any untagged version would get a tag pointing at the wrong commit. `CHANGELOG_PATHS` (newest first) plus a `changelogAt(sha)` helper means each commit is read at whichever location exists there, so `before` and `after` stay comparable across a rename. `findIntroducingCommit` passes all the paths to `git log`, and the fail-loud check now names them and says to prepend the new one.

## Notes for reviewers

The behavior is exercised by dry runs against real history, not by tests — this repo has none for the script:

| Range | Result |
| --- | --- |
| `46bc6c4..c83f231` (the move commit, the run that failed) | "nothing to do" — correct, no new entries |
| `7099c04~1..7099c04` (15.21.0 landing on the old path) | would tag `v15.21.0` → `7099c04b` |
| `7099c04~1..c83f231` (release *and* move in one range) | same single correct tag |
| synthetic commit with neither path | still fails loudly, naming both locations |

Two things intentionally left out:

- **The workflow `paths` filter lists only the current location.** The old path can never change again, so listing it would be dead config. A comment on the filter points at `CHANGELOG_PATHS` so the two stay in step on the next move.
- **No backfill for the move commit.** The tagging workflow won't retroactively fire, so if 15.21.0 or anything else is missing its tag, a `workflow_dispatch` run with `before`/`after` set will fill the gap.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PHvQvu6R7LZp1ZUw3GBMWf)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only release-tagging script and workflow path filter; no runtime, auth, or user-facing docs behavior changes beyond restoring tagging after the changelog move.
> 
> **Overview**
> **Updates doc release tagging** so it works after the changelog moved from `docs/app/references/changelog.mdx` to `docs/app/releases/changelog.mdx`.
> 
> The **tag-docs-release** workflow’s `paths` trigger now watches the new file, with a comment to keep `CHANGELOG_PATHS` in `scripts/tag-docs-release.mjs` in sync on the next move. The script replaces a single hardcoded path with **`CHANGELOG_PATHS`** (newest first) and **`changelogAt(sha)`**, which loads the changelog from whichever known path exists at that commit—so `before`/`after` comparisons and version detection stay correct when a commit range **straddles a rename**. **`findIntroducingCommit`** passes both paths to `git log`, and the missing-changelog error lists all looked-up locations and tells maintainers to prepend the new path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50c8b23875430d38c387e888b9eadebace118f99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->