### PR TITLE
docs: add missing visibilityStrategy migration patterns

### DIFF
--- a/docs/app/core-concepts/interacting-with-elements.mdx
+++ b/docs/app/core-concepts/interacting-with-elements.mdx
@@ -25,7 +25,7 @@ As of Cypress 16, the default visibility algorithm delegates to the browser's na
   - `display: none` on the element or any ancestor.
   - `visibility: hidden` or `visibility: collapse`.
   - `content-visibility: hidden`, or `content-visibility: auto` when not rendered.
-  - `opacity: 0` (when asserting visibility — see Opacity note below).
+  - `opacity: 0` (when asserting visibility, see the Opacity note below).
 
 :::info
 
@@ -93,13 +93,13 @@ Every pattern below uses [`.should()`](/api/commands/should) rather than [`.then
 
 ##### Waiting for an element before you interact with it
 
-`cy.get(selector).should('be.visible').click()` is a widespread pattern. Its value was never only the assertion — under the legacy algorithm, the assertion also kept retrying until the element was no longer clipped or covered.
+`cy.get(selector).should('be.visible').click()` is a widespread pattern. Its value was never only the assertion. Under the legacy algorithm, the assertion also kept retrying until the element was no longer clipped or covered.
 
 Under the modern algorithm that assertion resolves as soon as the browser considers the element rendered, so the wait ends earlier than it used to.
 
 **Action commands did not change.** Before every action, Cypress still scrolls the element into view and then verifies that it is not hidden, disabled, detached, readonly, animating, or [covered by another element](#Covering). The coverage check runs under both strategies, so `.click()` on a covered element is still refused under `'modern'`.
 
-That means the assertion was never what made the action wait. When an action follows, remove it — the action command already waits for strictly more conditions than `be.visible` does:
+That means the assertion was never what made the action wait. When an action follows, remove it. The action command already waits for strictly more conditions than `be.visible` does:
 
 ```javascript
 // Before
@@ -117,7 +117,7 @@ cy.get('#submit').click()
 
 Because the assertion resolves sooner, a subsequent action starts sooner. If your application replaces the element during that interval, the action fails with `we initially found matching element(s), but while waiting for them to become actionable, they disappeared from the page`. The message describes a detached element and does not mention visibility, which makes the cause easy to miss.
 
-Removing the redundant `should('be.visible')` does not fix this on its own. Wait on an application-level signal that the element is settled — a loading indicator disappearing, a request completing via [`cy.intercept()`](/api/commands/intercept), or a state class or attribute your application sets — and then perform the action.
+Removing the redundant `should('be.visible')` does not fix this on its own. Wait on an application-level signal that the element is settled, such as a loading indicator disappearing, a request completing via [`cy.intercept()`](/api/commands/intercept), or a state class or attribute your application sets. Then perform the action.
 
 :::
 
@@ -181,7 +181,7 @@ cy.get('#scroll-container button').should(($el) => {
 
 ##### Children inside a collapsed container that hides via `overflow: hidden` + `max-height: 0`
 
-Many UI libraries hide collapsible content by setting `max-height: 0` and `overflow: hidden` on a wrapper. The wrapper itself reports as hidden under the modern algorithm (its bounding rect collapses to zero), but children with their own non-zero dimensions inside that wrapper are not detected as hidden — `checkVisibility()` doesn't account for ancestor clipping. Most libraries also set `aria-hidden="true"` on the closed wrapper — assert on that instead:
+Many UI libraries hide collapsible content by setting `max-height: 0` and `overflow: hidden` on a wrapper. The wrapper itself reports as hidden under the modern algorithm (its bounding rect collapses to zero), but children with their own non-zero dimensions inside that wrapper are not detected as hidden, because `checkVisibility()` doesn't account for ancestor clipping. Most libraries also set `aria-hidden="true"` on the closed wrapper, so assert on that instead:
 
 ```javascript
 // Before

--- a/docs/app/core-concepts/interacting-with-elements.mdx
+++ b/docs/app/core-concepts/interacting-with-elements.mdx
@@ -109,57 +109,54 @@ cy.get('#submit').should('be.visible').click()
 cy.get('#submit').click()
 ```
 
-:::info
-
-<strong>
-  If a `.click()` or `.type()` now fails with "they disappeared from the page"
-</strong>
-
 Because the assertion passes sooner, the action that follows it starts sooner. If your application replaces the element in that window, the action fails with `we initially found matching element(s), but while waiting for them to become actionable, they disappeared from the page`. The error describes a detached element and never mentions visibility, so the cause is easy to miss.
 
 Removing the redundant `should('be.visible')` does not fix this on its own. Wait on a signal from your application that the element has settled, such as a loading indicator disappearing, a request completing with [`cy.intercept()`](/api/commands/intercept), or a class or attribute your application sets. Then perform the action.
 
-:::
-
-When you need to assert that a user can see and use an element, combine the built-in assertion with a coverage check in a single `.should()`:
+When you need to assert that a user can see and use an element, combine [`Cypress.dom.isVisible()`](/api/cypress-api/dom) with a coverage check. Define both as [custom queries](/api/cypress-api/custom-queries) so you can reuse them across your suite:
 
 ```javascript
-cy.get('#confirmation-banner').should(($el) => {
-  expect($el).to.be.visible
-
-  const rect = $el[0].getBoundingClientRect()
-  const elAtPoint = $el[0].ownerDocument.elementFromPoint(
+// cypress/support/commands.js
+const isCovered = (el) => {
+  const rect = el.getBoundingClientRect()
+  const elAtPoint = el.ownerDocument.elementFromPoint(
     rect.left + rect.width / 2,
     rect.top + rect.height / 2
   )
 
-  expect($el[0].contains(elAtPoint), 'element is not covered').to.be.true
+  return !el.contains(elAtPoint)
+}
+
+Cypress.Commands.addQuery('isCovered', function () {
+  return ($el) => isCovered($el[0])
+})
+
+Cypress.Commands.addQuery('isVisibleToUser', function () {
+  return ($el) => Cypress.dom.isVisible($el[0]) && !isCovered($el[0])
 })
 ```
+
+```javascript
+cy.get('#confirmation-banner').isVisibleToUser().should('be.true')
+```
+
+Both are queries rather than commands. A query reads state without changing it, and Cypress reruns it on each retry.
 
 ##### Elements covered by a `fixed` or `sticky` element
 
 The legacy algorithm treated a `fixed`- or `sticky`-positioned element as hidden when another element covered its center point. The modern algorithm does not hit test, so it reports the covered element as visible.
 
-Perform the same hit test the legacy algorithm used, with [`document.elementFromPoint()`](https://developer.mozilla.org/en-US/docs/Web/API/Document/elementFromPoint):
+Perform the same hit test the legacy algorithm used, with the `isCovered()` query defined above:
 
 ```javascript
 // Before
 cy.get('#toolbar-action').should('not.be.visible')
 
 // After
-cy.get('#toolbar-action').should(($el) => {
-  const rect = $el[0].getBoundingClientRect()
-  const elAtPoint = $el[0].ownerDocument.elementFromPoint(
-    rect.left + rect.width / 2,
-    rect.top + rect.height / 2
-  )
-
-  expect($el[0].contains(elAtPoint), 'element is covered').to.be.false
-})
+cy.get('#toolbar-action').isCovered().should('be.true')
 ```
 
-`elementFromPoint()` is relative to the viewport and returns `null` for a point outside it, which this assertion treats as covered. If the element can also scroll out of view, assert on its geometry instead, as in the next pattern.
+That query calls [`document.elementFromPoint()`](https://developer.mozilla.org/en-US/docs/Web/API/Document/elementFromPoint), which is relative to the viewport and returns `null` for a point outside it. The query treats that as covered. If the element can also scroll out of view, assert on its geometry instead, as in the next pattern.
 
 ##### Scroll-clipped elements
 
@@ -207,16 +204,23 @@ cy.get('.card-back').should('not.be.visible')
 cy.get('.card').should('have.attr', 'data-facing', 'front')
 ```
 
-If your component doesn't expose that state, check the sign of the transformed normal on the element that carries the rotation. A negative `m33` means the element faces away from the viewer. Read the computed style from your application's window, not the spec's:
+If your component doesn't expose that state, check the sign of the transformed normal on the element that carries the rotation. A positive `m33` means the element faces the viewer. Read the computed style from your application's window, not the spec's:
 
 ```javascript
-cy.get('.card-back').should(($el) => {
-  const el = $el[0]
-  const { transform } = el.ownerDocument.defaultView.getComputedStyle(el)
-  const { m33 } = new DOMMatrix(transform === 'none' ? undefined : transform)
+// cypress/support/commands.js
+Cypress.Commands.addQuery('facesViewer', function () {
+  return ($el) => {
+    const el = $el[0]
+    const { transform } = el.ownerDocument.defaultView.getComputedStyle(el)
+    const { m33 } = new DOMMatrix(transform === 'none' ? undefined : transform)
 
-  expect(m33, 'element faces away from the viewer').to.be.lessThan(0)
+    return m33 > 0
+  }
 })
+```
+
+```javascript
+cy.get('.card-back').facesViewer().should('be.false')
 ```
 
 ##### Text truncated with `text-overflow: ellipsis`

--- a/docs/app/core-concepts/interacting-with-elements.mdx
+++ b/docs/app/core-concepts/interacting-with-elements.mdx
@@ -49,7 +49,6 @@ The legacy algorithm additionally considered elements hidden when they were:
 
 - Clipped by an ancestor's `overflow: hidden`
 - Scrolled out of view of an `overflow: auto`/`overflow: scroll` ancestor
-- Scaled to zero in one axis via a `transform` (e.g. `transform: scale(0)`)
 - Rotated past 90 degrees via `transform` with `backface-visibility: hidden`
 - Covered by another element while positioned `fixed` or `sticky` (legacy only checks coverage for fixed- or sticky-positioned elements via `document.elementFromPoint`)
 
@@ -85,7 +84,84 @@ describe('My Test Suite', { visibilityStrategy: 'legacy' }, () => {
 
 When you encounter a test that fails under the modern algorithm, prefer updating the assertion to verify the same user-visible behavior in an algorithm-agnostic way rather than opting into `'legacy'`.
 
-**Scroll-clipped elements**
+Two kinds of assertion are affected, and they need different treatment:
+
+- **`should('be.visible')` used as a wait before interacting with an element.** Start with [Waiting for an element before you interact with it](#Waiting-for-an-element-before-you-interact-with-it) below. This is the most common usage, and in most cases the fix is to remove the assertion.
+- **`should('not.be.visible')` used to assert something is hidden.** These fail where the legacy algorithm detected a case the modern algorithm does not. The remaining patterns below cover each of those cases.
+
+Every pattern below uses [`.should()`](/api/commands/should) rather than [`.then()`](/api/commands/then), so that Cypress retries until the assertion passes or times out. This preserves the retry behavior you had with `should('not.be.visible')`.
+
+##### Waiting for an element before you interact with it
+
+`cy.get(selector).should('be.visible').click()` is a widespread pattern. Its value was never only the assertion — under the legacy algorithm, the assertion also kept retrying until the element was no longer clipped or covered.
+
+Under the modern algorithm that assertion resolves as soon as the browser considers the element rendered, so the wait ends earlier than it used to.
+
+**Action commands did not change.** Before every action, Cypress still scrolls the element into view and then verifies that it is not hidden, disabled, detached, readonly, animating, or [covered by another element](#Covering). The coverage check runs under both strategies, so `.click()` on a covered element is still refused under `'modern'`.
+
+That means the assertion was never what made the action wait. When an action follows, remove it — the action command already waits for strictly more conditions than `be.visible` does:
+
+```javascript
+// Before
+cy.get('#submit').should('be.visible').click()
+
+// After
+cy.get('#submit').click()
+```
+
+:::info
+
+<strong>
+  If a `.click()` or `.type()` now fails with "they disappeared from the page"
+</strong>
+
+Because the assertion resolves sooner, a subsequent action starts sooner. If your application replaces the element during that interval, the action fails with `we initially found matching element(s), but while waiting for them to become actionable, they disappeared from the page`. The message describes a detached element and does not mention visibility, which makes the cause easy to miss.
+
+Removing the redundant `should('be.visible')` does not fix this on its own. Wait on an application-level signal that the element is settled — a loading indicator disappearing, a request completing via [`cy.intercept()`](/api/commands/intercept), or a state class or attribute your application sets — and then perform the action.
+
+:::
+
+When the assertion itself is the point, and you need it to mean "a user could see and use this", combine the built-in assertion with a coverage check in a single retrying `.should()`:
+
+```javascript
+cy.get('#confirmation-banner').should(($el) => {
+  expect($el).to.be.visible
+
+  const rect = $el[0].getBoundingClientRect()
+  const elAtPoint = $el[0].ownerDocument.elementFromPoint(
+    rect.left + rect.width / 2,
+    rect.top + rect.height / 2
+  )
+
+  expect($el[0].contains(elAtPoint), 'element is not covered').to.be.true
+})
+```
+
+##### Elements covered by a `fixed` or `sticky` element
+
+The legacy algorithm treated a `fixed`- or `sticky`-positioned element as hidden when another element covered its center point. The modern algorithm does no hit testing, so it reports the covered element as visible.
+
+Perform the same hit test the legacy algorithm performed, using [`document.elementFromPoint()`](https://developer.mozilla.org/en-US/docs/Web/API/Document/elementFromPoint):
+
+```javascript
+// Before
+cy.get('#toolbar-action').should('not.be.visible')
+
+// After
+cy.get('#toolbar-action').should(($el) => {
+  const rect = $el[0].getBoundingClientRect()
+  const elAtPoint = $el[0].ownerDocument.elementFromPoint(
+    rect.left + rect.width / 2,
+    rect.top + rect.height / 2
+  )
+
+  expect($el[0].contains(elAtPoint), 'element is covered').to.be.false
+})
+```
+
+`elementFromPoint()` is relative to the viewport and returns `null` for a point outside it, which this assertion also treats as covered. If the element can be scrolled out of view, assert on its geometry instead, as in the next pattern.
+
+##### Scroll-clipped elements
 
 The modern algorithm reports elements scrolled out of an `overflow: auto` ancestor as visible (they are technically rendered, just outside the scroll container's visible area). Assert on the geometry directly:
 
@@ -94,15 +170,16 @@ The modern algorithm reports elements scrolled out of an `overflow: auto` ancest
 cy.get('#scroll-container button').should('not.be.visible')
 
 // After
-cy.get('#scroll-container button').then(($el) => {
+cy.get('#scroll-container button').should(($el) => {
   const container = $el[0].closest('#scroll-container')
+
   expect($el[0].getBoundingClientRect().top).to.be.greaterThan(
     container.getBoundingClientRect().bottom
   )
 })
 ```
 
-**Children inside a collapsed container that hides via `overflow: hidden` + `max-height: 0`**
+##### Children inside a collapsed container that hides via `overflow: hidden` + `max-height: 0`
 
 Many UI libraries hide collapsible content by setting `max-height: 0` and `overflow: hidden` on a wrapper. The wrapper itself reports as hidden under the modern algorithm (its bounding rect collapses to zero), but children with their own non-zero dimensions inside that wrapper are not detected as hidden — `checkVisibility()` doesn't account for ancestor clipping. Most libraries also set `aria-hidden="true"` on the closed wrapper — assert on that instead:
 
@@ -116,12 +193,40 @@ cy.get('.collapsible-content .nested-item')
   .should('have.attr', 'aria-hidden', 'true')
 ```
 
-**Text truncated with `text-overflow: ellipsis`**
+##### Elements rotated away with `backface-visibility: hidden`
 
-Truncated text is rendered with an ellipsis but the underlying text node is still considered visible by the browser. Assert that the truncating ancestor's `scrollWidth` exceeds its `clientWidth`:
+An element rotated past 90 degrees with `backface-visibility: hidden` presents its back face to the viewer and is not painted, but it keeps a non-zero bounding rect and `checkVisibility()` reports it as visible.
+
+Card-flip and carousel components almost always track their own facing state. Assert on that state, which is more readable than the geometry and does not depend on how the flip is implemented:
 
 ```javascript
-cy.get('.truncate-container').then(($el) => {
+// Before
+cy.get('.card-back').should('not.be.visible')
+
+// After
+cy.get('.card').should('have.attr', 'data-facing', 'front')
+```
+
+If no such state is exposed, check the sign of the transformed normal on the element that carries the rotation. A negative `m33` means the element faces away from the viewer. Read the computed style from the application's own window rather than the spec's:
+
+```javascript
+cy.get('.card-back').should(($el) => {
+  const el = $el[0]
+  const { transform } = el.ownerDocument.defaultView.getComputedStyle(el)
+  const { m33 } = new DOMMatrix(transform === 'none' ? undefined : transform)
+
+  expect(m33, 'element faces away from the viewer').to.be.lessThan(0)
+})
+```
+
+##### Text truncated with `text-overflow: ellipsis`
+
+Truncated text is rendered with an ellipsis but the underlying text node is still considered visible by the browser. Neither algorithm reports the container as hidden, so this pattern applies whenever you need to assert that text is being clipped.
+
+Assert that the truncating ancestor's `scrollWidth` exceeds its `clientWidth`:
+
+```javascript
+cy.get('.truncate-container').should(($el) => {
   expect($el[0].scrollWidth).to.be.greaterThan($el[0].clientWidth)
 })
 ```

--- a/docs/app/core-concepts/interacting-with-elements.mdx
+++ b/docs/app/core-concepts/interacting-with-elements.mdx
@@ -101,7 +101,7 @@ Action commands did not change. Before every action, Cypress still scrolls the e
 
 When an action follows the assertion, you can remove the assertion. The action command already waits on more conditions than `be.visible` does:
 
-```javascript
+```javascript title="cypress/e2e/spec.cy.js"
 // Before
 cy.get('#submit').should('be.visible').click()
 
@@ -115,8 +115,7 @@ Removing the redundant `should('be.visible')` does not fix this on its own. Wait
 
 When you need to assert that a user can see and use an element, combine [`Cypress.dom.isVisible()`](/api/cypress-api/dom) with a coverage check. Define both as [custom queries](/api/cypress-api/custom-queries) so you can reuse them across your suite:
 
-```javascript
-// cypress/support/commands.js
+```javascript title="cypress/support/commands.js"
 const isCovered = (el) => {
   const rect = el.getBoundingClientRect()
   const elAtPoint = el.ownerDocument.elementFromPoint(
@@ -136,7 +135,7 @@ Cypress.Commands.addQuery('isVisibleToUser', function () {
 })
 ```
 
-```javascript
+```javascript title="cypress/e2e/spec.cy.js"
 cy.get('#confirmation-banner').isVisibleToUser().should('be.true')
 ```
 
@@ -148,7 +147,7 @@ The legacy algorithm treated a `fixed`- or `sticky`-positioned element as hidden
 
 Perform the same hit test the legacy algorithm used, with the `isCovered()` query defined above:
 
-```javascript
+```javascript title="cypress/e2e/spec.cy.js"
 // Before
 cy.get('#toolbar-action').should('not.be.visible')
 
@@ -162,7 +161,7 @@ That query calls [`document.elementFromPoint()`](https://developer.mozilla.org/e
 
 The modern algorithm reports elements scrolled out of an `overflow: auto` ancestor as visible (they are technically rendered, just outside the scroll container's visible area). Assert on the geometry directly:
 
-```javascript
+```javascript title="cypress/e2e/spec.cy.js"
 // Before
 cy.get('#scroll-container button').should('not.be.visible')
 
@@ -180,7 +179,7 @@ cy.get('#scroll-container button').should(($el) => {
 
 Many UI libraries hide collapsible content by setting `max-height: 0` and `overflow: hidden` on a wrapper. The wrapper itself reports as hidden under the modern algorithm (its bounding rect collapses to zero), but children with their own non-zero dimensions inside that wrapper are not detected as hidden, because `checkVisibility()` doesn't account for ancestor clipping. Most libraries also set `aria-hidden="true"` on the closed wrapper, so assert on that instead:
 
-```javascript
+```javascript title="cypress/e2e/spec.cy.js"
 // Before
 cy.get('.collapsible-content .nested-item').should('not.be.visible')
 
@@ -196,7 +195,7 @@ An element rotated past 90 degrees with `backface-visibility: hidden` turns its 
 
 Card flip and carousel components usually track which face is showing. Assert on that state, so your test does not depend on how the flip is implemented:
 
-```javascript
+```javascript title="cypress/e2e/spec.cy.js"
 // Before
 cy.get('.card-back').should('not.be.visible')
 
@@ -206,8 +205,7 @@ cy.get('.card').should('have.attr', 'data-facing', 'front')
 
 If your component doesn't expose that state, check the sign of the transformed normal on the element that carries the rotation. A positive `m33` means the element faces the viewer. Read the computed style from your application's window, not the spec's:
 
-```javascript
-// cypress/support/commands.js
+```javascript title="cypress/support/commands.js"
 Cypress.Commands.addQuery('facesViewer', function () {
   return ($el) => {
     const el = $el[0]
@@ -219,7 +217,7 @@ Cypress.Commands.addQuery('facesViewer', function () {
 })
 ```
 
-```javascript
+```javascript title="cypress/e2e/spec.cy.js"
 cy.get('.card-back').facesViewer().should('be.false')
 ```
 
@@ -229,7 +227,7 @@ The browser renders truncated text with an ellipsis, but still considers the und
 
 Assert that the truncating ancestor's `scrollWidth` exceeds its `clientWidth`:
 
-```javascript
+```javascript title="cypress/e2e/spec.cy.js"
 cy.get('.truncate-container').should(($el) => {
   expect($el[0].scrollWidth).to.be.greaterThan($el[0].clientWidth)
 })

--- a/docs/app/core-concepts/interacting-with-elements.mdx
+++ b/docs/app/core-concepts/interacting-with-elements.mdx
@@ -99,7 +99,7 @@ Under the modern algorithm, the assertion passes as soon as the browser consider
 
 Action commands did not change. Before every action, Cypress still scrolls the element into view and checks that it is not hidden, disabled, detached, readonly, animating, or [covered by another element](#Covering). Cypress runs the coverage check under both strategies, so it still refuses to click a covered element under `'modern'`.
 
-When an action follows the assertion, you can remove the assertion. The action command already waits on more conditions than `be.visible` does:
+When an action follows the assertion, and the assertion was there to wait out clipping or coverage, you can remove it. The action command already checks both:
 
 ```javascript title="cypress/e2e/spec.cy.js"
 // Before
@@ -109,6 +109,8 @@ cy.get('#submit').should('be.visible').click()
 cy.get('#submit').click()
 ```
 
+Keep the assertion if you rely on it to wait out a fade-in. Actionability ignores `opacity`, so an element at `opacity: 0` is actionable, as described in the [Opacity](#Default-Behavior) note above. `should('be.visible')` is the only one of the two that waits for the element to become opaque.
+
 Because the assertion passes sooner, the action that follows it starts sooner. If your application replaces the element in that window, the action fails with `we initially found matching element(s), but while waiting for them to become actionable, they disappeared from the page`. The error describes a detached element and never mentions visibility, so the cause is easy to miss.
 
 Removing the redundant `should('be.visible')` does not fix this on its own. Wait on a signal from your application that the element has settled, such as a loading indicator disappearing, a request completing with [`cy.intercept()`](/api/commands/intercept), or a class or attribute your application sets. Then perform the action.
@@ -117,21 +119,34 @@ When you need to assert that a user can see and use an element, combine [`Cypres
 
 ```javascript title="cypress/support/commands.js"
 const isCovered = (el) => {
+  const win = el.ownerDocument.defaultView
   const rect = el.getBoundingClientRect()
   const elAtPoint = el.ownerDocument.elementFromPoint(
     rect.left + rect.width / 2,
     rect.top + rect.height / 2
   )
 
-  return !el.contains(elAtPoint)
+  if (el.contains(elAtPoint)) {
+    return false
+  }
+
+  // `pointer-events: none` makes the hit test fall through to an ancestor,
+  // which the legacy algorithm did not count as coverage
+  const ignoresPointerEvents =
+    win.getComputedStyle(el).pointerEvents === 'none' ||
+    (el.parentElement &&
+      win.getComputedStyle(el.parentElement).pointerEvents === 'none')
+
+  return !(ignoresPointerEvents && elAtPoint && elAtPoint.contains(el))
 }
 
 Cypress.Commands.addQuery('isCovered', function () {
-  return ($el) => isCovered($el[0])
+  return ($el) => Array.from($el).every(isCovered)
 })
 
 Cypress.Commands.addQuery('isVisibleToUser', function () {
-  return ($el) => Cypress.dom.isVisible($el[0]) && !isCovered($el[0])
+  return ($el) =>
+    Array.from($el).every((el) => Cypress.dom.isVisible(el) && !isCovered(el))
 })
 ```
 
@@ -139,13 +154,15 @@ Cypress.Commands.addQuery('isVisibleToUser', function () {
 cy.get('#confirmation-banner').isVisibleToUser().should('be.true')
 ```
 
-Both are queries rather than commands. A query reads state without changing it, and Cypress reruns it on each retry.
+Both are queries rather than commands. A query reads state without changing it, and Cypress reruns it on each retry. Each one checks every matched element, the way `be.visible` and `not.be.visible` do.
 
-##### Elements covered by a `fixed` or `sticky` element
+`isVisibleToUser()` hit tests every element it is given. The legacy algorithm only hit tested `fixed`- and `sticky`-positioned elements, so this query is stricter. Use it where you mean to assert that a user can see something, not as a blanket replacement for `be.visible`.
 
-The legacy algorithm treated a `fixed`- or `sticky`-positioned element as hidden when another element covered its center point. The modern algorithm does not hit test, so it reports the covered element as visible.
+##### `fixed` or `sticky` elements covered by something else
 
-Perform the same hit test the legacy algorithm used, with the `isCovered()` query defined above:
+The legacy algorithm treated a `fixed`- or `sticky`-positioned element as hidden when another element covered its center point. The element doing the covering can be positioned any way at all. The modern algorithm does not hit test, so it reports the covered element as visible.
+
+Run the same hit test with the `isCovered()` query defined above:
 
 ```javascript title="cypress/e2e/spec.cy.js"
 // Before
@@ -203,23 +220,9 @@ cy.get('.card-back').should('not.be.visible')
 cy.get('.card').should('have.attr', 'data-facing', 'front')
 ```
 
-If your component doesn't expose that state, check the sign of the transformed normal on the element that carries the rotation. A positive `m33` means the element faces the viewer. Read the computed style from your application's window, not the spec's:
+Prefer that over a geometric check. In a typical flip, the rotation that hides a face lives on an ancestor, and the face itself carries a static `transform: rotateY(180deg)` that never changes. Reading the computed `transform` off the element alone therefore returns the same value in both states, so the assertion passes whichever face is showing. Reproducing the legacy check means accumulating the transform across every `preserve-3d` ancestor, which is more DOM logic than the assertion is worth.
 
-```javascript title="cypress/support/commands.js"
-Cypress.Commands.addQuery('facesViewer', function () {
-  return ($el) => {
-    const el = $el[0]
-    const { transform } = el.ownerDocument.defaultView.getComputedStyle(el)
-    const { m33 } = new DOMMatrix(transform === 'none' ? undefined : transform)
-
-    return m33 > 0
-  }
-})
-```
-
-```javascript title="cypress/e2e/spec.cy.js"
-cy.get('.card-back').facesViewer().should('be.false')
-```
+If your component exposes no state at all, add an attribute that reflects which face is showing, then assert on it.
 
 ##### Text truncated with `text-overflow: ellipsis`
 

--- a/docs/app/core-concepts/interacting-with-elements.mdx
+++ b/docs/app/core-concepts/interacting-with-elements.mdx
@@ -84,22 +84,22 @@ describe('My Test Suite', { visibilityStrategy: 'legacy' }, () => {
 
 When you encounter a test that fails under the modern algorithm, prefer updating the assertion to verify the same user-visible behavior in an algorithm-agnostic way rather than opting into `'legacy'`.
 
-Two kinds of assertion are affected, and they need different treatment:
+Two kinds of assertion are affected, and each needs a different fix:
 
-- **`should('be.visible')` used as a wait before interacting with an element.** Start with [Waiting for an element before you interact with it](#Waiting-for-an-element-before-you-interact-with-it) below. This is the most common usage, and in most cases the fix is to remove the assertion.
-- **`should('not.be.visible')` used to assert something is hidden.** These fail where the legacy algorithm detected a case the modern algorithm does not. The remaining patterns below cover each of those cases.
+- **`should('be.visible')` used as a wait before an action.** This is the most common usage. See [Waiting for an element before you interact with it](#Waiting-for-an-element-before-you-interact-with-it) below, where the fix is usually to remove the assertion.
+- **`should('not.be.visible')` used to assert that something is hidden.** These fail in the cases the legacy algorithm detected and the modern algorithm does not. The remaining patterns cover each of those cases.
 
-Every pattern below uses [`.should()`](/api/commands/should) rather than [`.then()`](/api/commands/then), so that Cypress retries until the assertion passes or times out. This preserves the retry behavior you had with `should('not.be.visible')`.
+Every pattern below uses [`.should()`](/api/commands/should) rather than [`.then()`](/api/commands/then). Cypress retries `.should()` until it passes or times out, so these patterns keep the retry behavior of the assertion they replace.
 
 ##### Waiting for an element before you interact with it
 
-`cy.get(selector).should('be.visible').click()` is a widespread pattern. Its value was never only the assertion. Under the legacy algorithm, the assertion also kept retrying until the element was no longer clipped or covered.
+`cy.get(selector).should('be.visible').click()` is a common way to wait until an element is ready. Under the legacy algorithm, the assertion kept retrying until the element was no longer clipped or covered.
 
-Under the modern algorithm that assertion resolves as soon as the browser considers the element rendered, so the wait ends earlier than it used to.
+Under the modern algorithm, the assertion passes as soon as the browser considers the element rendered, so the wait ends earlier than it did before.
 
-**Action commands did not change.** Before every action, Cypress still scrolls the element into view and then verifies that it is not hidden, disabled, detached, readonly, animating, or [covered by another element](#Covering). The coverage check runs under both strategies, so `.click()` on a covered element is still refused under `'modern'`.
+Action commands did not change. Before every action, Cypress still scrolls the element into view and checks that it is not hidden, disabled, detached, readonly, animating, or [covered by another element](#Covering). Cypress runs the coverage check under both strategies, so it still refuses to click a covered element under `'modern'`.
 
-That means the assertion was never what made the action wait. When an action follows, remove it. The action command already waits for strictly more conditions than `be.visible` does:
+When an action follows the assertion, you can remove the assertion. The action command already waits on more conditions than `be.visible` does:
 
 ```javascript
 // Before
@@ -115,13 +115,13 @@ cy.get('#submit').click()
   If a `.click()` or `.type()` now fails with "they disappeared from the page"
 </strong>
 
-Because the assertion resolves sooner, a subsequent action starts sooner. If your application replaces the element during that interval, the action fails with `we initially found matching element(s), but while waiting for them to become actionable, they disappeared from the page`. The message describes a detached element and does not mention visibility, which makes the cause easy to miss.
+Because the assertion passes sooner, the action that follows it starts sooner. If your application replaces the element in that window, the action fails with `we initially found matching element(s), but while waiting for them to become actionable, they disappeared from the page`. The error describes a detached element and never mentions visibility, so the cause is easy to miss.
 
-Removing the redundant `should('be.visible')` does not fix this on its own. Wait on an application-level signal that the element is settled, such as a loading indicator disappearing, a request completing via [`cy.intercept()`](/api/commands/intercept), or a state class or attribute your application sets. Then perform the action.
+Removing the redundant `should('be.visible')` does not fix this on its own. Wait on a signal from your application that the element has settled, such as a loading indicator disappearing, a request completing with [`cy.intercept()`](/api/commands/intercept), or a class or attribute your application sets. Then perform the action.
 
 :::
 
-When the assertion itself is the point, and you need it to mean "a user could see and use this", combine the built-in assertion with a coverage check in a single retrying `.should()`:
+When you need to assert that a user can see and use an element, combine the built-in assertion with a coverage check in a single `.should()`:
 
 ```javascript
 cy.get('#confirmation-banner').should(($el) => {
@@ -139,9 +139,9 @@ cy.get('#confirmation-banner').should(($el) => {
 
 ##### Elements covered by a `fixed` or `sticky` element
 
-The legacy algorithm treated a `fixed`- or `sticky`-positioned element as hidden when another element covered its center point. The modern algorithm does no hit testing, so it reports the covered element as visible.
+The legacy algorithm treated a `fixed`- or `sticky`-positioned element as hidden when another element covered its center point. The modern algorithm does not hit test, so it reports the covered element as visible.
 
-Perform the same hit test the legacy algorithm performed, using [`document.elementFromPoint()`](https://developer.mozilla.org/en-US/docs/Web/API/Document/elementFromPoint):
+Perform the same hit test the legacy algorithm used, with [`document.elementFromPoint()`](https://developer.mozilla.org/en-US/docs/Web/API/Document/elementFromPoint):
 
 ```javascript
 // Before
@@ -159,7 +159,7 @@ cy.get('#toolbar-action').should(($el) => {
 })
 ```
 
-`elementFromPoint()` is relative to the viewport and returns `null` for a point outside it, which this assertion also treats as covered. If the element can be scrolled out of view, assert on its geometry instead, as in the next pattern.
+`elementFromPoint()` is relative to the viewport and returns `null` for a point outside it, which this assertion treats as covered. If the element can also scroll out of view, assert on its geometry instead, as in the next pattern.
 
 ##### Scroll-clipped elements
 
@@ -195,9 +195,9 @@ cy.get('.collapsible-content .nested-item')
 
 ##### Elements rotated away with `backface-visibility: hidden`
 
-An element rotated past 90 degrees with `backface-visibility: hidden` presents its back face to the viewer and is not painted, but it keeps a non-zero bounding rect and `checkVisibility()` reports it as visible.
+An element rotated past 90 degrees with `backface-visibility: hidden` turns its back face to the viewer, so the browser does not paint it. It keeps a non-zero bounding rect, and `checkVisibility()` reports it as visible.
 
-Card-flip and carousel components almost always track their own facing state. Assert on that state, which is more readable than the geometry and does not depend on how the flip is implemented:
+Card flip and carousel components usually track which face is showing. Assert on that state, so your test does not depend on how the flip is implemented:
 
 ```javascript
 // Before
@@ -207,7 +207,7 @@ cy.get('.card-back').should('not.be.visible')
 cy.get('.card').should('have.attr', 'data-facing', 'front')
 ```
 
-If no such state is exposed, check the sign of the transformed normal on the element that carries the rotation. A negative `m33` means the element faces away from the viewer. Read the computed style from the application's own window rather than the spec's:
+If your component doesn't expose that state, check the sign of the transformed normal on the element that carries the rotation. A negative `m33` means the element faces away from the viewer. Read the computed style from your application's window, not the spec's:
 
 ```javascript
 cy.get('.card-back').should(($el) => {
@@ -221,7 +221,7 @@ cy.get('.card-back').should(($el) => {
 
 ##### Text truncated with `text-overflow: ellipsis`
 
-Truncated text is rendered with an ellipsis but the underlying text node is still considered visible by the browser. Neither algorithm reports the container as hidden, so this pattern applies whenever you need to assert that text is being clipped.
+The browser renders truncated text with an ellipsis, but still considers the underlying text node visible. Neither algorithm reports the container as hidden, so use this pattern whenever you need to assert that text is clipped.
 
 Assert that the truncating ancestor's `scrollWidth` exceeds its `clientWidth`:
 

--- a/docs/app/core-concepts/interacting-with-elements.mdx
+++ b/docs/app/core-concepts/interacting-with-elements.mdx
@@ -154,9 +154,17 @@ Cypress.Commands.addQuery('isVisibleToUser', function () {
 cy.get('#confirmation-banner').isVisibleToUser().should('be.true')
 ```
 
-Both are queries rather than commands. A query reads state without changing it, and Cypress reruns it on each retry. Each one checks every matched element, the way `be.visible` and `not.be.visible` do.
+Both are queries rather than commands. A query reads state without changing it, and Cypress reruns it on each retry.
 
-`isVisibleToUser()` hit tests every element it is given. The legacy algorithm only hit tested `fixed`- and `sticky`-positioned elements, so this query is stricter. Use it where you mean to assert that a user can see something, not as a blanket replacement for `be.visible`.
+`isCovered()` requires every matched element to be covered, which is what `not.be.visible` asks for.
+
+`isVisibleToUser()` is stricter than `be.visible` in three ways, so treat it as its own assertion rather than a drop-in replacement:
+
+- It builds on `Cypress.dom.isVisible()`, which follows the configured strategy. Under `'modern'` you get modern visibility plus coverage, so a clipped or scrolled-out element still reports as visible. The patterns below cover those two cases.
+- It hit tests every element. The legacy algorithm only hit tested `fixed`- and `sticky`-positioned elements.
+- It requires every matched element to pass, while `be.visible` is satisfied when any one of them is visible. chai-jQuery implements that assertion as `$el.is(':visible')`, and jQuery's `.is()` matches on any element in the set.
+
+The hit test has one more consequence worth knowing. `elementFromPoint()` returns `null` for a point outside the viewport, which counts as covered, so anything below the fold reports as not visible to the user. The legacy algorithm never met that case, because a `fixed` or `sticky` element is in the viewport by definition. Cypress also scrolls an element into view before acting on it, so an element below the fold is still usable. Reach for `isVisibleToUser()` only where you expect the element to be on screen already.
 
 ##### `fixed` or `sticky` elements covered by something else
 


### PR DESCRIPTION
## Summary

Fills the gaps in "Updating tests that depended on the legacy algorithm" on the [Interacting with Elements](https://docs.cypress.io/app/core-concepts/interacting-with-elements) page. The section previously offered three rewrite patterns, all of them rewrites of `should('not.be.visible')`, leaving the most common usage and two of the legacy-only behaviors we list with no migration path at all. This adds those patterns, corrects one inaccurate bullet, and moves the reusable checks into custom queries.

## Why

Closes #6887

`visibilityStrategy` is documented as deprecated and slated for removal, so this section is the migration path for anyone who relied on the legacy algorithm. Two gaps made that path incomplete:

**The positive case had no pattern.** `cy.get(sel).should('be.visible').click()` is the most common usage by far, and under `'modern'` the assertion stops acting as the wait it used to be. Investigating this turned up something worth documenting plainly: action commands never changed. `ensureElIsNotCovered` in `packages/driver/src/cy/actionability.ts` sits outside the strategy branch, so a covered element still has its `.click()` refused under `'modern'`. The assertion was never what made the action wait, so in most cases the fix is to delete it. The page now says that, and covers the "they disappeared from the page" failure that shows up when the earlier-resolving wait lets an action start sooner.

**Coverage by a `fixed` or `sticky` element had no pattern**, despite being on our own list of legacy-only behaviors.

Two further problems surfaced while writing it:

- The `transform: scale(0)` bullet was wrong. `modernIsHidden` has an explicit zero-dimension guard on `getBoundingClientRect()`, so the modern algorithm catches it too. Removed from the legacy-only list.
- `backface-visibility` rotation is on that list and also had no pattern. Added.

The three existing patterns used `.then()`, which does not retry. They were replacing a retrying assertion with a non-retrying one and quietly giving up that behavior. All patterns now use `.should()`.

## Notes for reviewers

**Please look hardest at the two custom queries in `cypress/support/commands.js`.** They are the most load-bearing new content, and a self-review caught several defects in an earlier revision of this branch that I have since fixed. Worth confirming I got them right:

- `isCovered()` mirrors legacy's `elIsNotElementFromPoint`, including the `pointer-events: none` exemption where the hit test falls through to an ancestor.
- Both queries check every matched element via `.every()`, since `should('not.be.visible')` applies to the whole set rather than just the first element.
- `isVisibleToUser()` hit tests every element it is given, which is stricter than legacy's fixed/sticky-only rule. This is called out in the page, because over-applying the coverage check is exactly the trap described in cypress-io/cypress#34795, where it turned passing specs red.

**Queries rather than commands.** These use `Cypress.Commands.addQuery`, not `Cypress.Commands.add`. Both checks are synchronous and idempotent, and a non-retrying command would receive its subject once and hold it, undoing the retry behavior the section promises. Happy to revisit if you would rather they read as plain commands, but the retry loss is the tradeoff.

**One thing I deliberately did not include.** An earlier revision offered a geometric fallback for the `backface-visibility` case, reading `m33` off the element's computed transform. It could never fail: in a typical card flip the rotation lives on an ancestor and the face itself carries a static `rotateY(180deg)`, so the value is identical in both states. Reproducing the legacy check faithfully means accumulating the transform across every `preserve-3d` ancestor, which is more DOM logic than the assertion is worth. The page now recommends asserting on component state and explains why.

**Also unresolved, and out of scope here.** `Cypress.dom.isStrictlyHidden` and `Cypress.dom.isHiddenByAncestors` are still attached to `Cypress.dom` at runtime and are not strategy-gated. Together they are the legacy algorithm, which undercuts the "3,000 lines to reimplement" premise in cypress-io/cypress#34795. They are undocumented and absent from `cli/types/cypress.d.ts`, so I have not documented them as a supported path. Whether we want to bless that escape hatch is a product decision worth making deliberately.

**Scope note.** I touched two pre-existing em dashes outside the migration section (the `opacity: 0` bullet in Default Behavior, and the collapsed-container paragraph) so the page reads consistently. Easy to drop if you would rather keep the diff tight.

**Verification.** `npm run build` passes. That matters more than usual here: the site sets `onBrokenAnchors: 'throw'` and `onBrokenLinks: 'throw'`, so the build confirms the new cross-reference and every new link resolves. I also checked the rendered anchor ids and the ten `codeBlockTitle` elements in `dist/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZraHsGceNoUhqc9oKzMzQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01BZraHsGceNoUhqc9oKzMzQ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or test-runner behavior; main risk is inaccurate migration advice, which reviewers should validate against the custom query examples.
> 
> **Overview**
> Expands **Updating tests that depended on the legacy algorithm** on the Interacting with Elements page so teams migrating off deprecated `visibilityStrategy: 'legacy'` have concrete rewrites for cases that were missing or wrong.
> 
> The guide now distinguishes **`should('be.visible')` as a pre-action wait** (often redundant because action commands still enforce coverage and scroll) from **`should('not.be.visible')` assertions** that fail under the modern `checkVisibility()` path. It documents custom query examples **`isCovered`** and **`isVisibleToUser`**, adds patterns for **fixed/sticky overlap**, **backface-hidden rotations** (prefer component state over geometry), and tightens existing scroll/collapse/ellipsis examples by switching **`.then()` to `.should()`** so retries match the assertions they replace.
> 
> **Docs corrections:** removes **`transform: scale(0)`** from the legacy-only list (modern already treats zero bounding rects as hidden) and makes minor punctuation/consistency edits elsewhere on the page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0be1d81b3f989f29d33e16a26654bfce4de6969d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->