### PR TITLE
Add Cypress Tap Skill

### DIFF
--- a/docs/app/ai/ai-skills.mdx
+++ b/docs/app/ai/ai-skills.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Cypress AI Skills'
-description: 'Cypress AI Skills teach AI coding tools like Cursor, Claude Code, and GitHub Copilot to write, review, and explain Cypress tests using best practices.'
+description: 'Cypress AI Skills teach AI coding agents like Cursor, Claude Code, and GitHub Copilot to write, review, explain, and debug Cypress tests using best practices.'
 sidebar_label: Cypress skills for AI
 sidebar_position: 50
 slug: /app/tooling/ai-skills
@@ -10,13 +10,13 @@ slug: /app/tooling/ai-skills
 
 # Cypress AI Skills
 
-Cypress AI Skills teach your AI coding tool to write, review, and explain
-Cypress tests the way an experienced Cypress engineer would. Instead of generic
-test code built on brittle selectors and arbitrary waits, your AI tool produces
+Cypress AI Skills teach your AI coding agent to write, review, explain, and
+debug Cypress tests the way an experienced Cypress engineer would. Instead of generic
+test code built on brittle selectors and arbitrary waits, your AI agent produces
 tests that follow Cypress best practices and match the conventions already in
 your project.
 
-With Cypress AI Skills, your AI tool can:
+With Cypress AI Skills, your AI agent can:
 
 - Generate tests that follow Cypress best practices out of the box
 - Avoid flaky patterns like weak selectors, arbitrary waits, and inter-test
@@ -25,34 +25,37 @@ With Cypress AI Skills, your AI tool can:
   of reinventing them
 - Ground answers in official Cypress documentation rather than outdated
   training data
+- Run, watch, and debug tests against a live Cypress session, then fix failures
+  in the same loop that wrote them
 - Behave consistently across your team, no matter who writes the prompt
 
-Skills work with any AI coding tool that supports agent skills or custom
+Skills work with any AI coding agent that supports skills or custom
 instructions, including Cursor, Claude Code, and GitHub Copilot. They are
 published in the open source
 [Cypress AI Toolkit](https://github.com/cypress-io/ai-toolkit).
 
 ## What are AI Skills?
 
-AI Skills are instruction sets that tell your AI tool how to approach a
+AI Skills are instruction sets that tell your AI agent how to approach a
 specific Cypress workflow: what conventions to follow, how to reason about the
 task, and what good output looks like.
 
-Think of a generic AI tool as a brilliant but inexperienced new hire. Without
+Think of a generic AI agent as a brilliant but inexperienced new hire. Without
 guidance, it will do its best, but it won't know your team's standards, your
 project's conventions, or what good Cypress tests look like. A skill is the expert
 SOP manual you hand them on day one.
 
 ## Available Cypress skills
 
-Cypress publishes three skills. They are designed to work together:
+Cypress publishes four skills. They are designed to work together:
 `cypress-author` writes and fixes tests, `cypress-explain` reviews and explains
-them, and `cypress-docs` grounds both in official documentation.
+them, `cypress-docs` grounds them in official documentation, and `cypress-tap`
+runs and debugs them against a live Cypress session.
 
 ### `cypress-author`: create, update, and fix tests
 
 [`cypress-author`](https://github.com/cypress-io/ai-toolkit/tree/main/skills/cypress-author)
-improves how AI tools create, update, and fix Cypress end-to-end and component
+improves how AI agents create, update, and fix Cypress end-to-end and component
 tests. Use it when you're writing new tests or fixing broken or flaky ones.
 
 Before writing a single line, the skill reads your project: your Cypress
@@ -87,7 +90,7 @@ helps you understand, describe, and critique existing tests. Use it when
 auditing a suite, onboarding a new team member, or investigating a brittle test
 before rewriting it.
 
-Beyond what a generic AI tool knows, this skill:
+Beyond what a generic AI agent knows, this skill:
 
 - **Classifies your question first.** Whether you're asking about a Cypress
   concept or a specific test, it applies the right approach for each rather
@@ -108,12 +111,12 @@ Beyond what a generic AI tool knows, this skill:
 ### `cypress-docs`: look up accurate documentation
 
 [`cypress-docs`](https://github.com/cypress-io/ai-toolkit/tree/main/skills/cypress-docs)
-gives your AI tool reliable access to accurate, up-to-date Cypress
+gives your AI agent reliable access to accurate, up-to-date Cypress
 documentation. Use it to look up commands, APIs, and configuration options, or
 to confirm how a feature works in a specific Cypress version. It also supports
 the other Cypress skills, which consult official documentation while they work.
 
-Beyond what a generic AI tool knows, this skill:
+Beyond what a generic AI agent knows, this skill:
 
 - **Searches official sources first.** It routes queries to the correct
   section of docs.cypress.io (commands, guides, configuration, error messages)
@@ -129,9 +132,45 @@ Beyond what a generic AI tool knows, this skill:
   it scopes answers to what is available in that version and calls out
   differences explicitly.
 
+### `cypress-tap`: run and debug tests against a live session {#cypress-tap}
+
+The [`cypress-tap`](https://github.com/cypress-io/ai-toolkit/tree/main/skills/cypress-tap) skill
+instructs your AI agent on how to interact with a running `cypress open` session through the
+[`cypress tap`](/app/tooling/cypress-tap) CLI to run specs, read
+reporter and Command Log output, diagnose failures, and inspect the app under
+test from the terminal. Use it when authoring or debugging tests against a
+live session, so your AI agent can verify its own work rather than reporting a
+bare pass or fail.
+
+The skill requires Cypress `15.21.0` or later, a Chromium-based browser (Chrome,
+Chromium, Edge, or Electron), and a running `cypress open` session to attach to.
+To run a headless session instead, use `cypress run`.
+
+Beyond what a generic AI agent knows, this skill:
+
+- **Reads results the way the Cypress app does.** It pulls the spec overview,
+  each test's Command Log, the error and code frame, and the console properties
+  behind a command, drilling into a single command only when it needs to.
+- **Inspects the app at the moment it broke.** It pins a past command's DOM
+  snapshot and reads the page with `dom`, `aria`, and `inspect`, then clears the
+  pin when it is done.
+- **Keeps its reads small.** It caps the DOM, accessibility tree, and console
+  output it pulls back, so a large page never floods your AI agent's context,
+  and raises the caps only when it needs more.
+- **Waits for the real verdict.** It captures the run's start time, runs a single
+  spec, and polls `status` until a fresh `passed` or `failed` arrives for that
+  spec, so it never trusts a stale result left over from a previous run.
+- **Runs against the right session.** When more than one `cypress open` session
+  is running, it targets the one for your project, or a specific session you
+  name, instead of guessing.
+
+For the full CLI reference the skill builds on, including every command, its
+options, and end-to-end debugging walkthroughs, see
+[Drive Cypress with AI agents using `cypress tap`](/app/tooling/cypress-tap).
+
 ## Install Cypress AI Skills
 
-Cypress skills work with any AI coding tool that supports custom instructions,
+Cypress skills work with any AI coding agent that supports custom instructions,
 including Cursor, Claude Code, GitHub Copilot, and others.
 
 ### Install with the skills CLI
@@ -148,7 +187,8 @@ Or install each skill individually:
 <PackageManagerTabs
   exec={`skills add https://github.com/cypress-io/ai-toolkit --skill cypress-author
 skills add https://github.com/cypress-io/ai-toolkit --skill cypress-explain
-skills add https://github.com/cypress-io/ai-toolkit --skill cypress-docs`}
+skills add https://github.com/cypress-io/ai-toolkit --skill cypress-docs
+skills add https://github.com/cypress-io/ai-toolkit --skill cypress-tap`}
 />
 
 Skills installed this way don't update automatically. To update your installed
@@ -185,6 +225,10 @@ gh skill install cypress-io/ai-toolkit cypress-explain
 gh skill install cypress-io/ai-toolkit cypress-docs
 ```
 
+```bash
+gh skill install cypress-io/ai-toolkit cypress-tap
+```
+
 ### Install manually
 
 Installation steps vary by tool.
@@ -218,7 +262,7 @@ automatic update notifications, so check back periodically for new releases.
 
 ## How to use Cypress AI Skills
 
-You can invoke a skill explicitly with a slash command, or let your AI tool
+You can invoke a skill explicitly with a slash command, or let your AI agent
 load it automatically when your prompt is relevant:
 
 ```bash
@@ -312,6 +356,18 @@ providers, stubs, and baseline assertions by hand.
 real-time run failures.
 
 :::
+
+### Run and debug a test against a live session
+
+With `cypress open` running in your project, `cypress-tap` can run a spec, read
+the failure the way the Cypress app shows it, and inspect the app at the moment
+it broke, all from your AI agent. See the
+[`cypress tap` documentation](/app/tooling/cypress-tap) for the full command
+reference.
+
+```skill
+/cypress-tap Run cypress/e2e/checkout.cy.ts against my open Cypress session, poll for a verdict, and if it fails, read the failing test's Command Log and error and inspect the app at the failing command to tell me what caused it.
+```
 
 ### Summarize test coverage in plain language
 

--- a/docs/app/ai/ai-skills.mdx
+++ b/docs/app/ai/ai-skills.mdx
@@ -49,8 +49,7 @@ SOP manual you hand them on day one.
 
 Cypress publishes four skills. They are designed to work together:
 `cypress-author` writes and fixes tests, `cypress-explain` reviews and explains
-them, `cypress-docs` grounds them in official documentation, and `cypress-tap`
-runs and debugs them against a live Cypress session.
+them, `cypress-tap` runs and debugs them against a live Cypress session and `cypress-docs` grounds them in official documentation.
 
 ### `cypress-author`: create, update, and fix tests
 
@@ -108,30 +107,6 @@ Beyond what a generic AI agent knows, this skill:
 - **Keeps explanations concise and practical.** Focused on how things are
   used, not exhaustive API walkthroughs.
 
-### `cypress-docs`: look up accurate documentation
-
-[`cypress-docs`](https://github.com/cypress-io/ai-toolkit/tree/main/skills/cypress-docs)
-gives your AI agent reliable access to accurate, up-to-date Cypress
-documentation. Use it to look up commands, APIs, and configuration options, or
-to confirm how a feature works in a specific Cypress version. It also supports
-the other Cypress skills, which consult official documentation while they work.
-
-Beyond what a generic AI agent knows, this skill:
-
-- **Searches official sources first.** It routes queries to the correct
-  section of docs.cypress.io (commands, guides, configuration, error messages)
-  before your model reaches for Cypress knowledge it already has, which may be
-  outdated.
-- **Uses LLM-optimized documentation.** The skill discovers structured
-  Markdown content through the `/llms.txt` index on docs.cypress.io, giving
-  cleaner and more reliable results than scraping HTML.
-- **Grounds answers in docs, not training data.** If a claim can't be verified
-  in official documentation, it says so rather than inventing an API or
-  behavior, reducing the chance of a confident but incorrect answer.
-- **Stays version-aware.** When a Cypress version is detected in your project,
-  it scopes answers to what is available in that version and calls out
-  differences explicitly.
-
 ### `cypress-tap`: run and debug tests against a live session {#cypress-tap}
 
 The [`cypress-tap`](https://github.com/cypress-io/ai-toolkit/tree/main/skills/cypress-tap) skill
@@ -142,8 +117,8 @@ test from the terminal. Use it when authoring or debugging tests against a
 live session, so your AI agent can verify its own work rather than reporting a
 bare pass or fail.
 
-The skill requires Cypress `15.21.0` or later, a Chromium-based browser (Chrome,
-Chromium, Edge, or Electron), and a running `cypress open` session to attach to.
+The skill requires a Cypress version with access to cypress tap (`15.21.0` or later) and use of
+a browser supported by cypress tap, and a running `cypress open` session to attach to.
 To run a headless session instead, use `cypress run`.
 
 Beyond what a generic AI agent knows, this skill:
@@ -168,6 +143,30 @@ For the full CLI reference the skill builds on, including every command, its
 options, and end-to-end debugging walkthroughs, see
 [Drive Cypress with AI agents using `cypress tap`](/app/tooling/cypress-tap).
 
+### `cypress-docs`: look up accurate documentation
+
+[`cypress-docs`](https://github.com/cypress-io/ai-toolkit/tree/main/skills/cypress-docs)
+gives your AI agent reliable access to accurate, up-to-date Cypress
+documentation. Use it to look up commands, APIs, and configuration options, or
+to confirm how a feature works in a specific Cypress version. It also supports
+the other Cypress skills, which consult official documentation while they work.
+
+Beyond what a generic AI agent knows, this skill:
+
+- **Searches official sources first.** It routes queries to the correct
+  section of docs.cypress.io (commands, guides, configuration, error messages)
+  before your model reaches for Cypress knowledge it already has, which may be
+  outdated.
+- **Uses LLM-optimized documentation.** The skill discovers structured
+  Markdown content through the `/llms.txt` index on docs.cypress.io, giving
+  cleaner and more reliable results than scraping HTML.
+- **Grounds answers in docs, not training data.** If a claim can't be verified
+  in official documentation, it says so rather than inventing an API or
+  behavior, reducing the chance of a confident but incorrect answer.
+- **Stays version-aware.** When a Cypress version is detected in your project,
+  it scopes answers to what is available in that version and calls out
+  differences explicitly.
+
 ## Install Cypress AI Skills
 
 Cypress skills work with any AI coding agent that supports custom instructions,
@@ -187,8 +186,8 @@ Or install each skill individually:
 <PackageManagerTabs
   exec={`skills add https://github.com/cypress-io/ai-toolkit --skill cypress-author
 skills add https://github.com/cypress-io/ai-toolkit --skill cypress-explain
-skills add https://github.com/cypress-io/ai-toolkit --skill cypress-docs
-skills add https://github.com/cypress-io/ai-toolkit --skill cypress-tap`}
+skills add https://github.com/cypress-io/ai-toolkit --skill cypress-tap
+skills add https://github.com/cypress-io/ai-toolkit --skill cypress-docs`}
 />
 
 Skills installed this way don't update automatically. To update your installed
@@ -222,11 +221,11 @@ gh skill install cypress-io/ai-toolkit cypress-explain
 ```
 
 ```bash
-gh skill install cypress-io/ai-toolkit cypress-docs
+gh skill install cypress-io/ai-toolkit cypress-tap
 ```
 
 ```bash
-gh skill install cypress-io/ai-toolkit cypress-tap
+gh skill install cypress-io/ai-toolkit cypress-docs
 ```
 
 ### Install manually

--- a/docs/app/ai/ai-skills.mdx
+++ b/docs/app/ai/ai-skills.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Cypress AI Skills'
 description: 'Cypress AI Skills teach AI coding agents like Cursor, Claude Code, and GitHub Copilot to write, review, explain, and debug Cypress tests using best practices.'
-sidebar_label: Cypress skills for AI
+sidebar_label: Cypress AI Skills
 sidebar_position: 50
 slug: /app/tooling/ai-skills
 ---

--- a/docs/app/ai/cypress-tap.mdx
+++ b/docs/app/ai/cypress-tap.mdx
@@ -24,7 +24,7 @@ Code, GitHub Copilot, Windsurf, and Codex CLI.
 
 :::tip
 
-The easiest way to use `cypress tap` with an agent is the
+To get the most out of `cypress tap` with an agent, pair it with the
 [`cypress-tap` skill](/app/tooling/ai-skills#cypress-tap) from the
 [Cypress AI Toolkit](https://github.com/cypress-io/ai-toolkit). It tells your
 agent how to drive these commands correctly, such as polling for a real verdict

--- a/docs/app/ai/cypress-tap.mdx
+++ b/docs/app/ai/cypress-tap.mdx
@@ -22,6 +22,15 @@ This allows an agent can verify its own work as it codes, catching and fixing fa
 Any agent that can run shell commands can use it, including Cursor, Claude
 Code, GitHub Copilot, Windsurf, and Codex CLI.
 
+:::tip
+
+The easiest way to use `cypress tap` with an agent is the
+[`cypress-tap` skill](/app/tooling/ai-skills#cypress-tap). It tells your
+agent how to compose these commands, keep outputs minimal and poll for a real verdict, so you don't have to write those instructions
+yourself. .
+
+:::
+
 :::warning
 
 `cypress tap` is in [beta](/app/references/release-stages#Beta). It is enabled by
@@ -458,6 +467,15 @@ STYLES (2)
 
 ### Getting Started
 
+:::note
+
+The steps below walk through the commands by hand. If you want your agent to run
+this loop for you, install the
+[`cypress-tap` skill](/app/tooling/ai-skills#cypress-tap) instead of scripting
+the commands yourself.
+
+:::
+
 Start Cypress in your project and pick a testing type and browser:
 
 ```shell title="Command"
@@ -722,9 +740,26 @@ building.
 
 ### Add cypress tap to your agent's instructions
 
-To make your agent use it, add instructions to the file your agent reads:
+To make your agent use `cypress tap`, the simplest option is to install the
+[`cypress-tap` skill](/app/tooling/ai-skills#cypress-tap) from the Cypress AI
+Toolkit. It packages the workflow below, including polling for a real verdict,
+reading results, pinning and inspecting the app, and clearing pins, so your
+agent applies it without you writing the instructions by hand.
+
+Install it with the [`skills`](https://skills.sh/) CLI:
+
+<PackageManagerTabs exec="skills add https://github.com/cypress-io/ai-toolkit --skill cypress-tap" />
+
+or with the [GitHub CLI](https://cli.github.com/manual/gh_skill):
+
+```bash
+gh skill install cypress-io/ai-toolkit cypress-tap
+```
+
+Alternatively, add instructions to the file your agent reads:
 `AGENTS.md` for Cursor, Codex CLI, and most others, `CLAUDE.md` for Claude
-Code, or `.github/copilot-instructions.md` for GitHub Copilot.
+Code, or `.github/copilot-instructions.md` for GitHub Copilot. This allows
+you to write your own instructions and workflows for your agent.
 
 ```md title="AGENTS.md"
 ## Verify changes with Cypress
@@ -814,9 +849,10 @@ without relaying results back and forth:
 </CopyPrompt>
 
 `cypress tap` pairs well with
-[Cypress AI Skills](/app/tooling/ai-skills): the skills teach your agent how to
-write good Cypress tests, and `cypress tap` tells it what happened when those
-tests ran.
+[Cypress AI Skills](/app/tooling/ai-skills): `cypress-author` and
+`cypress-explain` teach your agent how to write and review good Cypress tests,
+and the [`cypress-tap` skill](/app/tooling/ai-skills#cypress-tap) drives these
+commands for you so your agent knows what happened when those tests ran.
 
 ## Verify a Cloud failure locally
 

--- a/docs/app/ai/cypress-tap.mdx
+++ b/docs/app/ai/cypress-tap.mdx
@@ -25,9 +25,11 @@ Code, GitHub Copilot, Windsurf, and Codex CLI.
 :::tip
 
 The easiest way to use `cypress tap` with an agent is the
-[`cypress-tap` skill](/app/tooling/ai-skills#cypress-tap). It tells your
-agent how to compose these commands, keep outputs minimal and poll for a real verdict, so you don't have to write those instructions
-yourself. .
+[`cypress-tap` skill](/app/tooling/ai-skills#cypress-tap) from the
+[Cypress AI Toolkit](https://github.com/cypress-io/ai-toolkit). It tells your
+agent how to drive these commands correctly, such as polling for a real verdict
+before trusting a pass or fail, so you don't have to write those instructions
+yourself.
 
 :::
 

--- a/docs/app/ai/overview.mdx
+++ b/docs/app/ai/overview.mdx
@@ -49,12 +49,14 @@ assertions that do not retry. These capabilities give it better information to
 work from.
 
 - **[Cypress skills for AI agents](/app/tooling/ai-skills)** teach your coding
-  tool to write, review, and explain tests the way an experienced Cypress
+  agent to write, review, and explain tests the way an experienced Cypress
   engineer would. Install them once per project.
 - **[`cypress tap`](/app/tooling/cypress-tap)** attaches your agent to a running
   open mode session from the terminal, so it can run a spec and then read the
   Command Log, the error, and the DOM as the Cypress app shows them. That closes
   the loop: the agent can verify its own fix instead of reporting pass or fail.
+  The [`cypress-tap` skill](/app/tooling/ai-skills#cypress-tap) packages this
+  workflow so your agent drives it correctly.
 - **[Cloud MCP](/cloud/integrations/cloud-mcp)** connects your agent to Cypress
   Cloud so it can read real run results, failures, and
   [Test Replay](/cloud/features/test-replay) data while you work, rather than

--- a/docs/app/debug/debugging.mdx
+++ b/docs/app/debug/debugging.mdx
@@ -143,9 +143,11 @@ npx cypress tap status --json
 npx cypress tap reporter --test-id <id>
 ```
 
-See [driving Cypress from the terminal with an AI agent](/app/tooling/cypress-tap)
-for the full workflow and
-a snippet you can drop into your agent's instructions file.
+The [`cypress-tap` skill](/app/tooling/ai-skills#cypress-tap) is the easiest way
+to hand this loop to your agent: it packages these commands so your agent drives
+them correctly, without you writing the steps by hand. For the full workflow, or
+a snippet you can drop into your agent's instructions file yourself, see
+[driving Cypress from the terminal with an AI agent](/app/tooling/cypress-tap).
 
 ## Using the Developer Tools
 

--- a/docs/app/debug/faq.mdx
+++ b/docs/app/debug/faq.mdx
@@ -2059,18 +2059,22 @@ Start Cypress in open mode with `cypress open`, then point your agent at the
 poll until it reports `passed` or `failed`, and `cypress tap reporter --test-id <test-id>`
 to read the failing test's Command Log, error, and code frame.
 
-Add those steps to the instructions file your agent reads, such as `AGENTS.md`
-or `CLAUDE.md`. See
+The easiest way is to install the
+[`cypress-tap` skill](/app/tooling/ai-skills#cypress-tap), which packages this
+loop so your agent runs it correctly. If you'd rather write the steps yourself,
+add them to the instructions file your agent reads, such as `AGENTS.md` or
+`CLAUDE.md`. See
 [Use cypress tap with AI agents](/app/tooling/cypress-tap#Use-cypress-tap-with-AI-agents)
 for a snippet you can copy.
 
 ### <Icon name="angle-right" /> How do I use Cypress with Cursor, Claude Code, or GitHub Copilot?
 
-Any AI coding tool that can run shell commands can drive Cypress through the
-`cypress tap` CLI. Start Cypress with `cypress open`, then add the
-`cypress tap` workflow to the instructions file your tool reads: `AGENTS.md`
-for Cursor and Codex CLI, `CLAUDE.md` for Claude Code, or
-`.github/copilot-instructions.md` for GitHub Copilot. See
+Any AI coding agent that can run shell commands can drive Cypress through the
+`cypress tap` CLI. Start Cypress with `cypress open`, then install the
+[`cypress-tap` skill](/app/tooling/ai-skills#cypress-tap) to hand it the
+workflow, or add the `cypress tap` steps yourself to the instructions file your
+agent reads: `AGENTS.md` for Cursor and Codex CLI, `CLAUDE.md` for Claude Code,
+or `.github/copilot-instructions.md` for GitHub Copilot. See
 [Use cypress tap with AI agents](/app/tooling/cypress-tap#Use-cypress-tap-with-AI-agents)
 for a snippet to copy.
 

--- a/docs/cloud/features/cypress-ai-features.mdx
+++ b/docs/cloud/features/cypress-ai-features.mdx
@@ -56,11 +56,11 @@ Cypress AI are easy-to-use capabilities and tools across your testing lifecycle.
 
 | When To Use       | AI Tool                                    | Outcome                                                                                                          |
 | ----------------- | ------------------------------------------ | ---------------------------------------------------------------------------------------------------------------- |
-| Author Tests      | `cypress-author` and `cypress-docs` Skills | Improves how AI tools create, update, and fix Cypress tests.                                                     |
+| Author Tests      | `cypress-author` and `cypress-docs` Skills | Improves how AI agents create, update, and fix Cypress tests.                                                    |
 | Understand Tests  | `cypress-explain` Skill                    | Helps AI describe, and critique existing tests.                                                                  |
 | Analyze & Triage  | Cloud MCP                                  | Gives AI coding assistants and AI agents a direct window into your application's health and stability            |
 | Triage & Automate | Cloud CLI                                  | Brings Cloud data and Test Replay access to the terminal for triage, scripting, CI, and terminal-based AI agents |
-| Run & Debug Tests | `cypress tap` CLI                          | Live Cypress app access for your agent. Drives Cypress and pulls the command log and DOM directly into context.  |
+| Run & Debug Tests | `cypress tap` CLI and `cypress-tap` Skill  | Live Cypress app access for your agent. Drives Cypress and pulls the command log and DOM directly into context.  |
 
 ## Capabilities in detail
 
@@ -193,11 +193,12 @@ This capability is included with UI Coverage and is not available on standard Cl
 **Best for:** teams wanting to providing instructions to improve the output of AI when working with Cypress.
 :::
 
-Use skills when you want your AI tool to:
+Use skills when you want your AI agent to:
 
 - Apply Cypress best practices to generated and reviewed tests
 - Steer away from brittle patterns and weak selectors
 - Produce more Cypress-focused explanations and critiques
+- Run and debug local tests against a live Cypress session with the `cypress-tap` CLI
 - Establish consistent AI behavior across your team and workflows
 
 [Read the AI Skills documentation →](/app/tooling/ai-skills)


### PR DESCRIPTION
<!--
Fill in every section. This template doubles as the historical record of the
change, so future readers can understand not just what changed but
why. Delete a section only if it is genuinely not applicable, and say so.
-->

## Summary

<!-- What does this PR change, in one or two sentences? Write for a reader who
has never seen the task. -->

## Why

<!-- The motivation and context. If this originated from an issue, a Slack/
Discord thread, a broken link, an outdated example, or a release, capture it
here so the reasoning survives after the source is gone. -->

Closes #<!-- issue number, or remove this line if none -->

## Notes for reviewers

<!-- Anything a reviewer should focus on: decisions made, alternatives
considered, areas of uncertainty, or follow-ups intentionally left out. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to MDX; no runtime, auth, or application logic changes.
> 
> **Overview**
> **Documents the fourth Cypress AI skill, `cypress-tap`, and wires it through the rest of the AI tooling docs.**
> 
> The [Cypress AI Skills](/app/tooling/ai-skills) page now treats agents as the audience (replacing “AI coding tool” wording), expands the value prop to **debug** tests, and adds a full **`cypress-tap`** section: what it does with `cypress open` + the `cypress tap` CLI, version/browser/session requirements, and install lines for `skills` and `gh skill`. Install blocks and a new **run and debug against a live session** example prompt were updated so all four skills are listed together.
> 
> **Cross-links** now steer readers to install the skill instead of hand-writing agent instructions: tips and notes on **`cypress-tap.mdx`**, the AI overview, debugging guide, debug FAQ, and Cloud **Cypress AI** feature tables (Run & Debug row and AI Skills bullets). Manual `AGENTS.md` snippets remain as the alternative path.
> 
> ## Why
> 
> Ships user-facing docs for the open-source `cypress-tap` skill in the AI Toolkit so agents can drive `cypress tap` with correct polling, reporter/command reads, and pin/inspect workflows without users maintaining that guidance themselves.
> 
> ## Notes for reviewers
> 
> Confirm anchor `#cypress-tap` and `/app/tooling/ai-skills#cypress-tap` links resolve as expected in the site build; no product code changes in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7efb0111498525fcf2abafe278f28b44a205174. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->