### PR TITLE
docs: fix `.end()` deprecation version and a dangling reference in the 16.0 migration guide

### DIFF
--- a/docs/app/releases/migration-guide.mdx
+++ b/docs/app/releases/migration-guide.mdx
@@ -52,7 +52,7 @@ Firefox, WebKit, and Electron continue to use the legacy network path and are un
 
 [`cy.intercept()`](/api/commands/intercept) works as before, and most suites need no edits. A few behaviors differ in Chrome, Chromium, and Edge on the native browser network. See [Native network interception](/app/guides/native-network-interception) for the full list with examples.
 
-Aside from the `cy.intercept()` behaviors above, your suite should not need any changes. Commands, stubbing, waiting, aliases, and assertions all work as they did before, and adopting the native browser network requires no configuration change.
+Aside from the `cy.intercept()` behaviors listed in that guide, your suite should not need any changes. Commands, stubbing, waiting, aliases, and assertions all work as they did before, and adopting the native browser network requires no configuration change.
 
 If you need a temporary escape hatch, either while you update those tests or if you hit behavior on the native browser network that the guide does not list, route every browser back through the legacy network path:
 
@@ -476,7 +476,7 @@ cy.get('[data-cy="name"]').type('Jane')
 ```
 
 `cy.end()` was deprecated in Cypress
-[15.16.0](/app/references/changelog#15-16-0) and removed in 16.0.
+[15.15.0](/app/references/changelog#15-15-0) and removed in 16.0.
 
 ### `Cypress.env()` removed
 


### PR DESCRIPTION
## Summary

Two fixes in the 16.0 migration guide: the `.end()` removal section now says the command was deprecated in 15.15.0 (was 15.16.0), and the native-network section no longer says "the `cy.intercept()` behaviors above" when no behaviors are listed above it.

## Why

Review feedback on #6451 (https://github.com/cypress-io/cypress-documentation/pull/6451#issuecomment-5442930510):

- The `.end()` deprecation shipped in 15.15.0 (cypress-io/cypress#33707). Both the app `cli/CHANGELOG.md` and the docs changelog place it under 15.15.0, and the deleted `end.mdx` said 15.15.0. The changelog anchor is updated along with the version.
- The behavior differences live on the Native network interception page, not above that paragraph, so the sentence now points at "that guide".

## Notes for reviewers

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only corrections to version numbers and cross-references; no runtime or API changes.
> 
> **Overview**
> This PR corrects two issues in the **Cypress 16.0 migration guide** (`migration-guide.mdx`).
> 
> In the **native browser network** section, the follow-up sentence no longer refers to "`cy.intercept()` behaviors above" (nothing is listed there). It now points readers to the behaviors **listed in the Native network interception guide**.
> 
> In the **`cy.end()` removed** section, the deprecation release is updated from **15.16.0** to **15.15.0**, including the changelog link anchor (`#15-15-0`), matching the product changelog and upstream release notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c379d88e8b7dfdc84b0fa58139f4f6f2b0bd216. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->