### PR TITLE
docs: add guidance on how granular to split specs and tests

### DIFF
--- a/docs/app/core-concepts/best-practices.mdx
+++ b/docs/app/core-concepts/best-practices.mdx
@@ -837,6 +837,30 @@ describe('my form', () => {
 })
 ```
 
+### Where the balance sits
+
+Grouping assertions has a limit in the other direction. A single test that walks
+an entire checkout flow (browse, add to cart, apply a coupon, enter shipping,
+pay, see the confirmation) reports one failure under one title, and a title like
+"completes checkout" tells the person debugging almost nothing about which part
+of the application broke. They have to open the run to find out.
+
+The most useful way to think about where a test starts and stops is the signal
+its failure sends. Both extremes weaken that signal:
+
+- A test large enough that its title no longer describes what failed hands the
+  diagnosis back to whoever is debugging.
+- Tests small enough that they all lean on the same lengthy setup fail together
+  the moment that setup breaks, and a screen of red tells you only that
+  something upstream went wrong.
+
+Aim for the middle: each test covers a meaningful piece of behavior, its title
+names that behavior, and a failure narrows down where to look. For the checkout
+example, that might be one test for adding an item to the cart, one for applying
+a coupon, and one for completing payment, each getting to its starting point
+[programmatically](#Having-Tests-Rely-On-The-State-Of-Previous-Tests) rather
+than by repeating the steps before it through the UI.
+
 ## <Icon name="angle-right" /> Using `after` Or `afterEach` Hooks
 
 :::danger

--- a/docs/app/core-concepts/best-practices.mdx
+++ b/docs/app/core-concepts/best-practices.mdx
@@ -219,6 +219,12 @@ your tests.
 
 :::
 
+Isolation applies to how you divide specs up, too. Organize specs around
+features and user flows rather than mirroring your application's page
+structure, and let spec duration and differing setup tell you when to split one
+up. See
+[How much to put in one spec file](/app/core-concepts/writing-and-organizing-tests#How-much-to-put-in-one-spec-file).
+
 We have several
 [Logging in recipes](https://github.com/cypress-io/cypress-example-recipes#logging-in-recipes)
 in our examples.

--- a/docs/app/core-concepts/writing-and-organizing-tests.mdx
+++ b/docs/app/core-concepts/writing-and-organizing-tests.mdx
@@ -180,6 +180,57 @@ it, and `--spec` picks which of the remaining specs to run this time.
 
 :::
 
+### How much to put in one spec file
+
+Should every page, section, or form get its own spec? Nothing requires your
+specs to mirror your application's structure. A good default is one spec per
+feature or user flow, with `describe()` blocks grouping related scenarios and
+several `it()` tests inside covering them.
+
+Two forces pull in opposite directions, and they're what to weigh when you're
+deciding where to draw the line:
+
+- The spec file is the unit Cypress runs, balances, and reports on. Cypress
+  distributes whole spec files across machines when you
+  [parallelize](/cloud/features/smart-orchestration/parallelization), so one
+  spec that runs far longer than the rest can hold up a run that is otherwise
+  finished.
+- Every spec pays fixed overhead. Cypress reloads the browser, your
+  [support file](#Support-file), and your application for each one. Twenty
+  specs of one test each run noticeably slower than one spec containing the
+  same twenty tests.
+
+Split a spec when:
+
+- It runs longer than a few minutes. See
+  [spec file duration](/app/guides/test-performance#Spec-file-duration) for
+  target ranges.
+- It covers areas that have little to do with each other, so a failure in one
+  says nothing about the others.
+- Its sections need different setup, such as a different seeded user, fixture,
+  or [test configuration](#Test-Configuration) like `viewportWidth` or
+  `browser`.
+- Several teams edit it constantly and collide in it.
+
+Keep tests in the same spec when:
+
+- They share the same `beforeEach`, and splitting them would repeat expensive
+  setup.
+- Each one finishes in seconds, where per-spec overhead would outweigh the
+  tests themselves.
+- The split you're considering is one test per file.
+
+A login page with a single form is one feature, so a `login.cy.js` covering a
+valid login, invalid credentials, and validation messages is right-sized. An
+account settings area with profile, billing, and notification sections is three
+features that happen to share a URL, and three specs are usually easier to work
+with, especially when each needs a different account state.
+
+One caveat worth calling out: splitting specs is not the same as splitting
+tests. Inside a spec, keep multiple assertions in a single test instead of
+writing a test per assertion. See
+[Creating "Tiny" Tests With A Single Assertion](/app/core-concepts/best-practices#Creating-Tiny-Tests-With-A-Single-Assertion).
+
 ## Support file
 
 The support file is your hook into every spec. It runs **before** every single

--- a/docs/app/core-concepts/writing-and-organizing-tests.mdx
+++ b/docs/app/core-concepts/writing-and-organizing-tests.mdx
@@ -226,9 +226,9 @@ account settings area with profile, billing, and notification sections is three
 features that happen to share a URL, and three specs are usually easier to work
 with, especially when each needs a different account state.
 
-One caveat worth calling out: splitting specs is not the same as splitting
-tests. Inside a spec, keep multiple assertions in a single test instead of
-writing a test per assertion. See
+Splitting specs is not the same as splitting tests. Inside a spec, the question
+becomes how much behavior a single `it()` should cover, which comes down to how
+quickly a failing test tells your team where to look. See
 [Creating "Tiny" Tests With A Single Assertion](/app/core-concepts/best-practices#Creating-Tiny-Tests-With-A-Single-Assertion).
 
 ## Support file
@@ -554,6 +554,12 @@ describe('Account settings', () => {
   })
 })
 ```
+
+How much a single `it()` should cover is a judgment call, and the useful test is
+whether its title would tell a teammate what broke when it fails. See
+[Where the balance sits](/app/core-concepts/best-practices#Where-the-balance-sits)
+in Best Practices, and [How much to put in one spec file](#How-much-to-put-in-one-spec-file)
+for the same decision at the file level.
 
 ### Assertion Styles
 

--- a/docs/app/run-tests/test-performance.mdx
+++ b/docs/app/run-tests/test-performance.mdx
@@ -52,6 +52,8 @@ A spec file is a single file containing one or more tests. Spec duration matters
 
 Aim for spec files with similar durations so parallel machines finish around the same time. Specs under 10 seconds rarely benefit from further splitting: the fixed per-spec overhead (browser launch, video encoding) often exceeds any time savings.
 
+For where to draw spec boundaries in the first place, and when a page, section, or form deserves its own file, see [How much to put in one spec file](/app/core-concepts/writing-and-organizing-tests#How-much-to-put-in-one-spec-file).
+
 ### Full suite duration
 
 | Suite size    | Target (serial)     | Target (parallel, 4+ machines) |

--- a/docs/cloud/features/smart-orchestration/parallelization.mdx
+++ b/docs/cloud/features/smart-orchestration/parallelization.mdx
@@ -43,6 +43,10 @@ Cypress will assign each spec file to an available machine based on our
 Due to this balance strategy, the run order of the spec files is not guaranteed
 when parallelized.
 
+Because whole spec files are what get distributed, specs of roughly similar
+duration parallelize best. For guidance on where to draw those boundaries, see
+[How much to put in one spec file](/app/core-concepts/writing-and-organizing-tests#How-much-to-put-in-one-spec-file).
+
 ## Turning on parallelization
 
 1. Refer to your CI provider's documentation on how to set up multiple machines


### PR DESCRIPTION
## Summary

Adds guidance on how granular to make specs and tests, a question the docs never answered directly. "How much to put in one spec file" goes into the Spec files section of Writing and Organizing Tests, and "Where the balance sits" goes into the "Tiny" Tests best practice to cover the same decision inside a spec. Four existing pages now cross-link to them.

## Why

This came out of a user question: should a page, section, or form get its own spec, or does it belong in one larger spec?

There was nowhere to point them. The docs cover the mechanics of specs (`specPattern`, support files, fixtures) and the consequences of spec size (duration benchmarks, parallelization balancing), but never the organizing decision itself.

The second half of the gap was subtler. "Creating 'Tiny' Tests With A Single Assertion" argues hard in one direction, stop splitting and add more assertions, and never names the opposite cliff. A reader who follows it literally arrives at a single test walking an entire checkout flow, and the docs would have told them they were right. The framing that resolves it is the signal a failure sends: a test whose title no longer describes what broke hands the diagnosis back to whoever is debugging, and tests small enough to share one lengthy setup all fail together when that setup breaks. Both extremes cost the team the same thing.

## Notes for reviewers

Two new sections, both integrated into existing pages rather than split out into a new guide:

- **`writing-and-organizing-tests.mdx` → "How much to put in one spec file"**, in the Spec files section. Gives a default (one spec per feature or user flow), names the two forces that pull against each other (specs are the unit of parallelization; every spec pays fixed reload overhead), lists signals for splitting versus keeping tests together, and works a login-versus-account-settings example.
- **`best-practices.mdx` → "Where the balance sits"**, closing the Tiny Tests section with the counterweight described above, linking to the "don't rely on previous tests" practice since programmatic setup is what makes the split affordable.

Cross-links from the places the same question arrives from a different angle: spec file duration in Optimize test performance, Splitting up your test suite in Parallelization, the organizing best practice in Best Practices, and Test Structure where readers first meet `describe()` and `it()`.

Worth a close read on the example choices (login, account settings, checkout) and on whether the split/keep-together signals match how you'd actually advise a team. The duration signal deliberately says "longer than a few minutes" and defers to the existing benchmark table rather than restating numbers that would then drift.

Unrelated, but noting it since it surfaced twice: `npm run lint:fix` wants to rewrite an escape in `.cursor/BUGBOT.md` on any run. I reverted it out of both commits, so it will keep riding along on unrelated PRs until someone fixes it at the source.

Verified with `npm run lint:fix` and `npm run build`. `onBrokenLinks`, `onBrokenAnchors`, and `onBrokenMarkdownLinks` are all `throw`, so the passing build confirms every new anchor and cross-link resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B4CE5eY6EUwKeuLdtc87zP

---
_Generated by [Claude Code](https://claude.ai/code/session_01B4CE5eY6EUwKeuLdtc87zP)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or API impact; risk is limited to link/anchor accuracy, which the PR author verified via build.
> 
> **Overview**
> This PR fills a documentation gap: **how coarse or fine to split Cypress specs and individual `it()` tests**, with two new sections and cross-links from related pages.
> 
> **Writing and organizing tests** gains **"How much to put in one spec file"** under Spec files. It recommends organizing by feature/user flow (not page structure), explains the tradeoff between parallelization units vs per-spec reload overhead, lists when to split vs keep tests together, and points readers to the existing tiny-tests guidance for in-spec granularity.
> 
> **Best practices** adds a short note under test isolation/organization linking to that section, and **"Where the balance sits"** after **Creating "Tiny" Tests With A Single Assertion"**—framing failures by **diagnostic signal** (oversized tests vs many tests sharing heavy setup) and suggesting programmatic setup for multi-step flows like checkout.
> 
> **Test performance**, **parallelization**, and **Test structure** each get a paragraph linking to the new organizing guidance so duration and CI parallelization advice connects to *where* to draw file boundaries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f3ec12413d32f4d9ef7598359f900b3ec5b0f0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->