### PR TITLE
docs: update Angular sample app link for the `cypress-component-testing-apps` rename

### DIFF
--- a/docs/app/write-tests/component-testing/angular/overview.mdx
+++ b/docs/app/write-tests/component-testing/angular/overview.mdx
@@ -126,7 +126,7 @@ export default {
 
 #### Sample Angular Apps
 
-- [Angular 21 Zoneless](https://github.com/cypress-io/cypress-component-testing-apps/tree/main/angular-zoneless)
+- [Angular 22](https://github.com/cypress-io/cypress-component-testing-apps/tree/main/angular)
 
 ## Styling
 


### PR DESCRIPTION
## Summary

Updates the Angular component-testing "Sample Angular Apps" link from "Angular 21 Zoneless" (`.../angular-zoneless`) to "Angular 22" (`.../angular`), matching the rename in [cypress-component-testing-apps#68](https://github.com/cypress-io/cypress-component-testing-apps/pull/68).

## Why

Cypress 16 merges zoneless mounting into `cypress/angular` (there's no longer a separate zoneless handler to differentiate), and the example app itself moved to Angular 22. `angular-zoneless` no longer describes anything, so [cypress-component-testing-apps#68](https://github.com/cypress-io/cypress-component-testing-apps/pull/68) renamed the directory to `angular`. This keeps the doc link in sync.

I also swept the rest of `docs/` for stale references to the removed `angular-standalone` example app (deleted in the same PR) and for other links into `cypress-component-testing-apps` — this was the only stale reference found.

## Notes for reviewers

The linked directory doesn't exist at `main` on `cypress-component-testing-apps` yet — [#68](https://github.com/cypress-io/cypress-component-testing-apps/pull/68) is still a draft pinned to a Cypress 16 pre-release build. Please don't merge this ahead of that PR, or the link will 404 in the interim.

Part of the Cypress 16 release-day checklist: cypress-io/cypress#33529

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link and label update with no runtime or API impact.
> 
> **Overview**
> Updates the **Sample Angular Apps** entry in the Angular component testing overview so it points at the renamed example in `cypress-component-testing-apps`.
> 
> The link label changes from **Angular 21 Zoneless** (`.../angular-zoneless`) to **Angular 22** (`.../angular`), matching the upstream rename after zoneless mounting was folded into `cypress/angular` and the sample app moved to Angular 22.
> 
> **Note for merge timing:** the target path on `main` of `cypress-component-testing-apps` may not exist until the companion rename PR lands; merging this doc change too early could briefly 404 the link.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03bfa82b1cf744728523fc78e247d5f53be8ce4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->