### PR TITLE
docs: document filing accessibility issues into a tracker with an AI agent

### DIFF
--- a/docs/accessibility/connect-and-extend/overview.mdx
+++ b/docs/accessibility/connect-and-extend/overview.mdx
@@ -26,6 +26,7 @@ Cypress Accessibility results don't have to stay in Cypress Cloud. This section 
 - **Grab a single run's results right now** — use the [Download report](/accessibility/connect-and-extend/download-reports) button. No setup, and the file works offline with any tool or AI agent.
 - **Enforce a standard in CI** — use the [Results API](/accessibility/connect-and-extend/results-api) to assert on a run's results and [block pull requests](/accessibility/guides/block-pull-requests) that don't meet it.
 - **Work with an AI agent** — a [downloaded report](/accessibility/work-with-ai-agents#Work-with-a-downloaded-report) gives an agent the full dataset at once, while [Cypress Cloud MCP](/accessibility/work-with-ai-agents#Cypress-Cloud-MCP) lets it query results live. See [Work with AI agents](/accessibility/work-with-ai-agents).
+- **Get the results into your issue tracker** — have an agent read the latest report for a branch, check what is already filed, and open only the missing tickets. See [File issues in your issue tracker](/accessibility/work-with-ai-agents#File-issues-in-your-issue-tracker).
 - **Track trends across many runs and projects** — use the [Data Extract API](/cloud/integrations/data-extract-api) and [Enterprise Reporting](/cloud/features/analytics/enterprise-reporting).
 
 :::info

--- a/docs/accessibility/faq.mdx
+++ b/docs/accessibility/faq.mdx
@@ -69,6 +69,10 @@ Three ways, from fastest to most durable. Copy the URL, which encodes the view, 
 
 Select the failing element to expand its detail, choose **Create Jira issue**, and pick a Jira project. **Summary** is prefilled with the rule name and **Description** with the Markdown issue snippet, including a link back to the violation in Cypress Cloud. Both are editable before you submit, so it's the right moment to add context a triager will want. Choose an issue type, complete any fields your Jira project requires, and submit. This requires the [Cypress Cloud Jira integration](/cloud/integrations/jira) to be installed for your organization; without it, the button doesn't appear.
 
+### <Icon name="angle-right" /> Can I file issues for a whole accessibility report at once?
+
+Yes, with an AI agent connected to both [Cypress Cloud MCP](/cloud/integrations/cloud-mcp) and your issue tracker. The agent reads the report for the latest run on a branch, checks Jira or another tracker for the issues that already exist, and creates only the ones that are missing, so a weekly refresh doesn't produce duplicates. [File issues in your issue tracker](/accessibility/work-with-ai-agents#File-issues-in-your-issue-tracker) walks through the prompts, how to group violations into tickets, and the guardrails to keep on an agent that can write.
+
 ### <Icon name="angle-right" /> Why does my Cypress Accessibility report show generated class names instead of meaningful selectors?
 
 Because nothing more meaningful was available on the element. Cypress Accessibility builds each violation target selector from a prioritized list of attributes, so an element with no test attribute and no useful `id` falls back to whatever identifies it, which in a component library often means a class like `.MuiIconButton-colorPrimary`. Add the attribute your application already renders to [`significantAttributes`](/accessibility/configuration/significantattributes) to make it the identifier, or use [`components`](/accessibility/configuration/components) to append component and team context to the existing one. Regenerate a past run afterward to see the new selectors without rerunning your tests.

--- a/docs/accessibility/guides/improve-accessibility.mdx
+++ b/docs/accessibility/guides/improve-accessibility.mdx
@@ -198,7 +198,7 @@ Two things make an agent's output more reliable here:
 - **Narrow the report first.** An agent triaging a vendor widget you were never going to fix costs tokens and produces work you'll reject. The scoping step above pays for itself immediately.
 - **Give elements names your codebase uses.** [`components`](/accessibility/configuration/components) adds attributes such as `data-component` or `data-team` to violation target selectors, so a failing element reads as `[data-cy="signup"][data-component="IconButton"]` instead of a generated selector, and the agent can find the source file without crawling your markup.
 
-[Work with AI agents](/accessibility/work-with-ai-agents) has more prompts for Cypress Accessibility, such as grouping violations by owner across the roles on your team.
+[Work with AI agents](/accessibility/work-with-ai-agents) has more prompts for Cypress Accessibility, such as grouping violations by owner across the roles on your team, or [filing the backlog into your issue tracker](/accessibility/work-with-ai-agents#File-issues-in-your-issue-tracker) without creating duplicates of tickets you already have.
 
 ## Prevent finished rules from regressing {#iterating-towards-success}
 

--- a/docs/accessibility/reports/element-detail-view.mdx
+++ b/docs/accessibility/reports/element-detail-view.mdx
@@ -196,6 +196,8 @@ When your organization has the [Cypress Cloud Jira integration](/cloud/integrati
 
 Cypress Cloud confirms with a link to the new issue key. Because the description carries the deep link, anyone working the ticket lands back on the failing element and its snapshot.
 
+This is the fastest route for a violation you are already looking at. To file a whole report's worth at once, hand the job to an AI agent instead: it can read the report, check your tracker for issues that already exist, and open only what is missing. See [File issues in your issue tracker](/accessibility/work-with-ai-agents#File-issues-in-your-issue-tracker).
+
 ## Make selectors readable before you triage
 
 How useful this view is depends heavily on how elements are named in it. A rules list where every failing button reads `.MuiIconButton-colorPrimary` tells you a violation exists but not where it lives, and a Jira ticket built from that selector sends someone hunting through the codebase.

--- a/docs/accessibility/work-with-ai-agents.mdx
+++ b/docs/accessibility/work-with-ai-agents.mdx
@@ -1,6 +1,6 @@
 ---
 title: Work with AI agents in Cypress Accessibility
-description: 'Use AI assistants alongside Cypress Accessibility: query Cloud results with Cypress Cloud MCP, align reports with component identification settings, and explore local browser LLM workflows.'
+description: 'Use AI assistants alongside Cypress Accessibility: query Cloud results with Cypress Cloud MCP, file violations into Jira or another issue tracker without duplicates, align reports with component identification settings, and explore local browser LLM workflows.'
 sidebar_label: Work with AI agents
 sidebar_position: 110
 ---
@@ -98,6 +98,68 @@ Download a report for each run you want to compare—for example, a `main` branc
 Ask the agent to keep the **Element URL** and **View URL** values in its output. Every row links back to the live snapshot in Cypress Cloud, so a summary, chart annotation, or ticket can point straight to the issue in context.
 
 :::
+
+## File issues in your issue tracker
+
+Triage usually ends in tickets, and typing them out one at a time is the slowest part of the job. An agent connected to both Cypress Cloud and your issue tracker can read the accessibility report for the latest run on `main`, check what has already been filed, and open only the tickets that are missing. Nothing new has to run in your pipeline, because the data comes from runs Cypress Cloud has already recorded.
+
+Cypress supplies the read side of this workflow. Cloud MCP is read-only, so the write side comes from your tracker's own MCP server or CLI, which Jira, GitHub, and Linear all publish. Connect both to the same agent before you start. For a single violation you are already looking at, the [Create Jira issue](/accessibility/reports/element-detail-view#Create-Jira-issue) button in Cypress Cloud is still faster than any prompt.
+
+### Decide what a ticket represents
+
+Agree on this before the agent creates anything. It decides both the size of your backlog and whether next week's refresh can tell an existing ticket from a new one.
+
+**Group by rule and view.** One ticket per rule per view is a good default: "Form elements must have labels on /checkout" is a unit of work someone can pick up and finish. A ticket per failing element buries the team in near-duplicates, and a ticket per rule across the whole application is usually too large to schedule. This matches the rule-by-rule approach in [Fix accessibility violations](/accessibility/guides/improve-accessibility).
+
+**Give every ticket the same shape.** Ask the agent to follow a fixed convention: a label such as `cypress-accessibility` on everything it opens, a summary pattern such as `[Accessibility] <rule ID> on <view name>`, and a description holding the rule, the severity, the failing selectors, and the link back to the report in Cypress Cloud. The convention is what makes the next refresh cheap, because deduplication becomes a search for a label and a rule ID rather than a judgment call about whether two sentences describe the same problem.
+
+**Group by component where it helps.** If your selectors carry [component names](#Map-violations-to-your-components), an agent can spot that one design-system component is behind failures on 15 views. That is one ticket for the component team rather than 15 for the page owners, so tell the agent which grouping you want.
+
+### Plan first, then create
+
+Run this in two passes. The first proposes tickets and checks them against your tracker without writing anything, so you see the batch before it exists. Replace `<branch>` with the branch you track, `<projectId>` with your Cypress project ID, and `<project key>` with the project in your tracker.
+
+<CopyPrompt
+  title="Plan tickets from the latest report"
+  subtext="See which failures are already tracked, which regressed, and which need a new ticket."
+  defaultCollapsed
+  prompt={`Refresh our accessibility backlog from Cypress Cloud, without creating anything yet.
+
+1. Find the latest completed run on <branch> for project <projectId> and pull its accessibility report.
+2. Group the failures into one proposed ticket per rule per view, sorted by severity. Include the failing element count and the Cypress Cloud link for each.
+3. For each proposed ticket, search <project key> in my issue tracker for a matching issue, open or closed in the last 90 days, matching on rule ID and view name.
+4. Report three groups: already tracked and open, previously closed but failing again, and not tracked at all.`}
+   >
+
+### Plan tickets from the latest report
+
+</CopyPrompt>
+
+The three groups matter. A failure that returns after its ticket was closed is a regression, and reopening or linking to that ticket keeps the history in one place instead of starting a fresh thread that loses the earlier investigation.
+
+<CopyPrompt
+  title="Create the missing issues"
+  subtext="Open tickets for the untracked failures only, in a format you can find again next week."
+  defaultCollapsed
+  prompt={`Create issues in <project key> for the untracked failures only. For each one: use the summary pattern [Accessibility] <rule ID> on <view name>, add the label cypress-accessibility, set priority from the rule severity, and put the rule description, the failing selectors, and the Cypress Cloud report link in the description.
+
+Then list the issues you created with their keys, and tell me anything you skipped and why.`}
+
+>
+
+### Create the missing issues
+
+</CopyPrompt>
+
+Once you trust the sequence, save both prompts as a custom instruction or skill in your AI client so the whole team refreshes the backlog the same way. Keep the approval step between them, and a few habits keep the writes reversible:
+
+- **Cap the first batch.** Ask for the 10 highest severity tickets before you ask for everything. A convention that looks right in a plan sometimes reads badly in your tracker.
+- **Label everything the agent opens.** One label makes a bad batch findable, and bulk-closable, in a single search.
+- **Keep closing in human hands.** Have the agent report regressions and possible duplicates, and let a person decide what gets closed, reopened, or merged.
+
+For a first sweep through a large backlog, work from a [downloaded report](#Work-with-a-downloaded-report) instead of live queries. Cloud MCP returns rule failures up to 25 at a time within a limit of 100 tool requests per hour, and a run with hundreds of failing elements can spend that budget on pagination alone. The file also carries an **Element URL** for every row, which is the link you want in the ticket body.
+
+Refresh on a cadence that matches how fast the report changes, such as weekly against the latest `main` run. This workflow is for the backlog on your main branch: catching a violation a pull request is about to introduce is a different job, and a faster one, because nobody has to file anything. See [Catch accessibility regressions](/accessibility/guides/detect-changes) and [Block pull requests and set policies](/accessibility/guides/block-pull-requests).
 
 ## Optimizing Cypress Accessibility for MCP use cases
 

--- a/docs/accessibility/work-with-ai-agents.mdx
+++ b/docs/accessibility/work-with-ai-agents.mdx
@@ -101,15 +101,21 @@ Ask the agent to keep the **Element URL** and **View URL** values in its output.
 
 ## File issues in your issue tracker
 
-Triage usually ends in tickets, and typing them out one at a time is the slowest part of the job. An agent connected to both Cypress Cloud and your issue tracker can read the accessibility report for the latest run on `main`, check what has already been filed, and open only the tickets that are missing. Nothing new has to run in your pipeline, because the data comes from runs Cypress Cloud has already recorded.
+Triage usually ends in tickets, and typing them out one at a time is the slowest part of the job. An agent connected to both Cypress Cloud and your issue tracker can read the accessibility report for the latest run, check what has already been filed, and open only the tickets that are missing. Nothing new has to run in your pipeline, because the data comes from runs Cypress Cloud has already recorded.
 
-Cypress supplies the read side of this workflow. Cloud MCP is read-only, so the write side comes from your tracker's own MCP server or CLI, which Jira, GitHub, and Linear all publish. Connect both to the same agent before you start. For a single violation you are already looking at, the [Create Jira issue](/accessibility/reports/element-detail-view#Create-Jira-issue) button in Cypress Cloud is still faster than any prompt.
+Cypress supplies the read side of this workflow. Cloud MCP is read-only, so the write side comes from your tracker's own MCP server or CLI, which Jira, GitHub, and Linear all publish. Connect both to the same agent before you start.
+
+:::note
+
+For a single violation you are already looking at, the [Create Jira issue](/accessibility/reports/element-detail-view#Create-Jira-issue) button in Cypress Cloud is faster than any prompt. Reach for an agent when you have a report's worth of findings to file at once.
+
+:::
 
 ### Decide what a ticket represents
 
 Agree on this before the agent creates anything. It decides both the size of your backlog and whether next week's refresh can tell an existing ticket from a new one.
 
-**Group by rule and view.** One ticket per rule per view is a good default: "Form elements must have labels on /checkout" is a unit of work someone can pick up and finish. A ticket per failing element buries the team in near-duplicates, and a ticket per rule across the whole application is usually too large to schedule. This matches the rule-by-rule approach in [Fix accessibility violations](/accessibility/guides/improve-accessibility).
+**Group by rule and view.** One ticket per rule per view is a good default: "Form elements must have labels on /checkout" is a unit of work someone can pick up and finish. A ticket per failing element buries the team in near-duplicates, and a ticket per rule across the whole application is usually too large to schedule.
 
 **Give every ticket the same shape.** Ask the agent to follow a fixed convention: a label such as `cypress-accessibility` on everything it opens, a summary pattern such as `[Accessibility] <rule ID> on <view name>`, and a description holding the rule, the severity, the failing selectors, and the link back to the report in Cypress Cloud. The convention is what makes the next refresh cheap, because deduplication becomes a search for a label and a rule ID rather than a judgment call about whether two sentences describe the same problem.
 
@@ -117,17 +123,21 @@ Agree on this before the agent creates anything. It decides both the size of you
 
 ### Plan first, then create
 
-Run this in two passes. The first proposes tickets and checks them against your tracker without writing anything, so you see the batch before it exists. Replace `<branch>` with the branch you track, `<projectId>` with your Cypress project ID, and `<project key>` with the project in your tracker.
+Run this in two passes. The first proposes tickets and checks them against your tracker without writing anything, so you see the batch before it exists. Replace the placeholders in both prompts:
+
+- `<branch>` is the branch you track, such as `main`.
+- `<projectId>` is your Cypress project ID, the `projectId` in your Cypress configuration file.
+- `<tracker project key>` identifies the project in your issue tracker that the tickets are filed into, such as the Jira project key `WEB` or the repository `acme/storefront` in GitHub. This has nothing to do with your Cypress project ID or your Cypress record key.
 
 <CopyPrompt
   title="Plan tickets from the latest report"
   subtext="See which failures are already tracked, which regressed, and which need a new ticket."
   defaultCollapsed
-  prompt={`Refresh our accessibility backlog from Cypress Cloud, without creating anything yet.
+  prompt={`Refresh our accessibility backlog using Cypress Cloud MCP, without creating anything yet.
 
 1. Find the latest completed run on <branch> for project <projectId> and pull its accessibility report.
 2. Group the failures into one proposed ticket per rule per view, sorted by severity. Include the failing element count and the Cypress Cloud link for each.
-3. For each proposed ticket, search <project key> in my issue tracker for a matching issue, open or closed in the last 90 days, matching on rule ID and view name.
+3. For each proposed ticket, search <tracker project key> in my issue tracker for a matching issue, open or closed in the last 90 days, matching on rule ID and view name.
 4. Report three groups: already tracked and open, previously closed but failing again, and not tracked at all.`}
    >
 
@@ -135,13 +145,11 @@ Run this in two passes. The first proposes tickets and checks them against your 
 
 </CopyPrompt>
 
-The three groups matter. A failure that returns after its ticket was closed is a regression, and reopening or linking to that ticket keeps the history in one place instead of starting a fresh thread that loses the earlier investigation.
-
 <CopyPrompt
   title="Create the missing issues"
   subtext="Open tickets for the untracked failures only, in a format you can find again next week."
   defaultCollapsed
-  prompt={`Create issues in <project key> for the untracked failures only. For each one: use the summary pattern [Accessibility] <rule ID> on <view name>, add the label cypress-accessibility, set priority from the rule severity, and put the rule description, the failing selectors, and the Cypress Cloud report link in the description.
+  prompt={`Create issues in <tracker project key> for the untracked failures only. For each one: use the summary pattern [Accessibility] <rule ID> on <view name>, add the label cypress-accessibility, set priority from the rule severity, and put the rule description, the failing selectors, and the Cypress Cloud report link in the description.
 
 Then list the issues you created with their keys, and tell me anything you skipped and why.`}
 
@@ -151,11 +159,7 @@ Then list the issues you created with their keys, and tell me anything you skipp
 
 </CopyPrompt>
 
-Once you trust the sequence, save both prompts as a custom instruction or skill in your AI client so the whole team refreshes the backlog the same way. Keep the approval step between them, and a few habits keep the writes reversible:
-
-- **Cap the first batch.** Ask for the 10 highest severity tickets before you ask for everything. A convention that looks right in a plan sometimes reads badly in your tracker.
-- **Label everything the agent opens.** One label makes a bad batch findable, and bulk-closable, in a single search.
-- **Keep closing in human hands.** Have the agent report regressions and possible duplicates, and let a person decide what gets closed, reopened, or merged.
+Once you trust the sequence, save both prompts as a custom instruction or skill in your AI client so the whole team refreshes the backlog the same way. Keep the approval step between them: creating issues is a write, and reading the plan first is what keeps a batch you did not intend out of your tracker.
 
 For a first sweep through a large backlog, work from a [downloaded report](#Work-with-a-downloaded-report) instead of live queries. Cloud MCP returns rule failures up to 25 at a time within a limit of 100 tool requests per hour, and a run with hundreds of failing elements can spend that budget on pagination alone. The file also carries an **Element URL** for every row, which is the link you want in the ticket body.
 

--- a/docs/accessibility/work-with-ai-agents.mdx
+++ b/docs/accessibility/work-with-ai-agents.mdx
@@ -127,7 +127,7 @@ Run this in two passes. The first proposes tickets and checks them against your 
 
 - `<branch>` is the branch you track, such as `main`.
 - `<projectId>` is your Cypress project ID, the `projectId` in your Cypress configuration file.
-- `<tracker project key>` identifies the project in your issue tracker that the tickets are filed into, such as the Jira project key `WEB` or the repository `acme/storefront` in GitHub. This has nothing to do with your Cypress project ID or your Cypress record key.
+- `<tracker project key>` identifies the project in your issue tracker that the tickets are filed into, such as the Jira project key `WEB` or the repository `acme/storefront` in GitHub.
 
 <CopyPrompt
   title="Plan tickets from the latest report"


### PR DESCRIPTION
## Summary

Adds a **File issues in your issue tracker** section to the Cypress Accessibility [Work with AI agents](https://docs.cypress.io/accessibility/work-with-ai-agents) guide. It documents a workflow where an agent connected to both Cypress Cloud MCP and an issue tracker reads the accessibility report for the latest run on a branch, checks what has already been filed, and opens only the tickets that are missing.

The section covers how to shape a ticket so repeat runs deduplicate by search rather than by guess, two prompts (a plan pass that writes nothing, then a create pass for the untracked failures only), and when to work from a downloaded report instead of live queries.

## Why

This came from user feedback asking for accessibility reporting data outside CI/CD environments:

> Reporting issues can be a pain, it would fantastic to have access to the reporting data outside of just CI/CD environments. I would love to be able to ask an AI agent to fetch the data from the main branch for a project and go through and start looking for issues from JIRA to see if it already exists, if not create the issues. Would be much better than manually going through the reporting interface to report all the issues.

Every piece of that already ships, it just was not connected anywhere in the docs:

- Cloud MCP reads accessibility results live and filters runs by git branch, so a project's main branch works from an editor with nothing added to CI.
- A downloaded report carries the full dataset with a deep link per row.
- Issue trackers publish their own MCP servers and CLIs for the write side, which Cloud MCP cannot do because it is read-only.

What was missing was the deduplication half of the ask ("see if it already exists"), which is what makes a repeatable refresh possible rather than a one-time dump that produces duplicate tickets on the second run. Today the only documented path from a report to a ticket is the **Create Jira issue** button, which files one violation at a time.

## Notes for reviewers

**Placement.** This started as a standalone guide under `docs/accessibility/guides/`, and was folded into `work-with-ai-agents.mdx` instead. That page already hosts the two data sources this workflow depends on (Cloud MCP and downloaded reports) plus the existing prompt patterns, and `improve-accessibility.mdx` already defers agent work to it, so a separate page would have split the same conversation across three places. The standalone file never existed on `main`, so no redirect is needed.

**Entry points added**, each where a reader hits this problem:

- Connect & extend overview, as a "Which should I use?" bullet.
- The **Create Jira issue** section of the element detail view, noting the bulk path.
- A new accessibility FAQ entry.
- The agent prompts section of the fix violations guide.

**Things worth a second opinion:**

- Third-party setup is deliberately vendor-neutral ("your tracker's own MCP server or CLI"). Documenting a specific Jira MCP configuration felt like it would go stale faster than we would notice.
- The ticket conventions (a `cypress-accessibility` label, an `[Accessibility] <rule ID> on <view name>` summary pattern) are a proposed convention rather than anything the product enforces. They are what makes the dedupe search work, so they are worth agreeing with.
- The stated limits, that Cloud MCP pages rule failures 25 at a time under 100 tool requests per hour, come from the Cloud MCP tool schemas and its usage limits section. Worth confirming they are still current.

**Verified** with `npm run lint:fix` and a full `npm run build`, which throws on broken links and anchors. All four cross-links resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RNjpz796oKiAxWq7zApasr

---
_Generated by [Claude Code](https://claude.ai/code/session_01RNjpz796oKiAxWq7zApasr)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no product or runtime impact; proposed ticket conventions and MCP rate limits are editorial and may need periodic verification.
> 
> **Overview**
> Documents an **agent-driven workflow** for turning Cypress Accessibility reports into issue-tracker tickets without duplicating work on repeat refreshes.
> 
> The main addition is **File issues in your issue tracker** on `work-with-ai-agents.mdx`: Cypress Cloud MCP (read) plus the tracker’s MCP/CLI (write), ticket shape (e.g. `cypress-accessibility` label, `[Accessibility] <rule> on <view>` summaries), a **plan-then-create** two-prompt flow with `CopyPrompt` blocks, and when to use a **downloaded report** instead of live MCP pagination limits.
> 
> **Cross-links** were added on the Connect & extend overview (“Which should I use?”), a new FAQ entry for filing a whole report at once, the fix-violations guide’s AI section, and the element detail view after **Create Jira issue** (single-violation UI vs bulk agent path). The work-with-ai-agents page **description** front matter was updated to mention issue filing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f0c31548c5b300c945f52cd4153d1eeba63ded6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->