### PR TITLE
docs: cypress release 15.21.1

### DIFF
--- a/docs/app/releases/changelog.mdx
+++ b/docs/app/releases/changelog.mdx
@@ -10,6 +10,15 @@ slug: /app/references/changelog
 
 # Changelog
 
+## 15.21.1
+
+_Released Aug 25, 2026_
+
+**Bugfixes:**
+
+- Fixed an issue where Chrome and Firefox offered to translate the application under test, showing a translation prompt during the run. Fixes [#34662](https://github.com/cypress-io/cypress/issues/34662).
+- Fixed an issue where every `cypress tap` command printed HTTP request lines, such as `GET /__cypress/sessions/<id>`, to the terminal of the `cypress open` session it attached to, burying that session's own output. Fixes [#34668](https://github.com/cypress-io/cypress/issues/34668).
+
 ## 15.21.0
 
 _Released Aug 18, 2026_


### PR DESCRIPTION
## Summary

Adds the Cypress App 15.21.1 changelog entry to `docs/app/releases/changelog.mdx`, copied from `cli/CHANGELOG.md` in the `cypress` repo.

## Why

Cypress 15.21.1 was published to npm on Aug 25, 2026. The docs changelog is the user-facing record of each release, so it needs the new entry to stay in sync with the repo changelog.

## Notes for reviewers

The entry is a verbatim copy of the 15.21.1 section of `cli/CHANGELOG.md` plus the `_Released Aug 25, 2026_` line that this changelog adds. Both bullets are patch bugfixes and neither links to a docs page, so there were no `https://docs.cypress.io/...` → repo-relative link rewrites to do this time. No other docs pages reference behavior changed by this release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog addition with no runtime or configuration impact.
> 
> **Overview**
> Documents **Cypress App 15.21.1** (released Aug 25, 2026) in `docs/app/releases/changelog.mdx` so the public docs match the published npm release.
> 
> The new section lists two patch **bugfixes**: suppressing browser translation prompts during runs in Chrome/Firefox ([#34662](https://github.com/cypress-io/cypress/issues/34662)), and stopping `cypress tap` from flooding the attached `cypress open` terminal with internal HTTP request lines ([#34668](https://github.com/cypress-io/cypress/issues/34668)). Content is aligned with `cli/CHANGELOG.md` plus the standard `_Released …_` line used on this page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ea242c3bd61032d58cfe68d18cc086d7295e618. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->