### PR TITLE
Remove early access note

### DIFF
--- a/docs/cloud/integrations/webhooks.mdx
+++ b/docs/cloud/integrations/webhooks.mdx
@@ -29,13 +29,6 @@ While Cypress Cloud already has many built-in methods of notifications related t
 [Slack](/cloud/integrations/slack) messages), webhooks deliver a **raw JSON payload** to your
 own service.
 
-:::note
-
-**Early access**: Webhooks will be available on all paid plans and during trials. The feature is rolling to admins and owners of Cypress Cloud organizations gradually, and may not yet be
-available for every organization. If you do not see webhooks in your project settings but want to try it early, contact your Cypress representative.
-
-:::
-
 ## Getting started
 
 **You need two things to get started:**


### PR DESCRIPTION
The rollout is completed already, this not is not needed.

<!--
Fill in every section. This template doubles as the historical record of the
change, so future readers can understand not just what changed but
why. Delete a section only if it is genuinely not applicable, and say so.
-->

## Summary

<!-- What does this PR change, in one or two sentences? Write for a reader who
has never seen the task. -->

## Why

<!-- The motivation and context. If this originated from an issue, a Slack/
Discord thread, a broken link, an outdated example, or a release, capture it
here so the reasoning survives after the source is gone. -->

Closes #<!-- issue number, or remove this line if none -->

## Notes for reviewers

<!-- Anything a reviewer should focus on: decisions made, alternatives
considered, areas of uncertainty, or follow-ups intentionally left out. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no product, API, or security impact.
> 
> **Overview**
> Removes the **Early access** admonition from the Cypress Cloud **Webhooks** integration page (`webhooks.mdx`), so the docs no longer say the feature is rolling out gradually or that admins may need to contact Cypress to try it early.
> 
> The rest of the page is unchanged; readers go straight from the webhooks overview to **Getting started**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74c26dd76808884bb29903378174051ff933bdd8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->