### PR TITLE
docs: close an unbalanced backtick in the Cypress.testingType row

### DIFF
--- a/docs/api/table-of-contents.mdx
+++ b/docs/api/table-of-contents.mdx
@@ -212,7 +212,7 @@ later time.
 | [`Cypress.Screenshot.defaults()`](/api/cypress-api/screenshot-api) | Set defaults for screenshots captured by the `.screenshot()` command and the automatic screenshots taken during test failures. |
 | [`Cypress.session`](/api/cypress-api/session)                      | A collection of helper methods related to the `.session()` command.                                                            |
 | [`Cypress.spec`](/api/cypress-api/spec)                            | An object with information about the currently executing spec file.                                                            |
-| [`Cypress.testingType`](/api/cypress-api/testing-type)             | The current testing type, eg. `"e2e"` or `"component".                                                                         |
+| [`Cypress.testingType`](/api/cypress-api/testing-type)             | The current testing type, eg. `"e2e"` or `"component"`.                                                                        |
 | [`Cypress.version`](/api/cypress-api/version)                      | The current Cypress version.                                                                                                   |
 
 ## Utilities


### PR DESCRIPTION
## Summary

Closes the unbalanced backtick in the `Cypress.testingType` row of the API table of contents (`` `"component". `` -> `` `"component"`. ``).

## Why

Review feedback on #6451 (https://github.com/cypress-io/cypress-documentation/pull/6451#issuecomment-5442930510). The typo predates the 16.0 branch, but the table was reflowed there, so fixing it on `release/16.0.0` keeps #6451's diff clean.

## Notes for reviewers

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-character documentation fix in an MDX table with no runtime or API behavior impact.
> 
> **Overview**
> Fixes a markdown typo in the **Cypress API** table on the API table of contents page: the `Cypress.testingType` usage cell now closes the inline code around `"component"` before the period (`"component".` → `"component".`), so the table renders correctly instead of breaking inline formatting.
> 
> This is documentation-only and addresses review feedback tied to a separate table reflow PR, applied on the release branch to keep that diff focused.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bf757c1600ceaaef2e5da70811f311380b34456. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->