### PR TITLE
docs: reflect the Starter plan's 10-user limit

### DIFF
--- a/docs/cloud/account-management/billing-and-usage.mdx
+++ b/docs/cloud/account-management/billing-and-usage.mdx
@@ -27,7 +27,7 @@ The card at the top of the page summarizes your subscription at a glance, so you
 - **Bundled test results:** the number of extra test results you have purchased up front, mid-term, to extend your allowance before you rely on on-demand pricing.
 - **On-demand test results:** the per-unit price for any test results recorded beyond your included and bundled amounts, so you can anticipate these costs before they appear on an invoice.
 - **cy.prompt executions:** how many [cy.prompt](/api/commands/prompt) executions your plan allows and how many you have used.
-- **Users:** how many of your plan's [user](/cloud/account-management/users) seats are in use. To see how many seats each plan allows, compare plans on the [pricing page](https://www.cypress.io/pricing).
+- **Users:** how many of your plan's [user](/cloud/account-management/users) seats are in use. To see how many seats each plan allows, compare plans on the [pricing page](https://www.cypress.io/pricing?utm_source=docs.cypress.io&utm_medium=billing-and-usage).
 - **Data Retention:** how long your recorded runs and their artifacts stay available in Cypress Cloud.
 - **Renews on:** the date your plan renews and your usage cycle resets.
 

--- a/docs/cloud/account-management/billing-and-usage.mdx
+++ b/docs/cloud/account-management/billing-and-usage.mdx
@@ -27,7 +27,7 @@ The card at the top of the page summarizes your subscription at a glance, so you
 - **Bundled test results:** the number of extra test results you have purchased up front, mid-term, to extend your allowance before you rely on on-demand pricing.
 - **On-demand test results:** the per-unit price for any test results recorded beyond your included and bundled amounts, so you can anticipate these costs before they appear on an invoice.
 - **cy.prompt executions:** how many [cy.prompt](/api/commands/prompt) executions your plan allows and how many you have used.
-- **Users:** how many of your plan's [user](/cloud/account-management/users) seats are in use. The Starter plan includes 10 users, the Team and Business plans include 50 users each, and the Enterprise plan has no user limit. A [free trial](/cloud/get-started/free-trial) includes 50 users.
+- **Users:** how many of your plan's [user](/cloud/account-management/users) seats are in use. To see how many seats each plan allows, compare plans on the [pricing page](https://www.cypress.io/pricing).
 - **Data Retention:** how long your recorded runs and their artifacts stay available in Cypress Cloud.
 - **Renews on:** the date your plan renews and your usage cycle resets.
 

--- a/docs/cloud/account-management/billing-and-usage.mdx
+++ b/docs/cloud/account-management/billing-and-usage.mdx
@@ -27,7 +27,7 @@ The card at the top of the page summarizes your subscription at a glance, so you
 - **Bundled test results:** the number of extra test results you have purchased up front, mid-term, to extend your allowance before you rely on on-demand pricing.
 - **On-demand test results:** the per-unit price for any test results recorded beyond your included and bundled amounts, so you can anticipate these costs before they appear on an invoice.
 - **cy.prompt executions:** how many [cy.prompt](/api/commands/prompt) executions your plan allows and how many you have used.
-- **Users:** how many of your plan's [user](/cloud/account-management/users) seats are in use.
+- **Users:** how many of your plan's [user](/cloud/account-management/users) seats are in use. The Starter plan includes 10 users, the Team and Business plans include 50 users each, and the Enterprise plan has no user limit. A [free trial](/cloud/get-started/free-trial) includes 50 users.
 - **Data Retention:** how long your recorded runs and their artifacts stay available in Cypress Cloud.
 - **Renews on:** the date your plan renews and your usage cycle resets.
 

--- a/docs/cloud/account-management/users.mdx
+++ b/docs/cloud/account-management/users.mdx
@@ -30,6 +30,13 @@ Organization [owner or admin](#User-roles) roles can invite
 
 _Note: only owners can give other users 'owner' access._
 
+Your plan determines how many users your organization can have: the Starter plan
+includes 10 users, the Team and Business plans include 50 users each, and the
+Enterprise plan has no user limit. A
+[free trial](/cloud/get-started/free-trial) includes 50 users. To see how many
+of those seats your organization is using, check the
+[Billing & Usage](/cloud/account-management/billing-and-usage) page.
+
 ### Invite a user to an organization:
 
 1. Select the [organization](/cloud/account-management/organizations) you

--- a/docs/cloud/account-management/users.mdx
+++ b/docs/cloud/account-management/users.mdx
@@ -30,11 +30,10 @@ Organization [owner or admin](#User-roles) roles can invite
 
 _Note: only owners can give other users 'owner' access._
 
-Your plan determines how many users your organization can have: the Starter plan
-includes 10 users, the Team and Business plans include 50 users each, and the
-Enterprise plan has no user limit. A
-[free trial](/cloud/get-started/free-trial) includes 50 users. To see how many
-of those seats your organization is using, check the
+Your plan determines how many users your organization can have. To compare the
+user seats each plan allows, see the
+[pricing page](https://www.cypress.io/pricing). To see how many of your seats
+are in use, check the
 [Billing & Usage](/cloud/account-management/billing-and-usage) page.
 
 ### Invite a user to an organization:

--- a/docs/cloud/account-management/users.mdx
+++ b/docs/cloud/account-management/users.mdx
@@ -32,7 +32,8 @@ _Note: only owners can give other users 'owner' access._
 
 Your plan determines how many users your organization can have. To compare the
 user seats each plan allows, see the
-[pricing page](https://www.cypress.io/pricing). To see how many of your seats
+[pricing page](https://www.cypress.io/pricing?utm_source=docs.cypress.io&utm_medium=manage-users).
+To see how many of your seats
 are in use, check the
 [Billing & Usage](/cloud/account-management/billing-and-usage) page.
 

--- a/docs/cloud/faq.mdx
+++ b/docs/cloud/faq.mdx
@@ -107,20 +107,11 @@ A [user](/cloud/account-management/users) is anyone with a login to
 Cypress Cloud who has been invited to see and review the test results of your
 organization.
 
-Each plan includes a set number of users:
-
-| Plan       | Users included |
-| ---------- | -------------- |
-| Starter    | 10             |
-| Team       | 50             |
-| Business   | 50             |
-| Enterprise | Unlimited      |
-
-A [30-day free trial](/cloud/get-started/free-trial) includes 50 users. To see
-how many of those seats your organization is using, check the
+Each plan includes a set number of users. To compare the user seats each plan
+allows, see the [pricing page](https://www.cypress.io/pricing). To see how many
+of your seats are in use, check the
 [Billing & Usage](/cloud/account-management/billing-and-usage) page in Cypress
-Cloud, and compare every plan on the
-[pricing page](https://www.cypress.io/pricing).
+Cloud.
 
 ### <Icon name="angle-right" /> How much does it cost?
 

--- a/docs/cloud/faq.mdx
+++ b/docs/cloud/faq.mdx
@@ -107,6 +107,21 @@ A [user](/cloud/account-management/users) is anyone with a login to
 Cypress Cloud who has been invited to see and review the test results of your
 organization.
 
+Each plan includes a set number of users:
+
+| Plan       | Users included |
+| ---------- | -------------- |
+| Starter    | 10             |
+| Team       | 50             |
+| Business   | 50             |
+| Enterprise | Unlimited      |
+
+A [30-day free trial](/cloud/get-started/free-trial) includes 50 users. To see
+how many of those seats your organization is using, check the
+[Billing & Usage](/cloud/account-management/billing-and-usage) page in Cypress
+Cloud, and compare every plan on the
+[pricing page](https://www.cypress.io/pricing).
+
 ### <Icon name="angle-right" /> How much does it cost?
 
 Please see our [Pricing Page](https://www.cypress.io/pricing) for more details.
@@ -149,7 +164,8 @@ Downgrading your account will **not** result in loss of access to Cypress Cloud.
 
 However, it will make your Cypress Cloud account subject to the limitations of
 your new plan. For example, downgrading to the _Starter_ plan will limit data
-retention to 30 days and test results to 500 per billing period.
+retention to 30 days, test results to 500 per billing period, and your
+organization to 10 [users](#What-counts-as-a-user).
 
 ### <Icon name="angle-right" /> When does my billing period reset?
 

--- a/docs/cloud/faq.mdx
+++ b/docs/cloud/faq.mdx
@@ -108,8 +108,9 @@ Cypress Cloud who has been invited to see and review the test results of your
 organization.
 
 Each plan includes a set number of users. To compare the user seats each plan
-allows, see the [pricing page](https://www.cypress.io/pricing). To see how many
-of your seats are in use, check the
+allows, see the
+[pricing page](https://www.cypress.io/pricing?utm_source=docs.cypress.io&utm_medium=cloud-faq).
+To see how many of your seats are in use, check the
 [Billing & Usage](/cloud/account-management/billing-and-usage) page in Cypress
 Cloud.
 

--- a/docs/cloud/get-started/free-trial.mdx
+++ b/docs/cloud/get-started/free-trial.mdx
@@ -9,7 +9,7 @@ sidebar_position: 15
 
 # Try Cypress Cloud free for 30 days
 
-A free trial is the fastest way to see what Cypress Cloud does for your team. Cloud is the quality platform that sits on top of your Cypress tests, bringing debugging, orchestration, and analytics together in one place. For **30 days** you get an all-access pass to every feature in our [Enterprise plan](https://www.cypress.io/pricing), the same capabilities the largest Cypress teams rely on, plus **50,000 test results** to put it to work on your own suite.
+A free trial is the fastest way to see what Cypress Cloud does for your team. Cloud is the quality platform that sits on top of your Cypress tests, bringing debugging, orchestration, and analytics together in one place. For **30 days** you get an all-access pass to every feature in our [Enterprise plan](https://www.cypress.io/pricing), the same capabilities the largest Cypress teams rely on, plus **50,000 test results** and **50 users**, so you can put it to work on your own suite with your whole team.
 
 No credit card is required to start, and your account stays yours when the trial ends.
 
@@ -106,7 +106,7 @@ the capabilities Cypress Cloud provides.
 
 You can choose and subscribe to a paid plan at any point during or after the trial. If a paid plan isn't the right fit when the 30 days are up, nothing is lost. Your account stays available to you and moves to our free **Starter** plan.
 
-The Starter plan keeps you running with a smaller feature set: data retention is limited to 30 days and test results to 500 per monthly period. You can compare every plan side by side on the [pricing page](https://www.cypress.io/pricing).
+The Starter plan keeps you running with a smaller feature set: data retention is limited to 30 days, test results to 500 per monthly period, and your organization to 10 [users](/cloud/account-management/users). You can compare every plan side by side on the [pricing page](https://www.cypress.io/pricing).
 
 ## Existing customers
 


### PR DESCRIPTION
## Summary

Documents the Starter plan's 10-user limit alongside its existing data retention and test result limits, and points readers to the pricing page wherever the docs mention how many user seats a plan allows.

## Why

The Starter plan allows 10 users, while Team, Business, and a free trial allow 50. The docs never stated user limits at all: the Starter plan was described only in terms of data retention (30 days) and test results (500 per billing period), so nothing told readers the seat cap existed or that Starter's is lower than the other plans. Seat counts are now sourced from the [pricing page](https://www.cypress.io/pricing) rather than repeated per page, so they stay correct as plans change.

Changes:

- `docs/cloud/faq.mdx` — "What counts as a user?" now notes that each plan includes a set number of users, linking to the pricing page to compare seats and to Billing & Usage to see current use. The downgrade answer now lists the 10-user Starter limit with the retention and test result limits it already covered.
- `docs/cloud/get-started/free-trial.mdx` — the Starter fallback paragraph names the 10-user limit, and the intro states the trial includes 50 users.
- `docs/cloud/account-management/billing-and-usage.mdx` — the **Users** bullet in "Plan overview" points to the pricing page for per-plan seats.
- `docs/cloud/account-management/users.mdx` — "Invite users" explains that your plan determines the user count, with the same two links.

## Notes for reviewers

**One screenshot still needs a re-capture and is not fixed here:** `static/img/cloud/organizations/oss-plan-3-billing.jpg`, used in the Open Source Plan steps on Billing & Usage, shows a **Starter** org with **Users 2/50**. It should read 2/10. I left the image alone rather than retouching the pixels, since a hand-edited screenshot tends to read as doctored.

Two other screenshots are still accurate and were left as-is: `billing/plan-overview.png` and `billing/billing-and-usage-tests-overview.png` both show a **Business** plan at **36/50**. No other image in the docs shows a plan's user count.

There was no "all plans get 50 users" claim anywhere to correct: the docs were silent on seat counts, not wrong about them.

Prose follows the Cypress Style Guide. Prettier passes on all four files.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SXBJzWTaewAxeFr5qwZKKd)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to billing and account-management pages; no product behavior or API changes.
> 
> **Overview**
> Cypress Cloud docs now explain that **plans cap how many users** an organization can have, instead of only describing retention and test-result limits.
> 
> **Starter** is called out as **10 users** wherever downgrade or post-trial fallback is described (FAQ downgrade answer, free-trial “when the trial ends”). The **30-day trial** intro now states **50 users** alongside the existing Enterprise-style allowance.
> 
> Across **Billing & Usage**, **Manage users**, and the **Cloud FAQ** (“What counts as a user?”), new copy points readers to the **pricing page** to compare per-plan seats and to **Billing & Usage** to see seats in use, with UTM-tagged links so limits stay authoritative on pricing rather than duplicated in docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66d527f1f8a8c1ff916c0cdb46ee2e5d48bb37af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->