### PR TITLE
docs: remove duplicated word in cy.request page

### DIFF
--- a/docs/api/commands/request.mdx
+++ b/docs/api/commands/request.mdx
@@ -47,7 +47,7 @@ cy.request('users/1.json') //  URL is  http://localhost:8080/users/1.json
 ```
 
 2. If you make a `cy.request()` prior to visiting a page, Cypress assumes the
-   host is the `baseUrl` property configured inside of of your
+   host is the `baseUrl` property configured inside of your
    [configuration file](/app/references/configuration).
 
 :::cypress-config-example


### PR DESCRIPTION
Removes an accidental duplicated word in the `cy.request` API docs: "configured inside of of your configuration file" becomes "configured inside of your configuration file" in `docs/api/commands/request.mdx`. Text-only change.