### PR TITLE
Add cypress-cloud-cli Skill

### DIFF
--- a/docs/app/ai/ai-skills.mdx
+++ b/docs/app/ai/ai-skills.mdx
@@ -27,6 +27,8 @@ With Cypress AI Skills, your AI agent can:
   training data
 - Run, watch, and debug tests against a live Cypress session, then fix failures
   in the same loop that wrote them
+- Triage recorded CI failures and flakes from Cypress Cloud without leaving the
+  terminal
 - Behave consistently across your team, no matter who writes the prompt
 
 Skills work with any AI coding agent that supports skills or custom
@@ -51,9 +53,11 @@ SOP manual you hand them on day one.
 
 ## Available Cypress skills
 
-Cypress publishes four skills. They are designed to work together:
+Cypress publishes five skills. They are designed to work together:
 `cypress-author` writes and fixes tests, `cypress-explain` reviews and explains
-them, `cypress-tap` runs and debugs them against a live Cypress session and `cypress-docs` grounds them in official documentation.
+them, and `cypress-tap` runs and debugs them against a live Cypress session.
+`cypress-cloud-cli` triages recorded runs and failures in Cypress Cloud, and
+`cypress-docs` grounds them all in official documentation.
 
 ### `cypress-author`: create, update, and fix tests
 
@@ -147,6 +151,46 @@ For the full CLI reference the skill builds on, including every command, its
 options, and end-to-end debugging walkthroughs, see
 [Drive Cypress with AI agents using `cypress tap`](/app/tooling/cypress-tap).
 
+### `cypress-cloud-cli`: triage recorded runs and failures {#cypress-cloud-cli}
+
+The [`cypress-cloud-cli`](https://github.com/cypress-io/ai-toolkit/tree/main/skills/cypress-cloud-cli)
+skill instructs your AI agent on how to investigate recorded Cypress Cloud runs
+through the [Cloud CLI](/cloud/integrations/cloud-cli): organizations, projects,
+runs, specs, tests, failure screenshots, and
+[Test Replay](/cloud/features/test-replay) data, all from the terminal. Use it to
+triage a CI failure or flake from a Cypress Cloud URL or test ID, so your AI
+agent finds the root cause from recorded evidence instead of sending you to the
+Cloud UI.
+
+The skill runs the Cloud CLI from the `@cypress/cloud` package, so it needs
+Node.js `22.21.0` or later, an authenticated CLI, and an organization with the
+Cloud CLI integration enabled. See
+[Configure the Cloud CLI](/cloud/integrations/cloud-cli#Configure-the-Cloud-CLI)
+for the setup.
+
+Beyond what a generic AI agent knows, this skill:
+
+- **Resolves a Cypress Cloud URL directly.** It reads the project, run number,
+  and test ID from a copied Cloud test URL and queries that test straight away,
+  instead of walking the organization and project lists to rediscover them.
+- **Targets the attempt that failed.** It reads a test's attempt history and
+  passes the failed attempt number to every Test Replay query, so a flaky test's
+  final passing retry never hides the failure it is diagnosing.
+- **Reconstructs the failure from Test Replay.** It pulls the commands leading up
+  to the failed command, the XHR and Fetch network events, and the application's
+  console logs, then correlates them to explain what broke.
+- **Distinguishes flake from a reproducible failure.** With no explicit flake
+  field to rely on, it infers flake from the retry history, a failed attempt
+  followed by a passing one, and reports the cause as `unknown` when the attempts
+  are inconclusive.
+- **Grounds every conclusion in evidence.** It reports the run, spec, test, and
+  timeline it inspected, and names the remaining gap when the evidence is
+  incomplete rather than guessing.
+
+For the full CLI reference the skill builds on, including every command, its
+options, and end-to-end triage walkthroughs, see
+[Cloud CLI](/cloud/integrations/cloud-cli).
+
 ### `cypress-docs`: look up accurate documentation
 
 [`cypress-docs`](https://github.com/cypress-io/ai-toolkit/tree/main/skills/cypress-docs)
@@ -191,6 +235,7 @@ Or install each skill individually:
   exec={`skills add https://github.com/cypress-io/ai-toolkit --skill cypress-author
 skills add https://github.com/cypress-io/ai-toolkit --skill cypress-explain
 skills add https://github.com/cypress-io/ai-toolkit --skill cypress-tap
+skills add https://github.com/cypress-io/ai-toolkit --skill cypress-cloud-cli
 skills add https://github.com/cypress-io/ai-toolkit --skill cypress-docs`}
 />
 
@@ -226,6 +271,10 @@ gh skill install cypress-io/ai-toolkit cypress-explain
 
 ```bash
 gh skill install cypress-io/ai-toolkit cypress-tap
+```
+
+```bash
+gh skill install cypress-io/ai-toolkit cypress-cloud-cli
 ```
 
 ```bash
@@ -372,6 +421,18 @@ reference.
 /cypress-tap Run cypress/e2e/checkout.cy.ts against my open Cypress session, poll for a verdict, and if it fails, read the failing test's Command Log and error and inspect the app at the failing command to tell me what caused it.
 ```
 
+### Triage a recorded Cloud failure
+
+When a test fails in CI and was recorded to Cypress Cloud, `cypress-cloud-cli`
+can pull the run, the failing test, and its Test Replay data from the terminal,
+then work out the most likely cause. See the
+[Cloud CLI documentation](/cloud/integrations/cloud-cli) for the full command
+reference.
+
+```skill
+/cypress-cloud-cli Diagnose why this Cypress Cloud test failed: <test URL>. Inspect its failed attempt and Test Replay timeline, and tell me the most likely root cause.
+```
+
 ### Summarize test coverage in plain language
 
 ```skill
@@ -447,3 +508,6 @@ can extend or complement your agentic workflows:
 - **[Cloud MCP](/cloud/integrations/cloud-mcp)**: Give your AI agent direct
   access to Cypress Cloud test results and failure data to investigate and fix
   issues without leaving your coding environment.
+- **[Cloud CLI](/cloud/integrations/cloud-cli)**: Query Cypress Cloud run results
+  and Test Replay data as JSON from the terminal, the CLI the `cypress-cloud-cli`
+  skill drives for terminal-based agents and your own automation.

--- a/docs/app/ai/overview.mdx
+++ b/docs/app/ai/overview.mdx
@@ -63,7 +63,10 @@ work from.
   guessing at why something failed.
 - **[Cloud CLI](/cloud/integrations/cloud-cli)** is the scriptable counterpart
   to Cloud MCP: the same Cloud run data as JSON in the terminal, for agents that
-  work through a shell and for your own automation.
+  work through a shell and for your own automation. The
+  [`cypress-cloud-cli` skill](/app/tooling/ai-skills#cypress-cloud-cli) instructs
+  your agent on how to work through that recorded run and test data to find a
+  failure's root cause.
 
 ## Analyze and debug with AI
 

--- a/docs/app/debug/debugging.mdx
+++ b/docs/app/debug/debugging.mdx
@@ -149,6 +149,14 @@ them correctly, without you writing the steps by hand. For the full workflow, or
 a snippet you can drop into your agent's instructions file yourself, see
 [driving Cypress from the terminal with an AI agent](/app/tooling/cypress-tap).
 
+When the failure happened in CI rather than locally, and the run was recorded to
+Cypress Cloud, your agent can triage it from the terminal too. The
+[`cypress-cloud-cli` skill](/app/tooling/ai-skills#cypress-cloud-cli) drives the
+[Cloud CLI](/cloud/integrations/cloud-cli) to read the failing run, its tests,
+and their [Test Replay](/cloud/features/test-replay) data, so the agent can find
+the likely cause from the recorded run before reproducing it locally with
+`cypress tap`.
+
 ## Using the Developer Tools
 
 Though Cypress has built out

--- a/docs/app/debug/faq.mdx
+++ b/docs/app/debug/faq.mdx
@@ -2108,7 +2108,10 @@ loop while you and your agent write code.
 To give an agent your Cypress CI results instead, use
 [Cloud MCP](/cloud/integrations/cloud-mcp) or the
 [Cloud CLI](/cloud/integrations/cloud-cli), which read recorded runs from
-Cypress Cloud.
+Cypress Cloud. The
+[`cypress-cloud-cli` skill](/app/tooling/ai-skills#cypress-cloud-cli) instructs
+your agent on how to drive the Cloud CLI — finding the failing run, reading its
+errors, and inspecting Test Replay — so it triages recorded failures correctly.
 
 ### <Icon name="angle-right" /> Does `cypress tap` require a Cypress Cloud account or a paid subscription?
 

--- a/docs/cloud/features/cypress-ai-features.mdx
+++ b/docs/cloud/features/cypress-ai-features.mdx
@@ -59,7 +59,7 @@ Cypress AI are easy-to-use capabilities and tools across your testing lifecycle.
 | Author Tests      | `cypress-author` and `cypress-docs` Skills | Improves how AI agents create, update, and fix Cypress tests.                                                    |
 | Understand Tests  | `cypress-explain` Skill                    | Helps AI describe, and critique existing tests.                                                                  |
 | Analyze & Triage  | Cloud MCP                                  | Gives AI coding assistants and AI agents a direct window into your application's health and stability            |
-| Triage & Automate | Cloud CLI                                  | Brings Cloud data and Test Replay access to the terminal for triage, scripting, CI, and terminal-based AI agents |
+| Triage & Automate | Cloud CLI and `cypress-cloud-cli` Skill    | Brings Cloud data and Test Replay access to the terminal for triage, scripting, CI, and terminal-based AI agents |
 | Run & Debug Tests | `cypress tap` CLI and `cypress-tap` Skill  | Live Cypress app access for your agent. Drives Cypress and pulls the command log and DOM directly into context.  |
 
 ## Capabilities in detail
@@ -199,6 +199,7 @@ Use skills when you want your AI agent to:
 - Steer away from brittle patterns and weak selectors
 - Produce more Cypress-focused explanations and critiques
 - Run and debug local tests against a live Cypress session with the `cypress-tap` CLI
+- Triage recorded Cloud runs, failures, and flakes with the `cy-cloud` CLI
 - Establish consistent AI behavior across your team and workflows
 
 [Read the AI Skills documentation →](/app/tooling/ai-skills)

--- a/docs/cloud/integrations/cloud-cli.mdx
+++ b/docs/cloud/integrations/cloud-cli.mdx
@@ -758,6 +758,18 @@ It reports the cache size before and after, and how many entries it removed:
 
 Because every command returns structured JSON and exposes its output schema with `--schema`, the Cloud CLI is a natural tool for AI coding agents. An agent can list failing tests, read errors, and pull Test Replay timelines, then use that context to propose a fix in your editor. The workflows below are written to run by hand or to hand to an agent.
 
+The easiest way to hand this to an agent is the [`cypress-cloud-cli` skill](/app/tooling/ai-skills#cypress-cloud-cli) from the Cypress AI Toolkit. It gives your agent the debugging know-how for `cy-cloud`: which attempt to replay for a flaky test, how to navigate the Test Replay timeline, and how to correlate the failed command with the network and console events around it, so it reaches a root cause instead of restating the error.
+
+Install it with the [`skills`](https://skills.sh/) CLI:
+
+<PackageManagerTabs exec="skills add https://github.com/cypress-io/ai-toolkit --skill cypress-cloud-cli" />
+
+or with the [GitHub CLI](https://cli.github.com/manual/gh_skill):
+
+```bash
+gh skill install cypress-io/ai-toolkit cypress-cloud-cli
+```
+
 If your agent runs shell commands (for example, Claude Code, Codex CLI, or Copilot CLI), point it at `cy-cloud` and describe the goal in plain language. Copy one of the prompts below to get started, replacing the `<projectId>`, `<branch>`, `<runNumber>`, and `<testId>` placeholders with your own values.
 
 <CopyPrompt
@@ -1032,6 +1044,7 @@ The Cloud CLI communicates with the Cypress Cloud API at `https://cloud-api.cypr
 ## See also
 
 - [Cloud MCP: Agentic debugging](/cloud/integrations/cloud-mcp)
+- [Cypress AI Skills](/app/tooling/ai-skills): the `cypress-cloud-cli` skill drives this CLI for your agent
 - [cypress tap: live Cypress app context in your terminal](/app/tooling/cypress-tap)
 - [Test Replay](/cloud/features/test-replay)
 - [Recording Cloud Runs](/cloud/features/recorded-runs)


### PR DESCRIPTION
<!--
Fill in every section. This template doubles as the historical record of the
change, so future readers can understand not just what changed but
why. Delete a section only if it is genuinely not applicable, and say so.
-->

## Summary

Add docs for https://github.com/cypress-io/ai-toolkit/pull/17

## Why

<!-- The motivation and context. If this originated from an issue, a Slack/
Discord thread, a broken link, an outdated example, or a release, capture it
here so the reasoning survives after the source is gone. -->

Closes #<!-- issue number, or remove this line if none -->

## Notes for reviewers

<!-- Anything a reviewer should focus on: decisions made, alternatives
considered, areas of uncertainty, or follow-ups intentionally left out. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only cross-linking and new skill content; no product code, auth, or runtime behavior changes.
> 
> **Overview**
> Documents the fifth Cypress AI Toolkit skill, **`cypress-cloud-cli`**, which teaches terminal-based agents to triage recorded Cypress Cloud runs via the Cloud CLI (`cy-cloud`).
> 
> The **Cypress AI Skills** page is the main update: skill count goes from four to five, with a dedicated section on URL resolution, failed-attempt replay, Test Replay correlation, flake inference, and evidence-backed conclusions; install steps for `skills` and `gh skill`; a sample `/cypress-cloud-cli` prompt; and a See also link to Cloud CLI.
> 
> **Cross-links** tie the skill into the AI map (`overview.mdx`), local vs CI debugging (`debugging.mdx`), the `cypress tap` CI FAQ (`faq.mdx`), the Cypress AI tools table and skills bullets (`cypress-ai-features.mdx`), and Cloud CLI’s “Use with AI agents” plus See also (`cloud-cli.mdx`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a6363f933a74552184c7afeec3593ecabdd164a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->