### PR TITLE
docs: arm64 on Ubuntu requires >=24.04

### DIFF
--- a/docs/app/get-started/install-cypress.mdx
+++ b/docs/app/get-started/install-cypress.mdx
@@ -30,7 +30,7 @@ Cypress supports running under these operating systems:
 
 - **macOS** >=13.5 _(Intel or Apple Silicon 64-bit (x64 or arm64))_
 - **Linux** _(x64 or arm64)_ see also [Linux Prerequisites](#Linux-Prerequisites) down below
-  - Ubuntu >=22.04
+  - Ubuntu >=22.04 _(arm64 requires Ubuntu >=24.04)_
   - Debian >=11
   - Fedora >=43
 - **Windows** 10 & 11 _(x64)_


### PR DESCRIPTION
Removes the implication that arm64 is supported on Ubuntu 22.04. arm64 on Ubuntu is supported only on 24.04 and newer.

Debian and Fedora arm64 statements are unchanged, as are the Docker image platform lists in the CI overview (those images are Debian-based).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only clarification of Linux arm64 support; no product or runtime behavior changes.
> 
> **Overview**
> Updates the **Operating System** requirements on the install page so **Ubuntu >=22.04** no longer reads as supporting **arm64** on 22.04 alone. The bullet now states that **arm64 on Ubuntu needs Ubuntu >=24.04**, while x64 on Ubuntu 22.04+ is unchanged.
> 
> No other supported-OS lines or CI/Docker platform lists are modified in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9153cf9da99a8aa2cfb366f829774e5a591a7f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->