### PR TITLE
document that runUrl is present in before:run events

### DIFF
--- a/docs/api/node-events/before-run-api.mdx
+++ b/docs/api/node-events/before-run-api.mdx
@@ -83,8 +83,10 @@ on('before:run', (details) => {
   //   specPattern: [
   //     '**/*.cy.{js,jsx,ts,tsx}'
   //   ],
+  //   If using Cypress Cloud:
   //   parallel: false,
   //   group: 'group-1',
+  //   runUrl: 'https://cloud.cypress.io/projects/pjmj9a/runs/22'
   //   tag: 'tag-1'
   // }
   // details will look something like this when run via `cypress open`:


### PR DESCRIPTION
This is useful for some of our newer APIs that use the run number or run URL as an input.

<!--
Fill in every section. This template doubles as the historical record of the
change, so future readers can understand not just what changed but
why. Delete a section only if it is genuinely not applicable, and say so.
-->

## Summary

<!-- What does this PR change, in one or two sentences? Write for a reader who
has never seen the task. -->

## Why

<!-- The motivation and context. If this originated from an issue, a Slack/
Discord thread, a broken link, an outdated example, or a release, capture it
here so the reasoning survives after the source is gone. -->

Closes #<!-- issue number, or remove this line if none -->

## Notes for reviewers

<!-- Anything a reviewer should focus on: decisions made, alternatives
considered, areas of uncertainty, or follow-ups intentionally left out. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only update to an API example; no application or test code changes.
> 
> **Overview**
> ## Summary
> 
> Updates the `before:run` API doc example so the `cypress run` `details` object includes **`runUrl`**, and labels **`parallel`**, **`group`**, and related fields as Cypress Cloud–specific.
> 
> ## Why
> 
> Newer APIs expect the run number or run URL from `before:run`; the example previously showed Cloud fields like `parallel` and `group` but not `runUrl`, which made that payload easy to miss.
> 
> ## Notes for reviewers
> 
> Docs-only change in the commented sample in `before-run-api.mdx`; no runtime or type changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56ab32e87edbea30b440783516ecc0f83f5730f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->