### PR TITLE
Add Cypress Cloud agent setup reference at /agent-setup.md

### DIFF
--- a/static/agent-setup.md
+++ b/static/agent-setup.md
@@ -35,6 +35,10 @@ scope.
   sends an established repo's runs to a different Cloud project. See phase 2.
 - Never install Cypress into more than one package. In a monorepo, pick one and
   say which.
+- Never install Cypress that is already declared. Running `add -D cypress` on a
+  repo whose `package.json` already lists it resolves to the latest version and
+  rewrites the declared range — a silent major upgrade. Use the manager's plain
+  install instead, so the declared range is honoured. See phase 2.
 - Never start a recorded run yourself. Verification uses `cypress run` without
   `--record`. The record key is not part of your job — if someone does paste a
   command containing one, use it only as a command argument and never write it to
@@ -46,12 +50,35 @@ scope.
 Read only — change nothing in this phase. Gather all of it before deciding
 anything.
 
-- **The repo.** Confirm the repository root and its git remote, and state them.
-  If the working tree already has uncommitted changes, say so, because your edits
-  will mix with the person's.
+- **The repo, and the directory you will work in.** Confirm the repository root
+  and its git remote, and state them. Then state the single directory you will
+  install and run from, and confirm it is a package root — it holds the
+  `package.json` that declares Cypress. Everything below is relative to that
+  directory, and phase 5 has to name it. If the working tree already has
+  uncommitted changes, say so, because your edits will mix with the person's.
 - **The package manager.** Take it from the lockfile, not from habit.
-- **Cypress.** Is `cypress` in `dependencies` or `devDependencies`? Is it
-  actually installed? Note the version.
+- **Cypress — establish three separate facts.** They can disagree, and which
+  action is correct depends on which of them is true. Run the commands; do not
+  infer.
+
+  1. **Declared** — is `cypress` in `dependencies` or `devDependencies`, and at
+     what range? Read the `package.json` in your operating directory.
+  2. **Resolvable** —
+     `node -e "console.log(require.resolve('cypress/package.json'))"`. Print the
+     path and state it. A path outside the package you are configuring means
+     Cypress is inherited from a parent directory, not installed here.
+  3. **Binary present** — `npx --no-install cypress version`, which reports the
+     package version and the binary version separately. The package can be
+     installed while the binary is not.
+
+  Do not substitute `ls node_modules`, `which cypress`, or the absence of a local
+  `node_modules` for any of these. Node resolves modules by walking _up_ the
+  directory tree, so Cypress can be entirely absent from the directory you are
+  standing in and still resolve from a parent — which happens routinely in
+  monorepo packages, git worktrees, and any repo checked out inside another
+  package. Those proxies report "not installed" for a repo that has Cypress, and
+  installing on top of that is how you cause the version change the hard rules
+  forbid.
 - **The config file.** Look for `cypress.config.js`, `.ts`, `.mjs`, `.cjs` — and
   for a legacy `cypress.json`, which means Cypress 9 or older.
 - **An existing project ID.** Check the config, `cypress.env.json`, and the
@@ -62,13 +89,16 @@ anything.
 - **Workspace layout.** In a monorepo, work out which single package should own
   Cypress.
 
-Package manager, by lockfile:
+Package manager, by lockfile. The second command matters: it installs what the
+lockfile already pins, without changing any declared version.
 
-- `pnpm-lock.yaml` — use `pnpm add -D cypress`
-- `yarn.lock` — use `yarn add -D cypress`
-- `package-lock.json` — use `npm install -D cypress`
-- `bun.lockb` — use `bun add -d cypress`
-- No lockfile — use `npm install -D cypress`
+- `pnpm-lock.yaml` — add with `pnpm add -D cypress`, plain install
+  `pnpm install`
+- `yarn.lock` — add with `yarn add -D cypress`, plain install `yarn install`
+- `package-lock.json` — add with `npm install -D cypress`, plain install
+  `npm ci`
+- `bun.lockb` — add with `bun add -d cypress`, plain install `bun install`
+- No lockfile — add with `npm install -D cypress`; there is nothing to honour
 
 Using the wrong manager writes a second lockfile alongside the first, which can
 break the person's CI. If an install fails, report the output — do not retry
@@ -78,6 +108,25 @@ with a different manager.
 
 Work out the whole plan before you touch anything, so that a "no" never leaves
 the repo half-configured.
+
+### Cypress
+
+Cross the two facts from phase 1. "Install only if it is missing" is not
+specific enough: two of these four cases are not an install at all, and one of
+them is destructive if you treat it as one.
+
+- **Declared, and resolvable.** Nothing. Report the version and move on.
+- **Declared, not resolvable.** Dependencies are simply not installed. Run the
+  manager's plain install from the phase-1 list — never `add -D cypress`, which
+  would resolve to the latest version and rewrite the declared range.
+- **Not declared, but resolvable.** Cypress resolves from outside this package.
+  Say where it resolved from, and ask. Declaring it here is usually right, but
+  it is the person's call, and some repos leave it undeclared deliberately.
+- **Neither.** Install it, using the add command from the phase-1 list.
+
+Separately, if Cypress is resolvable but `npx --no-install cypress version`
+shows no binary, run `npx cypress install`. That fetches the binary for the
+version already declared and does not touch `package.json`.
 
 ### The project ID
 
@@ -105,7 +154,8 @@ Ask first if any of these is true. Otherwise go ahead and report afterwards.
 
 ## 3. Apply
 
-Install Cypress — only if it is missing, using the manager from phase 1.
+Get Cypress present — whichever of install, plain install, ask, or nothing the
+phase-2 list selected. Do not shortcut it to "install if missing".
 
 Set the project ID. If there is no config file, create one. If there is, edit it
 in place: add the single `projectId` key and leave every other key, comment, and
@@ -210,5 +260,8 @@ Three details in there are not optional:
 - **An ambiguous monorepo.** Ask which package should own Cypress.
 - **A failed install.** Report the manager's own output. Do not work around it.
 
-Running this twice should be safe. Every phase checks before it writes, so a
-second pass on an already-configured repo should change nothing and say so.
+Running this twice is safe, but only because phase 1 detects by resolution
+rather than by looking for a local `node_modules`. A second pass on an
+already-configured repo lands in the declared-and-resolvable case, changes
+nothing, and says so. If you substitute a proxy check, that guarantee is gone:
+every pass reads "not installed" and installs again.

--- a/static/agent-setup.md
+++ b/static/agent-setup.md
@@ -22,9 +22,14 @@ cross into the agent's half.
 ## Hard rules
 
 You are operating in a repository you did not write, which may be someone's
-production codebase. The whole job is three small changes — a dev dependency,
-one config key, and possibly one spec file. Anything beyond that is out of
-scope.
+production codebase. In a repo that already has a JavaScript package, the whole job is three small
+changes — a dev dependency, one config key, and possibly one spec file. Anything
+beyond that is out of scope.
+
+These rules exist to protect work you did not write. A repo with no package at
+all has none to protect, and needs one before Cypress can be installed — see
+"When to stop" for the one case where creating it is in scope, and the check to
+run first.
 
 - Never commit or push. Leave every change in the working tree for the person to
   review.
@@ -316,14 +321,29 @@ Three details in there are not optional:
 
 - **No `package.json`.** Two different situations, and only one of them is a
   stop:
+
   - **An empty or near-empty repo** — often someone creating a fresh one
     specifically to try Cypress Cloud. That is a good candidate, not a dead end.
-    Offer to bootstrap it with `npm init -y`, and say so before you do:
-    creating `package.json` is a bigger change than the three this job is
-    scoped to, so it is the person's call.
+    Bootstrap it with `npm init -y` and carry on; there is no existing work to
+    protect and nothing to weigh up, so do not stop to ask.
+
+    First confirm you are at the repository root and that no `package.json`
+    exists anywhere between you and it. **A `package.json` in a parent
+    directory means you are in the wrong directory, not in an empty repo** —
+    say so and move there. Creating a second, nested one changes module
+    resolution for everything beneath it, which is the same trap as detecting
+    Cypress with `ls node_modules`.
+
+    Then say what you did, and what it implies: `npm init -y` writes no `type`
+    field, so the package is CommonJS and the config follows the CommonJS form
+    above. Mention that adding `"type": "module"` switches both, in case they
+    would rather have ESM. Do not ask which they want — state the default and
+    let them redirect you.
+
   - **A repo built on another stack** — a `go.mod`, `pyproject.toml` or
     `Gemfile` and no JavaScript package. Stop, and point the person at the
     manual setup guide.
+
 - **Cypress 9 or older.** Ask before migrating — see phase 2.
 - **An ambiguous monorepo.** Ask which package should own Cypress.
 - **A failed install.** Report the manager's own output. Do not work around it.

--- a/static/agent-setup.md
+++ b/static/agent-setup.md
@@ -79,6 +79,7 @@ anything.
   package. Those proxies report "not installed" for a repo that has Cypress, and
   installing on top of that is how you cause the version change the hard rules
   forbid.
+
 - **The config file.** Look for `cypress.config.js`, `.ts`, `.mjs`, `.cjs` — and
   for a legacy `cypress.json`, which means Cypress 9 or older.
 - **An existing project ID.** Check the config, `cypress.env.json`, and the

--- a/static/agent-setup.md
+++ b/static/agent-setup.md
@@ -6,11 +6,14 @@ agent to get a repo ready to record its first run. Follow the phases in order.
 
 ## Who does what
 
-| Role          | Responsibility                                                                                                                                          |
-| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Cypress Cloud | Supplies two separate things: the prompt, which carries the project ID and a link to this page, and the record command, which carries the record key.   |
-| The person    | Pastes the prompt to their agent. Reviews the diff afterwards. Runs the record command themselves, in their own terminal.                               |
-| The agent     | Everything on this page: detect, decide, apply, verify, hand back. Gets the project ID. Does not get the record key, and does not run the recorded run. |
+- **Cypress Cloud** supplies two separate things: the prompt, which carries the
+  project ID and a link to this page, and the record command, which carries the
+  record key.
+- **The person** pastes the prompt to their agent. Reviews the diff afterwards.
+  Runs the record command themselves, in their own terminal.
+- **The agent** does everything on this page: detect, decide, apply, verify, hand
+  back. Gets the project ID. Does not get the record key, and does not run the
+  recorded run.
 
 Keep that boundary. The setup work and the recorded run are deliberately two
 steps performed by two different parties, and the record key never needs to
@@ -61,13 +64,11 @@ anything.
 
 Package manager, by lockfile:
 
-| Lockfile            | Use                      |
-| ------------------- | ------------------------ |
-| `pnpm-lock.yaml`    | `pnpm add -D cypress`    |
-| `yarn.lock`         | `yarn add -D cypress`    |
-| `package-lock.json` | `npm install -D cypress` |
-| `bun.lockb`         | `bun add -d cypress`     |
-| none                | `npm install -D cypress` |
+- `pnpm-lock.yaml` — use `pnpm add -D cypress`
+- `yarn.lock` — use `yarn add -D cypress`
+- `package-lock.json` — use `npm install -D cypress`
+- `bun.lockb` — use `bun add -d cypress`
+- No lockfile — use `npm install -D cypress`
 
 Using the wrong manager writes a second lockfile alongside the first, which can
 break the person's CI. If an install fails, report the output — do not retry
@@ -80,12 +81,16 @@ the repo half-configured.
 
 ### The project ID
 
-| What you found                              | What to do                                                                                                                            |
-| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| No project ID anywhere                      | Add the one from the prompt.                                                                                                          |
-| The same ID as the prompt's                 | Nothing. Report that it is already set and move on.                                                                                   |
-| A different ID                              | Stop and ask. Show both values and explain that replacing it sends this repo's runs to a different Cloud project. Wait for an answer. |
-| `CYPRESS_PROJECT_ID` set in the environment | It overrides the config at runtime. Update the config as normal, and say that the variable must be unset or changed to match.         |
+What you found, and what to do about it:
+
+- **No project ID anywhere.** Add the one from the prompt.
+- **The same ID as the prompt's.** Nothing. Report that it is already set and
+  move on.
+- **A different ID.** Stop and ask. Show both values and explain that replacing
+  it sends this repo's runs to a different Cloud project. Wait for an answer.
+- **`CYPRESS_PROJECT_ID` set in the environment.** It overrides the config at
+  runtime. Update the config as normal, and say that the variable must be unset
+  or changed to match.
 
 ### When to ask before applying
 

--- a/static/agent-setup.md
+++ b/static/agent-setup.md
@@ -1,0 +1,209 @@
+# Cypress Cloud Agent Setup
+
+This page is read by an AI coding agent working inside someone's repository. It
+is linked from the prompt in Cypress Cloud's onboarding guide, which asks an
+agent to get a repo ready to record its first run. Follow the phases in order.
+
+## Who does what
+
+| Role          | Responsibility                                                                                                                                          |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Cypress Cloud | Supplies two separate things: the prompt, which carries the project ID and a link to this page, and the record command, which carries the record key.   |
+| The person    | Pastes the prompt to their agent. Reviews the diff afterwards. Runs the record command themselves, in their own terminal.                               |
+| The agent     | Everything on this page: detect, decide, apply, verify, hand back. Gets the project ID. Does not get the record key, and does not run the recorded run. |
+
+Keep that boundary. The setup work and the recorded run are deliberately two
+steps performed by two different parties, and the record key never needs to
+cross into the agent's half.
+
+## Hard rules
+
+You are operating in a repository you did not write, which may be someone's
+production codebase. The whole job is three small changes — a dev dependency,
+one config key, and possibly one spec file. Anything beyond that is out of
+scope.
+
+- Never commit or push. Leave every change in the working tree for the person to
+  review.
+- Never change what you did not come to change. Do not add, upgrade, downgrade,
+  or remove any other dependency. Do not touch CI configuration, build config,
+  existing tests, or any config key other than `projectId`.
+- Never overwrite an existing `projectId` without asking first. Replacing one
+  sends an established repo's runs to a different Cloud project. See phase 2.
+- Never install Cypress into more than one package. In a monorepo, pick one and
+  say which.
+- Never start a recorded run yourself. Verification uses `cypress run` without
+  `--record`. The record key is not part of your job — if someone does paste a
+  command containing one, use it only as a command argument and never write it to
+  `cypress.config.*`, `cypress.env.json`, `.env`, a shell profile, a CI file, or
+  any other file.
+
+## 1. Detect
+
+Read only — change nothing in this phase. Gather all of it before deciding
+anything.
+
+- **The repo.** Confirm the repository root and its git remote, and state them.
+  If the working tree already has uncommitted changes, say so, because your edits
+  will mix with the person's.
+- **The package manager.** Take it from the lockfile, not from habit.
+- **Cypress.** Is `cypress` in `dependencies` or `devDependencies`? Is it
+  actually installed? Note the version.
+- **The config file.** Look for `cypress.config.js`, `.ts`, `.mjs`, `.cjs` — and
+  for a legacy `cypress.json`, which means Cypress 9 or older.
+- **An existing project ID.** Check the config, `cypress.env.json`, and the
+  `CYPRESS_PROJECT_ID` environment variable.
+- **Existing specs.** Use `specPattern` from the config if it is set; otherwise
+  `cypress/e2e/**`, and `cypress/integration/**` for older layouts.
+- **Testing types.** Note whether the config defines `e2e`, `component`, or both.
+- **Workspace layout.** In a monorepo, work out which single package should own
+  Cypress.
+
+Package manager, by lockfile:
+
+| Lockfile            | Use                      |
+| ------------------- | ------------------------ |
+| `pnpm-lock.yaml`    | `pnpm add -D cypress`    |
+| `yarn.lock`         | `yarn add -D cypress`    |
+| `package-lock.json` | `npm install -D cypress` |
+| `bun.lockb`         | `bun add -d cypress`     |
+| none                | `npm install -D cypress` |
+
+Using the wrong manager writes a second lockfile alongside the first, which can
+break the person's CI. If an install fails, report the output — do not retry
+with a different manager.
+
+## 2. Decide
+
+Work out the whole plan before you touch anything, so that a "no" never leaves
+the repo half-configured.
+
+### The project ID
+
+| What you found                              | What to do                                                                                                                            |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| No project ID anywhere                      | Add the one from the prompt.                                                                                                          |
+| The same ID as the prompt's                 | Nothing. Report that it is already set and move on.                                                                                   |
+| A different ID                              | Stop and ask. Show both values and explain that replacing it sends this repo's runs to a different Cloud project. Wait for an answer. |
+| `CYPRESS_PROJECT_ID` set in the environment | It overrides the config at runtime. Update the config as normal, and say that the variable must be unset or changed to match.         |
+
+### When to ask before applying
+
+Ask first if any of these is true. Otherwise go ahead and report afterwards.
+
+- An existing project ID differs from the prompt's.
+- More than one package could reasonably own Cypress.
+- The repo only has a legacy `cypress.json` — migrating to Cypress 10+ is a
+  bigger change than this setup, and the person should choose it deliberately.
+- The repo has component tests but no e2e tests. The record command runs e2e by
+  default, so the person needs to know it will need `--component`.
+
+## 3. Apply
+
+Install Cypress — only if it is missing, using the manager from phase 1.
+
+Set the project ID. If there is no config file, create one. If there is, edit it
+in place: add the single `projectId` key and leave every other key, comment, and
+formatting choice alone. Do not reformat the file.
+
+```ts title="cypress.config.ts"
+import { defineConfig } from 'cypress'
+
+export default defineConfig({
+  projectId: 'YOUR_PROJECT_ID',
+  e2e: {
+    // leave any existing options untouched
+  },
+})
+```
+
+Scaffold a spec — only if the repo has none.
+
+```js title="cypress/e2e/cloud-setup.cy.js"
+describe('Cypress Cloud setup', () => {
+  it('records a run to Cypress Cloud', () => {
+    cy.wrap('cypress').should('equal', 'cypress')
+  })
+})
+```
+
+This spec deliberately does not visit a URL. A scaffolded `cy.visit('/')` fails
+when no application is running and no `baseUrl` is set, which would make the
+person's very first recorded run a red one. Only write a `cy.visit` test instead
+if `baseUrl` is already configured and you have confirmed the server runs.
+
+Ignore Cypress's output. Add these to `.gitignore` if absent:
+
+```text title=".gitignore"
+cypress/screenshots/
+cypress/videos/
+cypress/downloads/
+```
+
+## 4. Verify
+
+Prove the setup works before handing it back. Run the spec locally, without
+recording:
+
+```shell
+npx cypress run --spec cypress/e2e/cloud-setup.cy.js
+```
+
+The first run downloads the Cypress binary, which can take a minute. Do not hand
+off a setup that does not pass — fix it, or report the failure with the output.
+
+## 5. Hand back
+
+Your half is done and the next step is the person's. This is the moment the
+whole setup exists for, so be specific: say what you changed, say exactly where
+to get the command, and say which directory to run it from. Do not run it for
+them.
+
+Report it like this, filling in what you actually did:
+
+```text
+Cypress is set up to record to Cypress Cloud.
+
+  Cypress   installed 15.4.0 (was not present)
+  Config    cypress.config.ts — added projectId "abc123"
+  Spec      cypress/e2e/cloud-setup.cy.js — created
+  Ignored   cypress/screenshots, cypress/videos, cypress/downloads
+  Verified  1 passing (cypress run, not recorded)
+
+Please review the diff before going further.
+
+To record your first run:
+
+  1. Go back to Cypress Cloud, to the onboarding guide you copied the prompt from.
+  2. Under "Paste command into terminal", copy the command.
+  3. Run it from ./apps/web — that is where I installed Cypress.
+
+That command contains your record key. Run it; don't save it in a file. If you
+want it again later, export CYPRESS_RECORD_KEY in your shell session rather
+than committing it anywhere.
+
+The guide picks the run up on its own and moves you on to reviewing the
+results — you don't need to refresh it.
+```
+
+Three details in there are not optional:
+
+- **Name the directory.** The command has to run where Cypress is installed. In a
+  monorepo, the repo root is usually the wrong answer, and `npx cypress run` from
+  the wrong directory fails in a way that looks like a broken setup rather than a
+  wrong path.
+- **Say the guide updates itself.** Otherwise people sit on the page reloading it,
+  or assume nothing happened.
+- **If the repo only has component tests**, add that the command needs
+  `--component` — this is the point where it matters, not phase 2.
+
+## When to stop
+
+- **No `package.json`.** This is not a JavaScript project. Stop and point the
+  person at the manual setup guide.
+- **Cypress 9 or older.** Ask before migrating — see phase 2.
+- **An ambiguous monorepo.** Ask which package should own Cypress.
+- **A failed install.** Report the manager's own output. Do not work around it.
+
+Running this twice should be safe. Every phase checks before it writes, so a
+second pass on an already-configured repo should change nothing and say so.

--- a/static/agent-setup.md
+++ b/static/agent-setup.md
@@ -120,9 +120,15 @@ them is destructive if you treat it as one.
 - **Declared, not resolvable.** Dependencies are simply not installed. Run the
   manager's plain install from the phase-1 list — never `add -D cypress`, which
   would resolve to the latest version and rewrite the declared range.
-- **Not declared, but resolvable.** Cypress resolves from outside this package.
-  Say where it resolved from, and ask. Declaring it here is usually right, but
-  it is the person's call, and some repos leave it undeclared deliberately.
+- **Not declared, but resolvable from inside the repository.** Cypress comes
+  from a parent package or a workspace root. Say where it resolved from, and
+  ask. Declaring it here is usually right, but it is the person's call, and some
+  repos leave it undeclared deliberately.
+- **Not declared, and resolvable only from outside the repository root.** A path
+  like `~/node_modules/cypress` is a stray global install, never a deliberate
+  architecture choice, and asking whether to declare Cypress "here" makes no
+  sense. Treat it as not present, say what you found and where, and install
+  without asking.
 - **Neither.** Install it, using the add command from the phase-1 list.
 
 Separately, if Cypress is resolvable but `npx --no-install cypress version`
@@ -162,10 +168,35 @@ Set the project ID. If there is no config file, create one. If there is, edit it
 in place: add the single `projectId` key and leave every other key, comment, and
 formatting choice alone. Do not reformat the file.
 
+Take the config's extension and module syntax from the package, not from this
+page. Guessing wrong is a `SyntaxError` on the first run, not a warning:
+
+- **TypeScript already in use** — a `typescript` dependency or a `tsconfig.json`
+  — use `cypress.config.ts` with `import` / `export default`.
+- **`"type": "module"` in `package.json`** — use `cypress.config.js` with
+  `import` / `export default`.
+- **No `type` field** — this is the CommonJS default, and what `npm init -y`
+  produces. Use `cypress.config.js` with `require` / `module.exports`.
+
+TypeScript, or ESM:
+
 ```ts title="cypress.config.ts"
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
+  projectId: 'YOUR_PROJECT_ID',
+  e2e: {
+    // leave any existing options untouched
+  },
+})
+```
+
+CommonJS:
+
+```js title="cypress.config.js"
+const { defineConfig } = require('cypress')
+
+module.exports = defineConfig({
   projectId: 'YOUR_PROJECT_ID',
   e2e: {
     // leave any existing options untouched
@@ -188,6 +219,20 @@ when no application is running and no `baseUrl` is set, which would make the
 person's very first recorded run a red one. Only write a `cy.visit` test instead
 if `baseUrl` is already configured and you have confirmed the server runs.
 
+Scaffold the support file as well, if nothing matches
+`cypress/support/e2e.{js,jsx,ts,tsx}`. Cypress expects one by default and
+refuses to run without it, and a repo with no specs has no support file either —
+so the greenfield path, which is exactly what this page is for, fails
+verification unless you create it:
+
+```js title="cypress/support/e2e.js"
+// Loaded before every e2e spec. Custom commands and global hooks go here.
+```
+
+If you would rather not add the file, set `supportFile: false` in the config's
+`e2e` block instead. What you must not do is leave it unset with no file
+present.
+
 Ignore Cypress's output. Add these to `.gitignore` if absent:
 
 ```text title=".gitignore"
@@ -196,17 +241,31 @@ cypress/videos/
 cypress/downloads/
 ```
 
+If your install created `node_modules` in a repo that has no `.gitignore` at
+all, add `node_modules/` too. That looks like it conflicts with "never change
+what you did not come to change", so to be explicit: it does not. You created
+that directory, and leaving it untracked means the person's next commit carries
+their whole dependency tree.
+
 ## 4. Verify
 
-Prove the setup works before handing it back. Run the spec locally, without
+Prove the setup works before handing it back. Run one spec locally, without
 recording:
 
 ```shell
 npx cypress run --spec cypress/e2e/cloud-setup.cy.js
 ```
 
-The first run downloads the Cypress binary, which can take a minute. Do not hand
-off a setup that does not pass — fix it, or report the failure with the output.
+Point `--spec` at a spec that actually exists: the one you scaffolded, or — if
+the repo already had specs and you scaffolded nothing — a single existing one.
+`--spec` on a path that is not there fails as "no specs found", which reads like
+a broken setup at the very last step.
+
+Installing Cypress and fetching its binary can take several minutes; seven is
+not unusual on a cold cache. That is not a hang. Do not kill it and retry.
+
+Do not hand off a setup that does not pass — fix it, or report the failure with
+the output.
 
 ## 5. Hand back
 
@@ -255,8 +314,16 @@ Three details in there are not optional:
 
 ## When to stop
 
-- **No `package.json`.** This is not a JavaScript project. Stop and point the
-  person at the manual setup guide.
+- **No `package.json`.** Two different situations, and only one of them is a
+  stop:
+  - **An empty or near-empty repo** — often someone creating a fresh one
+    specifically to try Cypress Cloud. That is a good candidate, not a dead end.
+    Offer to bootstrap it with `npm init -y`, and say so before you do:
+    creating `package.json` is a bigger change than the three this job is
+    scoped to, so it is the person's call.
+  - **A repo built on another stack** — a `go.mod`, `pyproject.toml` or
+    `Gemfile` and no JavaScript package. Stop, and point the person at the
+    manual setup guide.
 - **Cypress 9 or older.** Ask before migrating — see phase 2.
 - **An ambiguous monorepo.** Ask which package should own Cypress.
 - **A failed install.** Report the manager's own output. Do not work around it.

--- a/static/agent-setup.md
+++ b/static/agent-setup.md
@@ -15,10 +15,6 @@ agent to get a repo ready to record its first run. Follow the phases in order.
   back. Gets the project ID. Does not get the record key, and does not run the
   recorded run.
 
-Keep that boundary. The setup work and the recorded run are deliberately two
-steps performed by two different parties, and the record key never needs to
-cross into the agent's half.
-
 ## Hard rules
 
 You are operating in a repository you did not write, which may be someone's

--- a/static/agent-setup.md
+++ b/static/agent-setup.md
@@ -1,4 +1,4 @@
-# Cypress Cloud Agent Setup
+# Set up a repository to record to Cypress Cloud
 
 This page is read by an AI coding agent working inside someone's repository. It
 is linked from the prompt in Cypress Cloud's onboarding guide, which asks an

--- a/static/agent-setup.md
+++ b/static/agent-setup.md
@@ -81,12 +81,11 @@ anything.
   installing on top of that is how you cause the version change the hard rules
   forbid.
 
-- **The config file.** Look for `cypress.config.js`, `.ts`, `.mjs`, `.cjs` — and
-  for a legacy `cypress.json`, which means Cypress 9 or older.
+- **The config file.** Look for `cypress.config.js`, `.ts`, `.mjs`, `.cjs`.
 - **An existing project ID.** Check the config, `cypress.env.json`, and the
   `CYPRESS_PROJECT_ID` environment variable.
 - **Existing specs.** Use `specPattern` from the config if it is set; otherwise
-  `cypress/e2e/**`, and `cypress/integration/**` for older layouts.
+  `cypress/e2e/**`.
 - **Testing types.** Note whether the config defines `e2e`, `component`, or both.
 - **Workspace layout.** In a monorepo, work out which single package should own
   Cypress.
@@ -155,10 +154,6 @@ Ask first if any of these is true. Otherwise go ahead and report afterwards.
 
 - An existing project ID differs from the prompt's.
 - More than one package could reasonably own Cypress.
-- The repo only has a legacy `cypress.json` — migrating to Cypress 10+ is a
-  bigger change than this setup, and the person should choose it deliberately.
-  Point them at
-  <https://docs.cypress.io/app/references/migration-guide#Migrating-to-Cypress-100>.
 - The repo has component tests but no e2e tests. The record command runs e2e by
   default, so the person needs to know it will need `--component`.
 
@@ -382,7 +377,9 @@ Three details in there are not optional:
     `Gemfile` and no JavaScript package. Stop, and point the person at
     <https://docs.cypress.io/cloud/get-started/setup>.
 
-- **Cypress 9 or older.** Ask before migrating — see phase 2, and link them to
+- **Cypress 9 or older**, from the version you read in phase 1. This setup
+  targets Cypress 10 and above, and migrating is a far bigger change than the
+  one you came to make. Stop, and point the person at
   <https://docs.cypress.io/app/references/migration-guide#Migrating-to-Cypress-100>.
 - **An ambiguous monorepo.** Ask which package should own Cypress.
 - **A failed install.** Report the manager's own output. Do not work around it.

--- a/static/agent-setup.md
+++ b/static/agent-setup.md
@@ -161,6 +161,8 @@ Ask first if any of these is true. Otherwise go ahead and report afterwards.
 - More than one package could reasonably own Cypress.
 - The repo only has a legacy `cypress.json` — migrating to Cypress 10+ is a
   bigger change than this setup, and the person should choose it deliberately.
+  Point them at
+  <https://docs.cypress.io/app/references/migration-guide#Migrating-to-Cypress-100>.
 - The repo has component tests but no e2e tests. The record command runs e2e by
   default, so the person needs to know it will need `--component`.
 
@@ -172,6 +174,13 @@ phase-2 list selected. Do not shortcut it to "install if missing".
 Set the project ID. If there is no config file, create one. If there is, edit it
 in place: add the single `projectId` key and leave every other key, comment, and
 formatting choice alone. Do not reformat the file.
+
+Use the ID the prompt gave you. `YOUR_PROJECT_ID` in the samples below is a
+placeholder, and it is a plausible-looking one, so it survives a copy without
+looking wrong. If the prompt carries no project ID, or you cannot tell which
+value is the ID, stop and ask for it. Do not invent one, and do not leave the
+placeholder in place: both produce a config that looks finished and cannot
+record.
 
 Take the config's extension and module syntax from the package, not from this
 page. Guessing wrong is a `SyntaxError` on the first run, not a warning:
@@ -209,7 +218,8 @@ module.exports = defineConfig({
 })
 ```
 
-Scaffold a spec — only if the repo has none.
+Scaffold a spec — only if the repo has none, or if phase 4 sends you back here
+because an existing spec failed for reasons of its own.
 
 ```js title="cypress/e2e/cloud-setup.cy.js"
 describe('Cypress Cloud setup', () => {
@@ -266,11 +276,31 @@ the repo already had specs and you scaffolded nothing — a single existing one.
 `--spec` on a path that is not there fails as "no specs found", which reads like
 a broken setup at the very last step.
 
+In a repo with component tests and no e2e tests, add `--component`. Without it,
+Cypress runs e2e by default and fails on a missing e2e configuration rather than
+on anything you did. This is the same fact phase 2 told you to warn the person
+about; it applies to your own verification first.
+
 Installing Cypress and fetching its binary can take several minutes; seven is
 not unusual on a cold cache. That is not a hang. Do not kill it and retry.
 
-Do not hand off a setup that does not pass — fix it, or report the failure with
-the output.
+Do not hand off a setup that does not pass. Which failures are yours to fix,
+though, depends on what failed:
+
+- **The setup failed.** A config that will not parse, a missing support file, a
+  spec that cannot be found, a project ID that did not take. Fix it and run
+  again.
+- **An existing spec failed on its own terms.** No application running, a
+  missing `baseUrl`, absent environment variables, a test that was already red
+  before you arrived. That is not your setup, and repairing it is exactly the
+  kind of change the hard rules forbid. Do not touch the test, the config, or
+  the environment to make it pass.
+
+  Instead, verify against something you control: scaffold the setup spec from
+  phase 3 and run that on its own, even in a repo that already has specs. If it
+  passes, the setup is sound. Say so, and say plainly in the hand-back that an
+  existing spec was already failing, which one, and why — it is useful for the
+  person to know, and it is theirs to decide about.
 
 ## 5. Hand back
 
@@ -279,15 +309,18 @@ whole setup exists for, so be specific: say what you changed, say exactly where
 to get the command, and say which directory to run it from. Do not run it for
 them.
 
-Report it like this, filling in what you actually did:
+Every change you made gets a line. This example is a greenfield repo, so it
+shows the whole set:
 
 ```text
 Cypress is set up to record to Cypress Cloud.
 
+  Package   package.json — created with npm init -y (CommonJS)
   Cypress   installed 15.4.0 (was not present)
-  Config    cypress.config.ts — added projectId "abc123"
+  Config    cypress.config.js — added projectId "abc123"
   Spec      cypress/e2e/cloud-setup.cy.js — created
-  Ignored   cypress/screenshots, cypress/videos, cypress/downloads
+  Support   cypress/support/e2e.js — created
+  Ignored   node_modules, cypress/screenshots, cypress/videos, cypress/downloads
   Verified  1 passing (cypress run, not recorded)
 
 Please review the diff before going further.
@@ -296,7 +329,7 @@ To record your first run:
 
   1. Go back to Cypress Cloud, to the onboarding guide you copied the prompt from.
   2. Under "Paste command into terminal", copy the command.
-  3. Run it from ./apps/web — that is where I installed Cypress.
+  3. Run it from ./ (the repository root) — that is where I installed Cypress.
 
 That command contains your record key. Run it; don't save it in a file. If you
 want it again later, export CYPRESS_RECORD_KEY in your shell session rather
@@ -305,6 +338,15 @@ than committing it anywhere.
 The guide picks the run up on its own and moves you on to reviewing the
 results — you don't need to refresh it.
 ```
+
+Drop the lines that do not apply. An established repo that already had a package
+and a support file gets neither of those lines, and its Cypress line might read
+`already declared 15.4.0, installed dependencies`. What you must not do is leave
+a line out for something you actually did: a change the report does not name is
+a change the person does not look for in the diff, and the package you created,
+the support file, and `node_modules/` in `.gitignore` are the three most often
+forgotten. If phase 4 turned up an existing spec that was already failing, add a
+line for that too.
 
 Three details in there are not optional:
 
@@ -341,10 +383,11 @@ Three details in there are not optional:
     let them redirect you.
 
   - **A repo built on another stack** — a `go.mod`, `pyproject.toml` or
-    `Gemfile` and no JavaScript package. Stop, and point the person at the
-    manual setup guide.
+    `Gemfile` and no JavaScript package. Stop, and point the person at
+    <https://docs.cypress.io/cloud/get-started/setup>.
 
-- **Cypress 9 or older.** Ask before migrating — see phase 2.
+- **Cypress 9 or older.** Ask before migrating — see phase 2, and link them to
+  <https://docs.cypress.io/app/references/migration-guide#Migrating-to-Cypress-100>.
 - **An ambiguous monorepo.** Ask which package should own Cypress.
 - **A failed install.** Report the manager's own output. Do not work around it.
 

--- a/static/agent-setup.md
+++ b/static/agent-setup.md
@@ -220,11 +220,6 @@ describe('Cypress Cloud setup', () => {
 })
 ```
 
-This spec deliberately does not visit a URL. A scaffolded `cy.visit('/')` fails
-when no application is running and no `baseUrl` is set, which would make the
-person's very first recorded run a red one. Only write a `cy.visit` test instead
-if `baseUrl` is already configured and you have confirmed the server runs.
-
 Scaffold the support file as well, if nothing matches
 `cypress/support/e2e.{js,jsx,ts,tsx}`. Cypress expects one by default and
 refuses to run without it, and a repo with no specs has no support file either —


### PR DESCRIPTION
## Summary

Adds `static/agent-setup.md`, which publishes at `https://docs.cypress.io/agent-setup.md` once deployed. It is a set of instructions for an AI coding agent that has been asked to prepare someone's repository to record its first run to Cypress Cloud: detect the existing setup, decide the whole plan before touching anything, apply three small changes (a dev dependency, a `projectId`, and possibly one spec file), verify locally without recording, then hand back to the person to run the record command themselves.

## Why

Cypress Cloud's onboarding guide gives the user a prompt to paste into their coding agent. That prompt carries the project ID and a link to a page the agent is expected to read for the rest of the instructions, and until now the page did not exist, so the link 404s (PD-8). This gives it a real, stable target.

It lives in `static/` rather than `docs/` on purpose. The audience is an agent reading raw markdown, not a human browsing the site, so the file should not appear in the sidebar, in site search, or as a rendered page. Sidebars are autogenerated from the `docs/` tree, so anything placed there shows up in the nav whether we want it to or not. Serving it from `static/` also matches a convention the site already follows: the `llm` plugin publishes a `.md` mirror at every docs route (`/app/get-started/why-cypress.md`), so appending `.md` to a URL is already the shape an agent expects here.

Two content notes, both easy to revisit in review:

- The draft's "Open questions" section is left out, per its own note that it is not part of the published page. Those questions (whether an always-green scaffolded test is the right call, and whether Cypress Cloud should emit `--component` for component-only repos) are still open for the team.
- The prose keeps the em dashes from the original draft. `AGENTS.md` bans them in docs pages; this is not a docs page, so the rule does not strictly apply, but say the word and I will convert them.

## Notes for reviewers

- Verified with a full `npm run build`. `dist/agent-setup.md` lands as raw markdown, and there is no route collision, since no doc slug named `agent-setup` exists.
- The information is deliberately structured as prose and lists rather than tables. Nothing renders this file, so a pipe table would only add alignment padding to maintain by hand.
- Worth a look at the boundary the page draws between the agent and the person: the agent gets the project ID and never the record key, and the recorded run is always the person's step, in their own terminal. That separation is the part most worth getting right.
- The `on.cypress.io/agent-setup` short link still needs to be pointed at this URL separately. That is a Cloud-side change, not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CPQ3zgrzsJDYxXNT2DckfP

---
_Generated by [Claude Code](https://claude.ai/code/session_01CPQ3zgrzsJDYxXNT2DckfP)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition under static/ with no application, auth, or build-logic changes beyond serving a new markdown file.
> 
> **Overview**
> **Adds** `static/agent-setup.md`, published as raw markdown at `/agent-setup.md` after deploy, so Cypress Cloud’s onboarding agent prompt has a stable target instead of a 404 (PD-8).
> 
> The page is an end-to-end playbook for coding agents: **detect** repo/Cypress state (including declared vs resolvable vs binary), **decide** before editing, **apply** minimal changes (dev dependency, `projectId`, optional scaffold spec/support), **verify** with `cypress run` (no `--record`), then **hand back** instructions for the human to run the record command. It encodes hard guardrails (no commit/push, no silent Cypress upgrades via `add` when already declared, never overwrite `projectId` without consent, never persist record keys) and lives under `static/` so it stays out of the docs sidebar and search.
> 
> **Why:** Cloud ships a prompt with project ID + link to this doc; the file did not exist until now.
> 
> **Notes for reviewers:** Agent vs person boundary (ID only to agent, record key only in terminal); optional follow-ups called out in the PR (scaffold test, `--component` in Cloud); short link `on.cypress.io/agent-setup` is a separate Cloud change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e4db23e58c3d26d948f7dafd4ea1e675ef2f14b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->