### PR TITLE
docs: make AI feature plan requirements explicit (no AI feature requires a paid plan)

### DIFF
--- a/docs/app/ai/ai-skills.mdx
+++ b/docs/app/ai/ai-skills.mdx
@@ -34,6 +34,9 @@ instructions, including Cursor, Claude Code, and GitHub Copilot. They are
 published in the open source
 [Cypress AI Toolkit](https://github.com/cypress-io/ai-toolkit).
 
+They are free to every Cypress user: no Cypress Cloud account, no paid
+subscription, and no usage limits. Install them into your agent and they work.
+
 ## What are AI Skills?
 
 AI Skills are instruction sets that tell your AI agent how to approach a

--- a/docs/app/ai/ai-skills.mdx
+++ b/docs/app/ai/ai-skills.mdx
@@ -35,7 +35,8 @@ published in the open source
 [Cypress AI Toolkit](https://github.com/cypress-io/ai-toolkit).
 
 They are free to every Cypress user: no Cypress Cloud account, no paid
-subscription, and no usage limits. Install them into your agent and they work.
+subscription, and no usage limits. Installing them into your agent is all it
+takes.
 
 ## What are AI Skills?
 

--- a/docs/app/ai/ai-test-generation.mdx
+++ b/docs/app/ai/ai-test-generation.mdx
@@ -53,7 +53,7 @@ _The demo above shows `cy.prompt` in action with [Cypress Studio](/app/guides/cy
 
 ## Get started
 
-`cy.prompt` uses AI under the hood, so it needs a secure connection to Cypress Cloud to interpret your prompts. Cypress Cloud manages those requests, applies organization-level controls, and tracks usage. We never use your prompts to train AI models, and you can turn AI features off at any time. `cy.prompt` is available on every [Cypress Cloud plan type](https://www.cypress.io/pricing).
+`cy.prompt` uses AI under the hood, so it needs a secure connection to Cypress Cloud to interpret your prompts. Cypress Cloud manages those requests, applies organization-level controls, and tracks usage. We never use your prompts to train AI models, and you can turn AI features off at any time. `cy.prompt` is available on every [Cypress Cloud plan](https://www.cypress.io/pricing?utm_source=docs.cypress.io&utm_medium=ai-test-generation), including the free Starter plan. No paid subscription is required; a paid plan raises your execution allowance and hourly limits.
 
 **To use `cy.prompt`, you must either:**
 

--- a/docs/app/ai/cypress-studio.mdx
+++ b/docs/app/ai/cypress-studio.mdx
@@ -61,7 +61,7 @@ Studio requires **internet access** and **sourcemaps**. See [enable sourcemaps](
   href="https://cloud.cypress.io/signup"
 />
 
-Free accounts include a two-week trial of all paid features, including higher AI usage limits.
+A free account is enough: Studio AI works on every Cypress Cloud plan, including the free Starter plan. New accounts also include a [30-day trial](/cloud/get-started/free-trial) of all paid features, which raises your AI usage limits while it lasts.
 
 To link your project to Cypress Cloud, see [Set up your project to record](/cloud/get-started/setup#Set-up-a-project-to-record).
 

--- a/docs/app/ai/cypress-tap.mdx
+++ b/docs/app/ai/cypress-tap.mdx
@@ -17,10 +17,12 @@ An AI agent can run a Cypress spec and get back pass or fail. What it can't get 
 
 `cypress tap` is an extension of the cypress CLI that lets you or an agent interact with an open-mode Cypress session and read its context from the terminal. With it, an agent can run a spec and poll its status, then read the failing test's Command Log and error as the Cypress app shows them. It can also inspect the DOM of the application under test at the moment a command ran.
 
-This allows an agent can verify its own work as it codes, catching and fixing failures in the same loop that created them.
+This allows an agent to verify its own work as it codes, catching and fixing failures in the same loop that created them.
 
 Any agent that can run shell commands can use it, including Cursor, Claude
 Code, GitHub Copilot, Windsurf, and Codex CLI.
+
+`cypress tap` is completely free. It ships with the `cypress` binary you already have, so there is no Cypress Cloud account to create, no plan to buy, and nothing extra to install.
 
 :::tip
 

--- a/docs/app/ai/cypress-tap.mdx
+++ b/docs/app/ai/cypress-tap.mdx
@@ -60,6 +60,11 @@ result when passed `--json`. Agents and scripts should prefer `--json`.
 - Requires Cypress v15.21.0+
 - If the `cypress tap` CLI and the session it attaches to are on incompatible versions, the CLI stops and reports the version mismatch.
 
+No Cypress Cloud account and no paid subscription are required. `cypress tap`
+ships with the `cypress` binary you already have and drives the open mode
+session on your own machine, so there is nothing to sign up for and no usage
+limits to track. That holds whether or not you record runs to Cypress Cloud.
+
 ## Available commands
 
 Below is the list of the commands `cypress tap` exposes:

--- a/docs/app/ai/cypress-tap.mdx
+++ b/docs/app/ai/cypress-tap.mdx
@@ -22,7 +22,7 @@ This allows an agent to verify its own work as it codes, catching and fixing fai
 Any agent that can run shell commands can use it, including Cursor, Claude
 Code, GitHub Copilot, Windsurf, and Codex CLI.
 
-`cypress tap` is completely free. It ships with the `cypress` binary you already have, so there is no Cypress Cloud account to create, no plan to buy, and nothing extra to install.
+`cypress tap` is completely free. It ships with the Cypress App you already have, so there is no Cypress Cloud account to create, no plan to buy, and nothing extra to install.
 
 :::tip
 
@@ -63,7 +63,7 @@ result when passed `--json`. Agents and scripts should prefer `--json`.
 - If the `cypress tap` CLI and the session it attaches to are on incompatible versions, the CLI stops and reports the version mismatch.
 
 No Cypress Cloud account and no paid subscription are required. `cypress tap`
-ships with the `cypress` binary you already have and drives the open mode
+ships with the Cypress App you already have and drives the open mode
 session on your own machine, so there is nothing to sign up for and no usage
 limits to track. That holds whether or not you record runs to Cypress Cloud.
 

--- a/docs/app/ai/overview.mdx
+++ b/docs/app/ai/overview.mdx
@@ -61,6 +61,9 @@ work from.
   Cloud so it can read real run results, failures, and
   [Test Replay](/cloud/features/test-replay) data while you work, rather than
   guessing at why something failed.
+- **[Cloud CLI](/cloud/integrations/cloud-cli)** is the scriptable counterpart
+  to Cloud MCP: the same Cloud run data as JSON in the terminal, for agents that
+  work through a shell and for your own automation.
 
 ## Analyze and debug with AI
 
@@ -73,17 +76,36 @@ work from.
 
 ## What each capability needs
 
-| Capability                              | Where it runs |       Needs Cypress Cloud       |
-| --------------------------------------- | :-----------: | :-----------------------------: |
-| Cypress Studio recording                |  Cypress App  |               No                |
-| Studio AI assertion suggestions         |  Cypress App  |               Yes               |
-| `cy.prompt`                             |  Cypress App  |     Yes, on any Cloud plan      |
-| Cypress skills for AI agents            |  Your editor  |               No                |
-| `cypress tap`                           | Your terminal |               No                |
-| Cloud MCP                               |  Your editor  |               Yes               |
-| Cypress AI failure and intent summaries | Cypress Cloud |     Yes, on any Cloud plan      |
-| Agent-ready accessibility reports       | Cypress Cloud | Yes, with Cypress Accessibility |
-| Agent-ready coverage reports            | Cypress Cloud |      Yes, with UI Coverage      |
+**No AI capability in Cypress requires a paid subscription.** Everything below
+works on the free
+[Starter plan](https://www.cypress.io/pricing?utm_source=docs.cypress.io&utm_medium=ai-overview),
+and some of it never touches Cypress Cloud at all. The exceptions are the
+agent-ready reports at the bottom of the table, which come with the Cypress
+Accessibility and UI Coverage solutions rather than with a Cloud plan.
+
+Paying raises limits rather than unlocking capabilities: a paid plan gets you a
+larger `cy.prompt` execution allowance and higher hourly limits on `cy.prompt`
+and Studio AI. See
+[AI usage limits](/cloud/features/cypress-ai-features#Usage-limits) for the
+numbers.
+
+| Capability                              | Where it runs | Cypress Cloud account |              Paid plan              |
+| --------------------------------------- | :-----------: | :-------------------: | :---------------------------------: |
+| Cypress Studio recording                |  Cypress App  |      Not needed       |                 No                  |
+| Studio AI assertion suggestions         |  Cypress App  |    Free plan works    |                 No                  |
+| `cy.prompt`                             |  Cypress App  |    Free plan works    |                 No                  |
+| Cypress skills for AI agents            |  Your editor  |      Not needed       |                 No                  |
+| `cypress tap`                           | Your terminal |      Not needed       |                 No                  |
+| Cloud MCP                               |  Your editor  |    Free plan works    |                 No                  |
+| Cloud CLI                               | Your terminal |    Free plan works    |                 No                  |
+| Cypress AI failure and intent summaries | Cypress Cloud |    Free plan works    |                 No                  |
+| Agent-ready accessibility reports       | Cypress Cloud |          Yes          | Included with Cypress Accessibility |
+| Agent-ready coverage reports            | Cypress Cloud |          Yes          |      Included with UI Coverage      |
+
+The capabilities that need a Cloud account need one because Cypress Cloud is
+what routes their AI requests securely, applies your organization's controls,
+and tracks usage. See
+[Why do I need a Cloud account?](/cloud/features/cypress-ai-features#Why-do-I-need-a-Cloud-Account)
 
 Organization admins and owners can turn AI capabilities on or off for everyone
 in the organization. See
@@ -96,3 +118,6 @@ in the organization. See
 - [Cypress skills for AI agents](/app/tooling/ai-skills)
 - [`cypress tap`](/app/tooling/cypress-tap)
 - [Cloud MCP](/cloud/integrations/cloud-mcp)
+- [Cloud CLI](/cloud/integrations/cloud-cli)
+- [Cypress AI](/cloud/features/cypress-ai-features) - availability, usage limits,
+  and pricing for every AI capability

--- a/docs/app/debug/faq.mdx
+++ b/docs/app/debug/faq.mdx
@@ -23,7 +23,9 @@ to record your test runs in CI.
 
 Additionally, we have premium solutions like [UI Coverage](/ui-coverage/get-started/introduction) and [Cypress Accessibility](/accessibility/get-started/introduction) which have separate pricing.
 
-Please see our [Pricing Page](https://www.cypress.io/pricing) for more details.
+Cypress AI is not a paid add-on. No AI capability requires a paid subscription: some, like the [Cypress skills for AI agents](/app/tooling/ai-skills) and the [`cypress tap` CLI](/app/tooling/cypress-tap), need no Cypress Cloud account at all, and the rest work on any Cloud plan, including the free Starter plan. See [Do AI features require a paid plan?](/cloud/faq#Do-AI-features-require-a-paid-plan) for the full breakdown.
+
+Please see our [Pricing Page](https://www.cypress.io/pricing?utm_source=docs.cypress.io&utm_medium=app-faq) for more details.
 
 ### <Icon name="angle-right" /> What operating systems do you support?
 
@@ -2108,11 +2110,16 @@ To give an agent your Cypress CI results instead, use
 [Cloud CLI](/cloud/integrations/cloud-cli), which read recorded runs from
 Cypress Cloud.
 
-### <Icon name="angle-right" /> Does `cypress tap` require a Cypress Cloud account?
+### <Icon name="angle-right" /> Does `cypress tap` require a Cypress Cloud account or a paid subscription?
 
-No. `cypress tap` talks only to the Cypress session running on your own
+No to both. `cypress tap` talks only to the Cypress session running on your own
 machine, so it needs no Cypress Cloud account, login, or network access. It
-ships with the `cypress` npm package like every other Cypress CLI command.
+ships with the `cypress` npm package like every other Cypress CLI command,
+carries no usage limits, and costs nothing.
+
+The same is true of the [Cypress skills for AI agents](/app/tooling/ai-skills).
+For where every other AI capability stands, see
+[Do AI features require a paid plan?](/cloud/faq#Do-AI-features-require-a-paid-plan)
 
 ### <Icon name="angle-right" /> Which browsers does `cypress tap` support?
 

--- a/docs/cloud/faq.mdx
+++ b/docs/cloud/faq.mdx
@@ -884,6 +884,30 @@ Cloud AI is part of Cypress AI: capabilities in Cypress Cloud (such as Test Inte
 
 See [AI at Cypress](/cloud/features/cypress-ai-features) for the full picture. For [`cy.prompt`](/api/commands/prompt) execution limits, billing, and the grace period, see [cy.prompt](#cyprompt) below.
 
+### <Icon name="angle-right" /> Do AI features require a paid plan?
+
+No. Every Cypress AI capability and tool is available without a paid
+subscription:
+
+- **No Cypress Cloud account needed:** the
+  [Cypress skills for AI agents](/app/tooling/ai-skills), the
+  [`cypress tap` CLI](/app/tooling/cypress-tap), and
+  [Cypress Studio](/app/guides/cypress-studio) recording (without AI
+  recommendations).
+- **Any Cloud plan, including the free Starter plan:**
+  [`cy.prompt`](/api/commands/prompt), Studio AI recommendations, Test Intent
+  Summaries, Error Summaries, [Cloud MCP](/cloud/integrations/cloud-mcp), and
+  the [Cloud CLI](/cloud/integrations/cloud-cli).
+- **Included with a premium solution:** UI Coverage Test Generation comes with
+  [UI Coverage](/ui-coverage/get-started/introduction), and agent-ready
+  accessibility reports come with
+  [Cypress Accessibility](/accessibility/get-started/introduction).
+
+A paid plan raises limits rather than unlocking capabilities: a larger
+`cy.prompt` execution allowance and higher hourly limits for `cy.prompt` and
+Studio AI. See
+[AI usage limits](/cloud/features/cypress-ai-features#Usage-limits).
+
 ## cy.prompt
 
 ### <Icon name="angle-right" /> What is a cy.prompt execution?

--- a/docs/cloud/features/cypress-ai-features.mdx
+++ b/docs/cloud/features/cypress-ai-features.mdx
@@ -244,7 +244,7 @@ Where the Cloud CLI and Cloud MCP give agents your recorded run data in
 Cypress Cloud, `cypress tap` gives your AI agent context to your Cypress session and your application-under-test on your
 machine, while developing and verifying tests before it ever runs in CI.
 
-It is completely free and needs no Cypress Cloud account: it ships with the `cypress` binary and drives the session already running on your machine.
+It is completely free and needs no Cypress Cloud account: it ships with the Cypress App and drives the session already running on your machine.
 
 Read the [cypress tap documentation →](/app/tooling/cypress-tap)
 

--- a/docs/cloud/features/cypress-ai-features.mdx
+++ b/docs/cloud/features/cypress-ai-features.mdx
@@ -248,6 +248,34 @@ Read the [cypress tap documentation →](/app/tooling/cypress-tap)
 
 ## FAQs
 
+### Do AI features require a paid subscription?
+
+No. Every AI capability and AI tool listed on this page is available without a
+paid subscription, and several of them run entirely on your machine without a
+Cypress Cloud account at all.
+
+| Capability / Tool                         | What it needs                                                                    |
+| ----------------------------------------- | -------------------------------------------------------------------------------- |
+| AI Skills                                 | Nothing. Install them into your agent.                                           |
+| `cypress tap` CLI                         | Nothing beyond Cypress v15.21.0+ and an open mode session.                       |
+| Cypress Studio recording                  | Nothing. Studio AI recommendations use your Cloud account.                       |
+| cy.prompt()                               | A Cypress Cloud account on any plan, including the free Starter plan.            |
+| Studio AI recommendations                 | A Cypress Cloud account on any plan, including the free Starter plan.            |
+| Test Intent Summaries and Error Summaries | A Cypress Cloud account on any plan, including the free Starter plan.            |
+| Cloud MCP and the Cloud CLI               | A Cypress Cloud account on any plan, including the free Starter plan.            |
+| UI Coverage Test Generation               | A [UI Coverage](/ui-coverage/get-started/introduction) subscription.             |
+| Agent-ready accessibility reports         | A [Cypress Accessibility](/accessibility/get-started/introduction) subscription. |
+
+What a paid plan changes is headroom, not access: a larger `cy.prompt`
+execution allowance and higher hourly limits for `cy.prompt` and Studio AI. See
+[Usage limits](#Usage-limits) below and
+[Cypress Cloud plans](https://www.cypress.io/pricing?utm_source=docs.cypress.io&utm_medium=cypress-ai-features)
+for full plan details.
+
+The two premium solutions in the table, UI Coverage and Cypress Accessibility,
+are products in their own right rather than AI capabilities gated behind a
+paywall. Their AI features come with the solution.
+
 ### Why do I need a Cloud Account?
 
 Cypress AI features use large language models (LLMs) to interpret prompts, analyze DOM state, and generate test code. Cypress Cloud manages those LLM requests securely on your behalf.
@@ -263,7 +291,7 @@ Without a Cloud account, there is no secure channel through which to route those
   href="https://cloud.cypress.io/signup"
 />
 
-Free accounts include a two-week trial of all paid features, including higher AI usage limits.
+Free accounts include a [30-day trial](/cloud/get-started/free-trial) of all paid features, including higher AI usage limits. When the trial ends, your account moves to the free Starter plan and AI features keep working at free plan limits.
 
 ### Usage limits
 
@@ -280,6 +308,7 @@ Some hourly limits apply to all plans. Those are as follows:
 | Test Intent Summaries       | Included               | Included                  |
 | Error Summaries             | Included               | Included                  |
 | AI Skills                   | unlimited              | unlimited                 |
+| `cypress tap` CLI           | unlimited              | unlimited                 |
 | Cloud MCP requests          | 100 per hour, per user | 100 per hour, per user    |
 | Cloud CLI requests          | 100 per hour, per user | 100 per hour, per user    |
 | UI Coverage Test Generation | Not available          | Included with UI Coverage |
@@ -290,9 +319,11 @@ If you need to increase your limits, contact support at support@cypress.io.
 
 ### Pricing
 
-AI Skills are available to all Cypress users.
+AI Skills and the `cypress tap` CLI are available to all Cypress users, with or without a Cypress Cloud account.
 
 Cloud MCP, the Cloud CLI, Test Intent Summaries and Error Summaries are available for free to all Cypress Cloud plans, including the Starter plan.
+
+`cy.prompt` is available on all Cypress Cloud plans, including the Starter plan. Each plan comes with an execution allowance. See [cy.prompt](/cloud/faq#cyprompt) in the Cloud FAQ for what counts as an execution and what happens when you reach your allowance.
 
 UI Coverage Test Generation is included with UI Coverage premium solutions subscriptions.
 

--- a/docs/cloud/features/cypress-ai-features.mdx
+++ b/docs/cloud/features/cypress-ai-features.mdx
@@ -34,9 +34,9 @@ Cypress AI is designed to solve these problems without changing how you already 
 
 ## Getting Started
 
-AI Capabilities are enabled by default for all users in your organization on an applicable plan. Login to your Cypress Cloud account to get started.
+AI Capabilities are enabled by default for all users in your organization on every Cypress Cloud plan, including the free Starter plan. Login to your Cypress Cloud account to get started.
 
-Each AI Tool must be enabled and installed individually. See each tool's documentation for instructions.
+Each AI Tool must be enabled and installed individually. See each tool's documentation for instructions. AI Skills and the `cypress tap` CLI run entirely on your machine, so you can start with those without a Cypress Cloud account at all.
 
 ## How Cypress AI Fits Into the Workflow
 
@@ -244,6 +244,8 @@ Where the Cloud CLI and Cloud MCP give agents your recorded run data in
 Cypress Cloud, `cypress tap` gives your AI agent context to your Cypress session and your application-under-test on your
 machine, while developing and verifying tests before it ever runs in CI.
 
+It is completely free and needs no Cypress Cloud account: it ships with the `cypress` binary and drives the session already running on your machine.
+
 Read the [cypress tap documentation →](/app/tooling/cypress-tap)
 
 ## FAQs
@@ -278,7 +280,9 @@ paywall. Their AI features come with the solution.
 
 ### Why do I need a Cloud Account?
 
-Cypress AI features use large language models (LLMs) to interpret prompts, analyze DOM state, and generate test code. Cypress Cloud manages those LLM requests securely on your behalf.
+This applies to the AI capabilities that call a large language model on your behalf, such as `cy.prompt`, Studio AI recommendations, and the Cloud summaries, along with the tools that read your recorded Cloud data. AI Skills and the `cypress tap` CLI call no LLM of their own and read no Cloud data, so they need no account. See [Do AI features require a paid subscription?](#Do-AI-features-require-a-paid-subscription) above.
+
+The capabilities that do use large language models rely on them to interpret prompts, analyze DOM state, and generate test code. Cypress Cloud manages those LLM requests securely on your behalf.
 
 Without a Cloud account, there is no secure channel through which to route those requests, no organizational controls to apply, and no way to enforce the data handling commitments Cypress makes to its customers.
 


### PR DESCRIPTION
## Summary

Makes it explicit across the AI docs that no Cypress AI capability requires a paid subscription, and that AI Skills and `cypress tap` need no Cypress Cloud account at all. Adds a dedicated "Do AI features require a paid plan?" answer to both the Cloud FAQ and the Cypress AI page, adds a plan-requirement column to the AI overview table, and scopes the page-wide "AI needs Cloud" framing so it no longer sweeps in the tools that run entirely on your machine.

## Why

A user on [cypress.io/ask](https://www.cypress.io/ask) asked "Does all AI Cypress features require paid subscription?" and followed up with "What about cypress tap". CypressGPT answered the first vaguely ("some higher usage limits and premium products may require paid plans") and could not answer the second at all, replying that `cypress tap` "is not the same as a paid-only feature" and offering to "help you figure out whether you need Cypress Cloud". ([Slack thread](https://cypressio.slack.com/archives/C09EHPFLR7F/p1787728025639719))

The docs were the cause. The facts existed but were scattered across the pricing section of the Cypress AI page, the Cloud MCP page, and the Cloud CLI page, with nothing stating the general rule. Two things actively pointed the wrong way:

- **"Why do I need a Cloud Account?"** opened with "Cypress AI features use large language models... Without a Cloud account, there is no secure channel through which to route those requests." Scoped to nothing in particular, it read as a blanket rule covering every AI feature on the page, including the two that call no LLM of their own.
- **"Getting Started"** said AI Capabilities are enabled "for all users in your organization on an applicable plan", which implies a gate without ever saying which plans qualify.

`cypress tap` had no statement anywhere about account or plan requirements, which is why the bot had nothing to retrieve.

## Notes for reviewers

**Please sanity-check the availability claims.** The tables assert specifics that should match what Cloud actually enforces today:

- `cypress tap` and AI Skills: free, no Cloud account, no usage limits.
- `cy.prompt`, Studio AI, Test Intent/Error Summaries, Cloud MCP, Cloud CLI: any plan including free Starter.
- UI Coverage Test Generation and agent-ready accessibility reports: included with those premium solutions.
- A paid plan raises the `cy.prompt` execution allowance and hourly limits rather than unlocking capabilities.

Two fixes outside the direct scope, both surfaced while verifying the above:

- Two pages said free accounts include a "two-week trial" of paid features. `/cloud/get-started/free-trial` says 30 days throughout, so the two-week mentions were corrected to 30-day.
- Fixed a broken sentence in the `cypress tap` intro ("This allows an agent can verify its own work").

`cypress tap` is in beta and sits under the Cloud-branded Cypress AI umbrella, so the "free, no account, no limits" claim now appears in several places. If tap ever gains a Cloud-backed capability, those are the lines to revisit.

One thing intentionally left alone: `docs/app/debug/faq.mdx` still describes `cypress tap` as shipping with the `cypress` npm package rather than the Cypress App. That wording predates this PR and is accurate in context (it is about where the CLI command comes from at install time). Happy to align it if reviewers prefer consistency.

`npm run lint:fix` and `npm run build` both pass, so every new cross-page anchor resolves (`onBrokenLinks` and `onBrokenAnchors` are `throw`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019N6jJJgu1YjjPrwpudsBwY

---
_Generated by [Claude Code](https://claude.ai/code/session_019N6jJJgu1YjjPrwpudsBwY)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only clarifications of pricing and availability; reviewers should confirm the stated plan/limit claims match what Cypress Cloud enforces today.
> 
> **Overview**
> **Docs now state clearly that no Cypress AI capability requires a paid subscription**, and that **AI Skills** and **`cypress tap`** need no Cypress Cloud account. The change is copy and structure across AI overview, per-feature pages, Cypress AI features, and App/Cloud FAQs—not product behavior.
> 
> The **AI overview** adds **Cloud CLI**, replaces the old single “needs Cloud” column with **Cypress Cloud account** and **Paid plan** columns, and adds prose that paid plans mainly raise **`cy.prompt`** / Studio AI limits. **`cy.prompt`**, **Studio AI**, **AI Skills**, and **`cypress tap`** pages each spell out free/Starter availability; **`cypress tap`** also gets a grammar fix and stronger “no signup, no limits” wording in **Requirements**.
> 
> **New FAQ:** “Do AI features require a paid plan?” on **Cloud FAQ** and **Cypress AI features** (with capability tables). **“Why do I need a Cloud account?”** is narrowed so it no longer reads as applying to on-machine tools. **Getting Started** on Cypress AI now says AI is on every plan including Starter. **Free-trial** mentions move from two weeks to **30 days** where they were wrong. Pricing links pick up **utm_source** query params in several places.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e64440bc2ee3d3482d9f17e8742434095954dc72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->