### PR TITLE
Cypress app Release `16.1.0`

### DIFF
--- a/docs/app/configure/client-certificates.mdx
+++ b/docs/app/configure/client-certificates.mdx
@@ -34,6 +34,10 @@ This document covers how to configure certificate file paths for use in your
 tests. The creation and management of certificate files themselves are outside
 the scope of Cypress documentation.
 
+The `clientCertificates` option on this page is for mutual TLS, where Cypress
+presents a client certificate to the endpoint. To trust a certificate your server
+presents, see [`trustedCertificates`](/app/references/configuration#trustedCertificates).
+
 :::
 
 ## Syntax
@@ -301,3 +305,9 @@ so that private keys are never accidentally committed.
 | -------------------------------------------- | -------------------------------------------------------------------- |
 | [15.16.0](/app/references/changelog#15-16-0) | Added support for ECDSA (EC) keys in PEM and PFX client certificates |
 | [8.0.0](/app/references/changelog#8-0-0)     | Added Client Certificates configuration options                      |
+
+## See also
+
+- [`trustedCertificates` configuration](/app/references/configuration#trustedCertificates)
+- [Native network interception](/app/guides/native-network-interception)
+- [Cypress Configuration](/app/references/configuration)

--- a/docs/app/configure/configuration.mdx
+++ b/docs/app/configure/configuration.mdx
@@ -211,15 +211,16 @@ For more options regarding screenshots, view the
 
 ### Browser
 
-| Option                  | Default | Description                                                                                                                                                                                                                                                                                                                                                          |
-| ----------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `defaultBrowser`        | `null`  | The default browser to launch if the "--browser" command line option is not provided. This option only affects the first browser launch; changing this option after the browser is already launched will have no effect. Set this to an installed browser (for example, `'chrome'`) to stop relying on the deprecated bundled Electron default — see the note below. |
-| `chromeWebSecurity`     | `true`  | Whether to enable Chromium-based browser's Web Security for same-origin policy and insecure mixed content.                                                                                                                                                                                                                                                           |
-| `blockHosts`            | `null`  | A String or Array of hosts that you wish to block traffic for. [Please read the notes for examples on using this.](#blockHosts)                                                                                                                                                                                                                                      |
-| `hosts`                 | `null`  | An Object of hostname patterns to IP addresses. Acts like a Cypress-specific `/etc/hosts` file, letting Cypress resolve custom hostnames within tests. [Please read the notes for examples on using this.](#hosts)                                                                                                                                                   |
-| `modifyObstructiveCode` | `true`  | Whether Cypress will search for and replace obstructive JS code in `.js` or `.html` files. [Please read the notes for more information on this setting.](#modifyObstructiveCode)                                                                                                                                                                                     |
-| `removeSRIAttributes`   | `false` | Whether Cypress will remove [Subresource Integrity (SRI)](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) `integrity` attributes from `<script>` and `<link>` elements so that first-party resources rewritten by Cypress are not blocked. [Please read the notes for more information on this setting.](#removeSRIAttributes)          |
-| `userAgent`             | `null`  | Enables you to override the default user agent the browser sends in all request headers. User agent values are typically used by servers to help identify the operating system, browser, and browser version. See [User-Agent MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent) for example user agent values.                |
+| Option                  | Default | Description                                                                                                                                                                                                                                                                                                                                                            |
+| ----------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `defaultBrowser`        | `null`  | The default browser to launch if the "--browser" command line option is not provided. This option only affects the first browser launch; changing this option after the browser is already launched will have no effect. Set this to an installed browser (for example, `'chrome'`) to stop relying on the deprecated bundled Electron default — see the note below.   |
+| `chromeWebSecurity`     | `true`  | Whether to enable Chromium-based browser's Web Security for same-origin policy and insecure mixed content.                                                                                                                                                                                                                                                             |
+| `blockHosts`            | `null`  | A String or Array of hosts that you wish to block traffic for. [Please read the notes for examples on using this.](#blockHosts)                                                                                                                                                                                                                                        |
+| `hosts`                 | `null`  | An Object of hostname patterns to IP addresses. Acts like a Cypress-specific `/etc/hosts` file, letting Cypress resolve custom hostnames within tests. [Please read the notes for examples on using this.](#hosts)                                                                                                                                                     |
+| `modifyObstructiveCode` | `true`  | Whether Cypress will search for and replace obstructive JS code in `.js` or `.html` files. [Please read the notes for more information on this setting.](#modifyObstructiveCode)                                                                                                                                                                                       |
+| `removeSRIAttributes`   | `false` | Whether Cypress will remove [Subresource Integrity (SRI)](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) `integrity` attributes from `<script>` and `<link>` elements so that first-party resources rewritten by Cypress are not blocked. [Please read the notes for more information on this setting.](#removeSRIAttributes)            |
+| `trustedCertificates`   | `[]`    | Certificates your application presents that the browser should trust, such as a self-signed or private-CA certificate. Applies only on the native browser network path (Chrome, Chromium, and Edge with `forceHttp1: false`), where it lets the browser cache that origin's assets across navigations. [Please read the notes for more details.](#trustedCertificates) |
+| `userAgent`             | `null`  | Enables you to override the default user agent the browser sends in all request headers. User agent values are typically used by servers to help identify the operating system, browser, and browser version. See [User-Agent MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent) for example user agent values.                  |
 
 :::caution
 
@@ -768,7 +769,8 @@ Cypress worked before version 16. See
 differences and how to update tests that rely on them. If undocumented behavior is what
 makes your suite pass, [open an issue](https://github.com/cypress-io/cypress/issues/new/choose).
 Setting it to `true` restarts the Cypress server when changed, and cannot be set per test
-or per suite.
+or per suite. Runs using `forceHttp1: true` route through the legacy network path and are
+unaffected by [`trustedCertificates`](#trustedCertificates).
 
 <ForceHttp1Deprecation />
 
@@ -992,6 +994,109 @@ How the contents are removed depends on the operating system:
 - On **Linux**, the folders are emptied directly and the contents are
   **permanently deleted**.
 
+### trustedCertificates
+
+<Icon name="angle-right" /> **trustedCertificates _(Object[])_**
+
+An optional array of certificates for the browser to trust on the native browser network path.
+
+Cypress launches every Chromium-based browser with `--ignore-certificate-errors` so that origins with self-signed or private-CA certificates can load under test. However, Chromium treats overridden certificate errors as clicked-through warnings and deliberately does not write responses from those origins to its HTTP disk cache. For an HTTPS application presenting an untrusted certificate, the browser disk cache remained empty, causing asset-heavy test suites to re-download every static asset on each `cy.visit`.
+
+Declaring certificates in `trustedCertificates` adds their SubjectPublicKeyInfo (SPKI) fingerprints to the `--ignore-certificate-errors-spki-list` flag, which Cypress passes only on the native browser network path (Chrome, Chromium, and Edge). Chromium honors the SPKI list over the blanket ignore flag, treating connections to declared origins as genuinely trusted rather than merely tolerated. As a result, static assets from those origins are written to the browser's HTTP disk cache and served from cache across navigations, matching production behavior.
+
+`trustedCertificates` is purely additive. Cypress continues passing the blanket `--ignore-certificate-errors` flag, so origins that you do not declare continue to load exactly as before.
+
+:::info
+
+`trustedCertificates` applies only to Chrome, Chromium, and Edge on the native browser network path. It has no effect on Firefox, WebKit, Electron, or runs where [`forceHttp1`](#forceHttp1) is set to `true` (which continue using the legacy network path).
+
+To provide client certificates for mutual TLS (mTLS) authentication where Cypress presents certificates to an endpoint, use [`clientCertificates`](/app/references/client-certificates) instead.
+
+:::
+
+#### Configuration syntax
+
+Each item in the `trustedCertificates` array must be an object with **exactly one** of the following keys:
+
+| Property   | Type     | Description                                                                                                                                                                     |
+| ---------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `filePath` | `String` | Path to a PEM-encoded certificate file. A relative path resolves against the project root.                                                                                      |
+| `pem`      | `String` | Inline PEM-encoded certificate text.                                                                                                                                            |
+| `spki`     | `String` | Precomputed base64-encoded SHA-256 fingerprint of the certificate's SubjectPublicKeyInfo (SPKI). Must be exactly 44 characters ending in `=` (matching `^[A-Za-z0-9+/]{43}=$`). |
+
+Every certificate in a PEM file or inline `pem` string is trusted, so you can declare a bundle that holds a leaf certificate and its issuing CA as a single entry.
+
+Providing zero keys, multiple keys in one entry, unknown keys, empty strings, or a malformed `spki` value will cause a configuration validation error. Validation only checks the shape of each entry: a `filePath` that cannot be read, or a PEM that cannot be parsed, fails at browser launch with an error naming the entry.
+
+Changing `trustedCertificates` restarts the browser but not the Cypress server.
+
+#### Certificate matching
+
+Chromium matches each SPKI fingerprint against **any certificate in the TLS chain the server presents**:
+
+- If your server sends the full certificate chain (for example, a leaf certificate and an intermediate or private CA certificate), you can declare either the leaf certificate or the CA certificate included in that chain.
+- If your server presents only the leaf certificate and no chain, you must declare the **leaf certificate**, because a CA fingerprint will not match if the server does not present the CA in its handshake.
+
+#### Generating an SPKI fingerprint
+
+To precompute a certificate's SPKI fingerprint for use with the `spki` property, run the following OpenSSL command:
+
+```shell
+openssl x509 -in cert.pem -pubkey -noout \
+  | openssl pkey -pubin -outform der \
+  | openssl dgst -sha256 -binary | base64
+```
+
+#### Examples
+
+Point at a certificate file on disk with `filePath`:
+
+:::cypress-config-example
+
+```ts
+{
+  trustedCertificates: [
+    { filePath: 'certs/dev-server.crt' },
+  ],
+}
+```
+
+:::
+
+Paste the certificate text inline with `pem`:
+
+:::cypress-config-example
+
+```ts
+{
+  trustedCertificates: [
+    {
+      pem: `-----BEGIN CERTIFICATE-----
+MIIDXjCCAkYCFH2GWLVnyyzmK8b9/0pw89/+/pqDMA0GCSqGSIb3DQEBCwUAMHQx
+...
+-----END CERTIFICATE-----`,
+    },
+  ],
+}
+```
+
+:::
+
+Declare a precomputed fingerprint with `spki` when you would rather not ship the
+certificate itself:
+
+:::cypress-config-example
+
+```ts
+{
+  trustedCertificates: [
+    { spki: 'YsaxHIp/FAcE7ClDGQW6MmEJry1/BD50ardH3b/NMbo=' },
+  ],
+}
+```
+
+:::
+
 ### Test files not found when using `spec` parameter
 
 When using the `--spec <path or mask>` argument, make it relative to the
@@ -1031,6 +1136,7 @@ DEBUG=cypress:cli,cypress:data-context:sources:FileDataSource,cypress:data-conte
 
 | Version                                      | Changes                                                                                                                                                                         |
 | -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [16.1.0](/app/references/changelog#16-1-0)   | Added `trustedCertificates` option.                                                                                                                                             |
 | [16.0.0](/app/references/changelog#16-0-0)   | Added `forceHttp1` option.                                                                                                                                                      |
 | [16.0.0](/app/references/changelog#16-0-0)   | Updated `blockHosts`, `viewportHeight`, and `viewportWidth` to no longer be settable with `Cypress.config()` during test execution.                                             |
 | [16.0.0](/app/references/changelog#16-0-0)   | Removed `allowCypressEnv` option.                                                                                                                                               |

--- a/docs/app/releases/changelog.mdx
+++ b/docs/app/releases/changelog.mdx
@@ -10,6 +10,14 @@ slug: /app/references/changelog
 
 # Changelog
 
+## 16.1.0
+
+_Released Sep 15, 2026_
+
+**Features:**
+
+- Added the [`trustedCertificates`](/app/references/configuration#trustedCertificates) configuration option. On the native browser network path (Chrome, Chromium, and Edge), declare a certificate your application under test presents (a self-signed development certificate, an internal certificate authority, or a precomputed SPKI fingerprint) and Chrome treats connections to that origin as trusted rather than merely tolerating its certificate errors. Static assets from the origin are then cached across navigations as they are in production. Previously nothing from an untrusted-certificate origin was ever written to the browser's disk cache, so asset-heavy specs re-downloaded every asset on each [`cy.visit()`](/api/commands/visit). Origins you do not declare continue to load exactly as before. Firefox, WebKit, Electron, and [`forceHttp1`](/app/references/configuration#forceHttp1) runs are unaffected. Addresses [#34760](https://github.com/cypress-io/cypress/issues/34760).
+
 ## 16.0.0
 
 _Released Sep 1, 2026_

--- a/docs/app/write-tests/native-network-interception.mdx
+++ b/docs/app/write-tests/native-network-interception.mdx
@@ -404,6 +404,32 @@ modifications do, because the browser only ever sees the response Cypress return
 Assertions on `request.headers` after `cy.wait()` and the Cypress command log report the
 modified request on both paths.
 
+## TLS certificates and caching
+
+Cypress launches every Chromium-based browser with the `--ignore-certificate-errors` flag so that origins with self-signed or private-CA certificates load without manual certificate prompts.
+
+However, Chromium's disk cache intentionally skips storing responses from connections whose certificate errors were merely ignored. For an HTTPS application under test using a self-signed or private-CA certificate, the browser disk cache remained empty, causing asset-heavy test suites to re-download every static asset on each `cy.visit`.
+
+Starting in Cypress 16.1.0, you can declare your server's certificates with the [`trustedCertificates`](/app/references/configuration#trustedCertificates) configuration option:
+
+:::cypress-config-example
+
+```ts
+{
+  trustedCertificates: [
+    { filePath: 'certs/dev-server.crt' },
+  ],
+}
+```
+
+:::
+
+When certificates are declared in `trustedCertificates`, Cypress adds their SubjectPublicKeyInfo (SPKI) fingerprints to `--ignore-certificate-errors-spki-list`, which it passes only on the native browser network path. Chromium honors this fingerprint list over the blanket ignore flag and treats connections to matching origins as trusted. Static assets are then cached to disk across navigations as they are in production.
+
+Chromium matches a fingerprint against any certificate in the chain the server presents during the TLS handshake. If your server presents an intermediate or CA certificate in its chain, declaring either that CA or the leaf certificate works. If your server presents only the leaf certificate without a chain, you must declare the leaf certificate.
+
+See [`trustedCertificates`](/app/references/configuration#trustedCertificates) for the full configuration reference.
+
 ## Writing tests that pass in every browser
 
 Assertions that describe your application rather than the transport pass in every browser
@@ -437,6 +463,7 @@ this gate; see [Using the legacy network path](#Using-the-legacy-network-path).
 
 ## See also
 
+- [`trustedCertificates` configuration](/app/references/configuration#trustedCertificates)
 - [`cy.intercept()`](/api/commands/intercept)
 - [`Cypress.browser`](/api/cypress-api/browser)
 - [`Cypress.isBrowser()`](/api/cypress-api/isbrowser)


### PR DESCRIPTION
# NOTE: use a merge commit

Contains documentation for `release/16.1.0`:

- #6892

Changelog:

- [x] 16.1.0 changelog entry: #6904

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes for a release; no runtime, auth, or data-handling code modified.
> 
> **Overview**
> ## Summary
> 
> Documents **Cypress 16.1.0** in the app docs: a new **`trustedCertificates`** configuration option, cross-links between mTLS (`clientCertificates`) and server-trust settings, and a full **16.1.0 changelog** entry.
> 
> ## Why
> 
> Release `16.1.0` ships `trustedCertificates` so Chromium on the native network path can treat declared self-signed/private-CA certs as truly trusted (SPKI list), enabling HTTP disk caching for HTTPS apps that previously re-downloaded assets on every `cy.visit`. This PR captures that behavior and the rest of the release notes for readers and reviewers merging the release branch.
> 
> Closes #6904 (changelog) and bundles related doc work (#6892).
> 
> ## Notes for reviewers
> 
> Focus on **accuracy of `trustedCertificates`** (syntax, native-path-only scope, `forceHttp1` interaction) and **changelog completeness** vs. the actual 16.1.0 release. Client-certificates and native-network-interception pages were updated only to disambiguate mTLS vs. trusting the server cert and to explain TLS caching—no product code in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67cd7f81e483cd8b69850fc6c02e88b0b124826f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

